### PR TITLE
Use case name in scenario assertion

### DIFF
--- a/crates/rstest-bdd-macros/tests/scenario.rs
+++ b/crates/rstest-bdd-macros/tests/scenario.rs
@@ -68,9 +68,12 @@ fn simple_search() {
 #[scenario("tests/features/multi.feature", index = 1)]
 #[serial]
 fn scenario_with_index(#[case] case_name: &str) {
-    let _ = case_name;
     with_locked_events(|events| {
-        assert_eq!(events.as_slice(), ["precondition", "action", "result"]);
+        assert_eq!(
+            events.as_slice(),
+            ["precondition", "action", "result"],
+            "Test case: {case_name}"
+        );
     });
     clear_events();
 }


### PR DESCRIPTION
## Summary
- mention scenario test case name in assertion

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6891300baeac83228bdabe863e9cefe5

## Summary by Sourcery

Enhance BDD scenario tests by including the case name in assertion failures and clean up unused variable

Enhancements:
- Add a custom assertion message displaying the scenario use case name for clearer test failures

Tests:
- Remove redundant `let _ = case_name;` from the scenario test