### PR TITLE
Handle typed placeholders and escaped braces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target/
 **/*.rs.bk
+**/*~
+.crush

--- a/CRUSH.md
+++ b/CRUSH.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/rstest-bdd-macros/src/codegen/wrapper.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper.rs
@@ -168,10 +168,6 @@ pub(crate) fn generate_wrapper_code(config: &WrapperConfig<'_>) -> TokenStream2 
         fn #wrapper_ident(ctx: &rstest_bdd::StepContext<'_>, text: &str) -> Result<(), String> {
             use std::panic::{catch_unwind, AssertUnwindSafe};
 
-            catch_unwind(AssertUnwindSafe(|| -> Result<(), String> {
-                #(#declares)*
-                let captures = rstest_bdd::extract_placeholders(&#pattern_ident, text.into())
-                    .expect("pattern mismatch");
                 #(#step_arg_parses)*
                 #ident(#(#arg_idents),*);
                 Ok(())

--- a/crates/rstest-bdd-macros/src/codegen/wrapper.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper.rs
@@ -144,7 +144,7 @@ pub(crate) fn generate_wrapper_code(config: &WrapperConfig<'_>) -> TokenStream2 
         .iter()
         .enumerate()
         .map(|(idx, _)| {
-            let index = syn::Index::from(idx + 1);  // +1 to skip the full match at index 0
+            let index = syn::Index::from(idx + 1); // +1 to skip the full match at index 0
             quote! { captures.get(#index).map(|m| m.as_str()).unwrap_or_default() }
         })
         .collect();

--- a/crates/rstest-bdd-macros/src/codegen/wrapper.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper.rs
@@ -168,7 +168,15 @@ pub(crate) fn generate_wrapper_code(config: &WrapperConfig<'_>) -> TokenStream2 
         fn #wrapper_ident(ctx: &rstest_bdd::StepContext<'_>, text: &str) -> Result<(), String> {
             use std::panic::{catch_unwind, AssertUnwindSafe};
 
-                #(#step_arg_parses)*
+            let captures = #pattern_ident
+                .regex()
+                .captures(text)
+                .ok_or_else(|| format!("Step text '{}' does not match pattern '{}'", text, #pattern))?;
+
+            #(#declares)*
+            #(#step_arg_parses)*
+
+            catch_unwind(AssertUnwindSafe(|| {
                 #ident(#(#arg_idents),*);
                 Ok(())
             }))

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -276,6 +276,17 @@ fn handle_escape_sequence(bytes: &[u8], i: usize, regex_source: &mut String) -> 
     }
 }
 
+/// Handle an escape inside a brace-delimited placeholder.
+///
+/// Returns the number of bytes to advance the inner index.
+fn handle_escape_in_brace(bytes: &[u8], i: usize) -> usize {
+    if let Some(&next) = bytes.get(i + 1) {
+        if next == b'{' || next == b'}' { 2 } else { 1 }
+    } else {
+        1
+    }
+}
+
 /// Handle a brace placeholder, extracting any type hint.
 ///
 /// Returns the number of bytes to advance the iterator.
@@ -290,17 +301,7 @@ fn handle_brace_placeholder(
     let mut j = start;
     while let Some(&b) = bytes.get(j) {
         match b {
-            b'\\' => {
-                if let Some(&next) = bytes.get(j + 1) {
-                    if next == b'{' || next == b'}' {
-                        j += 2;
-                    } else {
-                        j += 1;
-                    }
-                } else {
-                    j += 1;
-                }
-            }
+            b'\\' => j += handle_escape_in_brace(bytes, j),
             b'{' => {
                 depth += 1;
                 j += 1;

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -474,22 +474,4 @@ pub fn find_step(keyword: StepKeyword, text: StepText<'_>) -> Option<StepFn> {
     }
     None
 }
-pub use regex::{Match, Regex};
 
-/// Returns a greeting for the library.
-///
-/// # Examples
-///
-/// ```
-/// use rstest_bdd::greet;
-///
-/// assert_eq!(greet(), "Hello from rstest-bdd!");
-/// ```
-#[must_use]
-pub fn greet() -> &'static str {
-    "Hello from rstest-bdd!"
-}
-use inventory::{iter, submit};
-use std::collections::HashMap;
-use std::str::FromStr;
-use std::sync::{LazyLock, OnceLock};

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -474,4 +474,3 @@ pub fn find_step(keyword: StepKeyword, text: StepText<'_>) -> Option<StepFn> {
     }
     None
 }
-

--- a/crates/rstest-bdd/tests/placeholder_parsing.rs
+++ b/crates/rstest-bdd/tests/placeholder_parsing.rs
@@ -6,7 +6,8 @@ use rstest_bdd::{StepPattern, StepText, extract_placeholders};
 fn type_hint_uses_specialised_fragment() {
     // u32: positive integer
     let pat = StepPattern::from("value {n:u32}");
-    pat.compile().expect("Failed to compile pattern");
+    pat.compile()
+        .unwrap_or_else(|e| panic!("Failed to compile pattern: {e}"));
     let text = StepText::from("value 42");
     let Some(caps) = extract_placeholders(&pat, text) else {
         panic!("match expected for u32");
@@ -19,7 +20,8 @@ fn type_hint_uses_specialised_fragment() {
 
     // i32: negative integer
     let pat = StepPattern::from("value {n:i32}");
-    pat.compile().expect("Failed to compile pattern");
+    pat.compile()
+        .unwrap_or_else(|e| panic!("Failed to compile pattern: {e}"));
     let text = StepText::from("value -42");
     let Some(caps) = extract_placeholders(&pat, text) else {
         panic!("match expected for negative i32");
@@ -32,7 +34,8 @@ fn type_hint_uses_specialised_fragment() {
 
     // isize: negative integer
     let pat = StepPattern::from("value {n:isize}");
-    pat.compile().expect("Failed to compile pattern");
+    pat.compile()
+        .unwrap_or_else(|e| panic!("Failed to compile pattern: {e}"));
     let text = StepText::from("value -7");
     let Some(caps) = extract_placeholders(&pat, text) else {
         panic!("match expected for negative isize");
@@ -41,7 +44,8 @@ fn type_hint_uses_specialised_fragment() {
 
     // f64: floating point
     let pat = StepPattern::from("value {n:f64}");
-    pat.compile().expect("Failed to compile pattern");
+    pat.compile()
+        .unwrap_or_else(|e| panic!("Failed to compile pattern: {e}"));
     let text = StepText::from("value 2.71828");
     let Some(caps) = extract_placeholders(&pat, text) else {
         panic!("match expected for f64");
@@ -60,7 +64,8 @@ fn type_hint_uses_specialised_fragment() {
 #[test]
 fn handles_escaped_braces() {
     let pat = StepPattern::from(r"literal \{ brace {v} \}");
-    pat.compile().expect("Failed to compile pattern");
+    pat.compile()
+        .unwrap_or_else(|e| panic!("Failed to compile pattern: {e}"));
     let text = StepText::from("literal { brace data }");
     let Some(caps) = extract_placeholders(&pat, text) else {
         panic!("match expected");
@@ -71,7 +76,8 @@ fn handles_escaped_braces() {
 #[test]
 fn handles_nested_braces() {
     let pat = StepPattern::from("before {outer {inner}} after");
-    pat.compile().expect("Failed to compile pattern");
+    pat.compile()
+        .unwrap_or_else(|e| panic!("Failed to compile pattern: {e}"));
     let text = StepText::from("before value after");
     let Some(caps) = extract_placeholders(&pat, text) else {
         panic!("match expected");
@@ -82,7 +88,8 @@ fn handles_nested_braces() {
 #[test]
 fn unbalanced_braces_are_literals() {
     let pat = StepPattern::from("before {outer {inner} after");
-    pat.compile().expect("Failed to compile pattern");
+    pat.compile()
+        .unwrap_or_else(|e| panic!("Failed to compile pattern: {e}"));
     assert!(
         extract_placeholders(&pat, StepText::from("before value after")).is_none(),
         "text without literal brace should not match",

--- a/crates/rstest-bdd/tests/placeholder_parsing.rs
+++ b/crates/rstest-bdd/tests/placeholder_parsing.rs
@@ -6,6 +6,7 @@ use rstest_bdd::{StepPattern, StepText, extract_placeholders};
 fn type_hint_uses_specialised_fragment() {
     // u32: positive integer
     let pat = StepPattern::from("value {n:u32}");
+    pat.compile().expect("Failed to compile pattern");
     let text = StepText::from("value 42");
     let Some(caps) = extract_placeholders(&pat, text) else {
         panic!("match expected for u32");
@@ -18,6 +19,7 @@ fn type_hint_uses_specialised_fragment() {
 
     // i32: negative integer
     let pat = StepPattern::from("value {n:i32}");
+    pat.compile().expect("Failed to compile pattern");
     let text = StepText::from("value -42");
     let Some(caps) = extract_placeholders(&pat, text) else {
         panic!("match expected for negative i32");
@@ -30,6 +32,7 @@ fn type_hint_uses_specialised_fragment() {
 
     // isize: negative integer
     let pat = StepPattern::from("value {n:isize}");
+    pat.compile().expect("Failed to compile pattern");
     let text = StepText::from("value -7");
     let Some(caps) = extract_placeholders(&pat, text) else {
         panic!("match expected for negative isize");
@@ -38,6 +41,7 @@ fn type_hint_uses_specialised_fragment() {
 
     // f64: floating point
     let pat = StepPattern::from("value {n:f64}");
+    pat.compile().expect("Failed to compile pattern");
     let text = StepText::from("value 2.71828");
     let Some(caps) = extract_placeholders(&pat, text) else {
         panic!("match expected for f64");
@@ -56,6 +60,7 @@ fn type_hint_uses_specialised_fragment() {
 #[test]
 fn handles_escaped_braces() {
     let pat = StepPattern::from(r"literal \{ brace {v} \}");
+    pat.compile().expect("Failed to compile pattern");
     let text = StepText::from("literal { brace data }");
     let Some(caps) = extract_placeholders(&pat, text) else {
         panic!("match expected");
@@ -66,6 +71,7 @@ fn handles_escaped_braces() {
 #[test]
 fn handles_nested_braces() {
     let pat = StepPattern::from("before {outer {inner}} after");
+    pat.compile().expect("Failed to compile pattern");
     let text = StepText::from("before value after");
     let Some(caps) = extract_placeholders(&pat, text) else {
         panic!("match expected");
@@ -76,6 +82,7 @@ fn handles_nested_braces() {
 #[test]
 fn unbalanced_braces_are_literals() {
     let pat = StepPattern::from("before {outer {inner} after");
+    pat.compile().expect("Failed to compile pattern");
     assert!(
         extract_placeholders(&pat, StepText::from("before value after")).is_none(),
         "text without literal brace should not match",

--- a/crates/rstest-bdd/tests/placeholder_parsing.rs
+++ b/crates/rstest-bdd/tests/placeholder_parsing.rs
@@ -4,15 +4,52 @@ use rstest_bdd::{PatternStr, StepText, extract_placeholders};
 
 #[test]
 fn type_hint_uses_specialised_fragment() {
+    // u32: positive integer
     let pat = PatternStr::from("value {n:u32}");
     let text = StepText::from("value 42");
     let Some(caps) = extract_placeholders(pat, text) else {
-        panic!("match expected");
+        panic!("match expected for u32");
     };
     assert_eq!(caps, vec!["42"]);
     assert!(
         extract_placeholders(pat, StepText::from("value none")).is_none(),
-        "non-numeric text should not match"
+        "non-numeric text should not match u32",
+    );
+
+    // i32: negative integer
+    let pat = PatternStr::from("value {n:i32}");
+    let text = StepText::from("value -42");
+    let Some(caps) = extract_placeholders(pat, text) else {
+        panic!("match expected for negative i32");
+    };
+    assert_eq!(caps, vec!["-42"]);
+    assert!(
+        extract_placeholders(pat, StepText::from("value 42.5")).is_none(),
+        "float should not match i32",
+    );
+
+    // isize: negative integer
+    let pat = PatternStr::from("value {n:isize}");
+    let text = StepText::from("value -7");
+    let Some(caps) = extract_placeholders(pat, text) else {
+        panic!("match expected for negative isize");
+    };
+    assert_eq!(caps, vec!["-7"]);
+
+    // f64: floating point
+    let pat = PatternStr::from("value {n:f64}");
+    let text = StepText::from("value 2.71828");
+    let Some(caps) = extract_placeholders(pat, text) else {
+        panic!("match expected for f64");
+    };
+    assert_eq!(caps, vec!["2.71828"]);
+    assert!(
+        extract_placeholders(pat, StepText::from("value none")).is_none(),
+        "non-numeric text should not match f64",
+    );
+    assert!(
+        extract_placeholders(pat, StepText::from("value -0.001")).is_some(),
+        "negative float should match f64",
     );
 }
 
@@ -34,4 +71,13 @@ fn handles_nested_braces() {
         panic!("match expected");
     };
     assert_eq!(caps, vec!["value"]);
+}
+
+#[test]
+fn unbalanced_braces_are_literals() {
+    let pat = PatternStr::from("before {outer {inner} after");
+    assert!(
+        extract_placeholders(pat, StepText::from("before value after")).is_none(),
+        "text without literal brace should not match",
+    );
 }

--- a/crates/rstest-bdd/tests/placeholder_parsing.rs
+++ b/crates/rstest-bdd/tests/placeholder_parsing.rs
@@ -1,63 +1,63 @@
 //! Tests for placeholder extraction logic.
 
-use rstest_bdd::{PatternStr, StepText, extract_placeholders};
+use rstest_bdd::{StepPattern, StepText, extract_placeholders};
 
 #[test]
 fn type_hint_uses_specialised_fragment() {
     // u32: positive integer
-    let pat = PatternStr::from("value {n:u32}");
+    let pat = StepPattern::from("value {n:u32}");
     let text = StepText::from("value 42");
-    let Some(caps) = extract_placeholders(pat, text) else {
+    let Some(caps) = extract_placeholders(&pat, text) else {
         panic!("match expected for u32");
     };
     assert_eq!(caps, vec!["42"]);
     assert!(
-        extract_placeholders(pat, StepText::from("value none")).is_none(),
+        extract_placeholders(&pat, StepText::from("value none")).is_none(),
         "non-numeric text should not match u32",
     );
 
     // i32: negative integer
-    let pat = PatternStr::from("value {n:i32}");
+    let pat = StepPattern::from("value {n:i32}");
     let text = StepText::from("value -42");
-    let Some(caps) = extract_placeholders(pat, text) else {
+    let Some(caps) = extract_placeholders(&pat, text) else {
         panic!("match expected for negative i32");
     };
     assert_eq!(caps, vec!["-42"]);
     assert!(
-        extract_placeholders(pat, StepText::from("value 42.5")).is_none(),
+        extract_placeholders(&pat, StepText::from("value 42.5")).is_none(),
         "float should not match i32",
     );
 
     // isize: negative integer
-    let pat = PatternStr::from("value {n:isize}");
+    let pat = StepPattern::from("value {n:isize}");
     let text = StepText::from("value -7");
-    let Some(caps) = extract_placeholders(pat, text) else {
+    let Some(caps) = extract_placeholders(&pat, text) else {
         panic!("match expected for negative isize");
     };
     assert_eq!(caps, vec!["-7"]);
 
     // f64: floating point
-    let pat = PatternStr::from("value {n:f64}");
+    let pat = StepPattern::from("value {n:f64}");
     let text = StepText::from("value 2.71828");
-    let Some(caps) = extract_placeholders(pat, text) else {
+    let Some(caps) = extract_placeholders(&pat, text) else {
         panic!("match expected for f64");
     };
     assert_eq!(caps, vec!["2.71828"]);
     assert!(
-        extract_placeholders(pat, StepText::from("value none")).is_none(),
+        extract_placeholders(&pat, StepText::from("value none")).is_none(),
         "non-numeric text should not match f64",
     );
     assert!(
-        extract_placeholders(pat, StepText::from("value -0.001")).is_some(),
+        extract_placeholders(&pat, StepText::from("value -0.001")).is_some(),
         "negative float should match f64",
     );
 }
 
 #[test]
 fn handles_escaped_braces() {
-    let pat = PatternStr::from(r"literal \{ brace {v} \}");
+    let pat = StepPattern::from(r"literal \{ brace {v} \}");
     let text = StepText::from("literal { brace data }");
-    let Some(caps) = extract_placeholders(pat, text) else {
+    let Some(caps) = extract_placeholders(&pat, text) else {
         panic!("match expected");
     };
     assert_eq!(caps, vec!["data"]);
@@ -65,9 +65,9 @@ fn handles_escaped_braces() {
 
 #[test]
 fn handles_nested_braces() {
-    let pat = PatternStr::from("before {outer {inner}} after");
+    let pat = StepPattern::from("before {outer {inner}} after");
     let text = StepText::from("before value after");
-    let Some(caps) = extract_placeholders(pat, text) else {
+    let Some(caps) = extract_placeholders(&pat, text) else {
         panic!("match expected");
     };
     assert_eq!(caps, vec!["value"]);
@@ -75,9 +75,9 @@ fn handles_nested_braces() {
 
 #[test]
 fn unbalanced_braces_are_literals() {
-    let pat = PatternStr::from("before {outer {inner} after");
+    let pat = StepPattern::from("before {outer {inner} after");
     assert!(
-        extract_placeholders(pat, StepText::from("before value after")).is_none(),
+        extract_placeholders(&pat, StepText::from("before value after")).is_none(),
         "text without literal brace should not match",
     );
 }

--- a/crates/rstest-bdd/tests/placeholder_parsing.rs
+++ b/crates/rstest-bdd/tests/placeholder_parsing.rs
@@ -1,0 +1,37 @@
+//! Tests for placeholder extraction logic.
+
+use rstest_bdd::{PatternStr, StepText, extract_placeholders};
+
+#[test]
+fn type_hint_uses_specialised_fragment() {
+    let pat = PatternStr::from("value {n:u32}");
+    let text = StepText::from("value 42");
+    let Some(caps) = extract_placeholders(pat, text) else {
+        panic!("match expected");
+    };
+    assert_eq!(caps, vec!["42"]);
+    assert!(
+        extract_placeholders(pat, StepText::from("value none")).is_none(),
+        "non-numeric text should not match"
+    );
+}
+
+#[test]
+fn handles_escaped_braces() {
+    let pat = PatternStr::from(r"literal \{ brace {v} \}");
+    let text = StepText::from("literal { brace data }");
+    let Some(caps) = extract_placeholders(pat, text) else {
+        panic!("match expected");
+    };
+    assert_eq!(caps, vec!["data"]);
+}
+
+#[test]
+fn handles_nested_braces() {
+    let pat = PatternStr::from("before {outer {inner}} after");
+    let text = StepText::from("before value after");
+    let Some(caps) = extract_placeholders(pat, text) else {
+        panic!("match expected");
+    };
+    assert_eq!(caps, vec!["value"]);
+}

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -889,8 +889,9 @@ strings. Step wrapper functions parse these strings and convert them with
 `FromStr` before calling the original step. Scenario execution now searches the
 step registry using `find_step`, which falls back to placeholder matching when
 no exact pattern is present. This approach keeps the macros lightweight while
-supporting type‑safe parameters in steps. The parser does not handle nested or
-escaped braces; step patterns must contain simple, well-formed placeholders.
+supporting type‑safe parameters in steps. The parser handles escaped braces and
+nested brace pairs, preventing greedy captures while still requiring
+well‑formed placeholders.
 
 The sequence below summarizes how the runner locates and executes steps when
 placeholders are present:

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -197,7 +197,7 @@ Best practices for writing effective scenarios include:
 
 - **Use placeholders for dynamic values.** Pattern strings may include
   `format!`-style placeholders such as `{count:u32}`. Type hints narrow the
-  match; numeric hints support all Rust primitives (`u8`..`u128`, `i8`..`i128`,
+  match. Numeric hints support all Rust primitives (`u8..u128`, `i8..i128`,
   `usize`, `isize`, `f32`, `f64`). Escape literal braces with `\\{` and `\\}`.
   Nested braces inside placeholders are permitted. When no placeholder is
   present, the text must match exactly.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -197,9 +197,10 @@ Best practices for writing effective scenarios include:
 
 - **Use placeholders for dynamic values.** Pattern strings may include
   `format!`-style placeholders such as `{count:u32}`. Type hints narrow the
-  match, so `u32` captures only digits. Escape literal braces with `\\{` and
-  `\\}`. Nested braces inside placeholders are permitted. When no placeholder
-  is present, the text must match exactly.
+  match; numeric hints support all Rust primitives (`u8`..`u128`, `i8`..`i128`,
+  `usize`, `isize`, `f32`, `f64`). Escape literal braces with `\\{` and `\\}`.
+  Nested braces inside placeholders are permitted. When no placeholder is
+  present, the text must match exactly.
 
 ## Limitations and roadmap
 


### PR DESCRIPTION
## Summary
- parse type-hinted step placeholders and map common types to specialised regex fragments
- honour escaped and nested braces when building placeholder patterns
- document the expanded pattern syntax

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: too many arguments, validated files individually with `nixie`)*

------
https://chatgpt.com/codex/tasks/task_e_68900727d26883228254622b229aa77d

## Summary by Sourcery

Enhance step placeholder parsing by adding typed hints, escaped and nested braces support, update macro wrapper generation, refresh documentation, and add comprehensive tests

New Features:
- Support type-hinted placeholders in step patterns with specialized regex for integers and floats
- Allow escaped literal braces and nested braces in step pattern parsing to prevent greedy captures

Enhancements:
- Refactor the regex builder to handle escape sequences and brace-delimited placeholders with type hints
- Improve generated wrapper code to skip the full regex match, retrieve captures safely, and enrich panic messages

Documentation:
- Document expanded placeholder syntax, including type hints, escaped braces, and nested braces in user guide and design docs

Tests:
- Add unit tests for typed placeholders, escaped braces, nested braces, and unbalanced brace scenarios

Chores:
- Introduce CRUSH.md