### PR TITLE
Add Scenario Outline handling

### DIFF
--- a/crates/rstest-bdd-macros/src/lib.rs
+++ b/crates/rstest-bdd-macros/src/lib.rs
@@ -12,7 +12,6 @@ use quote::{format_ident, quote};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use syn::parse::{Parse, ParseStream};
-use syn::parse_quote;
 use syn::token::{Comma, Eq};
 use syn::{ItemFn, LitInt, LitStr, parse_macro_input};
 
@@ -544,7 +543,7 @@ pub fn scenario(attr: TokenStream, item: TokenStream) -> TokenStream {
                         segs == ["case"] || segs == ["rstest", "case"]
                     });
                     if !has_case_attr {
-                        p.attrs.push(parse_quote!(#[case]));
+                        p.attrs.push(syn::parse_quote!(#[case]));
                     }
                 }
                 syn::FnArg::Receiver(_) => {}

--- a/crates/rstest-bdd-macros/src/lib.rs
+++ b/crates/rstest-bdd-macros/src/lib.rs
@@ -516,9 +516,7 @@ fn create_parameter_mismatch_error(sig: &syn::Signature, header: &str) -> TokenS
         "parameter `{header}` not found for scenario outline column. Available parameters: [{}]",
         available_params.join(", ")
     );
-    syn::Error::new(proc_macro2::Span::call_site(), msg)
-        .to_compile_error()
-        .into()
+    syn::Error::new_spanned(sig, msg).to_compile_error().into()
 }
 
 /// Process scenario outline examples and modify function parameters.

--- a/crates/rstest-bdd-macros/tests/features/outline.feature
+++ b/crates/rstest-bdd-macros/tests/features/outline.feature
@@ -1,0 +1,11 @@
+Feature: Outline usage
+
+  Scenario Outline: Outline scenario
+    Given a precondition
+    When an action occurs
+    Then a result is produced
+
+    Examples:
+      | num |
+      | 1   |
+      | 2   |

--- a/crates/rstest-bdd-macros/tests/scenario.rs
+++ b/crates/rstest-bdd-macros/tests/scenario.rs
@@ -87,6 +87,7 @@ fn unmatched_feature() {
 }
 
 #[scenario(path = "tests/features/outline.feature")]
+#[serial]
 fn outline(num: String) {
     with_locked_events(|events| {
         assert_eq!(events.as_slice(), ["precondition", "action", "result"]);

--- a/crates/rstest-bdd-macros/tests/scenario.rs
+++ b/crates/rstest-bdd-macros/tests/scenario.rs
@@ -85,3 +85,12 @@ fn explicit_syntax() {
 fn unmatched_feature() {
     clear_events();
 }
+
+#[scenario(path = "tests/features/outline.feature")]
+fn outline(num: String) {
+    with_locked_events(|events| {
+        assert_eq!(events.as_slice(), ["precondition", "action", "result"]);
+    });
+    assert!(num == "1" || num == "2");
+    clear_events();
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -74,14 +74,14 @@ and run data-driven tests, making the framework genuinely useful.
   - [x] Modify the `#[scenario]` macro's code generation to correctly manage
     and pass fixtures to the step functions during execution.
 
-- [ ] **Scenario Outline Support**
+- [x] **Scenario Outline Support**
 
-  - [ ] Extend the `#[scenario]` macro to detect `Scenario Outline` and its
+  - [x] Extend the `#[scenario]` macro to detect `Scenario Outline` and its
     `Examples:` table in the parsed Gherkin AST.
 
-  - [ ] The macro must generate a single, parameterized `#[rstest]` function.
+  - [x] The macro generates a single, parameterized `#[rstest]` function.
 
-  - [ ] For each row in the `Examples:` table, the macro must generate a
+  - [x] For each row in the `Examples:` table, the macro generates a
     corresponding `#[case(...)]` attribute.
 
 - [ ] **Step Argument Parsing**

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -570,6 +570,9 @@ incrementally.
   Gherkin construct and generates the corresponding `#[rstest]` `#[case(...)]`
   attributes on the test function. This behaviour is now implemented and
   verified by the test suite.
+- Introduced lightweight `ExampleTable` and `ScenarioData` structs in the
+  macros crate. They encapsulate outline table rows and scenario metadata,
+  replacing a complex tuple return and enabling clearer helper functions.
 
 - Introduce the `{name:Type}` step argument parser, leveraging the `FromStr`
   trait for type conversion.

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -566,9 +566,10 @@ incrementally.
   integrate with `rstest`'s fixture system. This allows steps to request
   fixtures directly.
 
-- Implement support for `Scenario Outline`. The `#[scenario]` macro will be
-  extended to detect this Gherkin construct and generate the corresponding
-  `#[rstest]` `#[case(...)]` attributes on the test function.
+- Implement support for `Scenario Outline`. The `#[scenario]` macro detects this
+  Gherkin construct and generates the corresponding `#[rstest]` `#[case(...)]`
+  attributes on the test function. This behaviour is now implemented and
+  verified by the test suite.
 
 - Introduce the `{name:Type}` step argument parser, leveraging the `FromStr`
   trait for type conversion.

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -574,8 +574,8 @@ incrementally.
   macros crate. They encapsulate outline table rows and scenario metadata,
   replacing a complex tuple return and enabling clearer helper functions.
 - Improved diagnostics when a `Scenario Outline` column does not match a test
-  parameter. The macro lists available parameters so mismatches can be resolved
-  quickly.
+  parameter. The macro lists available parameters, so mismatches can be
+  resolved quickly.
 
 - Introduce the `{name:Type}` step argument parser, leveraging the `FromStr`
   trait for type conversion.

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -573,6 +573,9 @@ incrementally.
 - Introduced lightweight `ExampleTable` and `ScenarioData` structs in the
   macros crate. They encapsulate outline table rows and scenario metadata,
   replacing a complex tuple return and enabling clearer helper functions.
+- Improved diagnostics when a `Scenario Outline` column does not match a test
+  parameter. The macro lists available parameters so mismatches can be resolved
+  quickly.
 
 - Introduce the `{name:Type}` step argument parser, leveraging the `FromStr`
   trait for type conversion.

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -567,7 +567,7 @@ incrementally.
   fixtures directly.
 
 - Implement support for `Scenario Outline`. The `#[scenario]` macro detects this
-  Gherkin construct and generates the corresponding `#[rstest]` `#[case(...)]`
+  Gherkin construct and generates the corresponding `#[rstest]` `#[case(…)]`
   attributes on the test function. This behaviour is now implemented and
   verified by the test suite.
 - Introduced lightweight `ExampleTable` and `ScenarioData` structs in the

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -576,6 +576,8 @@ incrementally.
 - Improved diagnostics when a `Scenario Outline` column does not match a test
   parameter. The macro lists available parameters, so mismatches can be
   resolved quickly.
+- Errors for missing outline parameters use `syn::Error::new_spanned` for more
+  precise diagnostics.
 
 - Introduce the `{name:Type}` step argument parser, leveraging the `FromStr`
   trait for type conversion.


### PR DESCRIPTION
## Summary
- support Gherkin Scenario Outline in the `#[scenario]` macro
- mark roadmap item as complete
- document the new behaviour in the design document

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68871c68708c8322a04e05124847bc58

## Summary by Sourcery

Support Gherkin Scenario Outline in the #[scenario] macro by parsing example tables, generating rstest case attributes, refining error diagnostics, and updating documentation and tests.

New Features:
- Add support for Gherkin Scenario Outline in the #[scenario] macro, generating rstest #[case(...)] attributes from Examples tables

Enhancements:
- Introduce ExampleTable and ScenarioData structs to encapsulate outline table rows and scenario metadata
- Refactor error handling to use syn::Error for more precise compile-time diagnostics
- Improve parameter mismatch errors by listing available function parameters

Documentation:
- Document Scenario Outline behavior in the design document
- Mark the Scenario Outline roadmap item as complete

Tests:
- Add outline.feature and a corresponding test function to verify Scenario Outline support