### PR TITLE
Fix doc tables

### DIFF
--- a/docs/gherkin-syntax.md
+++ b/docs/gherkin-syntax.md
@@ -1,4 +1,3 @@
-
 # A Comprehensive Guide to Gherkin: From Executable Specifications to Practical Implementation
 
 ______________________________________________________________________
@@ -21,24 +20,21 @@ non-technical business stakeholders.[^3] Its primary role within the BDD
 lifecycle is to enable the creation of "executable specifications".[^3] These
 specifications, written in a plain-text, human-readable format, serve a dual
 purpose: they act as living documentation for the project's features and as
-automated tests that verify those features are implemented correctly.[^6]
-
-This duality creates a powerful "closed loop" feedback system. Business
+automated tests that verify those features are implemented correctly.[^6] This
+duality creates a powerful "closed loop" feedback system. Business
 requirements, articulated in Gherkin, are directly linked to the code that
 implements them.[^8] When a test passes, it provides concrete, verifiable proof
 that the corresponding requirement has been met. This ensures that development
 work remains aligned with business goals and that the documentation never
-becomes stale, as it is continuously validated against the running software.[^1]
-
-The effectiveness of Gherkin, however, is not guaranteed by its syntax alone.
-Its value is directly proportional to the level of collaboration within the
-team. The language is designed to facilitate conversations among the "Three
-Amigos"—the business analyst, the developer, and the tester—who bring their
-unique perspectives to the process of defining behavior.[^4] When these
+becomes stale, as it is continuously validated against the running
+software.[^1] The effectiveness of Gherkin, however, is not guaranteed by its
+syntax alone. Its value is directly proportional to the level of collaboration
+within the team. The language is designed to facilitate conversations among the
+"Three Amigos"—the business analyst, the developer, and the tester—who bring
+their unique perspectives to the process of defining behavior.[^4] When these
 stakeholders actively participate in writing, reviewing, and refining Gherkin
 specifications, the team builds a robust, shared understanding of the system's
 requirements before a single line of implementation code is written.
-
 Conversely, when this collaborative cycle is neglected, Gherkin can become an
 "unnecessary burden".[^11] If business stakeholders do not read or contribute
 to the feature files, the primary benefit of a business-readable format is
@@ -53,59 +49,46 @@ entire team's commitment to the BDD collaborative cycle.
 All Gherkin specifications are stored in plain-text files with a `.feature`
 extension.[^1] As a best practice, each file should focus on describing a
 single, cohesive software feature.[^13] The structure of these files is defined
-by a set of keywords that give meaning to each line.
-
-The core structure of any Gherkin test revolves around describing a specific
-example of behavior. This is accomplished through a sequence of steps that
-follow a clear, logical progression: context, action, and outcome.
+by a set of keywords that give meaning to each line. The core structure of any
+Gherkin test revolves around describing a specific example of behavior. This is
+accomplished through a sequence of steps that follow a clear, logical
+progression: context, action, and outcome.
 
 - `Feature`: Every `.feature` file must begin with the `Feature` keyword. This
   keyword provides a high-level name and description for the functionality
