### PR TITLE
Propagate step errors with Result

### DIFF
--- a/crates/rstest-bdd-macros/tests/features/missing_fixture.feature
+++ b/crates/rstest-bdd-macros/tests/features/missing_fixture.feature
@@ -1,0 +1,4 @@
+Feature: Missing fixture
+
+  Scenario: step requires missing fixture
+    Given a missing fixture is requested

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -233,7 +233,7 @@ fn extract_captured_values(re: &Regex, text: &str) -> Option<Vec<String>> {
 }
 
 /// Type alias for the stored step function pointer.
-pub type StepFn = for<'a> fn(&StepContext<'a>, &str);
+pub type StepFn = for<'a> fn(&StepContext<'a>, &str) -> Result<(), String>;
 
 /// Represents a single step definition registered with the framework.
 ///
@@ -368,9 +368,14 @@ mod tests {
     #[test]
     fn collects_registered_step() {
         fn sample() {}
-        fn wrapper(ctx: &StepContext<'_>, _text: &str) {
+        #[expect(
+            clippy::unnecessary_wraps,
+            reason = "required to match StepFn signature"
+        )]
+        fn wrapper(ctx: &StepContext<'_>, _text: &str) -> Result<(), String> {
             let _ = ctx;
             sample();
+            Ok(())
         }
 
         step!(StepKeyword::Given, "a pattern", wrapper, &[]);

--- a/crates/rstest-bdd/tests/fixture_context.rs
+++ b/crates/rstest-bdd/tests/fixture_context.rs
@@ -2,11 +2,12 @@
 
 use rstest_bdd::{Step, StepContext, iter, step};
 
-fn needs_value(ctx: &StepContext<'_>, _text: &str) {
-    let Some(val) = ctx.get::<u32>("number") else {
-        panic!("missing fixture");
-    };
+fn needs_value(ctx: &StepContext<'_>, _text: &str) -> Result<(), String> {
+    let val = ctx
+        .get::<u32>("number")
+        .ok_or_else(|| "missing fixture".to_string())?;
     assert_eq!(*val, 42);
+    Ok(())
 }
 
 step!(
@@ -28,5 +29,5 @@ fn context_passes_fixture() {
             || panic!("step 'a value' not found in registry"),
             |step| step.run,
         );
-    step_fn(&ctx, "a value");
+    step_fn(&ctx, "a value").unwrap_or_else(|err| panic!("step failed: {err}"));
 }

--- a/crates/rstest-bdd/tests/step_registry.rs
+++ b/crates/rstest-bdd/tests/step_registry.rs
@@ -1,13 +1,13 @@
 //! Behavioural test for step registry
 
-use rstest_bdd::{Step, iter, step};
+use rstest_bdd::{Step, StepError, iter, step};
 
 fn sample() {}
 #[expect(
     clippy::unnecessary_wraps,
     reason = "required to match StepFn signature"
 )]
-fn wrapper(ctx: &rstest_bdd::StepContext<'_>, _text: &str) -> Result<(), String> {
+fn wrapper(ctx: &rstest_bdd::StepContext<'_>, _text: &str) -> Result<(), StepError> {
     // Adapter for zero-argument step functions
     let _ = ctx;
     sample();

--- a/crates/rstest-bdd/tests/step_registry.rs
+++ b/crates/rstest-bdd/tests/step_registry.rs
@@ -3,10 +3,15 @@
 use rstest_bdd::{Step, iter, step};
 
 fn sample() {}
-fn wrapper(ctx: &rstest_bdd::StepContext<'_>, _text: &str) {
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "required to match StepFn signature"
+)]
+fn wrapper(ctx: &rstest_bdd::StepContext<'_>, _text: &str) -> Result<(), String> {
     // Adapter for zero-argument step functions
     let _ = ctx;
     sample();
+    Ok(())
 }
 
 step!(rstest_bdd::StepKeyword::When, "behavioural", wrapper, &[]);

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -462,7 +462,9 @@ classDiagram
         pattern: StepPattern
         run: StepFn
     }
-    class StepFn
+    class StepFn {
+        call(ctx: StepContext, text: &str) Result<(), String>
+    }
     class StepWrapper
     StepWrapper : extract_placeholders(pattern, text)
     StepWrapper : parse captures with FromStr
@@ -889,8 +891,8 @@ sequenceDiagram
     StepWrapper->>StepWrapper: extract_placeholders(pattern, text)
     StepWrapper->>StepWrapper: parse captures with FromStr
     StepWrapper->>StepFunction: call with typed args
-    StepFunction-->>StepWrapper: returns
-    StepWrapper-->>ScenarioRunner: returns
+    StepFunction-->>StepWrapper: Result<(), String>
+    StepWrapper-->>ScenarioRunner: Result<(), String>
 ```
 
 ## **Works cited**

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -463,7 +463,7 @@ classDiagram
         run: StepFn
     }
     class StepFn {
-        call(ctx: StepContext, text: &str) Result<(), String>
+        call(ctx: StepContext, text: &str) StepResult
     }
     class StepWrapper
     StepWrapper : extract_placeholders(pattern, text)
@@ -891,8 +891,8 @@ sequenceDiagram
     StepWrapper->>StepWrapper: extract_placeholders(pattern, text)
     StepWrapper->>StepWrapper: parse captures with FromStr
     StepWrapper->>StepFunction: call with typed args
-    StepFunction-->>StepWrapper: Result<(), String>
-    StepWrapper-->>ScenarioRunner: Result<(), String>
+    StepFunction-->>StepWrapper: ()
+    StepWrapper-->>ScenarioRunner: StepResult
 ```
 
 ## **Works cited**


### PR DESCRIPTION
## Summary
- replace panicking fixture lookups with contextual `Result` errors
- surface step execution failures in scenario runner
- document new `Result`-based step function signature

closes #11

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: FileNotFound: failed copying files from cache to destination for package ip-address)*

------
https://chatgpt.com/codex/tasks/task_e_688dc3dd510083229c92cbb1b1d51f17

## Summary by Sourcery

Propagate errors from step functions using Result instead of panics, and update the fixture lookup and scenario runner to surface contextual failures.

Enhancements:
- Change StepFn signature and generated wrappers to return Result<(), String>
- Replace unwrap-based fixture retrievals with ok_or_else errors including step function context
- Update scenario runner to catch step errors and emit detailed panic messages

Documentation:
- Revise class and sequence diagrams to reflect Result-based step function signature

Tests:
- Adapt tests to the new Result-returning step function signature and unwrap errors in test helpers