### PR TITLE
Refactor scenario test helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,36 @@
 
 *Where Rustaceans come for their gourd‑related puns.*
 
-> **TL;DR**: Behaviour‑Driven Development, idiomatic to Rust. Keep your unit tests and your acceptance tests on the same vine, run everything with `cargo test`, and reuse your `rstest` fixtures.
+> **TL;DR**: Behaviour‑Driven Development, idiomatic to Rust. Keep your unit
+> tests and your acceptance tests on the same vine, run everything with
+> `cargo test`, and reuse your `rstest` fixtures.
 
----
+______________________________________________________________________
 
 ## Why this crate?
 
-`rstest-bdd` brings the collaborative clarity of BDD to Rust **without** asking you to adopt a bespoke runner or a monolithic “world” object. Instead, it builds on the excellent `rstest` fixture and parametrisation model:
+`rstest-bdd` brings the collaborative clarity of BDD to Rust **without** asking
+you to adopt a bespoke runner or a monolithic “world” object. Instead, it
+builds on the excellent `rstest` fixture and parametrisation model:
 
 - **One runner to rule them all**: execute scenarios with `cargo test`.
 
-- **First‑class fixtures**: share `rstest` fixtures between unit, integration, and BDD tests.
+- **First‑class fixtures**: share `rstest` fixtures between unit, integration,
+  and BDD tests.
 
-- **Ergonomic step definitions**: `#[given]`, `#[when]`, `#[then]` with typed placeholders.
+- **Ergonomic step definitions**: `#[given]`, `#[when]`, `#[then]` with typed
+  placeholders.
 
-- **Feature parity**: Scenario Outlines, Background, data tables, and docstrings.
+- **Feature parity**: Scenario Outlines, Background, data tables, and
+  docstrings.
 
-- **Pytest‑bdd vibes**: explicit `#[scenario]` binding from test code to a named scenario.
+- **Pytest‑bdd vibes**: explicit `#[scenario]` binding from test code to a
+  named scenario.
 
-Think of it as *courgette‑driven* development: crisp, versatile, and it plays nicely with everything else on your plate.
+Think of it as *courgette‑driven* development: crisp, versatile, and it plays
+nicely with everything else on your plate.
 
----
+______________________________________________________________________
 
 ## Installation
 
@@ -38,11 +47,13 @@ thirtyfour = "0.x"                                       # only for the web exam
 
 Feature flags:
 
-- `tokio` / `async-std` — choose your async test attribute (`#[tokio::test]`, etc.).
+- `tokio` / `async-std` — choose your async test attribute (`#[tokio::test]`,
+  etc.).
 
-- `no-inventory` — fallback code‑gen registry for platforms where linker‑section collection is unwieldy.
+- `no-inventory` — fallback code‑gen registry for platforms where
+  linker‑section collection is unwieldy.
 
----
+______________________________________________________________________
 
 ## Quick start (end‑to‑end “Web Search”)
 
@@ -114,9 +125,10 @@ Run it:
 cargo test -p your-crate -- --nocapture
 ```
 
-Everything grows on the same trellis: your fixtures, your filters (`cargo test search`), and your parallelism all continue to work as usual.
+Everything grows on the same trellis: your fixtures, your filters
+(`cargo test search`), and your parallelism all continue to work as usual.
 
----
+______________________________________________________________________
 
 ## Step definitions 101
 
@@ -141,13 +153,15 @@ fn assert_count(#[from(basket)] b: &Basket, count: u32) {
 }
 ```
 
-- Patterns accept **typed placeholders** like `{count:u32}`; values parse via `FromStr`.
+- Patterns accept **typed placeholders** like `{count:u32}`; values parse via
+  `FromStr`.
 
 - Use `#[from(fixture_name)]` to inject any `rstest` fixture into a step.
 
-- Prefer readable step text first; compile‑time checks ensure you don’t forget an implementation.
+- Prefer readable step text first; compile‑time checks ensure you don’t forget
+  an implementation.
 
----
+______________________________________________________________________
 
 ## Scenario Outline ≈ parametrised tests
 
@@ -191,9 +205,10 @@ async fn see_message(#[from(browser)] driver: &mut WebDriver, message: String) {
 }
 ```
 
-Under the rind, `#[scenario]` expands to an `rstest` parametrised test, so cases show up individually in your runner.
+Under the rind, `#[scenario]` expands to an `rstest` parametrised test, so
+cases show up individually in your runner.
 
----
+______________________________________________________________________
 
 ## Background, tables, and docstrings
 
