### PR TITLE
Implement typed step arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,7 @@ name = "rstest-bdd"
 version = "0.1.0"
 dependencies = [
  "inventory",
+ "regex",
  "rstest",
  "rstest-bdd-macros",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,7 @@ dependencies = [
  "regex",
  "rstest",
  "rstest-bdd-macros",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/rstest-bdd-macros/src/lib.rs
+++ b/crates/rstest-bdd-macros/src/lib.rs
@@ -161,7 +161,7 @@ fn generate_wrapper_code(config: &WrapperConfig<'_>) -> TokenStream2 {
     quote! {
         fn #wrapper_ident(ctx: &rstest_bdd::StepContext<'_>, text: &str) {
             #(#declares)*
-            let captures = rstest_bdd::extract_placeholders(#pattern, text)
+            let captures = rstest_bdd::extract_placeholders(#pattern.into(), text.into())
                 .expect("pattern mismatch");
             #(#step_arg_parses)*
             #ident(#(#arg_idents),*);
@@ -516,7 +516,7 @@ fn generate_scenario_code(
             let mut ctx = rstest_bdd::StepContext::default();
             #(#ctx_inserts)*
             for (index, (keyword, text)) in steps.iter().enumerate() {
-                if let Some(f) = rstest_bdd::find_step(*keyword, text) {
+                if let Some(f) = rstest_bdd::find_step(*keyword, (*text).into()) {
                     f(&ctx, text);
                 } else {
                     panic!(

--- a/crates/rstest-bdd-macros/tests/inventory.rs
+++ b/crates/rstest-bdd-macros/tests/inventory.rs
@@ -15,17 +15,19 @@ fn result() {}
 #[test]
 fn macros_register_steps() {
     let cases = [
-        ("Given", "a precondition"),
-        ("When", "an action"),
-        ("Then", "a result"),
+        (rstest_bdd::StepKeyword::Given, "a precondition"),
+        (rstest_bdd::StepKeyword::When, "an action"),
+        (rstest_bdd::StepKeyword::Then, "a result"),
     ];
 
     for (keyword, pattern) in cases {
         assert!(
             iter::<Step>
                 .into_iter()
-                .any(|s| s.keyword == keyword && s.pattern == pattern),
-            "Step not registered: {keyword} {pattern}"
+                .any(|s| s.keyword == keyword && s.pattern.as_str() == pattern),
+            "Step not registered: {} {}",
+            keyword.as_str(),
+            pattern
         );
     }
 }

--- a/crates/rstest-bdd/Cargo.toml
+++ b/crates/rstest-bdd/Cargo.toml
@@ -9,7 +9,7 @@ workspace = true
 [dependencies]
 
 inventory = ">=0.3, <0.4"
-regex = "1.10"
+regex = "1.11.1"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/crates/rstest-bdd/Cargo.toml
+++ b/crates/rstest-bdd/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 
 inventory = ">=0.3, <0.4"
 regex = "1.10"
+thiserror = "1.0"
 
 [dev-dependencies]
 rstest = ">=0.18, <0.19"

--- a/crates/rstest-bdd/Cargo.toml
+++ b/crates/rstest-bdd/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 [dependencies]
 
 inventory = ">=0.3, <0.4"
+regex = "1.10"
 
 [dev-dependencies]
 rstest = ">=0.18, <0.19"

--- a/crates/rstest-bdd/tests/argument_parsing.rs
+++ b/crates/rstest-bdd/tests/argument_parsing.rs
@@ -1,0 +1,30 @@
+//! Behavioural test for step argument parsing
+
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenario, then, when};
+use std::cell::RefCell;
+
+#[fixture]
+fn account() -> RefCell<u32> {
+    RefCell::new(0)
+}
+
+#[given("I start with {amount:u32} dollars")]
+fn start_balance(#[from(account)] acc: &RefCell<u32>, amount: u32) {
+    *acc.borrow_mut() = amount;
+}
+
+#[when("I deposit {amount:u32} dollars")]
+fn deposit_amount(#[from(account)] acc: &RefCell<u32>, amount: u32) {
+    *acc.borrow_mut() += amount;
+}
+
+#[then("my balance is {expected:u32} dollars")]
+fn check_balance(#[from(account)] acc: &RefCell<u32>, expected: u32) {
+    assert_eq!(*acc.borrow(), expected);
+}
+
+#[scenario(path = "tests/features/argument.feature")]
+fn deposit_scenario(account: RefCell<u32>) {
+    let _ = account;
+}

--- a/crates/rstest-bdd/tests/features/argument.feature
+++ b/crates/rstest-bdd/tests/features/argument.feature
@@ -1,0 +1,5 @@
+Feature: Step arguments
+  Scenario: Deposit money
+    Given I start with 100 dollars
+    When I deposit 50 dollars
+    Then my balance is 150 dollars

--- a/crates/rstest-bdd/tests/fixture_context.rs
+++ b/crates/rstest-bdd/tests/fixture_context.rs
@@ -2,7 +2,7 @@
 
 use rstest_bdd::{Step, StepContext, iter, step};
 
-fn needs_value(ctx: &StepContext<'_>) {
+fn needs_value(ctx: &StepContext<'_>, _text: &str) {
     let Some(val) = ctx.get::<u32>("number") else {
         panic!("missing fixture");
     };
@@ -23,5 +23,5 @@ fn context_passes_fixture() {
             || panic!("step 'a value' not found in registry"),
             |step| step.run,
         );
-    step_fn(&ctx);
+    step_fn(&ctx, "a value");
 }

--- a/crates/rstest-bdd/tests/fixture_context.rs
+++ b/crates/rstest-bdd/tests/fixture_context.rs
@@ -9,7 +9,12 @@ fn needs_value(ctx: &StepContext<'_>, _text: &str) {
     assert_eq!(*val, 42);
 }
 
-step!("Given", "a value", needs_value, &["number"]);
+step!(
+    rstest_bdd::StepKeyword::Given,
+    "a value",
+    needs_value,
+    &["number"]
+);
 
 #[test]
 fn context_passes_fixture() {
@@ -18,7 +23,7 @@ fn context_passes_fixture() {
     ctx.insert("number", &number);
     let step_fn = iter::<Step>
         .into_iter()
-        .find(|s| s.pattern == "a value")
+        .find(|s| s.pattern.as_str() == "a value")
         .map_or_else(
             || panic!("step 'a value' not found in registry"),
             |step| step.run,

--- a/crates/rstest-bdd/tests/step_registry.rs
+++ b/crates/rstest-bdd/tests/step_registry.rs
@@ -9,12 +9,12 @@ fn wrapper(ctx: &rstest_bdd::StepContext<'_>, _text: &str) {
     sample();
 }
 
-step!("When", "behavioural", wrapper, &[]);
+step!(rstest_bdd::StepKeyword::When, "behavioural", wrapper, &[]);
 
 #[test]
 fn step_is_registered() {
-    let found = iter::<Step>
-        .into_iter()
-        .any(|step| step.pattern == "behavioural" && step.keyword == "When");
+    let found = iter::<Step>.into_iter().any(|step| {
+        step.pattern.as_str() == "behavioural" && step.keyword == rstest_bdd::StepKeyword::When
+    });
     assert!(found, "expected step not found");
 }

--- a/crates/rstest-bdd/tests/step_registry.rs
+++ b/crates/rstest-bdd/tests/step_registry.rs
@@ -3,7 +3,7 @@
 use rstest_bdd::{Step, iter, step};
 
 fn sample() {}
-fn wrapper(ctx: &rstest_bdd::StepContext<'_>) {
+fn wrapper(ctx: &rstest_bdd::StepContext<'_>, _text: &str) {
     // Adapter for zero-argument step functions
     let _ = ctx;
     sample();

--- a/docs/gherkin-syntax.md
+++ b/docs/gherkin-syntax.md
@@ -129,7 +129,7 @@ Gherkin provides several additional keywords.
 <!-- markdownlint-disable MD013 -->
 ### Table 1: Gherkin Keyword Reference
 
-For a quick and comprehensive overview, the following table summarises the
+For a quick and comprehensive overview, the following table summarizes the
 primary and secondary keywords in the Gherkin language.
 
 | Keyword          | Purpose/Description                                                                                                | Placement/Context                                                           | Example                                                     |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -84,15 +84,15 @@ and run data-driven tests, making the framework genuinely useful.
   - [x] For each row in the `Examples:` table, the macro generates a
     corresponding `#[case(...)]` attribute.
 
-- [ ] **Step Argument Parsing**
+- [x] **Step Argument Parsing**
 
-  - [ ] Implement a parser for `format!`-style placeholders (e.g.,
+  - [x] Implement a parser for `format!`-style placeholders (e.g.,
     `{count:u32}`).
 
-  - [ ] The runtime step-matching logic must extract values from the Gherkin
+  - [x] The runtime step-matching logic must extract values from the Gherkin
     step text based on these placeholders.
 
-  - [ ] Use the `FromStr` trait to convert the extracted string values into the
+  - [x] Use the `FromStr` trait to convert the extracted string values into the
     types specified in the function signature.
 
 ## Phase 3: Advanced Gherkin Features & Ergonomics

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -827,7 +827,8 @@ strings. Step wrapper functions parse these strings and convert them with
 `FromStr` before calling the original step. Scenario execution now searches the
 step registry using `find_step`, which falls back to placeholder matching when
 no exact pattern is present. This approach keeps the macros lightweight while
-supporting type‑safe parameters in steps.
+supporting type‑safe parameters in steps. The parser does not handle nested or
+escaped braces; step patterns must contain simple, well-formed placeholders.
 
 ## **Works cited**
 

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -444,6 +444,36 @@ calling `inventory::iter::<Step>()`. This provides an iterator over all
 registered `Step` instances, regardless of the file, module, or crate in which
 they were defined.
 
+```mermaid
+classDiagram
+    class StepContext {
+    }
+    class StepArg {
+        pat: Ident
+        ty: Type
+    }
+    class FixtureArg {
+        pat: Ident
+        name: Ident
+        ty: Type
+    }
+    class Step {
+        keyword: String
+        pattern: String
+        run: StepFn
+    }
+    class StepFn
+    class StepWrapper
+    StepWrapper : extract_placeholders(pattern, text)
+    StepWrapper : parse captures with FromStr
+    StepWrapper : call StepFunction
+    StepFn <|-- StepWrapper
+    StepContext <.. StepWrapper
+    StepArg <.. StepWrapper
+    FixtureArg <.. StepWrapper
+    Step o-- StepFn
+```
+
 ### 2.4 The Macro Expansion Process: A Compile-Time to Runtime Journey
 
 The interaction between the user's code, the `rstest-bdd` macros, and the final
@@ -826,7 +856,7 @@ steps appear in different modules. The macro also emits a compile-time array
 length assertion to ensure the generated fixture list matches the wrapper
 signature. Any mismatch is reported during compilation rather than at runtime.
 
-### 3.9 Step Argument Parsing Implementation
+### 3.9 Step-Argument Parsing Implementation
 
 The third phase introduces typed placeholders to step patterns. The runtime
 library exposes an `extract_placeholders` helper that converts a pattern with
@@ -838,7 +868,7 @@ no exact pattern is present. This approach keeps the macros lightweight while
 supporting type‑safe parameters in steps. The parser does not handle nested or
 escaped braces; step patterns must contain simple, well-formed placeholders.
 
-The sequence below summarises how the runner locates and executes steps when
+The sequence below summarizes how the runner locates and executes steps when
 placeholders are present:
 
 ```mermaid

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -830,6 +830,31 @@ no exact pattern is present. This approach keeps the macros lightweight while
 supporting type‑safe parameters in steps. The parser does not handle nested or
 escaped braces; step patterns must contain simple, well-formed placeholders.
 
+The sequence below summarises how the runner locates and executes steps when
+placeholders are present:
+
+```mermaid
+sequenceDiagram
+    participant ScenarioRunner
+    participant StepRegistry
+    participant StepWrapper
+    participant StepFunction
+
+    ScenarioRunner->>StepRegistry: find_step(keyword, text)
+    alt exact match
+        StepRegistry-->>ScenarioRunner: StepFn
+    else placeholder match
+        StepRegistry->>StepRegistry: extract_placeholders(pattern, text)
+        StepRegistry-->>ScenarioRunner: StepFn
+    end
+    ScenarioRunner->>StepWrapper: call StepFn(ctx, text)
+    StepWrapper->>StepWrapper: extract_placeholders(pattern, text)
+    StepWrapper->>StepWrapper: parse captures with FromStr
+    StepWrapper->>StepFunction: call with typed args
+    StepFunction-->>StepWrapper: returns
+    StepWrapper-->>ScenarioRunner: returns
+```
+
 ## **Works cited**
 
 [^1]: A Complete Guide To Behavior-Driven Testing With Pytest BDD, accessed on

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -422,6 +422,10 @@ The [`StepKeyword`](../crates/rstest-bdd/src/lib.rs) enum implements `FromStr`.
 Parsing failures return a `StepKeywordParseError` to ensure invalid step
 keywords are surfaced early.
 
+The [`StepPattern`](../crates/rstest-bdd/src/lib.rs) wrapper encapsulates the
+pattern text so that step lookups cannot accidentally mix arbitrary strings
+with registered patterns.
+
 Placing the `Step` struct in the runtime crate avoids a circular dependency
 between the procedural macros and the library. The macros will simply re-export
 the type when they begin submitting steps to the registry.

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -458,8 +458,8 @@ classDiagram
         ty: Type
     }
     class Step {
-        keyword: String
-        pattern: String
+        keyword: StepKeyword
+        pattern: StepPattern
         run: StepFn
     }
     class StepFn

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -418,6 +418,10 @@ pub struct Step {
 inventory::collect!(Step);
 ```
 
+The [`StepKeyword`](../crates/rstest-bdd/src/lib.rs) enum implements `FromStr`.
+Parsing failures return a `StepKeywordParseError` to ensure invalid step
+keywords are surfaced early.
+
 Placing the `Step` struct in the runtime crate avoids a circular dependency
 between the procedural macros and the library. The macros will simply re-export
 the type when they begin submitting steps to the registry.

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -404,8 +404,8 @@ location information for generating clear error messages.
 // A simplified representation of the step metadata.
 #[derive(Debug)]
 pub struct Step {
-    pub keyword: &'static str, // "Given", "When", or "Then"
-    pub pattern: &'static str, // The pattern string from the attribute, e.g., "A user has {count} cucumbers"
+    pub keyword: StepKeyword, // e.g., Given, When or Then
+    pub pattern: &'static StepPattern, // The pattern string from the attribute, e.g., "A user has {count} cucumbers"
     // A type-erased function pointer. Arguments will be wired up by the
     // scenario orchestrator in later phases.
     pub run: fn(),

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -818,6 +818,17 @@ steps appear in different modules. The macro also emits a compile-time array
 length assertion to ensure the generated fixture list matches the wrapper
 signature. Any mismatch is reported during compilation rather than at runtime.
 
+### 3.9 Step Argument Parsing Implementation
+
+The third phase introduces typed placeholders to step patterns. The runtime
+library exposes an `extract_placeholders` helper that converts a pattern with
+`{name:Type}` segments into a regular expression and returns the captured
+strings. Step wrapper functions parse these strings and convert them with
+`FromStr` before calling the original step. Scenario execution now searches the
+step registry using `find_step`, which falls back to placeholder matching when
+no exact pattern is present. This approach keeps the macros lightweight while
+supporting type‑safe parameters in steps.
+
 ## **Works cited**
 
 [^1]: A Complete Guide To Behavior-Driven Testing With Pytest BDD, accessed on

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -2,25 +2,55 @@
 
 ## Introduction
 
-Behaviour‑Driven Development (BDD) is a collaborative practice that emphasizes a shared understanding of software behaviour across roles. The design of `rstest‑bdd` integrates BDD concepts with the Rust testing ecosystem. BDD encourages collaboration between developers, quality‑assurance specialists and non‑technical business participants by describing system behaviour in a natural, domain‑specific language. `rstest‑bdd` achieves this without introducing a bespoke test runner; instead, it builds on the `rstest` crate so that unit tests and high‑level behaviour tests can co‑exist and run under `cargo test`. The framework reuses `rstest` fixtures for dependency injection and uses a procedural macro to bind tests to Gherkin scenarios, ensuring that functional tests live alongside unit tests and benefit from the same tooling.
+Behaviour‑Driven Development (BDD) is a collaborative practice that emphasizes
+a shared understanding of software behaviour across roles. The design of
+`rstest‑bdd` integrates BDD concepts with the Rust testing ecosystem. BDD
+encourages collaboration between developers, quality‑assurance specialists and
+non‑technical business participants by describing system behaviour in a
+natural, domain‑specific language. `rstest‑bdd` achieves this without
+introducing a bespoke test runner; instead, it builds on the `rstest` crate so
+that unit tests and high‑level behaviour tests can co‑exist and run under
+`cargo test`. The framework reuses `rstest` fixtures for dependency injection
+and uses a procedural macro to bind tests to Gherkin scenarios, ensuring that
+functional tests live alongside unit tests and benefit from the same tooling.
 
-This guide explains how to consume `rstest‑bdd` at the current stage of development. It relies on the implemented code rather than on aspirational features described in the design documents. Where the design proposes advanced behaviour, the implementation status is noted. Examples and explanations are organized by the so‑called *three amigos* of BDD: the business analyst/product owner, the developer, and the tester.
+This guide explains how to consume `rstest‑bdd` at the current stage of
+development. It relies on the implemented code rather than on aspirational
+features described in the design documents. Where the design proposes advanced
+behaviour, the implementation status is noted. Examples and explanations are
+organized by the so‑called *three amigos* of BDD: the business analyst/product
+owner, the developer, and the tester.
 
 ## The three amigos
 
-| Role ("amigo") | Primary concerns | Features provided by `rstest‑bdd` |
-| --- | --- | --- |
-| **Business analyst/product owner** | Writing and reviewing business‑readable specifications; ensuring that acceptance criteria are expressed clearly. | Gherkin `.feature` files are plain text and start with a `Feature` declaration; each `Scenario` describes a single behaviour. Steps are written using keywords `Given`, `When` and `Then`[GitHub](https://github.com/leynos/rstest-bdd/blob/a8ae628580788fb1ef5803419687d739b9592a34/docs/gherkin-syntax.md#L72-L91), producing living documentation that can be read by non‑technical stakeholders. |
-| **Developer** | Implementing step definitions in Rust and wiring them to the business specifications; using existing fixtures for setup/teardown. | Attribute macros `#[given]`, `#[when]` and `#[then]` register step functions and their pattern strings in a global step registry. A `#[scenario]` macro reads a feature file at compile time and generates a test that drives the registered steps. Fixture values from `rstest` can be injected into step functions via `#[from(fixture_name)]`. |
-| **Tester/QA** | Executing behaviour tests, ensuring correct sequencing of steps and verifying outcomes observable by the user. | Scenarios are executed via the standard `cargo test` runner; test functions annotated with `#[scenario]` run each step in order and panic if a step is missing. Assertions belong in `Then` steps; guidelines discourage inspecting internal state and encourage verifying observable outcomes. Testers can use `cargo test` filters and parallelism because the generated tests are ordinary Rust tests. |
+| Role ("amigo")                     | Primary concerns                                                                                                                  | Features provided by `rstest‑bdd`                                                                                                                                                                                                                                                                                                                                                                         |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Business analyst/product owner** | Writing and reviewing business‑readable specifications; ensuring that acceptance criteria are expressed clearly.                  | Gherkin `.feature` files are plain text and start with a `Feature` declaration; each `Scenario` describes a single behaviour. Steps are written using keywords `Given`, `When` and `Then`[GitHub](https://github.com/leynos/rstest-bdd/blob/a8ae628580788fb1ef5803419687d739b9592a34/docs/gherkin-syntax.md#L72-L91), producing living documentation that can be read by non‑technical stakeholders.      |
+| **Developer**                      | Implementing step definitions in Rust and wiring them to the business specifications; using existing fixtures for setup/teardown. | Attribute macros `#[given]`, `#[when]` and `#[then]` register step functions and their pattern strings in a global step registry. A `#[scenario]` macro reads a feature file at compile time and generates a test that drives the registered steps. Fixture values from `rstest` can be injected into step functions via `#[from(fixture_name)]`.                                                         |
+| **Tester/QA**                      | Executing behaviour tests, ensuring correct sequencing of steps and verifying outcomes observable by the user.                    | Scenarios are executed via the standard `cargo test` runner; test functions annotated with `#[scenario]` run each step in order and panic if a step is missing. Assertions belong in `Then` steps; guidelines discourage inspecting internal state and encourage verifying observable outcomes. Testers can use `cargo test` filters and parallelism because the generated tests are ordinary Rust tests. |
 
-The following sections expand on these responsibilities and show how to use the current API effectively.
+The following sections expand on these responsibilities and show how to use the
+current API effectively.
 
 ## Gherkin feature files
 
-Gherkin files describe behaviour in a structured, plain‑text format that can be read by both technical and non‑technical stakeholders. Each `.feature` file begins with a `Feature` declaration that provides a high‑level description of the functionality. A feature contains one or more `Scenario` sections, each of which documents a single example of system behaviour. Inside a scenario, the behaviour is expressed through a sequence of steps starting with `Given` (context), followed by `When` (action) and ending with `Then` (expected outcome). Secondary keywords `And` and `But` may chain additional steps of the same type for readability.
+Gherkin files describe behaviour in a structured, plain‑text format that can be
+read by both technical and non‑technical stakeholders. Each `.feature` file
+begins with a `Feature` declaration that provides a high‑level description of
+the functionality. A feature contains one or more `Scenario` sections, each of
+which documents a single example of system behaviour. Inside a scenario, the
+behaviour is expressed through a sequence of steps starting with `Given`
+(context), followed by `When` (action) and ending with `Then` (expected
+outcome). Secondary keywords `And` and `But` may chain additional steps of the
+same type for readability.
 
-In the current implementation, scenarios must adhere to the simple `Given‑When‑Then` pattern; advanced Gherkin features such as **Background**, **Scenario Outline**, **data tables** and **docstrings** are not yet supported. The design document describes these constructs and anticipates their inclusion, but they remain on the roadmap. Consumers should therefore avoid `Scenario Outline` and `Examples` tables for the time being and instead duplicate scenarios explicitly if multiple data sets are required.
+In the current implementation, scenarios must adhere to the simple
+`Given‑When‑Then` pattern; advanced Gherkin features such as **Background**,
+**Scenario Outline**, **data tables** and **docstrings** are not yet supported.
+The design document describes these constructs and anticipates their inclusion,
+but they remain on the roadmap. Consumers should therefore avoid
+`Scenario Outline` and `Examples` tables for the time being and instead
+duplicate scenarios explicitly if multiple data sets are required.
 
 ### Example feature file
 
@@ -33,17 +63,38 @@ Feature: Shopping basket
     Then the basket contains one pumpkin
 ```
 
-The feature file lives within the crate (commonly under `tests/features/`). The path to this file will be referenced by the `#[scenario]` macro in the test code.
+The feature file lives within the crate (commonly under `tests/features/`). The
+path to this file will be referenced by the `#[scenario]` macro in the test
+code.
 
 ## Step definitions
 
-Developers implement the behaviour described in a feature by writing step definition functions in Rust. Each step definition is an ordinary function annotated with one of the attribute macros `#[given]`, `#[when]` or `#[then]`. The annotation takes a single string literal; this string must match the text of the corresponding step in the feature file exactly. Unlike the aspirational design, the current implementation does not parse placeholders or capture groups from the pattern. Therefore, dynamic parameters cannot be extracted from step text; each unique step text requires its own definition.
+Developers implement the behaviour described in a feature by writing step
+definition functions in Rust. Each step definition is an ordinary function
+annotated with one of the attribute macros `#[given]`, `#[when]` or `#[then]`.
+The annotation takes a single string literal; this string must match the text
+of the corresponding step in the feature file exactly. Unlike the aspirational
+design, the current implementation does not parse placeholders or capture
+groups from the pattern. Therefore, dynamic parameters cannot be extracted from
+step text; each unique step text requires its own definition.
 
-The procedural macro implementation expands the annotated function into two parts: the original function and a wrapper function that registers the step in a global registry. The wrapper captures the step keyword, pattern string and associated fixtures and uses the `inventory` crate to publish them for later lookup.
+The procedural macro implementation expands the annotated function into two
+parts: the original function and a wrapper function that registers the step in
+a global registry. The wrapper captures the step keyword, pattern string and
+associated fixtures and uses the `inventory` crate to publish them for later
+lookup.
 
 ### Fixtures and the `#[from]` attribute
 
-`rstest‑bdd` builds on `rstest`’s fixture system rather than using a monolithic “world” object. Fixtures are defined using `#[rstest::fixture]` in the usual way, and they can be injected into step definitions through the `#[from(fixture_name)]` attribute. Internally, the step macros record the fixture names and generate wrapper code that, at runtime, retrieves references from a `StepContext`. This context is a key–value map of fixture names to type‑erased references. When a scenario runs, the generated test inserts its arguments (the `rstest` fixtures) into the `StepContext` before invoking each registered step.
+`rstest‑bdd` builds on `rstest`’s fixture system rather than using a monolithic
+“world” object. Fixtures are defined using `#[rstest::fixture]` in the usual
+way, and they can be injected into step definitions through the
+`#[from(fixture_name)]` attribute. Internally, the step macros record the
+fixture names and generate wrapper code that, at runtime, retrieves references
+from a `StepContext`. This context is a key–value map of fixture names to
+type‑erased references. When a scenario runs, the generated test inserts its
+arguments (the `rstest` fixtures) into the `StepContext` before invoking each
+registered step.
 
 Example:
 
@@ -78,63 +129,119 @@ fn test_add_to_basket(#[with(basket)] _: Basket) {
 }
 ```
 
-In this example, the step texts in the annotations must match the feature file verbatim. The `#[scenario]` macro binds the test function to the first scenario in the specified feature file and runs all registered steps before executing the body of `test_add_to_basket`.
+In this example, the step texts in the annotations must match the feature file
+verbatim. The `#[scenario]` macro binds the test function to the first scenario
+in the specified feature file and runs all registered steps before executing
+the body of `test_add_to_basket`.
 
 ## Binding tests to scenarios
 
-The `#[scenario]` macro is the entry point that ties a Rust test function to a scenario defined in a `.feature` file. It accepts two arguments:
+The `#[scenario]` macro is the entry point that ties a Rust test function to a
+scenario defined in a `.feature` file. It accepts two arguments:
 
-| Argument | Purpose | Status |
-| --- | --- | --- |
-| `path: &str` | Relative path to the feature file from the crate root. This is mandatory. | **Implemented**: the macro resolves the path at compile time and parses the feature using the `gherkin` crate. |
-| `index: usize` | Optional zero‑based index selecting a scenario when the file contains multiple scenarios. Defaults to `0`. | **Implemented**: the macro uses the index to pick the scenario. |
+| Argument       | Purpose                                                                                                      | Status                                                                                                         |
+| -------------- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| `path: &str`   | Relative path to the feature file from the crate root. This is mandatory.                                    | **Implemented**: the macro resolves the path at compile time and parses the feature using the `gherkin` crate. |
+| `index: usize` | Optional zero‑based index selecting a scenario when the file contains multiple scenarios. Defaults to `0`.   | **Implemented**: the macro uses the index to pick the scenario.                                                |
 
-The design document proposes a `name` argument to select scenarios by name and support for `Scenario Outline`, but these features are not yet implemented; only `path` and `index` are accepted.
+The design document proposes a `name` argument to select scenarios by name and
+support for `Scenario Outline`, but these features are not yet implemented;
+only `path` and `index` are accepted.
 
-During macro expansion, the feature file is read and parsed. The macro generates a new test function annotated with `#[rstest::rstest]` that performs the following steps:
+During macro expansion, the feature file is read and parsed. The macro
+generates a new test function annotated with `#[rstest::rstest]` that performs
+the following steps:
 
 1. Build a `StepContext` and insert the test’s fixture arguments into it.
 
-2. For each step in the scenario (according to the `Given‑When‑Then` sequence), look up a matching step function by `(keyword, pattern)` in the registry. A missing step triggers a panic with a clear error message, allowing developers to detect incomplete implementations.
+2. For each step in the scenario (according to the `Given‑When‑Then` sequence),
+   look up a matching step function by `(keyword, pattern)` in the registry. A
+   missing step triggers a panic with a clear error message, allowing
+   developers to detect incomplete implementations.
 
-3. Invoke the registered step function with the `StepContext` so that fixtures are available inside the step.
+3. Invoke the registered step function with the `StepContext` so that fixtures
+   are available inside the step.
 
-4. After executing all steps, run the original test body. This block can include extra assertions or cleanup logic beyond the behaviour described in the feature.
+4. After executing all steps, run the original test body. This block can
+   include extra assertions or cleanup logic beyond the behaviour described in
+   the feature.
 
-Because the generated code uses `#[rstest::rstest]`, it integrates seamlessly with `rstest` features such as parameterized tests and asynchronous fixtures. Tests are still discovered and executed by the standard Rust test runner, so one may filter or run them in parallel as usual.
+Because the generated code uses `#[rstest::rstest]`, it integrates seamlessly
+with `rstest` features such as parameterized tests and asynchronous fixtures.
+Tests are still discovered and executed by the standard Rust test runner, so
+one may filter or run them in parallel as usual.
 
 ## Running and maintaining tests
 
-Once feature files and step definitions are in place, scenarios run via the usual `cargo test` command. Test functions created by the `#[scenario]` macro behave like other `rstest` tests; they honour `#[tokio::test]` or `#[async_std::test]` attributes if applied on the original function. Each scenario runs its steps sequentially in the order defined in the feature file. When a step is not found, the test will panic and report which step is missing and where it occurs in the feature. This strictness ensures that behaviour specifications do not silently drift from the code.
+Once feature files and step definitions are in place, scenarios run via the
+usual `cargo test` command. Test functions created by the `#[scenario]` macro
+behave like other `rstest` tests; they honour `#[tokio::test]` or
+`#[async_std::test]` attributes if applied on the original function. Each
+scenario runs its steps sequentially in the order defined in the feature file.
+When a step is not found, the test will panic and report which step is missing
+and where it occurs in the feature. This strictness ensures that behaviour
+specifications do not silently drift from the code.
 
 Best practices for writing effective scenarios include:
 
-- **Keep scenarios focused.** Each scenario should test a single behaviour and contain exactly one `When` step. If multiple actions need to be tested, break them into separate scenarios.
+- **Keep scenarios focused.** Each scenario should test a single behaviour and
+  contain exactly one `When` step. If multiple actions need to be tested, break
+  them into separate scenarios.
 
-- **Make outcomes observable.** Assertions in `Then` steps should verify externally visible results such as UI messages or API responses, not internal state or database rows.
+- **Make outcomes observable.** Assertions in `Then` steps should verify
+  externally visible results such as UI messages or API responses, not internal
+  state or database rows.
 
-- **Avoid user interactions in** `Given` **steps.** `Given` steps establish context but should not perform actions.
+- **Avoid user interactions in** `Given` **steps.** `Given` steps establish
+  context but should not perform actions.
 
-- **Write feature files collaboratively.** The value of Gherkin lies in the conversation between the three amigos; ensure that business stakeholders read and contribute to the feature files.
+- **Write feature files collaboratively.** The value of Gherkin lies in the
+  conversation between the three amigos; ensure that business stakeholders read
+  and contribute to the feature files.
 
-- **Keep patterns exact.** Because the current implementation does not support placeholders or capturing groups, the pattern strings in `#[given]`, `#[when]` and `#[then]` must match the corresponding lines in the feature file character‑for‑character. Whitespace, capitalisation and punctuation must align.
+- **Use placeholders for dynamic values.** Pattern strings may include
+  `format!`-style placeholders such as `{count:u32}`. The framework extracts
+  the text at runtime and converts it with `FromStr`. When no placeholder is
+  present, the text must match exactly.
 
 ## Limitations and roadmap
 
-The `rstest‑bdd` project is evolving. Several features described in the design document and README remain unimplemented in the current codebase:
+The `rstest‑bdd` project is evolving. Several features described in the design
+document and README remain unimplemented in the current codebase:
 
-- **Step argument parsing and typed placeholders.** The design envisages patterns like `{"{count:u32}"}` that extract values and convert them via `FromStr`, but the existing macros treat the pattern as a literal string and pass no captured arguments to the step function. Step functions may only accept fixtures as arguments.
+- **Scenario outlines and example tables.** Parameterised scenarios using
+  `Scenario Outline` with an `Examples` table are proposed, but there is no
+  support for expanding multiple runs from a single template. Use explicit
+  scenarios instead.
 
-- **Scenario outlines and example tables.** Parameterised scenarios using `Scenario Outline` with an `Examples` table are proposed, but there is no support for expanding multiple runs from a single template. Use explicit scenarios instead.
+- **Background sections, data tables and docstrings.** The design notes plans
+  to support shared `Background` steps and to supply data tables and docstrings
+  as arguments to step functions. These are currently not implemented.
 
-- **Background sections, data tables and docstrings.** The design notes plans to support shared `Background` steps and to supply data tables and docstrings as arguments to step functions. These are currently not implemented.
+- **Selecting scenarios by name.** The README hints at a `name` argument for
+  the `#[scenario]` macro, but the macro only accepts `path` and optional
+  `index`.
 
-- **Selecting scenarios by name.** The README hints at a `name` argument for the `#[scenario]` macro, but the macro only accepts `path` and optional `index`.
+- **Wildcard keywords and** `*` **steps.** The asterisk (`*`) can replace any
+  step keyword in Gherkin to improve readability, but step lookup is based
+  strictly on the primary keyword. Using `*` in feature files will not match
+  any registered step.
 
-- **Wildcard keywords and** `*` **steps.** The asterisk (`*`) can replace any step keyword in Gherkin to improve readability, but step lookup is based strictly on the primary keyword. Using `*` in feature files will not match any registered step.
-
-Consult the project’s roadmap or repository for updates. When new features are added, patterns and examples may change. Meanwhile, adopting `rstest‑bdd` in its current form will be most effective when feature files remain simple and step definitions are explicit.
+Consult the project’s roadmap or repository for updates. When new features are
+added, patterns and examples may change. Meanwhile, adopting `rstest‑bdd` in
+its current form will be most effective when feature files remain simple and
+step definitions are explicit.
 
 ## Summary
 
-`rstest‑bdd` seeks to bring the collaborative clarity of Behaviour‑Driven Development to Rust without sacrificing the ergonomics of `rstest` and the convenience of `cargo test`. In its present form, the framework provides a core workflow: write Gherkin scenarios, implement matching Rust functions with `#[given]`, `#[when]` and `#[then]` annotations, inject fixtures via `#[from]`, and bind tests to scenarios with `#[scenario]`. Step definitions are discovered at link time via the `inventory` crate, and scenarios execute all steps in sequence before running any remaining test code. While advanced Gherkin constructs and parameterization remain on the horizon, this foundation allows teams to integrate acceptance criteria into their Rust test suites and to engage all three amigos in the specification process.
+`rstest‑bdd` seeks to bring the collaborative clarity of Behaviour‑Driven
+Development to Rust without sacrificing the ergonomics of `rstest` and the
+convenience of `cargo test`. In its present form, the framework provides a core
+workflow: write Gherkin scenarios, implement matching Rust functions with
+`#[given]`, `#[when]` and `#[then]` annotations, inject fixtures via `#[from]`,
+and bind tests to scenarios with `#[scenario]`. Step definitions are discovered
+at link time via the `inventory` crate, and scenarios execute all steps in
+sequence before running any remaining test code. While advanced Gherkin
+constructs and parameterization remain on the horizon, this foundation allows
+teams to integrate acceptance criteria into their Rust test suites and to
+engage all three amigos in the specification process.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -72,11 +72,11 @@ code.
 Developers implement the behaviour described in a feature by writing step
 definition functions in Rust. Each step definition is an ordinary function
 annotated with one of the attribute macros `#[given]`, `#[when]` or `#[then]`.
-The annotation takes a single string literal; this string must match the text
-of the corresponding step in the feature file exactly. Unlike the aspirational
-design, the current implementation does not parse placeholders or capture
-groups from the pattern. Therefore, dynamic parameters cannot be extracted from
-step text; each unique step text requires its own definition.
+The annotation takes a single string literal that acts as a pattern. The string
+may include `format!`‑style placeholders such as `{count:u32}`. At runtime the
+framework extracts these values from the step text and converts them with
+`FromStr`. Text outside placeholders must match the step in the feature file
+exactly.
 
 The procedural macro implementation expands the annotated function into two
 parts: the original function and a wrapper function that registers the step in
@@ -226,6 +226,8 @@ document and README remain unimplemented in the current codebase:
   step keyword in Gherkin to improve readability, but step lookup is based
   strictly on the primary keyword. Using `*` in feature files will not match
   any registered step.
+- **Limited placeholder parser.** Nested or escaped braces are not supported
+  in step patterns. Placeholders must be well formed and non-overlapping.
 
 Consult the project’s roadmap or repository for updates. When new features are
 added, patterns and examples may change. Meanwhile, adopting `rstest‑bdd` in

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -73,7 +73,7 @@ Developers implement the behaviour described in a feature by writing step
 definition functions in Rust. Each step definition is an ordinary function
 annotated with one of the attribute macros `#[given]`, `#[when]` or `#[then]`.
 The annotation takes a single string literal that acts as a pattern. The string
-may include `format!`‑style placeholders such as `{count:u32}`. At runtime the
+may include `format!`‑style placeholders such as `{count:u32}`. At runtime, the
 framework extracts these values from the step text and converts them with
 `FromStr`. Text outside placeholders must match the step in the feature file
 exactly.
@@ -227,7 +227,7 @@ document and README remain unimplemented in the current codebase:
   strictly on the primary keyword. Using `*` in feature files will not match
   any registered step.
 - **Limited placeholder parser.** Nested or escaped braces are not supported
-  in step patterns. Placeholders must be well formed and non-overlapping.
+  in step patterns. Placeholders must be well-formed and non-overlapping.
 
 Consult the project’s roadmap or repository for updates. When new features are
 added, patterns and examples may change. Meanwhile, adopting `rstest‑bdd` in


### PR DESCRIPTION
## Summary
- support format!-style placeholders in step patterns
- parse placeholder captures and convert with `FromStr`
- update scenario runner to find steps via placeholder matching
- document placeholder syntax and update roadmap
- add behavioural test covering typed arguments

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688971c027cc832294ef9a05b3e48a0b

## Summary by Sourcery

Enable typed step arguments by supporting format-style placeholders in step patterns, parsing captures with FromStr, and updating step lookup and macro-generated wrappers to handle dynamic parameters.

New Features:
- Support format!-style placeholders in step patterns with type conversion via FromStr
- Fallback to placeholder matching in step lookup when no exact pattern is found

Enhancements:
- Revamp step registry to use StepKeyword enum and PatternStr/StepPattern wrappers for stronger typing
- Update step macros and runtime to generate wrappers that extract, parse, and pass text arguments alongside fixtures

Build:
- Add regex and thiserror dependencies for placeholder parsing and error handling

Documentation:
- Update user guide, design documentation, and roadmap to describe placeholder syntax and typed arguments

Tests:
- Add behavioural test covering typed step arguments and update existing tests to new step signatures