### PR TITLE
Ensure outline scenario test runs serially

### DIFF
--- a/crates/rstest-bdd-macros/tests/scenario.rs
+++ b/crates/rstest-bdd-macros/tests/scenario.rs
@@ -87,7 +87,7 @@ fn unmatched_feature() {
 }
 
 #[scenario(path = "tests/features/outline.feature")]
-#[serial]
+#[serial] // EVENTS is shared, so run tests sequentially
 fn outline(num: String) {
     with_locked_events(|events| {
         assert_eq!(events.as_slice(), ["precondition", "action", "result"]);


### PR DESCRIPTION
## Summary
- document need for `#[serial]` on scenario outline test to avoid race on shared state

## Testing
- `make fmt`
- `make lint`
- `make test`

closes #14

------
https://chatgpt.com/codex/tasks/task_e_688dc3eee3248322858e35ea1106f84c

## Summary by Sourcery

Enhancements:
- Add explanatory comment on #[serial] attribute in the outline scenario test