### PR TITLE
Adopt Result-based step execution

### DIFF
--- a/crates/rstest-bdd-macros/src/codegen/scenario.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario.rs
@@ -59,7 +59,17 @@ pub(crate) fn generate_scenario_code(
             #(#ctx_inserts)*
             for (index, (keyword, text)) in steps.iter().enumerate() {
                 if let Some(f) = rstest_bdd::find_step(*keyword, (*text).into()) {
-                    f(&ctx, text);
+                    if let Err(err) = f(&ctx, text) {
+                        panic!(
+                            "Step failed at index {}: {} {} - {}\n(feature: {}, scenario: {})",
+                            index,
+                            keyword.as_str(),
+                            text,
+                            err,
+                            #feature_path_str,
+                            #scenario_name
+                        );
+                    }
                 } else {
                     panic!(
                         "Step not found at index {}: {} {} (feature: {}, scenario: {})",

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -233,7 +233,7 @@ fn extract_captured_values(re: &Regex, text: &str) -> Option<Vec<String>> {
 }
 
 /// Type alias for the stored step function pointer.
-pub type StepFn = for<'a> fn(&StepContext<'a>, &str);
+pub type StepFn = for<'a> fn(&StepContext<'a>, &str) -> Result<(), String>;
 
 /// Represents a single step definition registered with the framework.
 ///
@@ -368,9 +368,14 @@ mod tests {
     #[test]
     fn collects_registered_step() {
         fn sample() {}
-        fn wrapper(ctx: &StepContext<'_>, _text: &str) {
+        #[expect(
+            clippy::unnecessary_wraps,
+            reason = "wrapper must match StepFn signature"
+        )]
+        fn wrapper(ctx: &StepContext<'_>, _text: &str) -> Result<(), String> {
             let _ = ctx;
             sample();
+            Ok(())
         }
 
         step!(StepKeyword::Given, "a pattern", wrapper, &[]);

--- a/crates/rstest-bdd/tests/fixture_context.rs
+++ b/crates/rstest-bdd/tests/fixture_context.rs
@@ -3,9 +3,9 @@
 use rstest_bdd::{Step, StepContext, iter, step};
 
 fn needs_value(ctx: &StepContext<'_>, _text: &str) -> Result<(), String> {
-    let val = ctx
-        .get::<u32>("number")
-        .ok_or_else(|| "missing fixture".to_string())?;
+    let val = ctx.get::<u32>("number").ok_or_else(|| {
+        "Missing fixture 'number' of type 'u32' in step function 'needs_value'".to_string()
+    })?;
     assert_eq!(*val, 42);
     Ok(())
 }
@@ -31,4 +31,25 @@ fn context_passes_fixture() {
         );
     let result = step_fn(&ctx, "a value");
     assert!(result.is_ok(), "step execution failed: {result:?}");
+}
+
+#[test]
+fn context_missing_fixture_returns_error() {
+    let ctx = StepContext::default();
+    let step_fn = iter::<Step>
+        .into_iter()
+        .find(|s| s.pattern.as_str() == "a value")
+        .map_or_else(
+            || panic!("step 'a value' not found in registry"),
+            |step| step.run,
+        );
+    let result = step_fn(&ctx, "a value");
+    let err = match result {
+        Ok(()) => panic!("expected error when fixture is missing"),
+        Err(e) => e,
+    };
+    assert!(
+        err.contains("Missing fixture 'number' of type 'u32'"),
+        "unexpected error message"
+    );
 }

--- a/crates/rstest-bdd/tests/fixture_context.rs
+++ b/crates/rstest-bdd/tests/fixture_context.rs
@@ -2,11 +2,12 @@
 
 use rstest_bdd::{Step, StepContext, iter, step};
 
-fn needs_value(ctx: &StepContext<'_>, _text: &str) {
-    let Some(val) = ctx.get::<u32>("number") else {
-        panic!("missing fixture");
-    };
+fn needs_value(ctx: &StepContext<'_>, _text: &str) -> Result<(), String> {
+    let val = ctx
+        .get::<u32>("number")
+        .ok_or_else(|| "missing fixture".to_string())?;
     assert_eq!(*val, 42);
+    Ok(())
 }
 
 step!(
@@ -28,5 +29,6 @@ fn context_passes_fixture() {
             || panic!("step 'a value' not found in registry"),
             |step| step.run,
         );
-    step_fn(&ctx, "a value");
+    let result = step_fn(&ctx, "a value");
+    assert!(result.is_ok(), "step execution failed: {result:?}");
 }

--- a/crates/rstest-bdd/tests/step_registry.rs
+++ b/crates/rstest-bdd/tests/step_registry.rs
@@ -3,10 +3,15 @@
 use rstest_bdd::{Step, iter, step};
 
 fn sample() {}
-fn wrapper(ctx: &rstest_bdd::StepContext<'_>, _text: &str) {
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "wrapper must match StepFn signature"
+)]
+fn wrapper(ctx: &rstest_bdd::StepContext<'_>, _text: &str) -> Result<(), String> {
     // Adapter for zero-argument step functions
     let _ = ctx;
     sample();
+    Ok(())
 }
 
 step!(rstest_bdd::StepKeyword::When, "behavioural", wrapper, &[]);

--- a/crates/rstest-bdd/tests/step_registry.rs
+++ b/crates/rstest-bdd/tests/step_registry.rs
@@ -1,6 +1,6 @@
 //! Behavioural test for step registry
 
-use rstest_bdd::{Step, iter, step};
+use rstest_bdd::{Step, StepContext, iter, step};
 
 fn sample() {}
 #[expect(
@@ -16,10 +16,39 @@ fn wrapper(ctx: &rstest_bdd::StepContext<'_>, _text: &str) -> Result<(), String>
 
 step!(rstest_bdd::StepKeyword::When, "behavioural", wrapper, &[]);
 
+fn failing_wrapper(ctx: &StepContext<'_>, _text: &str) -> Result<(), String> {
+    let _ = ctx;
+    Err("boom".to_string())
+}
+
+step!(
+    rstest_bdd::StepKeyword::Given,
+    "fails",
+    failing_wrapper,
+    &[]
+);
+
 #[test]
 fn step_is_registered() {
     let found = iter::<Step>.into_iter().any(|step| {
         step.pattern.as_str() == "behavioural" && step.keyword == rstest_bdd::StepKeyword::When
     });
     assert!(found, "expected step not found");
+}
+
+#[test]
+fn wrapper_error_propagates() {
+    let step_fn = iter::<Step>
+        .into_iter()
+        .find(|s| s.pattern.as_str() == "fails")
+        .map_or_else(
+            || panic!("step 'fails' not found in registry"),
+            |step| step.run,
+        );
+    let result = step_fn(&StepContext::default(), "fails");
+    let err = match result {
+        Ok(()) => panic!("expected error from wrapper"),
+        Err(e) => e,
+    };
+    assert_eq!(err, "boom");
 }


### PR DESCRIPTION
## Summary
- return `Result` from generated step wrappers and fixture lookups
- panic with context when a step fails during scenario execution
- expose step functions as `Result`-returning pointers

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689008d46e148322b8cee3190bccd2b2

## Summary by Sourcery

Adopt Result-based execution for BDD step wrappers and fixtures to provide richer error handling and contextual panics.

New Features:
- Update generated step wrappers and registered StepFn to return Result<(), String> instead of unit

Enhancements:
- Change fixture lookups in wrappers to return Result with descriptive "Missing fixture" errors
- Modify scenario runner to panic with feature, scenario, step index, keyword, text, and error context on step failure

Tests:
- Adjust tests to handle Result returns from step functions and assert successful execution