### PR TITLE
Fix step_attr argument extraction

### DIFF
--- a/crates/rstest-bdd-macros/src/lib.rs
+++ b/crates/rstest-bdd-macros/src/lib.rs
@@ -268,9 +268,10 @@ fn step_attr(
     let pattern = parse_macro_input!(attr as LitStr);
     let mut func = parse_macro_input!(item as ItemFn);
 
-    let args = match extract_fixture_args(&mut func) {
+    let (fixtures, step_args) = match extract_args(&mut func) {
         Ok(args) => args,
         Err(err) => return error_to_tokens(&err),
+    };
 
     let ident = &func.sig.ident;
 


### PR DESCRIPTION
## Summary
- close `match` in `step_attr` and correctly return fixtures and step args

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688dba4c7ab08322a577c49f80852818