### PR TITLE
Improve error messages for complex step patterns

### DIFF
--- a/crates/rstest-bdd-macros/tests/trybuild.rs
+++ b/crates/rstest-bdd-macros/tests/trybuild.rs
@@ -10,4 +10,5 @@ fn step_macros_compile() {
     t.compile_fail("tests/ui/outline_empty_examples.rs");
     t.compile_fail("tests/ui/outline_missing_column.rs");
     t.compile_fail("tests/ui/outline_duplicate_headers.rs");
+    t.compile_fail("tests/ui/step_destructure_tuple.rs");
 }

--- a/crates/rstest-bdd-macros/tests/ui/step_destructure_tuple.rs
+++ b/crates/rstest-bdd-macros/tests/ui/step_destructure_tuple.rs
@@ -1,0 +1,7 @@
+//! Compile-fail test for tuple pattern arguments.
+use rstest_bdd_macros::given;
+
+#[given("coords")]
+fn tuple_pattern((x, y): (i32, i32)) {}
+
+fn main() {}

--- a/crates/rstest-bdd-macros/tests/ui/step_destructure_tuple.stderr
+++ b/crates/rstest-bdd-macros/tests/ui/step_destructure_tuple.stderr
@@ -1,0 +1,5 @@
+error: complex destructuring patterns are not yet supported - pattern contains 2 identifiers but exactly 1 is required
+ --> tests/ui/step_destructure_tuple.rs:5:18
+  |
+5 | fn tuple_pattern((x, y): (i32, i32)) {}
+  |                  ^^^^^^


### PR DESCRIPTION
## Summary
- extract identifiers recursively from tuple and struct patterns
- reject multi-identifier step arguments with a descriptive error
- add compile-fail test for tuple destructuring

closes #10

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688dc3946a28832292dd091eba8decf5

## Summary by Sourcery

Improve pattern handling in step macros by extracting identifiers from nested patterns and emitting clearer diagnostics for unsupported multi-identifier destructuring, and validate this behavior with a compile-fail test.

New Features:
- Extract identifiers recursively from identifiers, tuples, structs, tuple structs, and parenthesised patterns

Enhancements:
- Provide descriptive errors when step argument patterns resolve to multiple identifiers

Tests:
- Add compile-fail UI test for tuple destructuring in step definitions