### PR TITLE
Add step type relationships diagram

### DIFF
--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -445,6 +445,29 @@ calling `inventory::iter::<Step>()`. This provides an iterator over all
 registered `Step` instances, regardless of the file, module, or crate in which
 they were defined.
 
+The relationships among the core step types are shown below:
+
+```mermaid
+classDiagram
+    class Step {
+        + keyword: StepKeyword
+        + pattern: &'static StepPattern
+        + run: StepFn
+    }
+    class StepKeyword
+    class StepFn
+    class StepContext
+    Step --> StepPattern : pattern
+    Step --> StepKeyword : keyword
+    Step --> StepFn : run
+    class STEP_MAP {
+        + (StepKeyword, &'static str) => StepFn
+    }
+    StepPattern : +as_str(&self) -> &'static str
+    STEP_MAP --> StepFn : maps to
+    StepContext --> Step : uses
+```
+
 ```mermaid
 classDiagram
     class StepContext {


### PR DESCRIPTION
## Summary
- illustrate Step, StepKeyword, StepPattern, StepFn, StepContext, and STEP_MAP relationships with a Mermaid class diagram

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`
- `make nixie` *(fails: error: too many arguments. Expected 0 arguments but got 1)*

------
https://chatgpt.com/codex/tasks/task_e_68913ad503608322843ec086a2dc1485

## Summary by Sourcery

Documentation:
- Introduce a Mermaid diagram in rstest-bdd-design.md showing the relationships between Step, StepKeyword, StepPattern, StepFn, StepContext, and STEP_MAP