@@ -212,7 +227,7 @@ fn create_users(#[from(db)] conn: &mut DbConnection, users: Vec<(String, String)
 }
 ```
 
----
+______________________________________________________________________
 
 ## How it works (the short tour)
 
@@ -220,17 +235,23 @@ fn create_users(#[from(db)] conn: &mut DbConnection, users: Vec<(String, String)
 
   - `#[given] / #[when] / #[then]` register step metadata.
 
-  - `#[scenario]` binds a test function to a named scenario in a `.feature` file.
+  - `#[scenario]` binds a test function to a named scenario in a `.feature`
+    file.
 
-- **Discovery**: Steps are registered at compile time into a global registry (via linker‑section collection). At runtime, the generated test matches each Gherkin line against that registry and invokes the correct function.
+- **Discovery**: Steps are registered at compile time into a global registry
+  (via linker‑section collection). At runtime, the generated test matches each
+  Gherkin line against that registry and invokes the correct function.
 
-- **Safety rails**: If a step in the feature has no matching implementation, you get a **compile error** with a helpful message, not a late test failure.
+- **Safety rails**: If a step in the feature has no matching implementation,
+  you get a **compile error** with a helpful message, not a late test failure.
 
-- **Fixtures**: Because the generated test is an `rstest`, your fixture dependency graph Just Works™.
+- **Fixtures**: Because the generated test is an `rstest`, your fixture
+  dependency graph Just Works™.
 
-If your target platform dislikes linker sections, enable the `no-inventory` feature to switch to a build‑script registry.
+If your target platform dislikes linker sections, enable the `no-inventory`
+feature to switch to a build‑script registry.
 
----
+______________________________________________________________________
 
 ## Design principles
 
@@ -242,7 +263,7 @@ If your target platform dislikes linker sections, enable the `no-inventory` feat
 
 - **Zero new runners**: keep CI/CD and IDE behaviour unchanged.
 
----
+______________________________________________________________________
 
 ## Limitations
 
@@ -252,55 +273,61 @@ If your target platform dislikes linker sections, enable the `no-inventory` feat
 
 - IDE navigation from Gherkin to Rust may require tooling support.
 
-- Registry implementation relies on platform features; use `no-inventory` if needed.
+- Registry implementation relies on platform features; use `no-inventory` if
+  needed.
 
----
+______________________________________________________________________
 
 ## [Roadmap](docs/roadmap.md)
 
 1. **Core mechanics**: step registry, `#[scenario]`, exact matching (done/PoC).
 
-2. **Fixtures & parametrisation**: typed placeholders, Scenario Outline → `#[case]`.
+2. **Fixtures & parametrisation**: typed placeholders, Scenario Outline →
+   `#[case]`.
 
-3. **Feature parity & ergonomics**: Background, tables, docstrings, `scenarios!` macro, richer diagnostics.
+3. **Feature parity & ergonomics**: Background, tables, docstrings,
+   `scenarios!` macro, richer diagnostics.
 
 4. **Developer tools**: `cargo bdd list-steps`, editor integrations.
 
-We’re not here to replace `cucumber`; we’re here to offer a different trade‑off for teams already invested in `rstest` and `cargo test`.
+We’re not here to replace `cucumber`; we’re here to offer a different trade‑off
+for teams already invested in `rstest` and `cargo test`.
 
----
+______________________________________________________________________
 
 ## Comparison at a glance
 
-| Feature | `rstest-bdd` (proposed) | `cucumber` (Rust) |
-| --- | --- | --- |
-| Test runner | `cargo test` (`rstest` under the hood) | Custom runner (`World::run(...)`) |
-| State management | `rstest` fixtures | `World` struct |
-| Step discovery | Compile‑time registration + runtime match | Runner‑driven collection |
-| Scenario Outline | Maps to `rstest` parametrisation | Built into runner |
-| Async | Runtime‑agnostic via features | Built‑in with specified runtime |
-| Philosophy | BDD as an **extension** of `rstest` | Rust port of classic Cucumber |
+| Feature          | `rstest-bdd` (proposed)                     | `cucumber` (Rust)                 |
+| ---------------- | ------------------------------------------- | --------------------------------- |
+| Test runner      | `cargo test` (`rstest` under the hood)      | Custom runner (`World::run(...)`) |
+| State management | `rstest` fixtures                           | `World` struct                    |
+| Step discovery   | Compile‑time registration + runtime match   | Runner‑driven collection          |
+| Scenario Outline | Maps to `rstest` parametrisation            | Built into runner                 |
+| Async            | Runtime‑agnostic via features               | Built‑in with specified runtime   |
+| Philosophy       | BDD as an **extension** of `rstest`         | Rust port of classic Cucumber     |
 
----
+______________________________________________________________________
 
 ## Workspace layout
 
