### PR TITLE
Implement initial scenario macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,137 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "gherkin"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20b79820c0df536d1f3a089a2fa958f61cb96ce9e0f3f8f507f5a31179567755"
+dependencies = [
+ "heck",
+ "peg",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+ "textwrap",
+ "thiserror",
+ "typed-builder",
+]
 
 [[package]]
 name = "glob"
@@ -19,6 +146,12 @@ name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "indexmap"
@@ -52,6 +185,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "peg"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f76678828272f177ac33b7e2ac2e3e73cc6c1cd1e3e387928aa69562fa51367"
+dependencies = [
+ "peg-macros",
+ "peg-runtime",
+]
+
+[[package]]
+name = "peg-macros"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "636d60acf97633e48d266d7415a9355d4389cea327a193f87df395d88cd2b14d"
+dependencies = [
+ "peg-runtime",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "peg-runtime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555b1514d2d99d78150d3c799d4c357a3e2c2a8062cd108e93a06d9057629c5"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,6 +248,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
 name = "rstest-bdd"
 version = "0.1.0"
 dependencies = [
@@ -80,11 +305,40 @@ dependencies = [
 name = "rstest-bdd-macros"
 version = "0.1.0"
 dependencies = [
+ "gherkin",
+ "once_cell",
  "proc-macro2",
  "quote",
+ "rstest",
  "rstest-bdd",
  "syn",
  "trybuild",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -98,6 +352,12 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
@@ -141,6 +401,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+
+[[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +436,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -221,10 +524,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-builder"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe83c85a85875e8c4cb9ce4a890f05b23d38cd0d47647db7895d3d2a79566d2"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a3151c41d0b13e3d011f98adc24434560ef06673a155a6c7f66b9879eecce2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "winapi-util"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
 
 [[package]]
 name = "equivalent"
@@ -143,6 +168,12 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
@@ -160,7 +191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -179,6 +210,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +248,29 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
 
 [[package]]
 name = "peg"
@@ -245,6 +327,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7251471db004e509f4e75a62cca9435365b5ec7bcdff530d612ac7c87c44a792"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -311,6 +402,7 @@ dependencies = [
  "quote",
  "rstest",
  "rstest-bdd",
+ "serial_test",
  "syn",
  "trybuild",
 ]
@@ -352,6 +444,12 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -401,10 +499,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smawk"

--- a/crates/rstest-bdd-macros/Cargo.toml
+++ b/crates/rstest-bdd-macros/Cargo.toml
@@ -16,6 +16,9 @@ proc-macro2 = ">=1.0, <2.0"
 quote = ">=1.0, <2.0"
 syn = { version = ">=2.0, <3.0", features = ["full"] }
 rstest-bdd = { path = "../rstest-bdd" }
+gherkin = { version = ">=0.14, <0.15", default-features = false, features = ["parser"] }
 
 [dev-dependencies]
 trybuild = ">=1.0, <2.0"
+once_cell = ">=1.18, <2.0"
+rstest = ">=0.18, <0.19"

--- a/crates/rstest-bdd-macros/Cargo.toml
+++ b/crates/rstest-bdd-macros/Cargo.toml
@@ -22,3 +22,4 @@ gherkin = { version = ">=0.14, <0.15", default-features = false, features = ["pa
 trybuild = ">=1.0, <2.0"
 once_cell = ">=1.18, <2.0"
 rstest = ">=0.18, <0.19"
+serial_test = ">=2.0, <3.0"

--- a/crates/rstest-bdd-macros/src/lib.rs
+++ b/crates/rstest-bdd-macros/src/lib.rs
@@ -5,9 +5,28 @@
 //! step inventory system, enabling runtime discovery and execution of step
 //! definitions.
 
+use gherkin::{Feature, GherkinEnv, StepType};
 use proc_macro::TokenStream;
 use quote::quote;
+use std::path::PathBuf;
+use syn::Result;
+use syn::parse::{Parse, ParseStream};
+use syn::token::Eq;
 use syn::{ItemFn, LitStr, parse_macro_input};
+
+struct PathArg(LitStr);
+
+impl Parse for PathArg {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let ident: syn::Ident = input.parse()?;
+        input.parse::<Eq>()?;
+        if ident != "path" {
+            return Err(input.error("expected `path`"));
+        }
+        let lit: LitStr = input.parse()?;
+        Ok(Self(lit))
+    }
+}
 
 fn step_attr(attr: TokenStream, item: TokenStream, keyword: &str) -> TokenStream {
     let pattern = parse_macro_input!(attr as LitStr);
@@ -80,7 +99,7 @@ pub fn then(attr: TokenStream, item: TokenStream) -> TokenStream {
     step_attr(attr, item, "Then")
 }
 
-/// No-op macro for binding a scenario to a feature file.
+/// Bind a test to the first scenario in a feature file.
 ///
 /// *attr* The string literal gives the path to the feature file containing the
 /// scenario.
@@ -95,7 +114,70 @@ pub fn then(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     // test implementation
 /// }
 /// ```
+///
+/// # Panics
+///
+/// This macro does not panic. Invalid input results in a compile error.
 #[proc_macro_attribute]
-pub fn scenario(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    item
+pub fn scenario(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let PathArg(path_lit) = parse_macro_input!(attr as PathArg);
+    let path = PathBuf::from(path_lit.value());
+
+    let item_fn = parse_macro_input!(item as ItemFn);
+    let attrs = &item_fn.attrs;
+    let vis = &item_fn.vis;
+    let sig = &item_fn.sig;
+    let block = &item_fn.block;
+
+    let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") else {
+        return TokenStream::from(quote! { compile_error!("CARGO_MANIFEST_DIR not set"); });
+    };
+    let feature_path = PathBuf::from(manifest_dir).join(&path);
+
+    let feature = match Feature::parse_path(&feature_path, GherkinEnv::default()) {
+        Ok(f) => f,
+        Err(err) => {
+            let msg = format!("failed to parse feature file: {err}");
+            return TokenStream::from(quote! { compile_error!(#msg); });
+        }
+    };
+    let Some(scenario) = feature.scenarios.first() else {
+        return TokenStream::from(quote! { compile_error!("feature contains no scenarios"); });
+    };
+
+    let steps: Vec<(String, String)> = scenario
+        .steps
+        .iter()
+        .map(|s| {
+            let keyword = match s.ty {
+                StepType::Given => "Given",
+                StepType::When => "When",
+                StepType::Then => "Then",
+            };
+            (keyword.to_string(), s.value.clone())
+        })
+        .collect();
+
+    let keywords = steps.iter().map(|(k, _)| k);
+    let values = steps.iter().map(|(_, v)| v);
+
+    TokenStream::from(quote! {
+        #(#attrs)*
+        #[rstest::rstest]
+        #vis #sig {
+            let steps = [#((#keywords, #values)),*];
+            for (keyword, text) in steps {
+                let mut found = false;
+                for step in rstest_bdd::iter::<rstest_bdd::Step> {
+                    if step.keyword == keyword && step.pattern == text {
+                        (step.run)();
+                        found = true;
+                        break;
+                    }
+                }
+                assert!(found, "Step not found: {} {}", keyword, text);
+            }
+            #block
+        }
+    })
 }

--- a/crates/rstest-bdd-macros/src/lib.rs
+++ b/crates/rstest-bdd-macros/src/lib.rs
@@ -20,6 +20,28 @@ struct ScenarioArgs {
 
 impl Parse for ScenarioArgs {
     fn parse(input: ParseStream<'_>) -> Result<Self> {
+        if input.peek(LitStr) {
+            let path: LitStr = input.parse()?;
+            let mut index = None;
+
+            if input.peek(Comma) {
+                input.parse::<Comma>()?;
+                let ident: syn::Ident = input.parse()?;
+                if ident != "index" {
+                    return Err(input.error("expected `index`"));
+                }
+                input.parse::<Eq>()?;
+                let lit: LitInt = input.parse()?;
+                index = Some(lit.base10_parse()?);
+            }
+
+            if !input.is_empty() {
+                return Err(input.error("unexpected tokens"));
+            }
+
+            return Ok(Self { path, index });
+        }
+
         let mut path = None;
         let mut index = None;
 
@@ -46,6 +68,10 @@ impl Parse for ScenarioArgs {
         let Some(path) = path else {
             return Err(input.error("`path` is required"));
         };
+
+        if !input.is_empty() {
+            return Err(input.error("unexpected tokens"));
+        }
 
         Ok(Self { path, index })
     }
@@ -122,10 +148,11 @@ pub fn then(attr: TokenStream, item: TokenStream) -> TokenStream {
     step_attr(attr, item, "Then")
 }
 
-/// Bind a test to the first scenario in a feature file.
+/// Bind a test to a scenario defined in a feature file.
 ///
-/// *attr* The string literal gives the path to the feature file containing the
-/// scenario.
+/// *attr* Accepts either a bare string literal giving the path to the feature
+/// file or a `path = "..."` argument. An optional `index = N` argument selects
+/// which scenario to run when the file contains more than one.
 ///
 /// # Examples
 ///
@@ -136,6 +163,9 @@ pub fn then(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// fn test_user_login() {
 ///     // test implementation
 /// }
+///
+/// #[scenario(path = "user_login.feature", index = 1)]
+/// fn second_case() {}
 /// ```
 ///
 /// # Panics

--- a/crates/rstest-bdd-macros/src/lib.rs
+++ b/crates/rstest-bdd-macros/src/lib.rs
@@ -181,6 +181,10 @@ pub fn then(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// # Panics
 ///
 /// This macro does not panic. Invalid input results in a compile error.
+///
+/// The generated test runs all scenario steps before executing the original
+/// function body. Use the function block for additional assertions after the
+/// steps complete.
 #[proc_macro_attribute]
 pub fn scenario(attr: TokenStream, item: TokenStream) -> TokenStream {
     let ScenarioArgs { path, index } = parse_macro_input!(attr as ScenarioArgs);

--- a/crates/rstest-bdd-macros/src/lib.rs
+++ b/crates/rstest-bdd-macros/src/lib.rs
@@ -190,15 +190,11 @@ pub fn scenario(attr: TokenStream, item: TokenStream) -> TokenStream {
         #vis #sig {
             let steps = [#((#keywords, #values)),*];
             for (keyword, text) in steps {
-                let mut found = false;
-                for step in rstest_bdd::iter::<rstest_bdd::Step> {
-                    if step.keyword == keyword && step.pattern == text {
-                        (step.run)();
-                        found = true;
-                        break;
-                    }
+                if let Some(f) = rstest_bdd::lookup_step(keyword, text) {
+                    f();
+                } else {
+                    panic!("Step not found: {} {}", keyword, text);
                 }
-                assert!(found, "Step not found: {} {}", keyword, text);
             }
             #block
         }

--- a/crates/rstest-bdd-macros/tests/features/multi.feature
+++ b/crates/rstest-bdd-macros/tests/features/multi.feature
@@ -1,0 +1,11 @@
+Feature: Multiple scenarios
+
+  Scenario: First
+    Given a precondition
+    When an action occurs
+    Then a result is produced
+
+  Scenario: Second
+    Given a precondition
+    When an action occurs
+    Then a result is produced

--- a/crates/rstest-bdd-macros/tests/features/unmatched.feature
+++ b/crates/rstest-bdd-macros/tests/features/unmatched.feature
@@ -1,0 +1,4 @@
+Feature: Unmatched
+
+  Scenario: Step not defined
+    Given an undefined step

--- a/crates/rstest-bdd-macros/tests/features/web_search.feature
+++ b/crates/rstest-bdd-macros/tests/features/web_search.feature
@@ -1,0 +1,6 @@
+Feature: Web search
+
+  Scenario: Simple search
+    Given a precondition
+    When an action occurs
+    Then a result is produced

--- a/crates/rstest-bdd-macros/tests/fixtures/basic.feature
+++ b/crates/rstest-bdd-macros/tests/fixtures/basic.feature
@@ -1,0 +1,6 @@
+Feature: Example
+
+  Scenario: Example scenario
+    Given a precondition
+    When an action occurs
+    Then a result is produced

--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_empty_file.rs
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_empty_file.rs
@@ -1,0 +1,6 @@
+use rstest_bdd_macros::scenario;
+
+#[scenario(path = "tests/features/empty.feature")]
+fn empty() {}
+
+fn main() {}

--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_empty_file.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_empty_file.stderr
@@ -1,0 +1,7 @@
+error: failed to parse feature file: Could not read path: $WORKSPACE/target/tests/trybuild/rstest-bdd-macros/tests/features/empty.feature
+ --> tests/fixtures/scenario_empty_file.rs:3:1
+  |
+3 | #[scenario(path = "tests/features/empty.feature")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_file.rs
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_file.rs
@@ -1,0 +1,6 @@
+use rstest_bdd_macros::scenario;
+
+#[scenario(path = "tests/features/does_not_exist.feature")]
+fn missing() {}
+
+fn main() {}

--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_file.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_file.stderr
@@ -1,0 +1,7 @@
+error: failed to parse feature file: Could not read path: $WORKSPACE/target/tests/trybuild/rstest-bdd-macros/tests/features/does_not_exist.feature
+ --> tests/fixtures/scenario_missing_file.rs:3:1
+  |
+3 | #[scenario(path = "tests/features/does_not_exist.feature")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/rstest-bdd-macros/tests/fixtures/step_macros.rs
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_macros.rs
@@ -1,4 +1,4 @@
-use rstest_bdd_macros::{given, when, then, scenario};
+use rstest_bdd_macros::{given, when, then};
 
 #[given("a precondition")]
 fn precondition() {}
@@ -9,7 +9,5 @@ fn action() {}
 #[then("a result is produced")]
 fn result() {}
 
-#[scenario("basic.feature")]
-fn my_scenario() {}
 
 fn main() {}

--- a/crates/rstest-bdd-macros/tests/fixtures/step_macros.rs
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_macros.rs
@@ -1,3 +1,7 @@
+//! Step definitions used by `trybuild` fixtures.
+//!
+//! This module declares dummy Given/When/Then functions so the
+//! procedural macros can register steps for compile tests.
 use rstest_bdd_macros::{given, when, then};
 
 #[given("a precondition")]

--- a/crates/rstest-bdd-macros/tests/scenario.rs
+++ b/crates/rstest-bdd-macros/tests/scenario.rs
@@ -37,4 +37,21 @@ fn simple_search() {
         Err(p) => p.into_inner(),
     };
     assert_eq!(events.as_slice(), ["precondition", "action", "result"]);
+    drop(events);
+    if let Ok(mut g) = EVENTS.lock() {
+        g.clear();
+    }
+}
+
+#[scenario(path = "tests/features/multi.feature", index = 1)]
+fn second_scenario() {
+    let events = match EVENTS.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    assert_eq!(events.as_slice(), ["precondition", "action", "result"]);
+    drop(events);
+    if let Ok(mut g) = EVENTS.lock() {
+        g.clear();
+    }
 }

--- a/crates/rstest-bdd-macros/tests/scenario.rs
+++ b/crates/rstest-bdd-macros/tests/scenario.rs
@@ -1,0 +1,40 @@
+use rstest_bdd_macros::{given, scenario, then, when};
+use std::sync::{LazyLock, Mutex};
+
+static EVENTS: LazyLock<Mutex<Vec<&'static str>>> = LazyLock::new(|| Mutex::new(Vec::new()));
+
+#[given("a precondition")]
+fn precondition() {
+    let mut guard = match EVENTS.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    guard.push("precondition");
+}
+
+#[when("an action occurs")]
+fn action() {
+    let mut guard = match EVENTS.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    guard.push("action");
+}
+
+#[then("a result is produced")]
+fn result() {
+    let mut guard = match EVENTS.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    guard.push("result");
+}
+
+#[scenario(path = "tests/features/web_search.feature")]
+fn simple_search() {
+    let events = match EVENTS.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    assert_eq!(events.as_slice(), ["precondition", "action", "result"]);
+}

--- a/crates/rstest-bdd-macros/tests/scenario.rs
+++ b/crates/rstest-bdd-macros/tests/scenario.rs
@@ -30,7 +30,7 @@ fn result() {
     guard.push("result");
 }
 
-#[scenario(path = "tests/features/web_search.feature")]
+#[scenario("tests/features/web_search.feature")]
 fn simple_search() {
     let events = match EVENTS.lock() {
         Ok(g) => g,
@@ -45,6 +45,19 @@ fn simple_search() {
 
 #[scenario(path = "tests/features/multi.feature", index = 1)]
 fn second_scenario() {
+    let events = match EVENTS.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    assert_eq!(events.as_slice(), ["precondition", "action", "result"]);
+    drop(events);
+    if let Ok(mut g) = EVENTS.lock() {
+        g.clear();
+    }
+}
+
+#[scenario(path = "tests/features/web_search.feature", index = 0)]
+fn explicit_syntax() {
     let events = match EVENTS.lock() {
         Ok(g) => g,
         Err(p) => p.into_inner(),

--- a/crates/rstest-bdd-macros/tests/scenario.rs
+++ b/crates/rstest-bdd-macros/tests/scenario.rs
@@ -1,10 +1,18 @@
 use rstest_bdd_macros::{given, scenario, then, when};
+use serial_test::serial;
 use std::sync::{LazyLock, Mutex};
 
 static EVENTS: LazyLock<Mutex<Vec<&'static str>>> = LazyLock::new(|| Mutex::new(Vec::new()));
 
+fn clear_events() {
+    if let Ok(mut g) = EVENTS.lock() {
+        g.clear();
+    }
+}
+
 #[given("a precondition")]
 fn precondition() {
+    clear_events();
     let mut guard = match EVENTS.lock() {
         Ok(g) => g,
         Err(p) => p.into_inner(),
@@ -31,6 +39,7 @@ fn result() {
 }
 
 #[scenario("tests/features/web_search.feature")]
+#[serial]
 fn simple_search() {
     let events = match EVENTS.lock() {
         Ok(g) => g,
@@ -38,12 +47,11 @@ fn simple_search() {
     };
     assert_eq!(events.as_slice(), ["precondition", "action", "result"]);
     drop(events);
-    if let Ok(mut g) = EVENTS.lock() {
-        g.clear();
-    }
+    clear_events();
 }
 
 #[scenario(path = "tests/features/multi.feature", index = 1)]
+#[serial]
 fn second_scenario() {
     let events = match EVENTS.lock() {
         Ok(g) => g,
@@ -51,12 +59,11 @@ fn second_scenario() {
     };
     assert_eq!(events.as_slice(), ["precondition", "action", "result"]);
     drop(events);
-    if let Ok(mut g) = EVENTS.lock() {
-        g.clear();
-    }
+    clear_events();
 }
 
 #[scenario(path = "tests/features/web_search.feature", index = 0)]
+#[serial]
 fn explicit_syntax() {
     let events = match EVENTS.lock() {
         Ok(g) => g,
@@ -64,7 +71,12 @@ fn explicit_syntax() {
     };
     assert_eq!(events.as_slice(), ["precondition", "action", "result"]);
     drop(events);
-    if let Ok(mut g) = EVENTS.lock() {
-        g.clear();
-    }
+    clear_events();
+}
+
+#[scenario(path = "tests/features/unmatched.feature")]
+#[should_panic(expected = "Step not found")]
+#[serial]
+fn unmatched_feature() {
+    clear_events();
 }

--- a/crates/rstest-bdd-macros/tests/trybuild.rs
+++ b/crates/rstest-bdd-macros/tests/trybuild.rs
@@ -4,4 +4,6 @@
 fn step_macros_compile() {
     let t = trybuild::TestCases::new();
     t.pass("tests/fixtures/step_macros.rs");
+    t.compile_fail("tests/fixtures/scenario_missing_file.rs");
+    t.compile_fail("tests/fixtures/scenario_empty_file.rs");
 }

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -90,6 +90,18 @@ static STEP_MAP: LazyLock<HashMap<StepKey, fn()>> = LazyLock::new(|| {
 });
 
 /// Look up a registered step by keyword and pattern.
+///
+/// # Examples
+///
+/// ```
+/// use rstest_bdd::{step, lookup_step};
+///
+/// fn dummy() {}
+/// step!("Given", "a thing", dummy);
+///
+/// let step_fn = lookup_step("Given", "a thing");
+/// assert!(step_fn.is_some());
+/// ```
 #[must_use]
 pub fn lookup_step(keyword: &str, pattern: &str) -> Option<fn()> {
     STEP_MAP.get(&(keyword, pattern)).copied()

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -82,8 +82,12 @@ macro_rules! step {
 inventory::collect!(Step);
 
 static STEP_MAP: LazyLock<HashMap<StepKey, fn()>> = LazyLock::new(|| {
-    let mut map = HashMap::new();
-    for step in iter::<Step> {
+    // Collect registered steps first so we can allocate the map with
+    // an appropriate capacity. This avoids rehashing when many steps
+    // are present.
+    let steps: Vec<_> = iter::<Step>.into_iter().collect();
+    let mut map = HashMap::with_capacity(steps.len());
+    for step in steps {
         map.insert((step.keyword, step.pattern), step.run);
     }
     map

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,29 +36,29 @@ discovered and executed by a procedural macro at runtime.
   - [x] Ensure each macro generates an `inventory::submit!` block that
     constructs and registers a `Step` instance.
 
-- [ ] **Scenario Orchestrator Macro (Initial Version)**
+- [x] **Scenario Orchestrator Macro (Initial Version)**
 
-  - [ ] Implement a basic `#[scenario(path = "...")]` attribute macro.
+  - [x] Implement a basic `#[scenario(path = "...")]` attribute macro.
 
-  - [ ] The macro must, at compile-time, read and parse the specified
+  - [x] The macro must, at compile-time, read and parse the specified
     `.feature` file using the `gherkin` crate.
 
-  - [ ] The macro must generate a new test function annotated with `#[rstest]`.
+  - [x] The macro must generate a new test function annotated with `#[rstest]`.
 
-  - [ ] The body of the generated function must, at runtime, iterate through
+  - [x] The body of the generated function must, at runtime, iterate through
     the scenario's Gherkin steps and find matching `Step` definitions from the
     `inventory::iter`.
 
-  - [ ] For this phase, only support exact, case-sensitive string matching with
+  - [x] For this phase, only support exact, case-sensitive string matching with
     no argument parsing.
 
-- [ ] **Validation**
+- [x] **Validation**
 
-  - [ ] Create a simple `web_search.feature` file.
+  - [x] Create a simple `web_search.feature` file.
 
-  - [ ] Create a `test_web_search.rs` file with corresponding step definitions.
+  - [x] Create a `test_web_search.rs` file with corresponding step definitions.
 
-  - [ ] Create a test function annotated with `#[scenario]` that successfully
+  - [x] Create a test function annotated with `#[scenario]` that successfully
     runs the steps via `cargo test`.
 
 ## Phase 2: Fixtures and Parameterization

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -752,6 +752,17 @@ crates separate. The workspace contains two members:
 This layout allows each crate to evolve independently while sharing common
 configuration and lints at the workspace level.
 
+### 3.7 Initial Scenario Macro Implementation
+
+The first implementation of the `#[scenario]` macro keeps the scope narrow to
+validate the overall approach. The macro accepts a `path` argument pointing to
+a `*.feature` file. At compile time it reads and parses this file using the
+`gherkin` crate. Only the first `Scenario` in the file is bound to the test
+function. The generated test is annotated with `#[rstest]` and at runtime
+iterates over the scenario's steps, finding matching step definitions by exact
+string comparison. This version deliberately omits argument parsing and fixture
+handling to minimise complexity while proving the orchestration works.
+
 ## **Works cited**
 
 [^1]: A Complete Guide To Behavior-Driven Testing With Pytest BDD, accessed on

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -769,7 +769,8 @@ bare string literal for convenience (e.g.
 when combined with `index`. The generated test is annotated with `#[rstest]`
 and at runtime iterates over the selected scenario's steps, finding matching
 step definitions by exact string comparison. Argument parsing and fixture
-handling remain unimplemented to keep the orchestration simple.
+handling remain unimplemented to minimize complexity while proving the
+orchestration works.
 
 ## **Works cited**
 

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -518,7 +518,7 @@ fn test_my_scenario(my_fixture: MyFixture) { /\* final assertion \*/ }
 3. `rstest` first resolves and provides the `my_fixture` dependency.
 4. `rstest` then executes the body of the generated function.
 5. The generated code looks up each step using a map built from the global step
-   registry. This map is initialised once via `LazyLock`, avoiding repeated
+   registry. This map is initialized once via `LazyLock`, avoiding repeated
    iteration over `inventory::iter`. Fixtures like `my_fixture` are made
    available to the step functions through the context object passed to the
    call site.

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -200,7 +200,7 @@ Feature: User Login
 
 ```rust
 //...
-#[scenario(path = "features/login.feature", name = "Login with different credentials")]
+#[scenario(path = "features/login.feature", index = 0)]
 #[tokio::test]
 async fn test_login_scenarios(#[future] browser: WebDriver) {}
 
@@ -299,16 +299,18 @@ challenges and solutions, and the end-to-end code generation process.
 The user-facing functionality is enabled by a suite of procedural macros. Each
 macro has a distinct role in the compile-time orchestration of the BDD tests.
 
-- `#[scenario(path = "...", name = "...")]` - the primary entry point and
-  orchestrator.
+- `#[scenario("...")]` or `#[scenario(path = "...", index = N)]` – the primary
+  entry point and orchestrator.
 
   - **Arguments:**
 
     - `path: &str`: A mandatory, relative path from the crate root to the
-      `.feature` file containing the scenario.
+      `.feature` file containing the scenario. The path can be provided as a
+      bare string literal or with the explicit `path =` form when other
+      arguments are used.
 
-    - `name: &str`: A mandatory string specifying the `Scenario` or
-      `Scenario Outline` name to bind the test function to.
+    - `index: usize` (optional): Selects which scenario in the feature file to
+      execute. Defaults to `0` when omitted.
 
   - **Functionality:** This macro is responsible for the heavy lifting. At
     compile time, it reads and parses the specified feature file, finds the
@@ -761,10 +763,13 @@ validate the overall approach. It accepted only a `path` argument pointing to a
 `*.feature` file and always executed the first `Scenario` found. The macro now
 also accepts an optional `index` argument. When provided, the macro selects the
 scenario at that zero-based position. If omitted it defaults to `0`, matching
-the behaviour of the earlier version. The generated test is annotated with
-`#[rstest]` and at runtime iterates over the selected scenario's steps, finding
-matching step definitions by exact string comparison. Argument parsing and
-fixture handling remain unimplemented to keep the orchestration simple.
+the behaviour of the earlier version. The `path` argument may be provided as a
+bare string literal for convenience (e.g.
+`#[scenario("tests/example.feature")]`) or using the explicit `path =` form
+when combined with `index`. The generated test is annotated with `#[rstest]`
+and at runtime iterates over the selected scenario's steps, finding matching
+step definitions by exact string comparison. Argument parsing and fixture
+handling remain unimplemented to keep the orchestration simple.
 
 ## **Works cited**
 

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -754,14 +754,15 @@ configuration and lints at the workspace level.
 
 ### 3.7 Initial Scenario Macro Implementation
 
-The first implementation of the `#[scenario]` macro keeps the scope narrow to
-validate the overall approach. The macro accepts a `path` argument pointing to
-a `*.feature` file. At compile time it reads and parses this file using the
-`gherkin` crate. Only the first `Scenario` in the file is bound to the test
-function. The generated test is annotated with `#[rstest]` and at runtime
-iterates over the scenario's steps, finding matching step definitions by exact
-string comparison. This version deliberately omits argument parsing and fixture
-handling to minimise complexity while proving the orchestration works.
+The first implementation of the `#[scenario]` macro kept the scope narrow to
+validate the overall approach. It accepted only a `path` argument pointing to a
+`*.feature` file and always executed the first `Scenario` found. The macro now
+also accepts an optional `index` argument. When provided, the macro selects the
+scenario at that zero-based position. If omitted it defaults to `0`, matching
+the behaviour of the earlier version. The generated test is annotated with
+`#[rstest]` and at runtime iterates over the selected scenario's steps, finding
+matching step definitions by exact string comparison. Argument parsing and
+fixture handling remain unimplemented to keep the orchestration simple.
 
 ## **Works cited**
 

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -299,7 +299,7 @@ challenges and solutions, and the end-to-end code generation process.
 The user-facing functionality is enabled by a suite of procedural macros. Each
 macro has a distinct role in the compile-time orchestration of the BDD tests.
 
-- `#[scenario("...")]` or `#[scenario(path = "...", index = N)]` – the primary
+- `#[scenario("…")]` or `#[scenario(path = "…", index = N)]` – the primary
   entry point and orchestrator.
 
   - **Arguments:**

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -515,10 +515,11 @@ fn test_my_scenario(my_fixture: MyFixture) { /\* final assertion \*/ }
 2. The `rstest` test runner discovers the generated `test_my_scenario` function.
 3. `rstest` first resolves and provides the `my_fixture` dependency.
 4. `rstest` then executes the body of the generated function.
-5. The generated code runs the step-matching loop, executing each Gherkin step
-   by calling the appropriate registered function. Fixtures like `my_fixture`
-   are made available to these steps through the context object passed to the
-   `run` function pointer.
+5. The generated code looks up each step using a map built from the global step
+   registry. This map is initialised once via `LazyLock`, avoiding repeated
+   iteration over `inventory::iter`. Fixtures like `my_fixture` are made
+   available to the step functions through the context object passed to the
+   call site.
 6. If all steps pass, the original code from the user's `test_my_scenario`
    function body is executed.
 
@@ -549,7 +550,8 @@ incrementally.
   using `inventory::submit!`.
 
 - Implement a basic `#[scenario]` macro. This includes compile-time Gherkin
-  file parsing and the runtime step-matching loop. Initially, this will support
+  file parsing and a lookup map built at runtime from the step registry.
+  Initially, this map supports exact string matching with no argument parsing.
   only exact string matching with no argument parsing.
 
 - The goal of this phase is to validate the core architectural choice: that a


### PR DESCRIPTION
## Summary
- implement `#[scenario]` attribute macro
- test orchestrating steps from a `.feature` file
- document the initial macro design
- update roadmap to mark scenario orchestrator as done

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688414a9d8048322a7995d08c21e2315

## Summary by Sourcery

Implement the initial scenario orchestrator macro, update documentation to reflect its completion, add necessary dependencies, and provide end-to-end tests using feature files to validate step execution.

New Features:
- Introduce a #[scenario(path = "...")] attribute macro that reads and parses a .feature file at compile time and generates a rstest test binding to its first scenario

Enhancements:
- Emit compile-time errors for missing manifest directory, feature parsing failures, or absent scenarios

Build:
- Add gherkin, once_cell, and rstest crates to support feature parsing and scenario tests

Documentation:
- Mark the scenario orchestrator macro as completed in the roadmap and document its initial design in the rstest-bdd-design guide

Tests:
- Add feature fixtures and a scenario.rs integration test to verify step orchestration across Given/When/Then definitions