-  being tested.[^6] The text following the
-
-  `Feature` keyword, up to the first `Scenario` or other structural keyword,
-  serves as a free-form description. While this description is ignored by test
-  automation tools during execution, it is often included in generated reports
-  and serves as valuable documentation.[^6] A common convention is to use this
-  space for a user story narrative (e.g., "As a \[role\], the [feature] is
-  desired, so that \[benefit\]").
-
+  being tested.[^6] The text following the `Feature` keyword, up to the first
+  `Scenario` or other structural keyword, serves as a free-form description.
+  While this description is ignored by test automation tools during execution,
+  it is often included in generated reports and serves as valuable
+  documentation.[^6] A common convention is to use this space for a user story
+  narrative (e.g., "As a \[role\], the [feature] is desired, so that
+  \[benefit\]").
 - `Scenario`: A `Feature` contains one or more `Scenarios`. A `Scenario`
   describes a single, concrete example of the feature's behavior—a specific use
-  case or test case.[^1] Each
-
-  `Scenario` should be independent and test one, and only one, behavior.[^13]
-  This focus is crucial for clarity and maintenance; when a test fails, it
-  should point to a single, specific piece of broken functionality.
-
+  case or test case.[^1] Each `Scenario` should be independent and test one,
+  and only one, behavior.[^13] This focus is crucial for clarity and
+  maintenance; when a test fails, it should point to a single, specific piece
+  of broken functionality.
 - `Given`: This keyword sets the initial context or preconditions for a
   `Scenario`. It describes the state of the world *before* the main event of
-  the scenario occurs.[^1] A
-
-  `Given` step should put the system into a known state, such as preparing test
-  data in a database or ensuring a user is logged in.[^9] Best practices
-  strongly advise against describing user interactions in
-
-  `Given` steps; they are about establishing the scene, not the action.[^9]
-
+  the scenario occurs.[^1] A `Given` step should put the system into a known
+  state, such as preparing test data in a database or ensuring a user is logged
+  in.[^9] Best practices strongly advise against describing user interactions
+  in `Given` steps; they are about establishing the scene, not the action.[^9]
 - `When`: This keyword describes an event or an action. This is typically an
   interaction performed by a user (e.g., "the user clicks the login button") or
   an event triggered by an external system.[^1] To maintain the "one behavior
-  per scenario" rule, it is highly recommended to have only a single
-
-  `When` step in each `Scenario`.[^9] This step represents the pivotal action
-  that the scenario is designed to test.
-
+  per scenario" rule, it is highly recommended to have only a single `When`
+  step in each `Scenario`.[^9] This step represents the pivotal action that the
+  scenario is designed to test.
 - `Then`: This keyword defines the expected outcome or result of the action
   described in the `When` step. The code that implements a `Then` step (the
   "step definition") must contain assertions to verify that the actual outcome
   matches the expected outcome.[^1] A critical best practice is to ensure this
   outcome is observable from the user's perspective, such as a message on the
   screen or a change in the UI state. Verifying internal system states, like a
-  database record, directly in a
-
-  `Then` step is discouraged because it couples the test to implementation
-  details rather than observable behavior.[^9]
+  database record, directly in a `Then` step is discouraged because it couples
+  the test to implementation details rather than observable behavior.[^9]
 
 ### Section 1.3: Enhancing Readability and Flow
 
@@ -117,10 +100,8 @@ Gherkin provides several additional keywords.
   without repeating `Given`, `When`, or `Then`.[^9] These keywords are
   syntactically interchangeable and carry no special automation logic; their
   purpose is purely to improve the narrative flow and structure of the
-  scenario.[^18]
-
-  `But` is often used to express a negative condition, which can enhance
-  readability.
+  scenario.[^18] `But` is often used to express a negative condition, which can
+  enhance readability.
 
 ```gherkin
   Scenario: Simple Google search
@@ -136,9 +117,8 @@ Gherkin provides several additional keywords.
   `And`, `But`).[^14] This can be particularly useful when a scenario involves
   a list of items or conditions, as it can read more like a set of bullet
   points than a narrative sequence. The asterisk inherits the context of the
-  preceding keyword. For example, if it follows a
-
-  `Given`, it is treated as another `Given` step.[^19]
+  preceding keyword. For example, if it follows a `Given`, it is treated as
+  another `Given` step.[^19]
 
 ```gherkin
   Scenario: Setting up a user profile
@@ -146,7 +126,6 @@ Gherkin provides several additional keywords.
     * the user has a profile picture
     * the user has a bio
 ```
-
 <!-- markdownlint-disable MD013 -->
 ### Table 1: Gherkin Keyword Reference
 
@@ -171,7 +150,6 @@ primary and secondary keywords in the Gherkin language.
 | @                | Prefix for a Tag, used to organize and filter features or scenarios. 10                                            | Placed on the line(s) above Feature, Scenario, etc.                         | @smoke @regression                                          |
 | #                | Prefix for a single-line comment. Ignored by test runners. 14                                                      | Can be placed at the start of any new line.                                 | # This is a comment                                         |
 <!-- markdownlint-enable MD013 -->
-
 ______________________________________________________________________
 
 ## Part 2: Advanced Gherkin for Complex Scenarios
@@ -187,49 +165,39 @@ In many feature files, it is common to find that several scenarios share the
 exact same set of initial `Given` steps. For instance, multiple tests for an
 e-commerce site might all require the user to be logged in and have items in
 their cart. Repeating these steps in every scenario is inefficient and clutters
-the file.
-
-The `Background` keyword solves this problem by allowing definition of `Given`
-steps that are common to all `Scenarios` within that `Feature` file.[^1] These
-steps are automatically executed before each and every
-
+the file. The `Background` keyword solves this problem by allowing definition
+of `Given` steps that are common to all `Scenarios` within that `Feature`
+file.[^1] These steps are automatically executed before each and every
 `Scenario` in the file, acting as a shared setup routine.[^15]
 
 ```gherkin
 Feature: User profile management
   As a registered user, I want to manage my profile information.
-
   Background:
     Given the user is on the login page
     And the user is logged in as "testuser"
     And the user navigates to the profile page
-
   Scenario: Update user's name
     When the user updates their first name to "Jane"
     Then the profile should display the name "Jane Doe"
-
   Scenario: Add a profile picture
     When the user uploads a new profile picture
     Then the new profile picture should be displayed
 ```
 
-Best Practices for Background:
-
-While powerful, the Background keyword should be used judiciously.
+Best Practices for Background: While powerful, the Background keyword should be
+used judiciously.
 
 - **Keep it Short and Relevant:** A `Background` should only contain steps that
   are truly essential for *all* scenarios in the feature. If a setup step is
   only needed for a subset of scenarios, it belongs in their respective `Given`
-  sections.[^9] A good rule of thumb is to keep the
-
-  `Background` under four lines long.14.
-
+  sections.[^9] A good rule of thumb is to keep the `Background` under four
+  lines long.14.
 - **Focus on Prerequisite State, Not Noise:** The `Background` should not be
   used to set up complex states that are not immediately obvious to someone
   reading the scenarios. If the details are irrelevant to the business user
   (e.g., creating a specific site ID), abstract them into a higher-level, more
   declarative step like `Given I am logged in as a site owner`.[^14]
-
 - **Make it Vivid:** Use descriptive, colourful names to tell a coherent
   story. The human brain remembers narratives better than abstract identifiers
   like "User A" or "Site 1".[^14]
@@ -239,26 +207,19 @@ While powerful, the Background keyword should be used judiciously.
 Often, testing the same behavior requires a variety of different inputs and
 expected outputs. For example, testing a login form requires checking valid
 credentials, invalid passwords, invalid usernames, and empty fields. Writing a
-separate `Scenario` for each case would be highly repetitive.
-
-The `Scenario Outline` keyword is Gherkin's primary mechanism for data-driven
+separate `Scenario` for each case would be highly repetitive. The
+`Scenario Outline` keyword is Gherkin's primary mechanism for data-driven
 testing. It allows a scenario template to be executed multiple times with
-different data sets.[^10]
-
-**Syntax:**
+different data sets.[^10] **Syntax:**
 
 1. Replace the `Scenario` keyword with `Scenario Outline`.
-
 2. In the steps, use angle brackets (`< >`) to define placeholders for
    variables.[^13]
-
 3. Follow the `Scenario Outline` with an `Examples` table. The first row of
    this table is the header, and its column names must exactly match the
-   variable names used in the steps.[^20]
-
-The test runner will execute the entire scenario once for each data row in the
-`Examples` table, substituting the placeholder variables with the values from
-that row.[^16]
+   variable names used in the steps.[^20] The test runner will execute the
+   entire scenario once for each data row in the `Examples` table, substituting
+   the placeholder variables with the values from that row.[^16]
 
 ```gherkin
 Feature: Calculator Addition
@@ -269,9 +230,7 @@ Feature: Calculator Addition
     And I enter "<Number2>" into the calculator
     And I press the equals button
     Then the result should be "<Result>"
-
     Examples:
-
 | Number1 | Number2 | Result |
 | 2 | 3 | 5 |
 | 10 | 0 | 10 |
@@ -288,18 +247,14 @@ While a `Scenario Outline` is perfect for running an entire scenario with
 different data, sometimes only a structured set of data needs to be passed to a
 *single step*. For example, a `Given` step might need to create multiple user
 accounts with different roles, or a `Then` step might need to verify the
-contents of a shopping cart.
-
-`Data Tables` provide a way to pass a table of data directly to a step
-definition.[^14] They are defined using pipe (
-
-`|`) delimiters immediately below the step they belong to.
+contents of a shopping cart. `Data Tables` provide a way to pass a table of
+data directly to a step definition.[^14] They are defined using pipe ( `|`)
+delimiters immediately below the step they belong to.
 
 ```gherkin
 Feature: User administration
   Scenario: Create multiple new users
     Given the following users exist in the system:
-
 | name | email | role |
 | Alice | alice@example.com | admin |
 | Bob | bob@example.com | editor |
@@ -318,16 +273,11 @@ maps) and use it to perform the necessary setup.[^22]
 
 Sometimes the data required by a step is not a simple value or structured
 table, but a larger, free-form block of text. This is common when working with
-APIs (JSON/XML payloads), email content, or snippets of code.
-
-`Doc Strings` are Gherkin's solution for this. A `Doc String` allows a
-multi-line string to be passed to a step definition.[^14]
-
-Syntax:
-
-The text block is enclosed by a pair of triple double-quotes (""") or triple
-backticks (\`\`\`\`\`\`) on their own lines, immediately following the
-step.[^14]
+APIs (JSON/XML payloads), email content, or snippets of code. `Doc Strings` are
+Gherkin's solution for this. A `Doc String` allows a multi-line string to be
+passed to a step definition.[^14] Syntax: The text block is enclosed by a pair
+of triple double-quotes (""") or triple backticks (\`\`\`\`\`\`) on their own
+lines, immediately following the step.[^14]
 
 ```gherkin
 Feature: API for creating blog posts
@@ -352,30 +302,25 @@ tools with syntax highlighting and parsing.[^14]
 
 As a `Feature` grows more complex, a flat list of scenarios can become
 difficult to navigate. To provide an additional layer of organization, Gherkin
-version 6 introduced the `Rule` keyword.[^14]
-
-The purpose of the `Rule` keyword is to group a set of related scenarios that
-together represent a single, specific business rule that the system must
-enforce.[^9] This is particularly useful for features that have distinct sets
-of business logic.
+version 6 introduced the `Rule` keyword.[^14] The purpose of the `Rule` keyword
+is to group a set of related scenarios that together represent a single,
+specific business rule that the system must enforce.[^9] This is particularly
+useful for features that have distinct sets of business logic.
 
 ```gherkin
 Feature: Bank account withdrawals
   This feature describes the rules for withdrawing cash from a bank account.
-
   Rule: Users cannot go overdrawn
     Scenario: Attempt to withdraw more than the balance
       Given my account balance is $100
       When I attempt to withdraw $150
       Then the withdrawal should be rejected
       And I should see an "Insufficient funds" message
-
     Scenario: Attempt to withdraw the exact balance
       Given my account balance is $100
       When I attempt to withdraw $100
       Then the withdrawal should be successful
       And my new balance should be $0
-
   Rule: Daily withdrawal limits must be respected
     Scenario: Attempt to withdraw more than the daily limit
       Given my account balance is $1000
@@ -388,7 +333,6 @@ Feature: Bank account withdrawals
 Here, the `Rule` keyword clearly separates the scenarios related to overdraft
 protection from those related to daily withdrawal limits, making the feature
 file's intent much clearer.
-
 ______________________________________________________________________
 
 ## Part 3: Mastering Gherkin: Organization and Best Practices
@@ -403,56 +347,43 @@ the "how" of syntax to the "why" of effective specification.
 As a test suite grows, a method is needed to organize and selectively run
 subsets of scenarios. It might be desirable to run a quick "smoke test" suite,
 a full "regression" suite, or tests specific to a certain feature or
-environment.
-
-`Tags` are Gherkin's mechanism for this kind of organization. A tag is a simple
-annotation prefixed with an `@` symbol (e.g., `@smoke`, `@api`, `@ui`).[^10]
-Tags can be placed above
-
-`Feature`, `Scenario`, `Scenario Outline`, or even specific `Examples` tables
-to categorize them.[^14] A single element can have multiple tags.
+environment. `Tags` are Gherkin's mechanism for this kind of organization. A
+tag is a simple annotation prefixed with an `@` symbol (e.g., `@smoke`, `@api`,
+`@ui`).[^10] Tags can be placed above `Feature`, `Scenario`,
+`Scenario Outline`, or even specific `Examples` tables to categorize them.[^14]
+A single element can have multiple tags.
 
 ```gherkin
 @login @smoke
 Feature: User Login
-
   @happy-path @regression
   Scenario: Successful login with valid credentials
    ...
-
   @sad-path
   Scenario Outline: Failed login with invalid credentials
    ...
     @critical
     Examples: Invalid Password
-
 | username | password |
 | "testuser" | "wrongpassword" |
-
     Examples: Invalid Username
-
 | username | password |
 | "wronguser" | "password" |
 ```
 
 In this example, the entire feature is tagged with `@login` and `@smoke`. The
 successful login scenario is additionally tagged `@happy-path` and
-`@regression`. The `Examples` table for invalid passwords is tagged `@critical`.
-
-Most BDD test runners can then use these tags to filter which tests to execute.
-They typically support boolean expressions, allowing for complex selections 21:
+`@regression`. The `Examples` table for invalid passwords is tagged
+`@critical`. Most BDD test runners can then use these tags to filter which
+tests to execute. They typically support boolean expressions, allowing for
+complex selections 21:
 
 - **OR:** Run tests with `@smoke` OR `@regression`.
-
 - **AND:** Run tests with `@login` AND `@critical`.
-
 - **NOT:** Run all `@regression` tests that are NOT tagged `@smoke`.
-
 **Best Practices for Tags:**
-
 - **Standardize:** Agree on a standard set of tag names within the team to
   ensure consistency.
-
 - **Formatting:** Use lowercase for tag names and separate words with hyphens
   (e.g., `@work-in-progress`) for readability.[^13]
 
@@ -460,20 +391,16 @@ They typically support boolean expressions, allowing for complex selections 21:
 
 Effective Gherkin is an art that balances clarity, precision, and
 maintainability. The foundational principle that underpins all other best
-practices is the use of a **declarative style** over an imperative one.
-
-An imperative style describes the mechanics of an interaction—the "how." It
+practices is the use of a **declarative style** over an imperative one. An
+imperative style describes the mechanics of an interaction—the "how." It
 focuses on implementation details like clicking buttons, filling in text
 fields, or navigating to URLs.[^17]
 
 - **Imperative (Avoid):** `When I type "user@example.com" into the "email"
-  field and click the "submit" button`
-
-A declarative style describes the user's intent and the system's behavior—the
-"what." It abstracts away the implementation details.[^24]
-
+  field and click the "submit" button` A declarative style describes the user's
+  intent and the system's behavior—the "what." It abstracts away the
+  implementation details.[^24]
 - **Declarative (Prefer):** `When the user logs in with valid credentials`
-
 The declarative approach is superior for several reasons. Imperative tests are
 brittle; a minor UI change (like renaming a button from "Submit" to "Log In")
 can break the test, even if the underlying functionality is unchanged.
@@ -481,24 +408,17 @@ Declarative tests are more resilient because the implementation of "logging in"
 can change (from a UI flow to a direct API call) without requiring any
 modification to the Gherkin specification itself. This makes the feature file a
 true piece of "living documentation" that describes business value, not a
-fragile script of UI interactions.[^24]
-
-Building on this philosophy, several other rules contribute to high-quality
-Gherkin:
-
+fragile script of UI interactions.[^24] Building on this philosophy, several
+other rules contribute to high-quality Gherkin:
 - **The Cardinal Rule: One Scenario, One Behavior:** Each scenario should test
   a single, focused business rule or use case.[^13] If a scenario contains
-  multiple
-
-  `When-Then` pairs, it is likely testing multiple behaviors and should be
-  split into separate, more focused scenarios.[^13] This makes tests easier to
-  understand and debug.
-
+  multiple `When-Then` pairs, it is likely testing multiple behaviors and
+  should be split into separate, more focused scenarios.[^13] This makes tests
+  easier to understand and debug.
 - **Conciseness and Clarity:** Keep scenarios short and to the point. A good
   rule of thumb is to aim for fewer than 10 steps, with 5 or fewer being
   ideal.[^13] Similarly, feature files should not become monolithic; a dozen
   scenarios per file is a reasonable guideline.[^13]
-
 - **Precise Language:** Use clear, unambiguous language that is part of the
   project's shared domain vocabulary. Avoid technical jargon.[^10] Steps should
   be written as complete subject-predicate action phrases (e.g., "the user
@@ -515,7 +435,6 @@ the team. This requires attention to documentation and consistent style.
   and are completely ignored by test runners.[^14] Gherkin does not have a
   syntax for multi-line block comments; each line of a comment block must be
   individually prefixed with `#`.14.
-
 - **YAML Comments (An Advanced Technique):** For more structured metadata that
   doesn't belong in the behavioral specification itself—such as links to user
   stories, ticket IDs, or security classifications—a useful pattern is to use
@@ -528,21 +447,17 @@ the team. This requires attention to documentation and consistent style.
   # Status: Confirmed
   # References:
   #   - [https://jira.example.com/browse/TICKET-123](https://jira.example.com/browse/TICKET-123)
-
   Feature: User Data Security
    ...
 ```
 
 - **Code Style and Formatting:** Consistent formatting is crucial for
   readability, especially in a collaborative environment.
-
   - **Indentation:** Use a consistent indentation style. Two spaces is the
     recommended standard.[^13]
-
   - **Spacing:** Use blank lines to separate scenarios, and ensure consistent
     spacing around pipe (`|`) delimiters in tables to make them align
     visually.[^13]
-
   - **Capitalization:** Capitalize Gherkin keywords (`Given`, `When`, `Then`)
     and the first word of titles, but not other words in step phrases unless
     they are proper nouns.[^13]
@@ -567,7 +482,7 @@ Python's package management.
 
 ```bash
   pip install pytest pytest-bdd
-  
+
   ```
 
   For web UI testing, `selenium` and potentially other helper libraries are
@@ -575,11 +490,8 @@ Python's package management.
 
 - **Directory Structure:** A conventional project structure helps keep tests
   organized:
-
   - `features/`: This directory contains all Gherkin `.feature` files.
-
   - `tests/`: This directory holds Python test code.
-
     - `step_defs/`: It is a common practice to create a subdirectory within
       `tests/` to store the step definition files (e.g., `test_login.py`). This
       separates them from other types of tests (e.g., unit tests).
@@ -595,20 +507,18 @@ decorators.
   telling `pytest` that this function represents a specific Gherkin scenario.
   The decorator takes the path to the `.feature` file and the name of the
   `Scenario` as arguments.[^29] The decorated function itself often contains
-  just a
-
-  `pass` statement or a final, high-level assertion, as its main purpose is to
-  act as a collector for the steps and to be discoverable by the `pytest`
+  just a `pass` statement or a final, high-level assertion, as its main purpose
+  is to act as a collector for the steps and to be discoverable by the `pytest`
   runner.[^31]
 
 ```python
   # tests/step_defs/test_publish_article.py
   from pytest_bdd import scenario
-  
+
   @scenario('../../features/publish_article.feature', 'Publishing the article')
   def test_publish():
       pass
-  
+
   ```
 
 - **Step Decorators (**`@given`**,** `@when`**,** `@then`**):** Each Gherkin
@@ -621,22 +531,22 @@ decorators.
 
 ```python
   from pytest_bdd import given, when, then
-  
+
   @given("I'm an author user")
   def author_user():
       # Code to set up an author user
      ...
-  
+
   @when("I press the publish button")
   def press_publish_button():
       # Code to simulate pressing the button
      ...
-  
+
   @then("the article should be published")
   def article_is_published():
       # Code with assertions to verify publication
      ...
-  
+
   ```
 
 ### Section 4.3: State Management with Pytest Fixtures
@@ -647,25 +557,17 @@ mutable "World" or "Context" object that is passed between steps, `pytest-bdd`
 eschews this pattern. Instead, it fully embraces the idiomatic `pytest` fixture
 system for managing and sharing state between steps.[^32] This represents a
 philosophical shift from explicit state passing to implicit dependency
-injection.
-
-In this model, `Given` steps act as fixture factories. A function decorated
-with `@given` can return a value. By using the `target_fixture` argument in the
-decorator, this return value is injected into the `pytest` context as a named
-fixture, available exclusively for the duration of that scenario.[^31]
-Subsequent
-
-`When` and `Then` steps can then access this state simply by declaring a
-function argument with the same name as the target fixture. `pytest` handles
-the dependency injection automatically.
-
-This approach has profound benefits. It allows BDD test setup to be composed
-from the same reusable fixtures as standard unit and integration tests,
-unifying the entire test suite. It avoids the pitfalls of a single, monolithic
-context object and promotes cleaner, more modular step definitions.
-
-**Practical Example:**
-
+injection. In this model, `Given` steps act as fixture factories. A function
+decorated with `@given` can return a value. By using the `target_fixture`
+argument in the decorator, this return value is injected into the `pytest`
+context as a named fixture, available exclusively for the duration of that
+scenario.[^31] Subsequent `When` and `Then` steps can then access this state
+simply by declaring a function argument with the same name as the target
+fixture. `pytest` handles the dependency injection automatically. This approach
+has profound benefits. It allows BDD test setup to be composed from the same
+reusable fixtures as standard unit and integration tests, unifying the entire
+test suite. It avoids the pitfalls of a single, monolithic context object and
+promotes cleaner, more modular step definitions. **Practical Example:**
 **Feature File (**`bank_account.feature`**):**
 
 ```gherkin
@@ -681,29 +583,24 @@ Feature: Bank Account Transactions
 ```python
 import pytest
 from pytest_bdd import scenario, given, when, then, parsers
-
 # Standard pytest fixture to create a base account object
 @pytest.fixture
 def bank_account():
     return {'balance': 0}
-
 @scenario('../../features/bank_account.feature', 'Deposit into an account')
 def test_deposit():
     pass
-
 # This @given step creates and returns a value.
 # 'target_fixture="bank_account"' makes this value available as the 'bank_account' fixture
 # for this scenario, overriding the default fixture above.
 @given(parsers.parse('the account has an initial balance of {initial:d}'), target_fixture="bank_account")
 def account_with_initial_balance(initial):
     return {'balance': initial}
-
 # This @when step requests the 'bank_account' fixture via dependency injection.
 # It also requests 'deposit_amount', which is parsed from the step itself.
 @when(parsers.parse('the user deposits {deposit_amount:d}'))
 def user_deposits(bank_account, deposit_amount):
     bank_account['balance'] += deposit_amount
-
 # This @then step also requests the 'bank_account' fixture to perform its assertion.
 @then(parsers.parse('the new account balance should be {final_balance:d}'))
 def final_balance_is_correct(bank_account, final_balance):
@@ -721,17 +618,14 @@ steps.
   variant), and `re` (for regular expressions). The `parse` and `cfparse`
   styles, which use `{name:Type}` syntax, are generally preferred for their
   readability.[^34]
-
 - `Scenario Outline` **Parameters:** When using a `Scenario Outline`, the
   values from the `Examples` table are automatically parsed and passed as
   arguments to the corresponding step functions. Their names must match the
   headers in the `Examples` table.[^34]
-
 - `Data Tables`**:** A step definition function can access a `Data Table` by
   including a special argument named `datatable`. `pytest-bdd` will inject the
   table's content into this argument as a list of lists, where each inner list
   represents a row.[^22]
-
 - `Doc Strings`**:** Similarly, a `Doc String` can be accessed by including a
   special argument named `docstring`. This argument will receive the entire
   block text as a single, multi-line string.[^22]
@@ -752,37 +646,29 @@ Setting up `cucumber-rs` involves configuring the project's `Cargo.toml` file
 and establishing a conventional directory structure.
 
 - `Cargo.toml` **Configuration:**
-
   1. Add `cucumber` and an async runtime such as `tokio` to the
      `[dev-dependencies]`.
-
-  1. Define a new test target in the `Cargo.toml`. Crucially, set
+  2. Define a new test target in the `Cargo.toml`. Crucially, set
      `harness = false`. This tells Rust's default test harness (`libtest`) to
      stand down, allowing `cucumber-rs` to take control of the test execution
-     and output formatting.[^37]
-
-  Ini, TOML
+     and output formatting.[^37] Ini, TOML
 
   ```toml
   [dev-dependencies]
   cucumber = "0.20"
   tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-  
+
   [[test]]
   name = "cucumber_tests" # This name should match your runner file
   harness = false
-  
+
   ```
 
 - **Directory Structure:** A typical `cucumber-rs` project organizes its files
   as follows 37:
-
   - `tests/`: The root directory for integration tests.
-
   - `tests/features/`: Contains the Gherkin `.feature` files.
-
   - `tests/steps/`: Contains the Rust modules with step definitions.
-
   - `tests/cucumber_tests.rs`: The main test runner file. This file defines the
     `World` struct and includes a `main` function that invokes the
     `cucumber-rs` runner.
@@ -796,7 +682,6 @@ the `World`.
 - **Core Concept:** The `World` is a user-defined struct that holds all the
   mutable state for a single scenario. A new instance of the `World` is created
   for each scenario, ensuring that tests are isolated from one another.[^37]
-
 - **Implementation:** To be used by the framework, the struct must derive or
   implement the `cucumber::World` trait. The framework will then use
   `Default::default()` to create a new `World` for each scenario. If more
@@ -806,13 +691,13 @@ the `World`.
 ```rust
   // tests/cucumber_tests.rs
   use cucumber::World;
-  
+
   #
   pub struct CalculatorWorld {
       current_value: f64,
       memory: f64,
   }
-  
+
   ```
 
 ### Section 5.3: Asynchronous Step Definitions
@@ -822,14 +707,11 @@ well-suited for testing applications involving I/O operations like database
 queries or web requests.
 
 - **Attribute Macros:** Gherkin steps are linked to Rust functions using the
-  `#[given]`, `#[when]`, and `#[then]` attribute macros.[^35]
-
-  `cucumber-rs` enforces a stricter separation of these step types than some
-  other Cucumber implementations to prevent ambiguity.[^41]
-
+  `#[given]`, `#[when]`, and `#[then]` attribute macros.[^35] `cucumber-rs`
+  enforces a stricter separation of these step types than some other Cucumber
+  implementations to prevent ambiguity.[^41]
 - **Async Functions:** Step definition functions are typically `async` and are
   executed by the async runtime specified in the test runner (e.g., `tokio`).
-
 - **Function Signature:** Every step definition function must take a mutable
   reference to the `World` struct (`&mut MyWorld`) as its first argument. This
   is how steps read and modify the shared state of the scenario. Any parameters
@@ -839,22 +721,22 @@ queries or web requests.
   // tests/steps/calculator_steps.rs
   use crate::CalculatorWorld; // Assuming CalculatorWorld is in the parent module
   use cucumber::{given, when, then};
-  
+
   #[given(expr = "the calculator is cleared")]
   async fn calculator_is_cleared(world: &mut CalculatorWorld) {
       world.current_value = 0.0;
   }
-  
+
   #[when(expr = "I enter {float}")]
   async fn enter_number(world: &mut CalculatorWorld, num: f64) {
       world.current_value = num;
   }
-  
+
   #[then(expr = "the result should be {float}")]
   async fn result_is(world: &mut CalculatorWorld, expected: f64) {
       assert_eq!(world.current_value, expected);
   }
-  
+
   ```
 
 ### Section 5.4: Handling Data and Tables
@@ -867,14 +749,12 @@ into Rust types.
   (`expr = "..."`) specified in the attribute macro. The framework handles the
   conversion to the corresponding Rust type in the function signature (e.g.,
   `{float}` maps to `f64`).[^35]
-
 - **Accessing** `Data Tables` **and** `Doc Strings`**:** To access a
   `Data Table` or `Doc String` attached to a step, the step definition function
   must include an argument of type `&cucumber::gherkin::Step`. The table or doc
   string can then be accessed as an `Option` on this `Step` object:
-  `step.table` or `step.docstring`.[^40]
-
-  **Feature File (**`user_creation.feature`**):**
+  `step.table` or `step.docstring`.[^40] **Feature File
+  (**`user_creation.feature`**):**
 
 ```gherkin
   Scenario: Create a user with a bio
@@ -884,7 +764,7 @@ into Rust types.
       with a passion for Rust.
       """
     Then the user "Alice" should exist in the system
-  
+
   ```
 
   **Step Definition (**`user_steps.rs`**):**
@@ -892,21 +772,20 @@ into Rust types.
 ```rust
   use cucumber::{gherkin::Step, given};
   use crate::UserWorld;
-  
+
   #[given(expr = "I create a user {string} with the following bio:")]
   async fn create_user_with_bio(world: &mut UserWorld, name: String, step: &Step) {
       // Extract the doc string from the step
       let bio = step.docstring.as_ref().expect("Doc string not found").clone();
-  
+
       // Use the data to create a user and store it in the world
       world.create_user(name, bio);
   }
-  
+
   ```
 
   The same principle applies to `Data Tables`, where `step.table.as_ref()`
   would be used to access the table data, which can then be iterated over.[^42]
-
 ______________________________________________________________________
 
 ## Part 6: Synthesis: Implementation Variations and Quirks
@@ -928,17 +807,13 @@ BDD capabilities into the vast and mature `pytest` world. Its greatest strength
 is this very integration; it allows developers to reuse fixtures, leverage
 thousands of plugins for tasks like parallelization (`pytest-xdist`) and
 reporting (`pytest-html`), and manage BDD scenarios as just another type of
-`pytest` test.[^31]
-
-`cucumber-rs`, on the other hand, is a self-contained framework that provides
-its own test runner and ecosystem. Its strength lies in its idiomatic Rust
-implementation, featuring first-class `async` support and a strong, type-safe
-approach to state management via the `World` pattern.[^35] A Python team
-already invested in the
-
-`pytest` ecosystem will find `pytest-bdd` to be a natural and powerful
-extension. A Rust team will likely prefer the purpose-built, type-safe, and
-async-native design of `cucumber-rs`.
+`pytest` test.[^31] `cucumber-rs`, on the other hand, is a self-contained
+framework that provides its own test runner and ecosystem. Its strength lies in
+its idiomatic Rust implementation, featuring first-class `async` support and a
+strong, type-safe approach to state management via the `World` pattern.[^35] A
+Python team already invested in the `pytest` ecosystem will find `pytest-bdd`
+to be a natural and powerful extension. A Rust team will likely prefer the
+purpose-built, type-safe, and async-native design of `cucumber-rs`.
 
 ### Table 2: `pytest-bdd` vs. `cucumber-rs` Implementation Comparison
 
@@ -963,14 +838,12 @@ developers should be aware of specific implementation details that can act as
   `Feature`-level examples, focusing on compatibility with the latest core
   Gherkin developments.[^30] Teams migrating from other tools may find that
   certain syntax is no longer supported.
-
 - **Step Type Strictness:** `cucumber-rs` intentionally enforces a stricter
   separation between `given`, `when`, and `then` step types than the official
   Cucumber implementation. This is a design choice to prevent ambiguity, for
   example, by disallowing a `then` step from being used as a `given` step.[^41]
   While this promotes clearer scenarios, it can be a surprise for those
   accustomed to more lenient frameworks.
-
 - **State Management Paradigm:** The most significant "gotcha" is the
   difference in state management. The implicit, dependency-injection model of
   `pytest-bdd` fixtures and the explicit, shared-object model of the
@@ -985,139 +858,76 @@ Gherkin's syntax is deceptively simple. The true challenge and reward of
 adopting it lie not in memorizing keywords but in embracing the collaborative,
 behavior-first mindset it is designed to foster.[^8] When used effectively,
 Gherkin transforms testing from a purely technical, after-the-fact verification
-activity into an integral part of the requirements and design process.
-
-The ultimate goal is to create a suite of executable specifications that serve
-as a single, unambiguous source of truth for what the software does. This
-living documentation is invaluable for onboarding new team members,
-facilitating discussions about new features, and providing confidence that the
-application meets the needs of the business. While the tools and
-implementations will continue to evolve, Gherkin's core value proposition—as a
-language for building shared understanding—remains as relevant as ever.
+activity into an integral part of the requirements and design process. The
+ultimate goal is to create a suite of executable specifications that serve as a
+single, unambiguous source of truth for what the software does. This living
+documentation is invaluable for onboarding new team members, facilitating
+discussions about new features, and providing confidence that the application
+meets the needs of the business. While the tools and implementations will
+continue to evolve, Gherkin's core value proposition—as a language for building
+shared understanding—remains as relevant as ever.
 
 ## **Works cited**
 
-1. What is Gherkin and its role in Behavior-Driven Development (BDD) Scenarios,
-   <https://www.browserstack.com/guide/gherkin-and-its-role-bdd-scenarios>
-
-2. Cucumber (software) - Wikipedia,
-   <https://en.wikipedia.org/wiki/Cucumber_(software)>
-
-3. What Is Gherkin? - YouTube,
+[^1]: What is Gherkin and its role in Behavior-Driven Development (BDD)
+      Scenarios,
+      <https://www.browserstack.com/guide/gherkin-and-its-role-bdd-scenarios>
+[^3]: What Is Gherkin? - YouTube,
    <https://www.youtube.com/watch?v=bxeNxhOSGJg&pp=0gcJCfwAo7VqN5tD>
-
-4. How the Gherkin language bridges the gap between customers and developers,
+[^4]: How the Gherkin language bridges the gap between customers and developers,
    <https://opensource.com/article/23/2/gherkin-language-developers>
-
-5. Gherkin Syntax: Format, Language & Gherkin Test in Cucumber - ACCELQ,
-   <https://www.accelq.com/blog/gherkin-syntax/>
-
-6. Gherkin Keywords - Cucumber - Tools QA,
+[^6]: Gherkin Keywords - Cucumber - Tools QA,
    <https://toolsqa.com/cucumber/gherkin-keywords/>
-
-7. Writing Features - Gherkin Language — Behat 2.5.3 documentation,
-   <https://docs.behat.org/en/v2.5/guides/1.gherkin.html>
-
-8. BDD With Cucumber | Technical Debt,
+[^8]: BDD With Cucumber | Technical Debt,
    <https://technicaldebt.com/crib-sheets/bdd-with-cucumber/>
-
-9. Behavior Driven Development with Gherkin | The Complete Guide for BDD
+[^9]: Behavior Driven Development with Gherkin | The Complete Guide for BDD
    Testing,
    <https://testsigma.com/blog/behavior-driven-development-bdd-with-gherkin/>
-
-10. Gherkin in Testing: A Beginner's Guide | by Rafał Buczyński | Medium,
+[^10]: Gherkin in Testing: A Beginner's Guide | by Rafał Buczyński | Medium,
     <https://medium.com/@buczynski.rafal/gherkin-in-testing-a-beginners-guide-f2e179d5e2df>
-
-11. Pytest-BDD or Cucumber? : r/QualityAssurance - Reddit,
+[^11]: Pytest-BDD or Cucumber? : r/QualityAssurance - Reddit,
     <https://www.reddit.com/r/QualityAssurance/comments/frlcww/pytestbdd_or_cucumber/>
-
-12. Cucumber Gherkin Tutorial: Automation Testing Using Gherkin - Software
-    Testing Help,
     <https://www.softwaretestinghelp.com/cucumber-gherkin-framework-tutorial/>
-
-13. BDD 101: Writing Good Gherkin | Automation Panda,
+[^13]: BDD 101: Writing Good Gherkin | Automation Panda,
     <https://automationpanda.com/2017/01/30/bdd-101-writing-good-gherkin/>
-
-14. Reference - Cucumber, <https://cucumber.io/docs/gherkin/reference/>
-
-15. Gherkin Keywords in SpecFlow - Tutorials Point,
+[^14]: Reference - Cucumber, <https://cucumber.io/docs/gherkin/reference/>
+[^15]: Gherkin Keywords in SpecFlow - Tutorials Point,
     <https://www.tutorialspoint.com/specflow/specflow_gherkin_keywords.htm>
-
-16. Gherkin Keywords in Behave - Tutorials Point,
+[^16]: Gherkin Keywords in Behave - Tutorials Point,
     <https://www.tutorialspoint.com/behave/behave_gherkin_keywords.htm>
-
-17. Gherkin best practices | 8 tips - Redsauce,
+[^17]: Gherkin best practices | 8 tips - Redsauce,
     <https://www.redsauce.net/en/article?post=gherkin-best-practices>
-
-18. BDD 101: Gherkin By Example - Automation Panda,
+[^18]: BDD 101: Gherkin By Example - Automation Panda,
     <https://automationpanda.com/2017/01/27/bdd-101-gherkin-by-example/>
-
-19. pytest-bdd 8.0.0 documentation - Read the Docs,
+[^19]: pytest-bdd 8.0.0 documentation - Read the Docs,
     <https://pytest-bdd.readthedocs.io/en/8.0.0/>
-
-20. Writing scenarios with Gherkin syntax - GeeksforGeeks,
+[^20]: Writing scenarios with Gherkin syntax - GeeksforGeeks,
     <https://www.geeksforgeeks.org/software-testing/writing-scenarios-with-gherkin-syntax/>
-
-21. Advanced Gherkin Techniques | EPF Docs,
-    <https://docs.eggplantsoftware.com/epf/epf-advanced-gherkin/>
-
-22. pytest-bdd - PyPI, <https://pypi.org/project/pytest-bdd/>
-
-23. Cucumber Data Tables | Baeldung,
-    <https://www.baeldung.com/cucumber-data-tables>
-
-24. Writing better Gherkin - Cucumber,
+[^22]: pytest-bdd - PyPI, <https://pypi.org/project/pytest-bdd/>
+[^24]: Writing better Gherkin - Cucumber,
     <https://cucumber.io/docs/bdd/better-gherkin/>
-
-25. andredesousa/gherkin-best-practices: This is a guideline of … - GitHub,
-    <https://github.com/andredesousa/gherkin-best-practices>
-
-26. How to do block comments in Gherkin? - Stack Overflow,
-    <https://stackoverflow.com/questions/7113594/how-to-do-block-comments-in-gherkin>
-
-27. YAML Comments in Gherkin Feature Files - Automation Panda,
+[^27]: YAML Comments in Gherkin Feature Files - Automation Panda,
     <https://automationpanda.com/2017/12/10/yaml-comments-in-gherkin-feature-files/>
-
-28. Understanding Pytest BDD - BrowserStack,
+[^28]: Understanding Pytest BDD - BrowserStack,
     <https://www.browserstack.com/guide/pytest-bdd>
-
-29. pytest-bdd - Read the Docs,
+[^29]: pytest-bdd - Read the Docs,
     <https://readthedocs.org/projects/pytest-bdd/downloads/pdf/latest/>
-
-30. Pytest-BDD: the BDD framework for pytest — pytest-bdd 8.1.0 documentation,
-    <https://pytest-bdd.readthedocs.io/>
-
-31. the BDD framework for pytest — pytest-bdd 8.1.0 documentation,
+[^30]: Pytest-BDD: the BDD framework for pytest — pytest-bdd 8.1.0
+       documentation, <https://pytest-bdd.readthedocs.io/>
+[^31]: the BDD framework for pytest — pytest-bdd 8.1.0 documentation,
     <https://pytest-bdd.readthedocs.io/en/latest/>
-
-32. A Complete Guide To Behavior-Driven Testing With Pytest BDD,
+[^32]: A Complete Guide To Behavior-Driven Testing With Pytest BDD,
     <https://pytest-with-eric.com/bdd/pytest-bdd/>
-
-33. Chapter 2 - Setting Up pytest-bdd - Test Automation University,
-    <https://testautomationu.applitools.com/behavior-driven-python-with-pytest-bdd/chapter2.html>
-
-34. Welcome to Pytest-BDD's documentation! — Pytest-BDD 4.1.0 …,
+[^34]: Welcome to Pytest-BDD's documentation! — Pytest-BDD 4.1.0 …,
     <https://pytest-bdd.readthedocs.io/en/4.1.0/>
-
-35. Cucumber testing framework for Rust. Fully native, no external test runners
-    or dependencies. - GitHub, <https://github.com/cucumber-rs/cucumber>
-
-36. cucumber - Rust - [Docs.rs](http://Docs.rs), <https://docs.rs/cucumber>
-
-37. Cucumber in Rust - Beginner's Tutorial - Florianrein's Blog,
+[^35]: Cucumber testing framework for Rust. Fully native, no external test
+       runners or dependencies. - GitHub,
+       <https://github.com/cucumber-rs/cucumber>
+[^37]: Cucumber in Rust - Beginner's Tutorial - Florianrein's Blog,
     <https://www.florianreinhard.de/cucumber-in-rust-beginners-tutorial/>
-
-38. Quickstart - Cucumber Rust Book,
-    <https://cucumber-rs.github.io/cucumber/current/quickstart.html>
-
-39. cucumber/[README.md](http://README.md) at main - GitHub,
-    <https://github.com/cucumber-rs/cucumber/blob/main/README.md>
-
-40. Introduction - Cucumber Rust Book,
+[^40]: Introduction - Cucumber Rust Book,
     <https://cucumber-rs.github.io/cucumber/main/>
-
-41. Data tables - Cucumber Rust Book,
+[^41]: Data tables - Cucumber Rust Book,
     <https://cucumber-rs.github.io/cucumber/main/writing/data_tables.html>
-
-42. Python BDD Framework Comparison | Automation Panda,
+[^42]: Python BDD Framework Comparison | Automation Panda,
     <https://automationpanda.com/2019/04/02/python-bdd-framework-comparison/>

--- a/docs/gherkin-syntax.md
+++ b/docs/gherkin-syntax.md
@@ -4,26 +4,26 @@ ______________________________________________________________________
 
 ## Part 1: The Philosophy and Foundation of Gherkin
 
-Behavior-Driven Development (BDD) is a collaborative software development
+Behaviour-Driven Development (BDD) is a collaborative software development
 process that aims to create a shared understanding of how an application should
 behave from the perspectives of developers, testers, and business stakeholders.
 At the heart of this process lies a critical challenge: communication. Gherkin
 was created to solve this challenge. It is not merely a testing syntax; it is a
 structured, natural language designed to be the definitive, single source of
-truth for a system's behavior.[^1]
+truth for a system's behaviour.[^1]
 
 ### Section 1.1: Gherkin as the Cornerstone of BDD
 
 Gherkin is a Domain-Specific Language (DSL) that functions as a "communication
 tool," bridging the often-significant gap between technical teams and
-non-technical business stakeholders.[^3] Its primary role within the BDD
-lifecycle is to enable the creation of "executable specifications".[^3] These
+non-technical business stakeholders.[^2] Its primary role within the BDD
+lifecycle is to enable the creation of "executable specifications".[^2] These
 specifications, written in a plain-text, human-readable format, serve a dual
 purpose: they act as living documentation for the project's features and as
-automated tests that verify those features are implemented correctly.[^6] This
+automated tests that verify those features are implemented correctly.[^3] This
 duality creates a powerful "closed loop" feedback system. Business
 requirements, articulated in Gherkin, are directly linked to the code that
-implements them.[^8] When a test passes, it provides concrete, verifiable proof
+implements them.[^4] When a test passes, it provides concrete, verifiable proof
 that the corresponding requirement has been met. This ensures that development
 work remains aligned with business goals and that the documentation never
 becomes stale, as it is continuously validated against the running
@@ -31,14 +31,14 @@ software.[^1] The effectiveness of Gherkin, however, is not guaranteed by its
 syntax alone. Its value is directly proportional to the level of collaboration
 within the team. The language is designed to facilitate conversations among the
 "Three Amigos"—the business analyst, the developer, and the tester—who bring
-their unique perspectives to the process of defining behavior.[^4] When these
+their unique perspectives to the process of defining behaviour.[^5] When these
 stakeholders actively participate in writing, reviewing, and refining Gherkin
 specifications, the team builds a robust, shared understanding of the system's
 requirements before a single line of implementation code is written.
 Conversely, when this collaborative cycle is neglected, Gherkin can become an
-"unnecessary burden".[^11] If business stakeholders do not read or contribute
-to the feature files, the primary benefit of a business-readable format is
-lost. Developers and QA engineers are left with an additional layer of
+"unnecessary burden".[^6] If business stakeholders do not read or contribute to
+the feature files, the primary benefit of a business-readable format is lost.
+Developers and QA engineers are left with an additional layer of
 abstraction—translating tests from a constrained natural-language format into
 code—without the collaborative payoff. Therefore, the decision to adopt Gherkin
 is fundamentally a cultural and process-oriented one. Its success hinges on the
@@ -48,38 +48,38 @@ entire team's commitment to the BDD collaborative cycle.
 
 All Gherkin specifications are stored in plain-text files with a `.feature`
 extension.[^1] As a best practice, each file should focus on describing a
-single, cohesive software feature.[^13] The structure of these files is defined
+single, cohesive software feature.[^7] The structure of these files is defined
 by a set of keywords that give meaning to each line. The core structure of any
-Gherkin test revolves around describing a specific example of behavior. This is
-accomplished through a sequence of steps that follow a clear, logical
+Gherkin test revolves around describing a specific example of behaviour. This
+is accomplished through a sequence of steps that follow a clear, logical
 progression: context, action, and outcome.
 
 - `Feature`: Every `.feature` file must begin with the `Feature` keyword. This
   keyword provides a high-level name and description for the functionality
-  being tested.[^6] The text following the `Feature` keyword, up to the first
+  being tested.[^3] The text following the `Feature` keyword, up to the first
   `Scenario` or other structural keyword, serves as a free-form description.
   While this description is ignored by test automation tools during execution,
   it is often included in generated reports and serves as valuable
-  documentation.[^6] A common convention is to use this space for a user story
+  documentation.[^3] A common convention is to use this space for a user story
   narrative (e.g., "As a \[role\], the [feature] is desired, so that
   \[benefit\]").
 - `Scenario`: A `Feature` contains one or more `Scenarios`. A `Scenario`
-  describes a single, concrete example of the feature's behavior—a specific use
-  case or test case.[^1] Each `Scenario` should be independent and test one,
-  and only one, behavior.[^13] This focus is crucial for clarity and
+  describes a single, concrete example of the feature's behaviour—a specific
+  use case or test case.[^1] Each `Scenario` should be independent and test
+  one, and only one, behaviour.[^7] This focus is crucial for clarity and
   maintenance; when a test fails, it should point to a single, specific piece
   of broken functionality.
 - `Given`: This keyword sets the initial context or preconditions for a
   `Scenario`. It describes the state of the world *before* the main event of
   the scenario occurs.[^1] A `Given` step should put the system into a known
   state, such as preparing test data in a database or ensuring a user is logged
-  in.[^9] Best practices strongly advise against describing user interactions
-  in `Given` steps; they are about establishing the scene, not the action.[^9]
+  in.[^8] Best practices strongly advise against describing user interactions
+  in `Given` steps; they are about establishing the scene, not the action.[^8]
 - `When`: This keyword describes an event or an action. This is typically an
   interaction performed by a user (e.g., "the user clicks the login button") or
-  an event triggered by an external system.[^1] To maintain the "one behavior
+  an event triggered by an external system.[^1] To maintain the "one behaviour
   per scenario" rule, it is highly recommended to have only a single `When`
-  step in each `Scenario`.[^9] This step represents the pivotal action that the
+  step in each `Scenario`.[^8] This step represents the pivotal action that the
   scenario is designed to test.
 - `Then`: This keyword defines the expected outcome or result of the action
   described in the `When` step. The code that implements a `Then` step (the
@@ -88,7 +88,7 @@ progression: context, action, and outcome.
   outcome is observable from the user's perspective, such as a message on the
   screen or a change in the UI state. Verifying internal system states, like a
   database record, directly in a `Then` step is discouraged because it couples
-  the test to implementation details rather than observable behavior.[^9]
+  the test to implementation details rather than observable behaviour.[^8]
 
 ### Section 1.3: Enhancing Readability and Flow
 
@@ -97,10 +97,10 @@ Gherkin provides several additional keywords.
 
 - `And`, `But`: When a `Scenario` requires multiple preconditions, actions,
   or outcomes, the `And` and `But` keywords are used to chain steps together
-  without repeating `Given`, `When`, or `Then`.[^9] These keywords are
+  without repeating `Given`, `When`, or `Then`.[^8] These keywords are
   syntactically interchangeable and carry no special automation logic; their
   purpose is purely to improve the narrative flow and structure of the
-  scenario.[^18] `But` is often used to express a negative condition, which can
+  scenario.[^9] `But` is often used to express a negative condition, which can
   enhance readability.
 
 ```gherkin
@@ -114,11 +114,11 @@ Gherkin provides several additional keywords.
 
 - `*` **(Asterisk)**: Gherkin also supports using an asterisk (`*`) as a
   substitute for any of the primary step keywords (`Given`, `When`, `Then`,
-  `And`, `But`).[^14] This can be particularly useful when a scenario involves
+  `And`, `But`).[^10] This can be particularly useful when a scenario involves
   a list of items or conditions, as it can read more like a set of bullet
   points than a narrative sequence. The asterisk inherits the context of the
   preceding keyword. For example, if it follows a `Given`, it is treated as
-  another `Given` step.[^19]
+  another `Given` step.[^11]
 
 ```gherkin
   Scenario: Setting up a user profile
@@ -129,14 +129,14 @@ Gherkin provides several additional keywords.
 <!-- markdownlint-disable MD013 -->
 ### Table 1: Gherkin Keyword Reference
 
-For a quick and comprehensive overview, the following table summarizes the
+For a quick and comprehensive overview, the following table summarises the
 primary and secondary keywords in the Gherkin language.
 
 | Keyword          | Purpose/Description                                                                                                | Placement/Context                                                           | Example                                                     |
 | ---------------- | ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- | ----------------------------------------------------------- |
 | Feature          | The primary keyword. Provides a high-level description of a software feature and groups related scenarios. 14      | Must be the first keyword in a .feature file.                               | Feature: User Login                                         |
-| Rule             | (Gherkin v6+) Groups multiple scenarios under a single business rule for better organization. 14                   | Optional. Placed within a Feature, before the Scenarios it groups.          | Rule: Users cannot withdraw more than their account balance |
-| Scenario         | Describes a single, concrete example of a feature's behavior. An alias, Example, can also be used. 14              | Placed within a Feature or Rule.                                            | Scenario: Successful login with valid credentials           |
+| Rule             | (Gherkin v6+) Groups multiple scenarios under a single business rule for better organisation. 14                   | Optional. Placed within a Feature, before the Scenarios it groups.          | Rule: Users cannot withdraw more than their account balance |
+| Scenario         | Describes a single, concrete example of a feature's behaviour. An alias, Example, can also be used. 14              | Placed within a Feature or Rule.                                            | Scenario: Successful login with valid credentials           |
 | Scenario Outline | A template for running the same scenario multiple times with different data sets. Alias: Scenario Template. 20     | Placed within a Feature or Rule. Must be followed by an Examples table.     | Scenario Outline: Attempt login with various credentials    |
 | Background       | Defines a set of Given steps that are common to all scenarios in a feature file. 1                                 | Placed within a Feature, before the first Scenario or Rule.                 | Background: Given the user is on the login page             |
 | Given            | Sets the initial context or preconditions for a scenario. Describes the state of the system before an action. 9    | The first step in a Given-When-Then sequence.                               | Given the account balance is $100                           |
@@ -147,7 +147,7 @@ primary and secondary keywords in the Gherkin language.
 | Examples         | A data table that provides values for the variables in a Scenario Outline. Alias: Scenarios. 14 | Must follow a Scenario Outline.                                             | `Examples:` |
 | \| (pipe)        | Delimiter for Data Tables and Examples tables. 14                                            | Must appear immediately under the related step or Examples header.          | See lines 296–306 |
 | """ or ```       | Delimiters for a Doc String, a multi-line block of text passed to a single step. 14                                | Placed on new lines immediately following a step.                           | Then the email body should contain: """Hello World"""       |
-| @                | Prefix for a Tag, used to organize and filter features or scenarios. 10                                            | Placed on the line(s) above Feature, Scenario, etc.                         | @smoke @regression                                          |
+| @                | Prefix for a Tag, used to organise and filter features or scenarios. 10                                            | Placed on the line(s) above Feature, Scenario, etc.                         | @smoke @regression                                          |
 | #                | Prefix for a single-line comment. Ignored by test runners. 14                                                      | Can be placed at the start of any new line.                                 | # This is a comment                                         |
 <!-- markdownlint-enable MD013 -->
 ______________________________________________________________________
@@ -168,7 +168,7 @@ their cart. Repeating these steps in every scenario is inefficient and clutters
 the file. The `Background` keyword solves this problem by allowing definition
 of `Given` steps that are common to all `Scenarios` within that `Feature`
 file.[^1] These steps are automatically executed before each and every
-`Scenario` in the file, acting as a shared setup routine.[^15]
+`Scenario` in the file, acting as a shared setup routine.[^12]
 
 ```gherkin
 Feature: User profile management
@@ -191,35 +191,35 @@ used judiciously.
 - **Keep it Short and Relevant:** A `Background` should only contain steps that
   are truly essential for *all* scenarios in the feature. If a setup step is
   only needed for a subset of scenarios, it belongs in their respective `Given`
-  sections.[^9] A good rule of thumb is to keep the `Background` under four
+  sections.[^8] A good rule of thumb is to keep the `Background` under four
   lines long.14.
 - **Focus on Prerequisite State, Not Noise:** The `Background` should not be
   used to set up complex states that are not immediately obvious to someone
   reading the scenarios. If the details are irrelevant to the business user
   (e.g., creating a specific site ID), abstract them into a higher-level, more
-  declarative step like `Given I am logged in as a site owner`.[^14]
+  declarative step like `Given I am logged in as a site owner`.[^10]
 - **Make it Vivid:** Use descriptive, colourful names to tell a coherent
   story. The human brain remembers narratives better than abstract identifiers
-  like "User A" or "Site 1".[^14]
+  like "User A" or "Site 1".[^10]
 
 ### Section 2.2: Data-Driven Testing with `Scenario Outline` and `Examples`
 
-Often, testing the same behavior requires a variety of different inputs and
+Often, testing the same behaviour requires a variety of different inputs and
 expected outputs. For example, testing a login form requires checking valid
 credentials, invalid passwords, invalid usernames, and empty fields. Writing a
 separate `Scenario` for each case would be highly repetitive. The
 `Scenario Outline` keyword is Gherkin's primary mechanism for data-driven
 testing. It allows a scenario template to be executed multiple times with
-different data sets.[^10] **Syntax:**
+different data sets.[^13] **Syntax:**
 
 1. Replace the `Scenario` keyword with `Scenario Outline`.
 2. In the steps, use angle brackets (`< >`) to define placeholders for
-   variables.[^13]
+   variables.[^7]
 3. Follow the `Scenario Outline` with an `Examples` table. The first row of
    this table is the header, and its column names must exactly match the
-   variable names used in the steps.[^20] The test runner will execute the
+   variable names used in the steps.[^14] The test runner will execute the
    entire scenario once for each data row in the `Examples` table, substituting
-   the placeholder variables with the values from that row.[^16]
+   the placeholder variables with the values from that row.[^15]
 
 ```gherkin
 Feature: Calculator Addition
@@ -248,7 +248,7 @@ different data, sometimes only a structured set of data needs to be passed to a
 *single step*. For example, a `Given` step might need to create multiple user
 accounts with different roles, or a `Then` step might need to verify the
 contents of a shopping cart. `Data Tables` provide a way to pass a table of
-data directly to a step definition.[^14] They are defined using pipe ( `|`)
+data directly to a step definition.[^10] They are defined using pipe ( `|`)
 delimiters immediately below the step they belong to.
 
 ```gherkin
@@ -267,7 +267,7 @@ Unlike an `Examples` table, this `Data Table` does not cause the scenario to
 run multiple times. Instead, the entire table is passed as a single argument to
 the step definition for "Given the following users exist in the system:". The
 automation code can then parse this table (often as a list of lists or list of
-maps) and use it to perform the necessary setup.[^22]
+maps) and use it to perform the necessary setup.[^16]
 
 ### Section 2.4: Incorporating Block Text with `Doc Strings`
 
@@ -275,9 +275,9 @@ Sometimes the data required by a step is not a simple value or structured
 table, but a larger, free-form block of text. This is common when working with
 APIs (JSON/XML payloads), email content, or snippets of code. `Doc Strings` are
 Gherkin's solution for this. A `Doc String` allows a multi-line string to be
-passed to a step definition.[^14] Syntax: The text block is enclosed by a pair
+passed to a step definition.[^10] Syntax: The text block is enclosed by a pair
 of triple double-quotes (""") or triple backticks (\`\`\`\`\`\`) on their own
-lines, immediately following the step.[^14]
+lines, immediately following the step.[^10]
 
 ```gherkin
 Feature: API for creating blog posts
@@ -296,15 +296,15 @@ Feature: API for creating blog posts
 In the step definition, the entire content of the `Doc String` is passed as a
 single string argument. Advanced Gherkin parsers also allow specifying a
 content type (e.g., `"""json`) after the opening delimiter, which can help
-tools with syntax highlighting and parsing.[^14]
+tools with syntax highlighting and parsing.[^10]
 
 ### Section 2.5: Grouping with the `Rule` Keyword
 
 As a `Feature` grows more complex, a flat list of scenarios can become
-difficult to navigate. To provide an additional layer of organization, Gherkin
-version 6 introduced the `Rule` keyword.[^14] The purpose of the `Rule` keyword
+difficult to navigate. To provide an additional layer of organisation, Gherkin
+version 6 introduced the `Rule` keyword.[^10] The purpose of the `Rule` keyword
 is to group a set of related scenarios that together represent a single,
-specific business rule that the system must enforce.[^9] This is particularly
+specific business rule that the system must enforce.[^8] This is particularly
 useful for features that have distinct sets of business logic.
 
 ```gherkin
@@ -344,13 +344,13 @@ the "how" of syntax to the "why" of effective specification.
 
 ### Section 3.1: Organizing and Filtering with `Tags`
 
-As a test suite grows, a method is needed to organize and selectively run
+As a test suite grows, a method is needed to organise and selectively run
 subsets of scenarios. It might be desirable to run a quick "smoke test" suite,
 a full "regression" suite, or tests specific to a certain feature or
-environment. `Tags` are Gherkin's mechanism for this kind of organization. A
+environment. `Tags` are Gherkin's mechanism for this kind of organisation. A
 tag is a simple annotation prefixed with an `@` symbol (e.g., `@smoke`, `@api`,
-`@ui`).[^10] Tags can be placed above `Feature`, `Scenario`,
-`Scenario Outline`, or even specific `Examples` tables to categorize them.[^14]
+`@ui`).[^13] Tags can be placed above `Feature`, `Scenario`,
+`Scenario Outline`, or even specific `Examples` tables to categorise them.[^10]
 A single element can have multiple tags.
 
 ```gherkin
@@ -385,7 +385,7 @@ complex selections 21:
 - **Standardize:** Agree on a standard set of tag names within the team to
   ensure consistency.
 - **Formatting:** Use lowercase for tag names and separate words with hyphens
-  (e.g., `@work-in-progress`) for readability.[^13]
+  (e.g., `@work-in-progress`) for readability.[^7]
 
 ### Section 3.2: The Art of Writing Good Gherkin
 
@@ -398,8 +398,8 @@ fields, or navigating to URLs.[^17]
 
 - **Imperative (Avoid):** `When I type "user@example.com" into the "email"
   field and click the "submit" button` A declarative style describes the user's
-  intent and the system's behavior—the "what." It abstracts away the
-  implementation details.[^24]
+  intent and the system's behaviour—the "what." It abstracts away the
+  implementation details.[^18]
 - **Declarative (Prefer):** `When the user logs in with valid credentials`
 The declarative approach is superior for several reasons. Imperative tests are
 brittle; a minor UI change (like renaming a button from "Submit" to "Log In")
@@ -408,22 +408,22 @@ Declarative tests are more resilient because the implementation of "logging in"
 can change (from a UI flow to a direct API call) without requiring any
 modification to the Gherkin specification itself. This makes the feature file a
 true piece of "living documentation" that describes business value, not a
-fragile script of UI interactions.[^24] Building on this philosophy, several
+fragile script of UI interactions.[^18] Building on this philosophy, several
 other rules contribute to high-quality Gherkin:
-- **The Cardinal Rule: One Scenario, One Behavior:** Each scenario should test
-  a single, focused business rule or use case.[^13] If a scenario contains
-  multiple `When-Then` pairs, it is likely testing multiple behaviors and
-  should be split into separate, more focused scenarios.[^13] This makes tests
+- **The Cardinal Rule: One Scenario, One Behaviour:** Each scenario should test
+  a single, focused business rule or use case.[^7] If a scenario contains
+  multiple `When-Then` pairs, it is likely testing multiple behaviours and
+  should be split into separate, more focused scenarios.[^7] This makes tests
   easier to understand and debug.
 - **Conciseness and Clarity:** Keep scenarios short and to the point. A good
   rule of thumb is to aim for fewer than 10 steps, with 5 or fewer being
-  ideal.[^13] Similarly, feature files should not become monolithic; a dozen
-  scenarios per file is a reasonable guideline.[^13]
+  ideal.[^7] Similarly, feature files should not become monolithic; a dozen
+  scenarios per file is a reasonable guideline.[^7]
 - **Precise Language:** Use clear, unambiguous language that is part of the
-  project's shared domain vocabulary. Avoid technical jargon.[^10] Steps should
+  project's shared domain vocabulary. Avoid technical jargon.[^13] Steps should
   be written as complete subject-predicate action phrases (e.g., "the user
   enters a search term") and consistently use the present tense to maintain a
-  clear narrative.[^13]
+  clear narrative.[^7]
 
 ### Section 3.3: Documentation and Maintenance
 
@@ -432,15 +432,15 @@ the team. This requires attention to documentation and consistent style.
 
 - **Comments (`#`):** Gherkin supports single-line comments, which begin with a
   hash sign (`#`). These are intended for developers or other technical readers
-  and are completely ignored by test runners.[^14] Gherkin does not have a
+  and are completely ignored by test runners.[^10] Gherkin does not have a
   syntax for multi-line block comments; each line of a comment block must be
   individually prefixed with `#`.14.
 - **YAML Comments (An Advanced Technique):** For more structured metadata that
-  doesn't belong in the behavioral specification itself—such as links to user
+  doesn't belong in the behavioural specification itself—such as links to user
   stories, ticket IDs, or security classifications—a useful pattern is to use
   YAML-formatted comments at the top of a feature file. This keeps the metadata
-  organized, human-readable, and potentially parsable by external reporting or
-  analysis tools.[^27]
+  organised, human-readable, and potentially parsable by external reporting or
+  analysis tools.[^19]
 
 ```gherkin
   # Id: TICKET-123
@@ -454,13 +454,13 @@ the team. This requires attention to documentation and consistent style.
 - **Code Style and Formatting:** Consistent formatting is crucial for
   readability, especially in a collaborative environment.
   - **Indentation:** Use a consistent indentation style. Two spaces is the
-    recommended standard.[^13]
+    recommended standard.[^7]
   - **Spacing:** Use blank lines to separate scenarios, and ensure consistent
     spacing around pipe (`|`) delimiters in tables to make them align
-    visually.[^13]
-  - **Capitalization:** Capitalize Gherkin keywords (`Given`, `When`, `Then`)
+    visually.[^7]
+  - **Capitalisation:** Capitalise Gherkin keywords (`Given`, `When`, `Then`)
     and the first word of titles, but not other words in step phrases unless
-    they are proper nouns.[^13]
+    they are proper nouns.[^7]
 
 ______________________________________________________________________
 
@@ -470,7 +470,7 @@ ______________________________________________________________________
 standalone test runner but a powerful plugin for the `pytest` framework. This
 design choice allows it to seamlessly integrate with and leverage the entire
 `pytest` ecosystem, including its renowned fixture system, extensive plugin
-library, and robust test execution capabilities.[^22]
+library, and robust test execution capabilities.[^16]
 
 ### Section 4.1: Project Setup and Configuration
 
@@ -486,10 +486,10 @@ Python's package management.
   ```
 
   For web UI testing, `selenium` and potentially other helper libraries are
-  typically installed.[^28]
+  typically installed.[^20]
 
 - **Directory Structure:** A conventional project structure helps keep tests
-  organized:
+  organised:
   - `features/`: This directory contains all Gherkin `.feature` files.
   - `tests/`: This directory holds Python test code.
     - `step_defs/`: It is a common practice to create a subdirectory within
@@ -506,10 +506,10 @@ decorators.
   a `.feature` file and a Python test file. It decorates a Python function,
   telling `pytest` that this function represents a specific Gherkin scenario.
   The decorator takes the path to the `.feature` file and the name of the
-  `Scenario` as arguments.[^29] The decorated function itself often contains
+  `Scenario` as arguments.[^21] The decorated function itself often contains
   just a `pass` statement or a final, high-level assertion, as its main purpose
   is to act as a collector for the steps and to be discoverable by the `pytest`
-  runner.[^31]
+  runner.[^22]
 
 ```python
   # tests/step_defs/test_publish_article.py
@@ -524,10 +524,10 @@ decorators.
 - **Step Decorators (**`@given`**,** `@when`**,** `@then`**):** Each Gherkin
   step is mapped to a Python function using a corresponding decorator:
   `@given`, `@when`, or `@then`. The string argument passed to the decorator
-  must exactly match the text of the step in the `.feature` file.[^28] For
+  must exactly match the text of the step in the `.feature` file.[^20] For
   readability and maintainability, step aliases can be created by stacking
   multiple decorators on a single function, allowing different Gherkin phrases
-  to execute the same code.[^30]
+  to execute the same code.[^23]
 
 ```python
   from pytest_bdd import given, when, then
@@ -555,13 +555,13 @@ One of the most significant and powerful aspects of `pytest-bdd` is its
 approach to state management. Unlike many traditional Cucumber tools that use a
 mutable "World" or "Context" object that is passed between steps, `pytest-bdd`
 eschews this pattern. Instead, it fully embraces the idiomatic `pytest` fixture
-system for managing and sharing state between steps.[^32] This represents a
+system for managing and sharing state between steps.[^24] This represents a
 philosophical shift from explicit state passing to implicit dependency
 injection. In this model, `Given` steps act as fixture factories. A function
 decorated with `@given` can return a value. By using the `target_fixture`
 argument in the decorator, this return value is injected into the `pytest`
 context as a named fixture, available exclusively for the duration of that
-scenario.[^31] Subsequent `When` and `Then` steps can then access this state
+scenario.[^22] Subsequent `When` and `Then` steps can then access this state
 simply by declaring a function argument with the same name as the target
 fixture. `pytest` handles the dependency injection automatically. This approach
 has profound benefits. It allows BDD test setup to be composed from the same
@@ -617,18 +617,18 @@ steps.
   including `parse` (for `string.format()` style), `cfparse` (a more powerful
   variant), and `re` (for regular expressions). The `parse` and `cfparse`
   styles, which use `{name:Type}` syntax, are generally preferred for their
-  readability.[^34]
+  readability.[^25]
 - `Scenario Outline` **Parameters:** When using a `Scenario Outline`, the
   values from the `Examples` table are automatically parsed and passed as
   arguments to the corresponding step functions. Their names must match the
-  headers in the `Examples` table.[^34]
+  headers in the `Examples` table.[^25]
 - `Data Tables`**:** A step definition function can access a `Data Table` by
   including a special argument named `datatable`. `pytest-bdd` will inject the
   table's content into this argument as a list of lists, where each inner list
-  represents a row.[^22]
+  represents a row.[^16]
 - `Doc Strings`**:** Similarly, a `Doc String` can be accessed by including a
   special argument named `docstring`. This argument will receive the entire
-  block text as a single, multi-line string.[^22]
+  block text as a single, multi-line string.[^16]
 
 ______________________________________________________________________
 
@@ -638,7 +638,7 @@ For developers in the Rust ecosystem, `cucumber-rs` provides a native,
 idiomatic implementation of a Cucumber test runner. Unlike `pytest-bdd`, it is
 a self-contained framework designed from the ground up for Rust, with
 first-class support for `async` programming and a strong emphasis on type
-safety.[^35]
+safety.[^26]
 
 ### Section 5.1: Project Setup in the Rust Ecosystem
 
@@ -651,7 +651,7 @@ and establishing a conventional directory structure.
   2. Define a new test target in the `Cargo.toml`. Crucially, set
      `harness = false`. This tells Rust's default test harness (`libtest`) to
      stand down, allowing `cucumber-rs` to take control of the test execution
-     and output formatting.[^37] Ini, TOML
+     and output formatting.[^27] Ini, TOML
 
   ```toml
   [dev-dependencies]
@@ -664,7 +664,7 @@ and establishing a conventional directory structure.
 
   ```
 
-- **Directory Structure:** A typical `cucumber-rs` project organizes its files
+- **Directory Structure:** A typical `cucumber-rs` project organises its files
   as follows 37:
   - `tests/`: The root directory for integration tests.
   - `tests/features/`: Contains the Gherkin `.feature` files.
@@ -681,12 +681,12 @@ the `World`.
 
 - **Core Concept:** The `World` is a user-defined struct that holds all the
   mutable state for a single scenario. A new instance of the `World` is created
-  for each scenario, ensuring that tests are isolated from one another.[^37]
+  for each scenario, ensuring that tests are isolated from one another.[^27]
 - **Implementation:** To be used by the framework, the struct must derive or
   implement the `cucumber::World` trait. The framework will then use
   `Default::default()` to create a new `World` for each scenario. If more
-  complex initialization is needed, a custom constructor can be specified using
-  the `#[world(init =...)]` attribute.[^35]
+  complex initialisation is needed, a custom constructor can be specified using
+  the `#[world(init =...)]` attribute.[^26]
 
 ```rust
   // tests/cucumber_tests.rs
@@ -707,15 +707,15 @@ well-suited for testing applications involving I/O operations like database
 queries or web requests.
 
 - **Attribute Macros:** Gherkin steps are linked to Rust functions using the
-  `#[given]`, `#[when]`, and `#[then]` attribute macros.[^35] `cucumber-rs`
+  `#[given]`, `#[when]`, and `#[then]` attribute macros.[^26] `cucumber-rs`
   enforces a stricter separation of these step types than some other Cucumber
-  implementations to prevent ambiguity.[^41]
+  implementations to prevent ambiguity.[^28]
 - **Async Functions:** Step definition functions are typically `async` and are
   executed by the async runtime specified in the test runner (e.g., `tokio`).
 - **Function Signature:** Every step definition function must take a mutable
   reference to the `World` struct (`&mut MyWorld`) as its first argument. This
   is how steps read and modify the shared state of the scenario. Any parameters
-  parsed from the step string follow this `World` argument.[^35]
+  parsed from the step string follow this `World` argument.[^26]
 
 ```rust
   // tests/steps/calculator_steps.rs
@@ -748,12 +748,12 @@ into Rust types.
   either regular expressions (`regex = "..."`) or Cucumber Expressions
   (`expr = "..."`) specified in the attribute macro. The framework handles the
   conversion to the corresponding Rust type in the function signature (e.g.,
-  `{float}` maps to `f64`).[^35]
+  `{float}` maps to `f64`).[^26]
 - **Accessing** `Data Tables` **and** `Doc Strings`**:** To access a
   `Data Table` or `Doc String` attached to a step, the step definition function
   must include an argument of type `&cucumber::gherkin::Step`. The table or doc
   string can then be accessed as an `Option` on this `Step` object:
-  `step.table` or `step.docstring`.[^40] **Feature File
+  `step.table` or `step.docstring`.[^29] **Feature File
   (**`user_creation.feature`**):**
 
 ```gherkin
@@ -785,16 +785,16 @@ into Rust types.
   ```
 
   The same principle applies to `Data Tables`, where `step.table.as_ref()`
-  would be used to access the table data, which can then be iterated over.[^42]
+  would be used to access the table data, which can then be iterated over.[^30]
 ______________________________________________________________________
 
 ## Part 6: Synthesis: Implementation Variations and Quirks
 
-While Gherkin provides a standardized language for specifying behavior, its
+While Gherkin provides a standardised language for specifying behaviour, its
 implementation across different programming languages and frameworks reveals
 distinct philosophies and technical quirks. A deep dive into `pytest-bdd` for
 Python and `cucumber-rs` for Rust highlights a fundamental divergence in
-approach: one prioritizes deep integration with an existing, powerful testing
+approach: one prioritises deep integration with an existing, powerful testing
 ecosystem, while the other favors a purpose-built, "pure" implementation of the
 Cucumber paradigm.
 
@@ -805,12 +805,12 @@ The choice between `pytest-bdd` and `cucumber-rs` is less about which is
 tooling, and development philosophy. `pytest-bdd` acts as a bridge, bringing
 BDD capabilities into the vast and mature `pytest` world. Its greatest strength
 is this very integration; it allows developers to reuse fixtures, leverage
-thousands of plugins for tasks like parallelization (`pytest-xdist`) and
+thousands of plugins for tasks like parallelisation (`pytest-xdist`) and
 reporting (`pytest-html`), and manage BDD scenarios as just another type of
-`pytest` test.[^31] `cucumber-rs`, on the other hand, is a self-contained
+`pytest` test.[^22] `cucumber-rs`, on the other hand, is a self-contained
 framework that provides its own test runner and ecosystem. Its strength lies in
 its idiomatic Rust implementation, featuring first-class `async` support and a
-strong, type-safe approach to state management via the `World` pattern.[^35] A
+strong, type-safe approach to state management via the `World` pattern.[^26] A
 Python team already invested in the `pytest` ecosystem will find `pytest-bdd`
 to be a natural and powerful extension. A Rust team will likely prefer the
 purpose-built, type-safe, and async-native design of `cucumber-rs`.
@@ -823,7 +823,7 @@ purpose-built, type-safe, and async-native design of `cucumber-rs`.
 | State Management       | Uses pytest's fixture system. State is shared via dependency injection. Given steps can act as fixture factories using target_fixture. 31 | Uses an explicit, mutable World struct. A new World instance is created for each scenario and passed as a mutable reference (&mut World) to each step. 37 |
 | Step Definition Syntax | Functions are decorated with @given, @when, @then. A separate @scenario decorator links a test function to a feature file scenario. 29    | async functions are decorated with #[given], #[when], #[then] attribute macros. A central main function invokes the runner. 35                            |
 | Data Table Handling    | The step function accepts a special datatable argument, which contains the data as a list of lists. 22                                    | The step function accepts a &Step argument, and the table is accessed via step.table.as_ref(). 42                                                         |
-| Ecosystem & Tooling    | Leverages the entire pytest ecosystem: fixtures, hooks, and thousands of plugins for reporting, parallelization, etc. 28                  | Provides its own ecosystem for execution, filtering, and output formatting. Integrates with Rust's build system (cargo) and async runtimes (tokio). 35    |
+| Ecosystem & Tooling    | Leverages the entire pytest ecosystem: fixtures, hooks, and thousands of plugins for reporting, parallelisation, etc. 28                  | Provides its own ecosystem for execution, filtering, and output formatting. Integrates with Rust's build system (cargo) and async runtimes (tokio). 35    |
 
 ### Section 6.2: Common Quirks and Gotchas
 
@@ -836,12 +836,12 @@ developers should be aware of specific implementation details that can act as
   implements a *subset* of Gherkin. It has intentionally removed support for
   older or less common features like vertical `Examples` tables and
   `Feature`-level examples, focusing on compatibility with the latest core
-  Gherkin developments.[^30] Teams migrating from other tools may find that
+  Gherkin developments.[^23] Teams migrating from other tools may find that
   certain syntax is no longer supported.
 - **Step Type Strictness:** `cucumber-rs` intentionally enforces a stricter
   separation between `given`, `when`, and `then` step types than the official
   Cucumber implementation. This is a design choice to prevent ambiguity, for
-  example, by disallowing a `then` step from being used as a `given` step.[^41]
+  example, by disallowing a `then` step from being used as a `given` step.[^28]
   While this promotes clearer scenarios, it can be a surprise for those
   accustomed to more lenient frameworks.
 - **State Management Paradigm:** The most significant "gotcha" is the
@@ -855,8 +855,8 @@ developers should be aware of specific implementation details that can act as
 ### Section 6.3: The Evolving Landscape: Gherkin as Living Documentation
 
 Gherkin's syntax is deceptively simple. The true challenge and reward of
-adopting it lie not in memorizing keywords but in embracing the collaborative,
-behavior-first mindset it is designed to foster.[^8] When used effectively,
+adopting it lie not in memorising keywords but in embracing the collaborative,
+behaviour-first mindset it is designed to foster.[^4] When used effectively,
 Gherkin transforms testing from a purely technical, after-the-fact verification
 activity into an integral part of the requirements and design process. The
 ultimate goal is to create a suite of executable specifications that serve as a
@@ -869,65 +869,65 @@ shared understanding—remains as relevant as ever.
 
 ## **Works cited**
 
-[^1]: What is Gherkin and its role in Behavior-Driven Development (BDD)
+[^1]: What is Gherkin and its role in Behaviour-Driven Development (BDD)
       Scenarios,
       <https://www.browserstack.com/guide/gherkin-and-its-role-bdd-scenarios>
-[^3]: What Is Gherkin? - YouTube,
+[^2]: What Is Gherkin? - YouTube,
    <https://www.youtube.com/watch?v=bxeNxhOSGJg&pp=0gcJCfwAo7VqN5tD>
-[^4]: How the Gherkin language bridges the gap between customers and developers,
-   <https://opensource.com/article/23/2/gherkin-language-developers>
-[^6]: Gherkin Keywords - Cucumber - Tools QA,
+[^3]: Gherkin Keywords - Cucumber - Tools QA,
    <https://toolsqa.com/cucumber/gherkin-keywords/>
-[^8]: BDD With Cucumber | Technical Debt,
+[^4]: BDD With Cucumber | Technical Debt,
    <https://technicaldebt.com/crib-sheets/bdd-with-cucumber/>
-[^9]: Behavior Driven Development with Gherkin | The Complete Guide for BDD
-   Testing,
-   <https://testsigma.com/blog/behavior-driven-development-bdd-with-gherkin/>
-[^10]: Gherkin in Testing: A Beginner's Guide | by Rafał Buczyński | Medium,
-    <https://medium.com/@buczynski.rafal/gherkin-in-testing-a-beginners-guide-f2e179d5e2df>
-[^11]: Pytest-BDD or Cucumber? : r/QualityAssurance - Reddit,
+[^5]: How the Gherkin language bridges the gap between customers and developers,
+   <https://opensource.com/article/23/2/gherkin-language-developers>
+[^6]: Pytest-BDD or Cucumber? : r/QualityAssurance - Reddit,
     <https://www.reddit.com/r/QualityAssurance/comments/frlcww/pytestbdd_or_cucumber/>
     <https://www.softwaretestinghelp.com/cucumber-gherkin-framework-tutorial/>
-[^13]: BDD 101: Writing Good Gherkin | Automation Panda,
+[^7]: BDD 101: Writing Good Gherkin | Automation Panda,
     <https://automationpanda.com/2017/01/30/bdd-101-writing-good-gherkin/>
-[^14]: Reference - Cucumber, <https://cucumber.io/docs/gherkin/reference/>
-[^15]: Gherkin Keywords in SpecFlow - Tutorials Point,
+[^8]: Behaviour Driven Development with Gherkin | The Complete Guide for BDD
+   Testing,
+   <https://testsigma.com/blog/behaviour-driven-development-bdd-with-gherkin/>
+[^9]: BDD 101: Gherkin By Example - Automation Panda,
+    <https://automationpanda.com/2017/01/27/bdd-101-gherkin-by-example/>
+[^10]: Reference - Cucumber, <https://cucumber.io/docs/gherkin/reference/>
+[^11]: pytest-bdd 8.0.0 documentation - Read the Docs,
+    <https://pytest-bdd.readthedocs.io/en/8.0.0/>
+[^12]: Gherkin Keywords in SpecFlow - Tutorials Point,
     <https://www.tutorialspoint.com/specflow/specflow_gherkin_keywords.htm>
-[^16]: Gherkin Keywords in Behave - Tutorials Point,
+[^13]: Gherkin in Testing: A Beginner's Guide | by Rafał Buczyński | Medium,
+    <https://medium.com/@buczynski.rafal/gherkin-in-testing-a-beginners-guide-f2e179d5e2df>
+[^14]: Writing scenarios with Gherkin syntax - GeeksforGeeks,
+    <https://www.geeksforgeeks.org/software-testing/writing-scenarios-with-gherkin-syntax/>
+[^15]: Gherkin Keywords in Behave - Tutorials Point,
     <https://www.tutorialspoint.com/behave/behave_gherkin_keywords.htm>
+[^16]: pytest-bdd - PyPI, <https://pypi.org/project/pytest-bdd/>
 [^17]: Gherkin best practices | 8 tips - Redsauce,
     <https://www.redsauce.net/en/article?post=gherkin-best-practices>
-[^18]: BDD 101: Gherkin By Example - Automation Panda,
-    <https://automationpanda.com/2017/01/27/bdd-101-gherkin-by-example/>
-[^19]: pytest-bdd 8.0.0 documentation - Read the Docs,
-    <https://pytest-bdd.readthedocs.io/en/8.0.0/>
-[^20]: Writing scenarios with Gherkin syntax - GeeksforGeeks,
-    <https://www.geeksforgeeks.org/software-testing/writing-scenarios-with-gherkin-syntax/>
-[^22]: pytest-bdd - PyPI, <https://pypi.org/project/pytest-bdd/>
-[^24]: Writing better Gherkin - Cucumber,
+[^18]: Writing better Gherkin - Cucumber,
     <https://cucumber.io/docs/bdd/better-gherkin/>
-[^27]: YAML Comments in Gherkin Feature Files - Automation Panda,
+[^19]: YAML Comments in Gherkin Feature Files - Automation Panda,
     <https://automationpanda.com/2017/12/10/yaml-comments-in-gherkin-feature-files/>
-[^28]: Understanding Pytest BDD - BrowserStack,
+[^20]: Understanding Pytest BDD - BrowserStack,
     <https://www.browserstack.com/guide/pytest-bdd>
-[^29]: pytest-bdd - Read the Docs,
+[^21]: pytest-bdd - Read the Docs,
     <https://readthedocs.org/projects/pytest-bdd/downloads/pdf/latest/>
-[^30]: Pytest-BDD: the BDD framework for pytest — pytest-bdd 8.1.0
-       documentation, <https://pytest-bdd.readthedocs.io/>
-[^31]: the BDD framework for pytest — pytest-bdd 8.1.0 documentation,
+[^22]: the BDD framework for pytest — pytest-bdd 8.1.0 documentation,
     <https://pytest-bdd.readthedocs.io/en/latest/>
-[^32]: A Complete Guide To Behavior-Driven Testing With Pytest BDD,
+[^23]: Pytest-BDD: the BDD framework for pytest — pytest-bdd 8.1.0
+       documentation, <https://pytest-bdd.readthedocs.io/>
+[^24]: A Complete Guide To Behaviour-Driven Testing With Pytest BDD,
     <https://pytest-with-eric.com/bdd/pytest-bdd/>
-[^34]: Welcome to Pytest-BDD's documentation! — Pytest-BDD 4.1.0 …,
+[^25]: Welcome to Pytest-BDD's documentation! — Pytest-BDD 4.1.0 …,
     <https://pytest-bdd.readthedocs.io/en/4.1.0/>
-[^35]: Cucumber testing framework for Rust. Fully native, no external test
+[^26]: Cucumber testing framework for Rust. Fully native, no external test
        runners or dependencies. - GitHub,
        <https://github.com/cucumber-rs/cucumber>
-[^37]: Cucumber in Rust - Beginner's Tutorial - Florianrein's Blog,
+[^27]: Cucumber in Rust - Beginner's Tutorial - Florianrein's Blog,
     <https://www.florianreinhard.de/cucumber-in-rust-beginners-tutorial/>
-[^40]: Introduction - Cucumber Rust Book,
-    <https://cucumber-rs.github.io/cucumber/main/>
-[^41]: Data tables - Cucumber Rust Book,
+[^28]: Data tables - Cucumber Rust Book,
     <https://cucumber-rs.github.io/cucumber/main/writing/data_tables.html>
-[^42]: Python BDD Framework Comparison | Automation Panda,
+[^29]: Introduction - Cucumber Rust Book,
+    <https://cucumber-rs.github.io/cucumber/main/>
+[^30]: Python BDD Framework Comparison | Automation Panda,
     <https://automationpanda.com/2019/04/02/python-bdd-framework-comparison/>

--- a/docs/gherkin-syntax.md
+++ b/docs/gherkin-syntax.md
@@ -11,38 +11,38 @@ behave from the perspectives of developers, testers, and business stakeholders.
 At the heart of this process lies a critical challenge: communication. Gherkin
 was created to solve this challenge. It is not merely a testing syntax; it is a
 structured, natural language designed to be the definitive, single source of
-truth for a system's behavior.1
+truth for a system's behavior.[^1]
 
 ### Section 1.1: Gherkin as the Cornerstone of BDD
 
 Gherkin is a Domain-Specific Language (DSL) that functions as a "communication
 tool," bridging the often-significant gap between technical teams and
-non-technical business stakeholders.3 Its primary role within the BDD lifecycle
-is to enable the creation of "executable specifications".3 These
+non-technical business stakeholders.[^3] Its primary role within the BDD
+lifecycle is to enable the creation of "executable specifications".[^3] These
 specifications, written in a plain-text, human-readable format, serve a dual
 purpose: they act as living documentation for the project's features and as
-automated tests that verify those features are implemented correctly.6
+automated tests that verify those features are implemented correctly.[^6]
 
 This duality creates a powerful "closed loop" feedback system. Business
 requirements, articulated in Gherkin, are directly linked to the code that
-implements them.8 When a test passes, it provides concrete, verifiable proof
+implements them.[^8] When a test passes, it provides concrete, verifiable proof
 that the corresponding requirement has been met. This ensures that development
 work remains aligned with business goals and that the documentation never
-becomes stale, as it is continuously validated against the running software.1
+becomes stale, as it is continuously validated against the running software.[^1]
 
 The effectiveness of Gherkin, however, is not guaranteed by its syntax alone.
 Its value is directly proportional to the level of collaboration within the
 team. The language is designed to facilitate conversations among the "Three
 Amigos"—the business analyst, the developer, and the tester—who bring their
-unique perspectives to the process of defining behavior.4 When these
+unique perspectives to the process of defining behavior.[^4] When these
 stakeholders actively participate in writing, reviewing, and refining Gherkin
 specifications, the team builds a robust, shared understanding of the system's
 requirements before a single line of implementation code is written.
 
 Conversely, when this collaborative cycle is neglected, Gherkin can become an
-"unnecessary burden".11 If business stakeholders do not read or contribute to
-the feature files, the primary benefit of a business-readable format is lost.
-Developers and QA engineers are left with an additional layer of
+"unnecessary burden".[^11] If business stakeholders do not read or contribute
+to the feature files, the primary benefit of a business-readable format is
+lost. Developers and QA engineers are left with an additional layer of
 abstraction—translating tests from a constrained natural-language format into
 code—without the collaborative payoff. Therefore, the decision to adopt Gherkin
 is fundamentally a cultural and process-oriented one. Its success hinges on the
@@ -51,9 +51,9 @@ entire team's commitment to the BDD collaborative cycle.
 ### Section 1.2: The Anatomy of a `.feature` File
 
 All Gherkin specifications are stored in plain-text files with a `.feature`
-extension.1 As a best practice, each file should focus on describing a single,
-cohesive software feature.13 The structure of these files is defined by a set
-of keywords that give meaning to each line.
+extension.[^1] As a best practice, each file should focus on describing a
+single, cohesive software feature.[^13] The structure of these files is defined
+by a set of keywords that give meaning to each line.
 
 The core structure of any Gherkin test revolves around describing a specific
 example of behavior. This is accomplished through a sequence of steps that
@@ -61,51 +61,51 @@ follow a clear, logical progression: context, action, and outcome.
 
 - `Feature`: Every `.feature` file must begin with the `Feature` keyword. This
   keyword provides a high-level name and description for the functionality
-  being tested.6 The text following the
+  being tested.[^6] The text following the
 
   `Feature` keyword, up to the first `Scenario` or other structural keyword,
   serves as a free-form description. While this description is ignored by test
   automation tools during execution, it is often included in generated reports
-  and serves as valuable documentation.6 A common convention is to use this
+  and serves as valuable documentation.[^6] A common convention is to use this
   space for a user story narrative (e.g., "As a \[role\], the [feature] is
   desired, so that \[benefit\]").
 
 - `Scenario`: A `Feature` contains one or more `Scenarios`. A `Scenario`
   describes a single, concrete example of the feature's behavior—a specific use
-  case or test case.1 Each
+  case or test case.[^1] Each
 
-  `Scenario` should be independent and test one, and only one, behavior.13 This
-  focus is crucial for clarity and maintenance; when a test fails, it should
-  point to a single, specific piece of broken functionality.
+  `Scenario` should be independent and test one, and only one, behavior.[^13]
+  This focus is crucial for clarity and maintenance; when a test fails, it
+  should point to a single, specific piece of broken functionality.
 
 - `Given`: This keyword sets the initial context or preconditions for a
   `Scenario`. It describes the state of the world *before* the main event of
-  the scenario occurs.1 A
+  the scenario occurs.[^1] A
 
   `Given` step should put the system into a known state, such as preparing test
-  data in a database or ensuring a user is logged in.9 Best practices strongly
-  advise against describing user interactions in
+  data in a database or ensuring a user is logged in.[^9] Best practices
+  strongly advise against describing user interactions in
 
-  `Given` steps; they are about establishing the scene, not the action.9
+  `Given` steps; they are about establishing the scene, not the action.[^9]
 
 - `When`: This keyword describes an event or an action. This is typically an
   interaction performed by a user (e.g., "the user clicks the login button") or
-  an event triggered by an external system.1 To maintain the "one behavior per
-  scenario" rule, it is highly recommended to have only a single
+  an event triggered by an external system.[^1] To maintain the "one behavior
+  per scenario" rule, it is highly recommended to have only a single
 
-  `When` step in each `Scenario`.9 This step represents the pivotal action that
-  the scenario is designed to test.
+  `When` step in each `Scenario`.[^9] This step represents the pivotal action
+  that the scenario is designed to test.
 
 - `Then`: This keyword defines the expected outcome or result of the action
   described in the `When` step. The code that implements a `Then` step (the
   "step definition") must contain assertions to verify that the actual outcome
-  matches the expected outcome.1 A critical best practice is to ensure this
+  matches the expected outcome.[^1] A critical best practice is to ensure this
   outcome is observable from the user's perspective, such as a message on the
   screen or a change in the UI state. Verifying internal system states, like a
   database record, directly in a
 
   `Then` step is discouraged because it couples the test to implementation
-  details rather than observable behavior.9
+  details rather than observable behavior.[^9]
 
 ### Section 1.3: Enhancing Readability and Flow
 
@@ -114,10 +114,10 @@ Gherkin provides several additional keywords.
 
 - `And`, `But`: When a `Scenario` requires multiple preconditions, actions,
   or outcomes, the `And` and `But` keywords are used to chain steps together
-  without repeating `Given`, `When`, or `Then`.9 These keywords are
+  without repeating `Given`, `When`, or `Then`.[^9] These keywords are
   syntactically interchangeable and carry no special automation logic; their
   purpose is purely to improve the narrative flow and structure of the
-  scenario.18
+  scenario.[^18]
 
   `But` is often used to express a negative condition, which can enhance
   readability.
@@ -133,12 +133,12 @@ Gherkin provides several additional keywords.
 
 - `*` **(Asterisk)**: Gherkin also supports using an asterisk (`*`) as a
   substitute for any of the primary step keywords (`Given`, `When`, `Then`,
-  `And`, `But`).14 This can be particularly useful when a scenario involves a
-  list of items or conditions, as it can read more like a set of bullet points
-  than a narrative sequence. The asterisk inherits the context of the preceding
-  keyword. For example, if it follows a
+  `And`, `But`).[^14] This can be particularly useful when a scenario involves
+  a list of items or conditions, as it can read more like a set of bullet
+  points than a narrative sequence. The asterisk inherits the context of the
+  preceding keyword. For example, if it follows a
 
-  `Given`, it is treated as another `Given` step.19
+  `Given`, it is treated as another `Given` step.[^19]
 
 ```gherkin
   Scenario: Setting up a user profile
@@ -190,10 +190,10 @@ their cart. Repeating these steps in every scenario is inefficient and clutters
 the file.
 
 The `Background` keyword solves this problem by allowing definition of `Given`
-steps that are common to all `Scenarios` within that `Feature` file.1 These
+steps that are common to all `Scenarios` within that `Feature` file.[^1] These
 steps are automatically executed before each and every
 
-`Scenario` in the file, acting as a shared setup routine.15
+`Scenario` in the file, acting as a shared setup routine.[^15]
 
 ```gherkin
 Feature: User profile management
@@ -220,7 +220,7 @@ While powerful, the Background keyword should be used judiciously.
 - **Keep it Short and Relevant:** A `Background` should only contain steps that
   are truly essential for *all* scenarios in the feature. If a setup step is
   only needed for a subset of scenarios, it belongs in their respective `Given`
-  sections.9 A good rule of thumb is to keep the
+  sections.[^9] A good rule of thumb is to keep the
 
   `Background` under four lines long.14.
 
@@ -228,11 +228,11 @@ While powerful, the Background keyword should be used judiciously.
   used to set up complex states that are not immediately obvious to someone
   reading the scenarios. If the details are irrelevant to the business user
   (e.g., creating a specific site ID), abstract them into a higher-level, more
-  declarative step like `Given I am logged in as a site owner`.14
+  declarative step like `Given I am logged in as a site owner`.[^14]
 
 - **Make it Vivid:** Use descriptive, colourful names to tell a coherent
   story. The human brain remembers narratives better than abstract identifiers
-  like "User A" or "Site 1".14
+  like "User A" or "Site 1".[^14]
 
 ### Section 2.2: Data-Driven Testing with `Scenario Outline` and `Examples`
 
@@ -243,22 +243,22 @@ separate `Scenario` for each case would be highly repetitive.
 
 The `Scenario Outline` keyword is Gherkin's primary mechanism for data-driven
 testing. It allows a scenario template to be executed multiple times with
-different data sets.10
+different data sets.[^10]
 
 **Syntax:**
 
 1. Replace the `Scenario` keyword with `Scenario Outline`.
 
 2. In the steps, use angle brackets (`< >`) to define placeholders for
-   variables.13
+   variables.[^13]
 
 3. Follow the `Scenario Outline` with an `Examples` table. The first row of
    this table is the header, and its column names must exactly match the
-   variable names used in the steps.20
+   variable names used in the steps.[^20]
 
 The test runner will execute the entire scenario once for each data row in the
 `Examples` table, substituting the placeholder variables with the values from
-that row.16
+that row.[^16]
 
 ```gherkin
 Feature: Calculator Addition
@@ -291,7 +291,7 @@ accounts with different roles, or a `Then` step might need to verify the
 contents of a shopping cart.
 
 `Data Tables` provide a way to pass a table of data directly to a step
-definition.14 They are defined using pipe (
+definition.[^14] They are defined using pipe (
 
 `|`) delimiters immediately below the step they belong to.
 
@@ -312,7 +312,7 @@ Unlike an `Examples` table, this `Data Table` does not cause the scenario to
 run multiple times. Instead, the entire table is passed as a single argument to
 the step definition for "Given the following users exist in the system:". The
 automation code can then parse this table (often as a list of lists or list of
-maps) and use it to perform the necessary setup.22
+maps) and use it to perform the necessary setup.[^22]
 
 ### Section 2.4: Incorporating Block Text with `Doc Strings`
 
@@ -321,12 +321,13 @@ table, but a larger, free-form block of text. This is common when working with
 APIs (JSON/XML payloads), email content, or snippets of code.
 
 `Doc Strings` are Gherkin's solution for this. A `Doc String` allows a
-multi-line string to be passed to a step definition.14
+multi-line string to be passed to a step definition.[^14]
 
 Syntax:
 
 The text block is enclosed by a pair of triple double-quotes (""") or triple
-backticks (\`\`\`\`\`\`) on their own lines, immediately following the step.14
+backticks (\`\`\`\`\`\`) on their own lines, immediately following the
+step.[^14]
 
 ```gherkin
 Feature: API for creating blog posts
@@ -345,18 +346,18 @@ Feature: API for creating blog posts
 In the step definition, the entire content of the `Doc String` is passed as a
 single string argument. Advanced Gherkin parsers also allow specifying a
 content type (e.g., `"""json`) after the opening delimiter, which can help
-tools with syntax highlighting and parsing.14
+tools with syntax highlighting and parsing.[^14]
 
 ### Section 2.5: Grouping with the `Rule` Keyword
 
 As a `Feature` grows more complex, a flat list of scenarios can become
 difficult to navigate. To provide an additional layer of organization, Gherkin
-version 6 introduced the `Rule` keyword.14
+version 6 introduced the `Rule` keyword.[^14]
 
 The purpose of the `Rule` keyword is to group a set of related scenarios that
 together represent a single, specific business rule that the system must
-enforce.9 This is particularly useful for features that have distinct sets of
-business logic.
+enforce.[^9] This is particularly useful for features that have distinct sets
+of business logic.
 
 ```gherkin
 Feature: Bank account withdrawals
@@ -405,11 +406,11 @@ a full "regression" suite, or tests specific to a certain feature or
 environment.
 
 `Tags` are Gherkin's mechanism for this kind of organization. A tag is a simple
-annotation prefixed with an `@` symbol (e.g., `@smoke`, `@api`, `@ui`).10 Tags
-can be placed above
+annotation prefixed with an `@` symbol (e.g., `@smoke`, `@api`, `@ui`).[^10]
+Tags can be placed above
 
 `Feature`, `Scenario`, `Scenario Outline`, or even specific `Examples` tables
-to categorize them.14 A single element can have multiple tags.
+to categorize them.[^14] A single element can have multiple tags.
 
 ```gherkin
 @login @smoke
@@ -453,7 +454,7 @@ They typically support boolean expressions, allowing for complex selections 21:
   ensure consistency.
 
 - **Formatting:** Use lowercase for tag names and separate words with hyphens
-  (e.g., `@work-in-progress`) for readability.13
+  (e.g., `@work-in-progress`) for readability.[^13]
 
 ### Section 3.2: The Art of Writing Good Gherkin
 
@@ -463,13 +464,13 @@ practices is the use of a **declarative style** over an imperative one.
 
 An imperative style describes the mechanics of an interaction—the "how." It
 focuses on implementation details like clicking buttons, filling in text
-fields, or navigating to URLs.17
+fields, or navigating to URLs.[^17]
 
 - **Imperative (Avoid):** `When I type "user@example.com" into the "email"
   field and click the "submit" button`
 
 A declarative style describes the user's intent and the system's behavior—the
-"what." It abstracts away the implementation details.24
+"what." It abstracts away the implementation details.[^24]
 
 - **Declarative (Prefer):** `When the user logs in with valid credentials`
 
@@ -480,28 +481,29 @@ Declarative tests are more resilient because the implementation of "logging in"
 can change (from a UI flow to a direct API call) without requiring any
 modification to the Gherkin specification itself. This makes the feature file a
 true piece of "living documentation" that describes business value, not a
-fragile script of UI interactions.24
+fragile script of UI interactions.[^24]
 
 Building on this philosophy, several other rules contribute to high-quality
 Gherkin:
 
 - **The Cardinal Rule: One Scenario, One Behavior:** Each scenario should test
-  a single, focused business rule or use case.13 If a scenario contains multiple
+  a single, focused business rule or use case.[^13] If a scenario contains
+  multiple
 
   `When-Then` pairs, it is likely testing multiple behaviors and should be
-  split into separate, more focused scenarios.13 This makes tests easier to
+  split into separate, more focused scenarios.[^13] This makes tests easier to
   understand and debug.
 
 - **Conciseness and Clarity:** Keep scenarios short and to the point. A good
   rule of thumb is to aim for fewer than 10 steps, with 5 or fewer being
-  ideal.13 Similarly, feature files should not become monolithic; a dozen
-  scenarios per file is a reasonable guideline.13
+  ideal.[^13] Similarly, feature files should not become monolithic; a dozen
+  scenarios per file is a reasonable guideline.[^13]
 
 - **Precise Language:** Use clear, unambiguous language that is part of the
-  project's shared domain vocabulary. Avoid technical jargon.10 Steps should be
-  written as complete subject-predicate action phrases (e.g., "the user enters
-  a search term") and consistently use the present tense to maintain a clear
-  narrative.13
+  project's shared domain vocabulary. Avoid technical jargon.[^10] Steps should
+  be written as complete subject-predicate action phrases (e.g., "the user
+  enters a search term") and consistently use the present tense to maintain a
+  clear narrative.[^13]
 
 ### Section 3.3: Documentation and Maintenance
 
@@ -510,8 +512,8 @@ the team. This requires attention to documentation and consistent style.
 
 - **Comments (`#`):** Gherkin supports single-line comments, which begin with a
   hash sign (`#`). These are intended for developers or other technical readers
-  and are completely ignored by test runners.14 Gherkin does not have a syntax
-  for multi-line block comments; each line of a comment block must be
+  and are completely ignored by test runners.[^14] Gherkin does not have a
+  syntax for multi-line block comments; each line of a comment block must be
   individually prefixed with `#`.14.
 
 - **YAML Comments (An Advanced Technique):** For more structured metadata that
@@ -519,7 +521,7 @@ the team. This requires attention to documentation and consistent style.
   stories, ticket IDs, or security classifications—a useful pattern is to use
   YAML-formatted comments at the top of a feature file. This keeps the metadata
   organized, human-readable, and potentially parsable by external reporting or
-  analysis tools.27
+  analysis tools.[^27]
 
 ```gherkin
   # Id: TICKET-123
@@ -535,15 +537,15 @@ the team. This requires attention to documentation and consistent style.
   readability, especially in a collaborative environment.
 
   - **Indentation:** Use a consistent indentation style. Two spaces is the
-    recommended standard.13
+    recommended standard.[^13]
 
   - **Spacing:** Use blank lines to separate scenarios, and ensure consistent
     spacing around pipe (`|`) delimiters in tables to make them align
-    visually.13
+    visually.[^13]
 
   - **Capitalization:** Capitalize Gherkin keywords (`Given`, `When`, `Then`)
     and the first word of titles, but not other words in step phrases unless
-    they are proper nouns.13
+    they are proper nouns.[^13]
 
 ______________________________________________________________________
 
@@ -553,7 +555,7 @@ ______________________________________________________________________
 standalone test runner but a powerful plugin for the `pytest` framework. This
 design choice allows it to seamlessly integrate with and leverage the entire
 `pytest` ecosystem, including its renowned fixture system, extensive plugin
-library, and robust test execution capabilities.22
+library, and robust test execution capabilities.[^22]
 
 ### Section 4.1: Project Setup and Configuration
 
@@ -569,7 +571,7 @@ Python's package management.
   ```
 
   For web UI testing, `selenium` and potentially other helper libraries are
-  typically installed.28
+  typically installed.[^28]
 
 - **Directory Structure:** A conventional project structure helps keep tests
   organized:
@@ -592,11 +594,12 @@ decorators.
   a `.feature` file and a Python test file. It decorates a Python function,
   telling `pytest` that this function represents a specific Gherkin scenario.
   The decorator takes the path to the `.feature` file and the name of the
-  `Scenario` as arguments.29 The decorated function itself often contains just a
+  `Scenario` as arguments.[^29] The decorated function itself often contains
+  just a
 
   `pass` statement or a final, high-level assertion, as its main purpose is to
   act as a collector for the steps and to be discoverable by the `pytest`
-  runner.31
+  runner.[^31]
 
 ```python
   # tests/step_defs/test_publish_article.py
@@ -611,10 +614,10 @@ decorators.
 - **Step Decorators (**`@given`**,** `@when`**,** `@then`**):** Each Gherkin
   step is mapped to a Python function using a corresponding decorator:
   `@given`, `@when`, or `@then`. The string argument passed to the decorator
-  must exactly match the text of the step in the `.feature` file.28 For
+  must exactly match the text of the step in the `.feature` file.[^28] For
   readability and maintainability, step aliases can be created by stacking
   multiple decorators on a single function, allowing different Gherkin phrases
-  to execute the same code.30
+  to execute the same code.[^30]
 
 ```python
   from pytest_bdd import given, when, then
@@ -642,14 +645,15 @@ One of the most significant and powerful aspects of `pytest-bdd` is its
 approach to state management. Unlike many traditional Cucumber tools that use a
 mutable "World" or "Context" object that is passed between steps, `pytest-bdd`
 eschews this pattern. Instead, it fully embraces the idiomatic `pytest` fixture
-system for managing and sharing state between steps.32 This represents a
+system for managing and sharing state between steps.[^32] This represents a
 philosophical shift from explicit state passing to implicit dependency
 injection.
 
 In this model, `Given` steps act as fixture factories. A function decorated
 with `@given` can return a value. By using the `target_fixture` argument in the
 decorator, this return value is injected into the `pytest` context as a named
-fixture, available exclusively for the duration of that scenario.31 Subsequent
+fixture, available exclusively for the duration of that scenario.[^31]
+Subsequent
 
 `When` and `Then` steps can then access this state simply by declaring a
 function argument with the same name as the target fixture. `pytest` handles
@@ -716,21 +720,21 @@ steps.
   including `parse` (for `string.format()` style), `cfparse` (a more powerful
   variant), and `re` (for regular expressions). The `parse` and `cfparse`
   styles, which use `{name:Type}` syntax, are generally preferred for their
-  readability.34
+  readability.[^34]
 
 - `Scenario Outline` **Parameters:** When using a `Scenario Outline`, the
   values from the `Examples` table are automatically parsed and passed as
   arguments to the corresponding step functions. Their names must match the
-  headers in the `Examples` table.34
+  headers in the `Examples` table.[^34]
 
 - `Data Tables`**:** A step definition function can access a `Data Table` by
   including a special argument named `datatable`. `pytest-bdd` will inject the
   table's content into this argument as a list of lists, where each inner list
-  represents a row.22
+  represents a row.[^22]
 
 - `Doc Strings`**:** Similarly, a `Doc String` can be accessed by including a
   special argument named `docstring`. This argument will receive the entire
-  block text as a single, multi-line string.22
+  block text as a single, multi-line string.[^22]
 
 ______________________________________________________________________
 
@@ -740,7 +744,7 @@ For developers in the Rust ecosystem, `cucumber-rs` provides a native,
 idiomatic implementation of a Cucumber test runner. Unlike `pytest-bdd`, it is
 a self-contained framework designed from the ground up for Rust, with
 first-class support for `async` programming and a strong emphasis on type
-safety.35
+safety.[^35]
 
 ### Section 5.1: Project Setup in the Rust Ecosystem
 
@@ -755,7 +759,7 @@ and establishing a conventional directory structure.
   1. Define a new test target in the `Cargo.toml`. Crucially, set
      `harness = false`. This tells Rust's default test harness (`libtest`) to
      stand down, allowing `cucumber-rs` to take control of the test execution
-     and output formatting.37
+     and output formatting.[^37]
 
   Ini, TOML
 
@@ -791,13 +795,13 @@ the `World`.
 
 - **Core Concept:** The `World` is a user-defined struct that holds all the
   mutable state for a single scenario. A new instance of the `World` is created
-  for each scenario, ensuring that tests are isolated from one another.37
+  for each scenario, ensuring that tests are isolated from one another.[^37]
 
 - **Implementation:** To be used by the framework, the struct must derive or
   implement the `cucumber::World` trait. The framework will then use
   `Default::default()` to create a new `World` for each scenario. If more
   complex initialization is needed, a custom constructor can be specified using
-  the `#[world(init =...)]` attribute.35
+  the `#[world(init =...)]` attribute.[^35]
 
 ```rust
   // tests/cucumber_tests.rs
@@ -818,10 +822,10 @@ well-suited for testing applications involving I/O operations like database
 queries or web requests.
 
 - **Attribute Macros:** Gherkin steps are linked to Rust functions using the
-  `#[given]`, `#[when]`, and `#[then]` attribute macros.35
+  `#[given]`, `#[when]`, and `#[then]` attribute macros.[^35]
 
   `cucumber-rs` enforces a stricter separation of these step types than some
-  other Cucumber implementations to prevent ambiguity.41
+  other Cucumber implementations to prevent ambiguity.[^41]
 
 - **Async Functions:** Step definition functions are typically `async` and are
   executed by the async runtime specified in the test runner (e.g., `tokio`).
@@ -829,7 +833,7 @@ queries or web requests.
 - **Function Signature:** Every step definition function must take a mutable
   reference to the `World` struct (`&mut MyWorld`) as its first argument. This
   is how steps read and modify the shared state of the scenario. Any parameters
-  parsed from the step string follow this `World` argument.35
+  parsed from the step string follow this `World` argument.[^35]
 
 ```rust
   // tests/steps/calculator_steps.rs
@@ -862,13 +866,13 @@ into Rust types.
   either regular expressions (`regex = "..."`) or Cucumber Expressions
   (`expr = "..."`) specified in the attribute macro. The framework handles the
   conversion to the corresponding Rust type in the function signature (e.g.,
-  `{float}` maps to `f64`).35
+  `{float}` maps to `f64`).[^35]
 
 - **Accessing** `Data Tables` **and** `Doc Strings`**:** To access a
   `Data Table` or `Doc String` attached to a step, the step definition function
   must include an argument of type `&cucumber::gherkin::Step`. The table or doc
   string can then be accessed as an `Option` on this `Step` object:
-  `step.table` or `step.docstring`.40
+  `step.table` or `step.docstring`.[^40]
 
   **Feature File (**`user_creation.feature`**):**
 
@@ -901,7 +905,7 @@ into Rust types.
   ```
 
   The same principle applies to `Data Tables`, where `step.table.as_ref()`
-  would be used to access the table data, which can then be iterated over.42
+  would be used to access the table data, which can then be iterated over.[^42]
 
 ______________________________________________________________________
 
@@ -924,13 +928,13 @@ BDD capabilities into the vast and mature `pytest` world. Its greatest strength
 is this very integration; it allows developers to reuse fixtures, leverage
 thousands of plugins for tasks like parallelization (`pytest-xdist`) and
 reporting (`pytest-html`), and manage BDD scenarios as just another type of
-`pytest` test.31
+`pytest` test.[^31]
 
 `cucumber-rs`, on the other hand, is a self-contained framework that provides
 its own test runner and ecosystem. Its strength lies in its idiomatic Rust
 implementation, featuring first-class `async` support and a strong, type-safe
-approach to state management via the `World` pattern.35 A Python team already
-invested in the
+approach to state management via the `World` pattern.[^35] A Python team
+already invested in the
 
 `pytest` ecosystem will find `pytest-bdd` to be a natural and powerful
 extension. A Rust team will likely prefer the purpose-built, type-safe, and
@@ -957,13 +961,13 @@ developers should be aware of specific implementation details that can act as
   implements a *subset* of Gherkin. It has intentionally removed support for
   older or less common features like vertical `Examples` tables and
   `Feature`-level examples, focusing on compatibility with the latest core
-  Gherkin developments.30 Teams migrating from other tools may find that
+  Gherkin developments.[^30] Teams migrating from other tools may find that
   certain syntax is no longer supported.
 
 - **Step Type Strictness:** `cucumber-rs` intentionally enforces a stricter
   separation between `given`, `when`, and `then` step types than the official
   Cucumber implementation. This is a design choice to prevent ambiguity, for
-  example, by disallowing a `then` step from being used as a `given` step.41
+  example, by disallowing a `then` step from being used as a `given` step.[^41]
   While this promotes clearer scenarios, it can be a surprise for those
   accustomed to more lenient frameworks.
 
@@ -979,7 +983,7 @@ developers should be aware of specific implementation details that can act as
 
 Gherkin's syntax is deceptively simple. The true challenge and reward of
 adopting it lie not in memorizing keywords but in embracing the collaborative,
-behavior-first mindset it is designed to foster.8 When used effectively,
+behavior-first mindset it is designed to foster.[^8] When used effectively,
 Gherkin transforms testing from a purely technical, after-the-fact verification
 activity into an integral part of the requirements and design process.
 

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -23,16 +23,16 @@ The core philosophy of `rstest-bdd` is to fuse the human-readable,
 requirement-driven specifications of Gherkin 3 with the powerful,
 developer-centric features of
 
-`rstest`.[^4] The primary value proposition is the unification of high-level
+`rstest`.[^2] The primary value proposition is the unification of high-level
 functional and acceptance tests with low-level unit tests. Both test types
 coexist within the same project, use the same fixture model for dependency
 injection, and are executed by the standard `cargo test` command. This approach
 eliminates the need for a separate test runner, reducing CI/CD configuration
 complexity and lowering the barrier to adoption for teams already invested in
-the Rust testing ecosystem.[^6]
+the Rust testing ecosystem.[^3]
 
 The design is heavily modeled on `pytest-bdd`, a successful plugin for Python's
-`pytest` framework.[^8]
+`pytest` framework.[^4]
 
 `pytest-bdd`'s success stems from its ability to leverage the full power of its
 host framework—including fixtures, parameterization, and a vast plugin
@@ -75,15 +75,15 @@ for each step defined in the Gherkin scenario. This is where the core
 `rstest-bdd` macros come into play.
 
 A key design choice, inherited from `pytest-bdd`, is that the Rust test module
-is the primary entry point, not the feature file.[^9] A test function is
+is the primary entry point, not the feature file.[^5] A test function is
 explicitly bound to a Gherkin scenario using the
 
 `#[scenario]` attribute macro, which is a direct parallel to `pytest-bdd`'s
-`@scenario` decorator.[^6]
+`@scenario` decorator.[^3]
 
 State is managed and passed between steps using `rstest`'s native fixture
 system, a cornerstone of this design. This contrasts with other BDD frameworks
-that often rely on a monolithic `World` object.[^11] By using fixtures,
+that often rely on a monolithic `World` object.[^6] By using fixtures,
 
 `rstest-bdd` allows for the reuse of setup and teardown logic already written
 for unit tests, promoting a Don't Repeat Yourself (DRY) approach.[^1]
@@ -171,12 +171,12 @@ Gherkin features necessary for comprehensive testing.
 #### 1.3.1 Parameterization with `Scenario Outline`
 
 Gherkin's `Scenario Outline` allows a single scenario to be run with multiple
-sets of data from an `Examples` table.[^13]
+sets of data from an `Examples` table.[^8]
 
 `rstest-bdd` will map this concept directly to `rstest`'s powerful
 parameterization capabilities. The `#[scenario]` macro will detect a
 `Scenario Outline` and generate code equivalent to a standard `rstest`
-parameterized test using multiple `#[case]` attributes.[^15]
+parameterized test using multiple `#[case]` attributes.[^9]
 
 **Feature File (**`login.feature`**):**
 
@@ -225,7 +225,7 @@ async fn see_message(#[from(browser)] driver: &mut WebDriver, message: String) {
 To provide an ergonomic and type-safe way of extracting parameters from step
 strings, `rstest-bdd` will support a `format!`-like syntax. This avoids the
 need for raw regular expressions in most cases and leverages Rust's existing
-`FromStr` trait for "magic conversion", a core feature of `rstest`.[^4] This is
+`FromStr` trait for "magic conversion", a core feature of `rstest`.[^2] This is
 directly analogous to the `parsers` module in `pytest-bdd`.1.
 
 **Example:**
@@ -258,7 +258,7 @@ other essential Gherkin constructs.
 - **Data Tables:** A Gherkin data table provides a way to pass a structured
   block of data to a single step. `rstest-bdd` will make this data available as
   a `Vec<Vec<String>>` argument to the step function, mirroring `pytest-bdd`'s
-  `datatable` argument.[^19]
+  `datatable` argument.[^11]
 
   **Feature File:**
 
@@ -286,7 +286,7 @@ fn create_users(
 
 - **Docstrings:** A Gherkin docstring allows a larger block of multi-line text
   to be passed to a step. This will be provided as a `String` argument to the
-  step function, again mirroring `pytest-bdd`.[^19]
+  step function, again mirroring `pytest-bdd`.[^11]
 
 ## Part 2: Architectural and API Specification
 
@@ -349,7 +349,7 @@ with the project's core goals:
 
 1. **Custom Test Runner:** The framework could provide its own test runner
    binary, similar to the `cucumber` crate which requires a `main` function to
-   invoke `World::run(...)`.[^11] This runner would be responsible for
+   invoke `World::run(...)`.[^6] This runner would be responsible for
    discovering feature files and step definitions. However, this approach would
    completely bypass
 
@@ -383,7 +383,7 @@ architectural cornerstone.
 The `inventory` crate provides a clean and powerful abstraction over the
 link-time collection mechanism described above. It offers "typed distributed
 plugin registration," allowing different parts of a program to submit items
-into a collection that can be iterated over at runtime.[^24]
+into a collection that can be iterated over at runtime.[^12]
 
 For `rstest-bdd`, this pattern is used to create a global registry of all step
 definitions. First, a struct is defined to hold the metadata for each step.
@@ -413,7 +413,7 @@ inventory::collect!(Step);
 
 The `#[given]`, `#[when]`, and `#[then]` macros will expand into an
 `inventory::submit!` block. This macro call constructs an instance of the
-`Step` struct at compile time and registers it for collection.[^24]
+`Step` struct at compile time and registers it for collection.[^12]
 
 At runtime, the code generated by the `#[scenario]` macro can retrieve a
 complete list of all step definitions across the entire application simply by
@@ -580,7 +580,7 @@ in its tight integration with the Rust compiler and `rstest`.
   runner and `rstest` as its foundation. This means it works out-of-the-box
   with the entire Rust ecosystem, including CI/CD pipelines, code coverage
   tools, and test filtering mechanisms, without requiring a separate runner or
-  special configuration.[^6]
+  special configuration.[^3]
 
 - **Powerful Fixture Reuse:** By leveraging `rstest` fixtures for state
   management, developers can reuse existing setup/teardown logic from their
@@ -607,13 +607,13 @@ in its tight integration with the Rust compiler and `rstest`.
 - **High Macro Complexity:** The implementation of the `#[scenario]` macro is
   non-trivial. It involves compile-time file I/O, parsing, and extensive code
   generation via `quote!`. Debugging and maintaining this macro will be a
-  significant challenge.[^31]
+  significant challenge.[^13]
 
 - **Reliance on "Magic" and Portability:** The `inventory` crate's use of
   linker sections is powerful but potentially "magic." It abstracts away
-  complex system-level behavior that may be a conceptual hurdle for some users
+  complex system-level behaviour that may be a conceptual hurdle for some users
   and has platform-specific considerations that may not be suitable for all
-  targets, such as some embedded systems or Windows/PE environments.[^24]
+  targets, such as some embedded systems or Windows/PE environments.[^12]
 
 **Mitigation:** For niche targets, a `no-inventory` feature flag could be
 provided. This would trigger a fallback mechanism using a `build.rs` script to
@@ -667,13 +667,13 @@ The core distinction lies in their integration philosophy. `cucumber-rs`
 provides a *Cucumber implementation in Rust*. It brings the established,
 cross-language Cucumber ecosystem's concepts—such as a dedicated test runner, a
 mandatory `World` state object, and built-in concurrency management—into a Rust
-project.[^11] It aims for consistency with
+project.[^6] It aims for consistency with
 
 `cucumber-jvm`, `cucumber-js`, etc.
 
 In contrast, the proposed `rstest-bdd` provides a *BDD layer for the native
 Rust testing ecosystem*. It adapts BDD principles to be idiomatic within the
-existing paradigms of `cargo test` and `rstest`.[^17] This leads to a different
+existing paradigms of `cargo test` and `rstest`.[^14] This leads to a different
 developer experience. A
 
 `cucumber-rs` user asks, "How do I manage state in my `World` struct?" A
@@ -732,43 +732,43 @@ and unit testing workflows under the powerful `rstest` umbrella.
 
 [^1]: A Complete Guide To Behavior-Driven Testing With Pytest BDD, accessed on
     July 20, 2025, <https://pytest-with-eric.com/bdd/pytest-bdd/>
-[^4]: rstest - [crates.io](http://crates.io): Rust Package Registry, accessed on
+[^2]: rstest - [crates.io](http://crates.io): Rust Package Registry, accessed on
     July 20, 2025, <https://crates.io/crates/rstest/0.12.0>
-[^6]: Pytest-BDD: the BDD framework for pytest — pytest-bdd 8.1.0 documentation,
+[^3]: Pytest-BDD: the BDD framework for pytest — pytest-bdd 8.1.0 documentation,
     accessed on July 20, 2025, <https://pytest-bdd.readthedocs.io/>
+[^4]: Behavior-Driven Python with pytest-bdd - Test Automation University -
+    Applitools, accessed on July 20, 2025,
+    <https://testautomationu.applitools.com/behaviour-driven-python-with-pytest-bdd/>
+[^5]: Python Testing 101: pytest-bdd - Automation Panda, accessed on July 20,
+    2025,
+    <https://automationpanda.com/2018/10/22/python-testing-101-pytest-bdd/>
+[^6]: Introduction - Cucumber Rust Book, accessed on July 20, 2025,
+    <https://cucumber-rs.github.io/cucumber/main/>
 [^7]: Behavior-Driven Development: Python with Pytest BDD -
     [Testomat.io](http://Testomat.io), accessed on July 20, 2025,
     <https://testomat.io/blog/pytest-bdd/>
-[^8]: Behavior-Driven Python with pytest-bdd - Test Automation University -
-    Applitools, accessed on July 20, 2025,
-    <https://testautomationu.applitools.com/behavior-driven-python-with-pytest-bdd/>
-[^9]: Python Testing 101: pytest-bdd - Automation Panda, accessed on July 20,
-    2025,
-    <https://automationpanda.com/2018/10/22/python-testing-101-pytest-bdd/>
-[^10]: pytest-bdd - Read the Docs, accessed on July 20, 2025,
-    <https://readthedocs.org/projects/pytest-bdd/downloads/pdf/latest/>
-[^11]: Introduction - Cucumber Rust Book, accessed on July 20, 2025,
-    <https://cucumber-rs.github.io/cucumber/main/>
-[^13]: Scenario Outline in PyTest – BDD - QA Automation Expert, accessed on July
+[^8]: Scenario Outline in PyTest – BDD - QA Automation Expert, accessed on July
     20, 2025,
     <https://qaautomation.expert/2024/04/11/scenario-outline-in-pytest-bdd/>
-    <https://testautomationu.applitools.com/behavior-driven-python-with-pytest-bdd/chapter5.html>
-[^15]: How can I create parameterized tests in Rust? - Stack Overflow, accessed
+    <https://testautomationu.applitools.com/behaviour-driven-python-with-pytest-bdd/chapter5.html>
+[^9]: How can I create parameterized tests in Rust? - Stack Overflow, accessed
        on July 20, 2025,
        <https://stackoverflow.com/questions/34662713/how-can-i-create-parameterized-tests-in-rust>
-[^17]: la10736/rstest: Fixture-based test framework for Rust - GitHub, accessed
-       on July 20, 2025, <https://github.com/la10736/rstest>
-[^19]: pytest-bdd - PyPI, accessed on July 20, 2025,
+[^10]: pytest-bdd - Read the Docs, accessed on July 20, 2025,
+    <https://readthedocs.org/projects/pytest-bdd/downloads/pdf/latest/>
+[^11]: pytest-bdd - PyPI, accessed on July 20, 2025,
     <https://pypi.org/project/pytest-bdd/>
     <https://www.reddit.com/r/rust/comments/1hwx3tn/what_is_a_good_pattern_to_share_state_between/>
      GitHub, accessed on July 20, 2025,
     <https://github.com/rust-lang/rust/issues/44034>
-[^24]: inventory - Rust - [Docs.rs](http://Docs.rs), accessed on July 20, 2025,
+[^12]: inventory - Rust - [Docs.rs](http://Docs.rs), accessed on July 20, 2025,
     <https://docs.rs/inventory>
     <https://www.luizdeaguiar.com.br/2022/08/shared-steps-and-hooks-with-pytest-bdd/>
-[^31]: Guide to Rust procedural macros |
+[^13]: Guide to Rust procedural macros |
     [developerlife.com](http://developerlife.com), accessed on July 20, 2025,
     <https://developerlife.com/2022/03/30/rust-proc-macro/>
     <https://medium.com/@alfred.weirich/the-rust-macro-system-part-1-an-introduction-to-attribute-macros-73c963fd63ea>
      <https://github.com/cucumber-rs/cucumber>
     <https://www.florianreinhard.de/cucumber-in-rust-beginners-tutorial/>
+[^14]: la10736/rstest: Fixture-based test framework for Rust - GitHub, accessed
+       on July 20, 2025, <https://github.com/la10736/rstest>

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -23,20 +23,20 @@ The core philosophy of `rstest-bdd` is to fuse the human-readable,
 requirement-driven specifications of Gherkin 3 with the powerful,
 developer-centric features of
 
-`rstest`.4 The primary value proposition is the unification of high-level
+`rstest`.[^4] The primary value proposition is the unification of high-level
 functional and acceptance tests with low-level unit tests. Both test types
 coexist within the same project, use the same fixture model for dependency
 injection, and are executed by the standard `cargo test` command. This approach
 eliminates the need for a separate test runner, reducing CI/CD configuration
 complexity and lowering the barrier to adoption for teams already invested in
-the Rust testing ecosystem.6
+the Rust testing ecosystem.[^6]
 
 The design is heavily modeled on `pytest-bdd`, a successful plugin for Python's
-`pytest` framework.8
+`pytest` framework.[^8]
 
 `pytest-bdd`'s success stems from its ability to leverage the full power of its
 host framework—including fixtures, parameterization, and a vast plugin
-ecosystem—rather than replacing it.1 By emulating this model,
+ecosystem—rather than replacing it.[^1] By emulating this model,
 
 `rstest-bdd` will provide a familiar and robust BDD experience that feels
 native to Rust developers who appreciate the capabilities of `rstest`.
@@ -46,13 +46,13 @@ native to Rust developers who appreciate the capabilities of `rstest`.
 To illustrate the intended workflow, this section presents a complete,
 narrative example of testing a web search feature. This walkthrough mirrors the
 structure of typical `pytest-bdd` tutorials, demonstrating the journey from a
-plain-language specification to an executable test.1
+plain-language specification to an executable test.[^1]
 
 #### 1.2.1 Step 1: The Feature File
 
 The process begins with a `.feature` file written in Gherkin. This file
 describes the desired functionality in a way that can be understood and
-validated by non-technical stakeholders.1
+validated by non-technical stakeholders.[^1]
 
 **File:** `tests/features/web_search.feature`
 
@@ -75,18 +75,18 @@ for each step defined in the Gherkin scenario. This is where the core
 `rstest-bdd` macros come into play.
 
 A key design choice, inherited from `pytest-bdd`, is that the Rust test module
-is the primary entry point, not the feature file.9 A test function is
+is the primary entry point, not the feature file.[^9] A test function is
 explicitly bound to a Gherkin scenario using the
 
 `#[scenario]` attribute macro, which is a direct parallel to `pytest-bdd`'s
-`@scenario` decorator.6
+`@scenario` decorator.[^6]
 
 State is managed and passed between steps using `rstest`'s native fixture
 system, a cornerstone of this design. This contrasts with other BDD frameworks
-that often rely on a monolithic `World` object.11 By using fixtures,
+that often rely on a monolithic `World` object.[^11] By using fixtures,
 
 `rstest-bdd` allows for the reuse of setup and teardown logic already written
-for unit tests, promoting a Don't Repeat Yourself (DRY) approach.1
+for unit tests, promoting a Don't Repeat Yourself (DRY) approach.[^1]
 
 **File:** `tests/test_web_search.rs`
 
@@ -161,7 +161,7 @@ cargo test
 `#[scenario]` orchestrates the execution of the `given`, `when`, and `then`
 steps in the correct order. This seamless integration means all standard
 `cargo` and `rstest` features, such as test filtering and parallel execution,
-work out of the box.7
+work out of the box.[^7]
 
 ### 1.3 Advanced Usage Patterns
 
@@ -171,12 +171,12 @@ Gherkin features necessary for comprehensive testing.
 #### 1.3.1 Parameterization with `Scenario Outline`
 
 Gherkin's `Scenario Outline` allows a single scenario to be run with multiple
-sets of data from an `Examples` table.13
+sets of data from an `Examples` table.[^13]
 
 `rstest-bdd` will map this concept directly to `rstest`'s powerful
 parameterization capabilities. The `#[scenario]` macro will detect a
 `Scenario Outline` and generate code equivalent to a standard `rstest`
-parameterized test using multiple `#[case]` attributes.15
+parameterized test using multiple `#[case]` attributes.[^15]
 
 **Feature File (**`login.feature`**):**
 
@@ -225,7 +225,7 @@ async fn see_message(#[from(browser)] driver: &mut WebDriver, message: String) {
 To provide an ergonomic and type-safe way of extracting parameters from step
 strings, `rstest-bdd` will support a `format!`-like syntax. This avoids the
 need for raw regular expressions in most cases and leverages Rust's existing
-`FromStr` trait for "magic conversion", a core feature of `rstest`.4 This is
+`FromStr` trait for "magic conversion", a core feature of `rstest`.[^4] This is
 directly analogous to the `parsers` module in `pytest-bdd`.1.
 
 **Example:**
@@ -250,7 +250,7 @@ To achieve feature parity with modern BDD tools, the framework will support
 other essential Gherkin constructs.
 
 - **Background:** Steps defined in a `Background` section are executed before
-  each `Scenario` in a feature file.10 This maps naturally to common setup
+  each `Scenario` in a feature file.[^10] This maps naturally to common setup
   logic and will be handled automatically by the
 
   `#[scenario]` macro.
@@ -258,7 +258,7 @@ other essential Gherkin constructs.
 - **Data Tables:** A Gherkin data table provides a way to pass a structured
   block of data to a single step. `rstest-bdd` will make this data available as
   a `Vec<Vec<String>>` argument to the step function, mirroring `pytest-bdd`'s
-  `datatable` argument.19
+  `datatable` argument.[^19]
 
   **Feature File:**
 
@@ -286,7 +286,7 @@ fn create_users(
 
 - **Docstrings:** A Gherkin docstring allows a larger block of multi-line text
   to be passed to a step. This will be provided as a `String` argument to the
-  step function, again mirroring `pytest-bdd`.19
+  step function, again mirroring `pytest-bdd`.[^19]
 
 ## Part 2: Architectural and API Specification
 
@@ -341,7 +341,7 @@ shared compile-time state to build a map of available steps.22. This stands in
 stark contrast to
 
 `pytest`, which provides a rich runtime plugin system that `pytest-bdd` hooks
-into to discover tests and steps dynamically during a collection phase.7
+into to discover tests and steps dynamically during a collection phase.[^7]
 
 This fundamental constraint of the Rust compiler forces a specific
 architectural choice. Several potential solutions exist, but only one aligns
@@ -349,9 +349,9 @@ with the project's core goals:
 
 1. **Custom Test Runner:** The framework could provide its own test runner
    binary, similar to the `cucumber` crate which requires a `main` function to
-   invoke `World::run(...)`.11 This runner would be responsible for discovering
-   feature files and step definitions. However, this approach would completely
-   bypass
+   invoke `World::run(...)`.[^11] This runner would be responsible for
+   discovering feature files and step definitions. However, this approach would
+   completely bypass
 
    `rstest` and `cargo test`, violating the primary design goal of seamless
    integration. It would effectively be a reimplementation of `cucumber-rs`,
@@ -383,7 +383,7 @@ architectural cornerstone.
 The `inventory` crate provides a clean and powerful abstraction over the
 link-time collection mechanism described above. It offers "typed distributed
 plugin registration," allowing different parts of a program to submit items
-into a collection that can be iterated over at runtime.24
+into a collection that can be iterated over at runtime.[^24]
 
 For `rstest-bdd`, this pattern is used to create a global registry of all step
 definitions. First, a struct is defined to hold the metadata for each step.
@@ -413,7 +413,7 @@ inventory::collect!(Step);
 
 The `#[given]`, `#[when]`, and `#[then]` macros will expand into an
 `inventory::submit!` block. This macro call constructs an instance of the
-`Step` struct at compile time and registers it for collection.24
+`Step` struct at compile time and registers it for collection.[^24]
 
 At runtime, the code generated by the `#[scenario]` macro can retrieve a
 complete list of all step definitions across the entire application simply by
@@ -580,12 +580,12 @@ in its tight integration with the Rust compiler and `rstest`.
   runner and `rstest` as its foundation. This means it works out-of-the-box
   with the entire Rust ecosystem, including CI/CD pipelines, code coverage
   tools, and test filtering mechanisms, without requiring a separate runner or
-  special configuration.6
+  special configuration.[^6]
 
 - **Powerful Fixture Reuse:** By leveraging `rstest` fixtures for state
   management, developers can reuse existing setup/teardown logic from their
   unit tests for BDD scenarios. This promotes code reuse and consistency across
-  the entire test suite.1
+  the entire test suite.[^1]
 
 - **Compile-Time Safety:** By validating that every Gherkin step has a
   corresponding implementation at compile time, the framework can fail fast
@@ -607,13 +607,13 @@ in its tight integration with the Rust compiler and `rstest`.
 - **High Macro Complexity:** The implementation of the `#[scenario]` macro is
   non-trivial. It involves compile-time file I/O, parsing, and extensive code
   generation via `quote!`. Debugging and maintaining this macro will be a
-  significant challenge.31
+  significant challenge.[^31]
 
 - **Reliance on "Magic" and Portability:** The `inventory` crate's use of
   linker sections is powerful but potentially "magic." It abstracts away
   complex system-level behavior that may be a conceptual hurdle for some users
   and has platform-specific considerations that may not be suitable for all
-  targets, such as some embedded systems or Windows/PE environments.24
+  targets, such as some embedded systems or Windows/PE environments.[^24]
 
 **Mitigation:** For niche targets, a `no-inventory` feature flag could be
 provided. This would trigger a fallback mechanism using a `build.rs` script to
@@ -667,13 +667,13 @@ The core distinction lies in their integration philosophy. `cucumber-rs`
 provides a *Cucumber implementation in Rust*. It brings the established,
 cross-language Cucumber ecosystem's concepts—such as a dedicated test runner, a
 mandatory `World` state object, and built-in concurrency management—into a Rust
-project.11 It aims for consistency with
+project.[^11] It aims for consistency with
 
 `cucumber-jvm`, `cucumber-js`, etc.
 
 In contrast, the proposed `rstest-bdd` provides a *BDD layer for the native
 Rust testing ecosystem*. It adapts BDD principles to be idiomatic within the
-existing paradigms of `cargo test` and `rstest`.17 This leads to a different
+existing paradigms of `cargo test` and `rstest`.[^17] This leads to a different
 developer experience. A
 
 `cucumber-rs` user asks, "How do I manage state in my `World` struct?" A

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -449,7 +449,7 @@ fn given_i_am_a_user(mut user_context: UserContext) { /\*... \*/ }
 
 ```rust
 
-# 
+#
 
 fn test_my_scenario(my_fixture: MyFixture) { /\* final assertion \*/ }
 ```
@@ -730,93 +730,45 @@ and unit testing workflows under the powerful `rstest` umbrella.
 
 ## **Works cited**
 
-1. A Complete Guide To Behavior-Driven Testing With Pytest BDD, accessed on
-    July 20, 2025, <https://pytest-with-eric.com/bdd/pytest-bdd/>
-2. Understanding the differences between BDD & TDD - Cucumber, accessed on
-    July 20, 2025, <https://cucumber.io/blog/bdd/bdd-vs-tdd/>
-3. Understanding Pytest BDD - BrowserStack, accessed on July 20, 2025,
-    <https://www.browserstack.com/guide/pytest-bdd>
-4. rstest - [crates.io](http://crates.io): Rust Package Registry, accessed on
-    July 20, 2025, <https://crates.io/crates/rstest/0.12.0>
-5. rstest - [crates.io](http://crates.io): Rust Package Registry, accessed on
-    July 20, 2025, <https://crates.io/crates/rstest>
-6. Pytest-BDD: the BDD framework for pytest — pytest-bdd 8.1.0 documentation,
-    accessed on July 20, 2025, <https://pytest-bdd.readthedocs.io/>
-7. Behavior-Driven Development: Python with Pytest BDD -
-    [Testomat.io](http://Testomat.io), accessed on July 20, 2025,
-    <https://testomat.io/blog/pytest-bdd/>
-8. Behavior-Driven Python with pytest-bdd - Test Automation University -
-    Applitools, accessed on July 20, 2025,
-    <https://testautomationu.applitools.com/behavior-driven-python-with-pytest-bdd/>
-9. Python Testing 101: pytest-bdd - Automation Panda, accessed on July 20,
-    2025,
-    <https://automationpanda.com/2018/10/22/python-testing-101-pytest-bdd/>
-10. pytest-bdd - Read the Docs, accessed on July 20, 2025,
-    <https://readthedocs.org/projects/pytest-bdd/downloads/pdf/latest/>
-11. Introduction - Cucumber Rust Book, accessed on July 20, 2025,
-    <https://cucumber-rs.github.io/cucumber/main/>
-12. fixture in rstest - Rust - [Docs.rs](http://Docs.rs), accessed on July 20,
-    2025, <https://docs.rs/rstest/latest/rstest/attr.fixture.html>
-13. Scenario Outline in PyTest – BDD - QA Automation Expert, accessed on July
-    20, 2025,
-    <https://qaautomation.expert/2024/04/11/scenario-outline-in-pytest-bdd/>
-14. Chapter 5 - Using Scenario Outlines - Test Automation University -
-    Applitools, accessed on July 20, 2025,
-    <https://testautomationu.applitools.com/behavior-driven-python-with-pytest-bdd/chapter5.html>
-15. How can I create parameterized tests in Rust? - Stack Overflow, accessed on
-    July 20, 2025,
-    <https://stackoverflow.com/questions/34662713/how-can-i-create-parameterized-tests-in-rust>
-16. Parameterize Tests in Rust: rstest - Qxf2 BLOG, accessed on July 20, 2025,
-    <https://qxf2.com/blog/parameterize-tests-rust-part1/>
-17. la10736/rstest: Fixture-based test framework for Rust - GitHub, accessed on
-    July 20, 2025, <https://github.com/la10736/rstest>
-18. Welcome to Pytest-BDD's documentation! — Pytest-BDD 4.1.0 documentation,
-    accessed on July 20, 2025, <https://pytest-bdd.readthedocs.io/en/4.1.0/>
-19. pytest-bdd - PyPI, accessed on July 20, 2025,
-    <https://pypi.org/project/pytest-bdd/>
-20. Procedural Macros - The Rust Reference, accessed on July 20, 2025,
-    <https://doc.rust-lang.org/reference/procedural-macros.html>
-21. What is a good pattern to share state between procedural macros? : r/rust -
-    Reddit, accessed on July 20, 2025,
-    <https://www.reddit.com/r/rust/comments/1hwx3tn/what_is_a_good_pattern_to_share_state_between/>
-22. Crate local state for procedural macros? · Issue #44034 · rust-lang/rust -
-    GitHub, accessed on July 20, 2025,
-    <https://github.com/rust-lang/rust/issues/44034>
-23. Quickstart - Cucumber Rust Book, accessed on July 20, 2025,
-    <https://cucumber-rs.github.io/cucumber/current/quickstart.html>
-24. inventory - Rust - [Docs.rs](http://Docs.rs), accessed on July 20, 2025,
-    <https://docs.rs/inventory>
-25. inventory - [crates.io](http://crates.io): Rust Package Registry, accessed
-    on July 20, 2025, <https://crates.io/crates/inventory>
-26. gherkin - [crates.io](http://crates.io): Rust Package Registry, accessed on
-    July 20, 2025, <https://crates.io/crates/gherkin>
-27. gherkin - Rust - [Docs.rs](http://Docs.rs), accessed on July 20, 2025,
-    <https://docs.rs/gherkin>
-28. Macro quote - Rust - [Docs.rs](http://Docs.rs), accessed on July 20, 2025,
-    <https://docs.rs/quote/latest/quote/macro.quote.html>
-29. quote in quote - Rust, accessed on July 20, 2025,
-    <https://jeltef.github.io/derive_more/quote/macro.quote.html>
-30. Shared Steps and Hooks with Pytest-BDD - LuizDeAguiar, accessed on July 20,
-    2025,
-    <https://www.luizdeaguiar.com.br/2022/08/shared-steps-and-hooks-with-pytest-bdd/>
-31. Guide to Rust procedural macros |
-    [developerlife.com](http://developerlife.com), accessed on July 20, 2025,
-    <https://developerlife.com/2022/03/30/rust-proc-macro/>
-32. The Rust Macro System: Part 1 — An Introduction to Attribute Macros | by
-    Alfred Weirich, accessed on July 20, 2025,
-    <https://medium.com/@alfred.weirich/the-rust-macro-system-part-1-an-introduction-to-attribute-macros-73c963fd63ea>
-33. Cucumber testing framework for Rust. Fully native, no external test runners
-    or dependencies. - GitHub, accessed on July 20, 2025,
-    <https://github.com/cucumber-rs/cucumber>
-34. cucumber - Rust - [Docs.rs](http://Docs.rs), accessed on July 20, 2025,
-    <https://docs.rs/cucumber>
-35. State | Cucumber, accessed on July 20, 2025,
-    <https://cucumber.io/docs/cucumber/state/>
-36. World in cucumber - Rust - [Docs.rs](http://Docs.rs), accessed on July 20,
-    2025, <https://docs.rs/cucumber/latest/cucumber/trait.World.html>
-37. Cucumber in Rust - Beginner's Tutorial - Florianrein's Blog, accessed on
-    July 20, 2025,
-    <https://www.florianreinhard.de/cucumber-in-rust-beginners-tutorial/>
-
 [^1]: A Complete Guide To Behavior-Driven Testing With Pytest BDD, accessed on
     July 20, 2025, <https://pytest-with-eric.com/bdd/pytest-bdd/>
+[^4]: rstest - [crates.io](http://crates.io): Rust Package Registry, accessed on
+    July 20, 2025, <https://crates.io/crates/rstest/0.12.0>
+[^6]: Pytest-BDD: the BDD framework for pytest — pytest-bdd 8.1.0 documentation,
+    accessed on July 20, 2025, <https://pytest-bdd.readthedocs.io/>
+[^7]: Behavior-Driven Development: Python with Pytest BDD -
+    [Testomat.io](http://Testomat.io), accessed on July 20, 2025,
+    <https://testomat.io/blog/pytest-bdd/>
+[^8]: Behavior-Driven Python with pytest-bdd - Test Automation University -
+    Applitools, accessed on July 20, 2025,
+    <https://testautomationu.applitools.com/behavior-driven-python-with-pytest-bdd/>
+[^9]: Python Testing 101: pytest-bdd - Automation Panda, accessed on July 20,
+    2025,
+    <https://automationpanda.com/2018/10/22/python-testing-101-pytest-bdd/>
+[^10]: pytest-bdd - Read the Docs, accessed on July 20, 2025,
+    <https://readthedocs.org/projects/pytest-bdd/downloads/pdf/latest/>
+[^11]: Introduction - Cucumber Rust Book, accessed on July 20, 2025,
+    <https://cucumber-rs.github.io/cucumber/main/>
+[^13]: Scenario Outline in PyTest – BDD - QA Automation Expert, accessed on July
+    20, 2025,
+    <https://qaautomation.expert/2024/04/11/scenario-outline-in-pytest-bdd/>
+    <https://testautomationu.applitools.com/behavior-driven-python-with-pytest-bdd/chapter5.html>
+[^15]: How can I create parameterized tests in Rust? - Stack Overflow, accessed
+       on July 20, 2025,
+       <https://stackoverflow.com/questions/34662713/how-can-i-create-parameterized-tests-in-rust>
+[^17]: la10736/rstest: Fixture-based test framework for Rust - GitHub, accessed
+       on July 20, 2025, <https://github.com/la10736/rstest>
+[^19]: pytest-bdd - PyPI, accessed on July 20, 2025,
+    <https://pypi.org/project/pytest-bdd/>
+    <https://www.reddit.com/r/rust/comments/1hwx3tn/what_is_a_good_pattern_to_share_state_between/>
+     GitHub, accessed on July 20, 2025,
+    <https://github.com/rust-lang/rust/issues/44034>
+[^24]: inventory - Rust - [Docs.rs](http://Docs.rs), accessed on July 20, 2025,
+    <https://docs.rs/inventory>
+    <https://www.luizdeaguiar.com.br/2022/08/shared-steps-and-hooks-with-pytest-bdd/>
+[^31]: Guide to Rust procedural macros |
+    [developerlife.com](http://developerlife.com), accessed on July 20, 2025,
+    <https://developerlife.com/2022/03/30/rust-proc-macro/>
+    <https://medium.com/@alfred.weirich/the-rust-macro-system-part-1-an-introduction-to-attribute-macros-73c963fd63ea>
+     <https://github.com/cucumber-rs/cucumber>
+    <https://www.florianreinhard.de/cucumber-in-rust-beginners-tutorial/>


### PR DESCRIPTION
## Summary
- run `mdtablefix` on docs
- reformat Markdown and wrap footnotes

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687f2fa9030c832289e84106792e4ec5

## Summary by Sourcery

Standardize markdown documentation by converting numeric footnote citations to markdown footnote syntax and reflow text for consistent formatting

Documentation:
- Convert inline numeric footnotes to markdown [^n] syntax in gherkin-syntax.md and rstest-bdd-design.md
- Rewrap and reflow documentation text for improved readability and consistency