-```
+```text
 rstest-bdd/             # Runtime crate (re-exports macros for convenience)
 rstest-bdd-macros/      # Procedural macro crate
 ```
 
----
+______________________________________________________________________
 
 ## Prior art & acknowledgements
 
-- Inspired by the ergonomics of **pytest‑bdd** and the fixture model of **rstest**.
+- Inspired by the ergonomics of **pytest‑bdd** and the fixture model of
+  **rstest**.
 
-- Uses a global step registry pattern popularised in Rust by the **inventory** crate.
+- Uses a global step registry pattern popularised in Rust by the **inventory**
+  crate.
 
 - Tips the hat to **cucumber‑rs** for bringing Cucumber’s ideas to Rust.
 
----
+______________________________________________________________________
 
 ## Contributing
 
@@ -308,19 +335,24 @@ Issues, ideas, and PRs are very welcome. Please include:
 
 - A minimal repro (feature file + steps) when filing bugs.
 
-- Before/after compiler output if you hit macro errors (the more precise, the better).
+- Before/after compiler output if you hit macro errors (the more precise, the
+  better).
 
 - Platform info if you suspect a registry/linker quirk.
 
 Let’s **seed** a lovely ecosystem together.
 
----
+______________________________________________________________________
 
 ## Licence
 
-ISC Licence — because that’s how we roll. You’re free to use, copy, modify, and distribute this software for any purpose, with or without fee, provided that the copyright notice and this permission notice are included in all copies. The software is provided “as is”, without warranty of any kind. See `LICENSE` for the full text.
+ISC Licence — because that’s how we roll. You’re free to use, copy, modify, and
+distribute this software for any purpose, with or without fee, provided that
+the copyright notice and this permission notice are included in all copies. The
+software is provided “as is”, without warranty of any kind. See `LICENSE` for
+the full text.
 
----
+______________________________________________________________________
 
 ## Appendix: FAQ
 
@@ -328,14 +360,18 @@ ISC Licence — because that’s how we roll. You’re free to use, copy, modify
 Yes; nothing here requires nightly.
 
 **Can I mix BDD tests with unit tests in the same crate?**\
-Absolutely. They run under the same `cargo test` umbrella and can share fixtures.
+Absolutely. They run under the same `cargo test` umbrella and can share
+fixtures.
 
 **Will it slow my build?**\
-There’s some compile‑time I/O to parse `.feature` files. For large suites, caching parsed ASTs in `OUT_DIR` mitigates this (built in).
+There’s some compile‑time I/O to parse `.feature` files. For large suites,
+caching parsed ASTs in `OUT_DIR` mitigates this (built in).
 
 **Do I *have* to use regexes in step patterns?**\
-No. Prefer typed placeholders like `{n:u32}`; fall back to regex groups only when you really need them.
+No. Prefer typed placeholders like `{n:u32}`; fall back to regex groups only
+when you really need them.
 
----
+______________________________________________________________________
 
-Happy testing — and may your scenarios be **gourd‑geous** and your failures easy to **squash**. 🎃🧪🦀
+Happy testing — and may your scenarios be **gourd‑geous** and your failures
+easy to **squash**. 🎃🧪🦀

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -762,7 +762,7 @@ The first implementation of the `#[scenario]` macro kept the scope narrow to
 validate the overall approach. It accepted only a `path` argument pointing to a
 `*.feature` file and always executed the first `Scenario` found. The macro now
 also accepts an optional `index` argument. When provided, the macro selects the
-scenario at that zero-based position. If omitted it defaults to `0`, matching
+scenario at that zero-based position. If omitted, it defaults to `0`, matching
 the behaviour of the earlier version. The `path` argument may be provided as a
 bare string literal for convenience (e.g.
 `#[scenario("tests/example.feature")]`) or using the explicit `path =` form


### PR DESCRIPTION
## Summary
- extract `with_events` helper to handle poisoned mutex recovery
- switch scenario step functions to use the helper
- clarify README fenced block with language tag
- add missing comma in scenario macro documentation

## Testing
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_68853bcc96388322b2cd13225550df75

## Summary by Sourcery

Centralize mutex locking logic for scenario tests by extracting helper functions to recover from poisoned locks and simplify test code, and improve documentation formatting in the README and design docs.

Bug Fixes:
- Recover from poisoned mutex in scenario tests by extracting a helper to unwrap poisoned locks

Enhancements:
- Extract get_events_guard and with_locked_events helpers to centralize mutex lock handling and simplify event management
- Migrate scenario step functions to use with_locked_events helper instead of inline lock code

Documentation:
- Add language tags to README fenced code blocks and consistent separators
- Fix formatting in README for readability and add missing comma in scenario macro documentation

Tests:
- Refactor scenario tests to use new helper functions for event locking