### PR TITLE
Fix AGENTS.md punctuation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 - **Clarity over cleverness.** Be concise, but favour explicit over terse or
   obscure idioms. Prefer code that's easy to follow.
 - **Use functions and composition.** Avoid repetition by extracting reusable
-  logic. Prefer generators or comprehensions, and declarative code to
+  logic. Prefer generators or comprehensions and favour declarative code over
   imperative repetition when readable.
 - **Small, meaningful functions.** Functions must be small, clear in purpose,
   single responsibility, and obey command/query segregation.
@@ -30,7 +30,7 @@
   the test logic.
 - **Keep file size manageable.** No single code file may be longer than 400
   lines. Long switch statements or dispatch tables should be broken up by
-  feature and constituents colocated with targets. Large blocks of test data
+  feature, and constituents colocated with targets. Large blocks of test data
   should be moved to external data files.
 
 ## Documentation Maintenance
@@ -156,11 +156,11 @@ project:
   non-breaking updates to minor and patch versions while preventing breaking
   changes from new major versions. This approach is critical for ensuring build
   stability and reproducibility.
-- **Prohibit unstable version specifiers.** Wildcard (`*`), or
-  open-ended inequality (`>=`), version requirements are strictly forbidden as
-  they introduce unacceptable risk and unpredictability. Tilde requirements
-  (`~`) should only be used where a dependency must be locked to patch-level
-  updates for a specific, documented reason.
+- **Prohibit unstable version specifiers.** Wildcard (`*`) or
+ open-ended inequality (`>=`) version requirements are strictly forbidden as
+ they introduce unacceptable risk and unpredictability. Tilde requirements
+ (`~`) should only be used where a dependency must be locked to patch-level
+ updates for a specific, documented reason.
 
 ### Error Handling
 


### PR DESCRIPTION
## Summary
- refine guidance around generators and declarative code
- clarify comma usage in code style guidance
- smooth wording about wildcard version specifiers

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68871a500cac83229d76fb2928732de2