### PR TITLE
Add Background step support

### DIFF
--- a/crates/rstest-bdd-macros/tests/features/background.feature
+++ b/crates/rstest-bdd-macros/tests/features/background.feature
@@ -1,0 +1,11 @@
+Feature: Background execution
+  Background:
+    Given a background step
+
+  Scenario: first scenario
+    When an action occurs
+    Then a result is produced
+
+  Scenario: second scenario
+    When an action occurs
+    Then a result is produced

--- a/crates/rstest-bdd-macros/tests/scenario.rs
+++ b/crates/rstest-bdd-macros/tests/scenario.rs
@@ -37,6 +37,12 @@ where
     f(&mut guard)
 }
 
+#[given("a background step")]
+fn background_step() {
+    clear_events();
+    with_locked_events(|events| events.push("background"));
+}
+
 #[given("a precondition")]
 fn precondition() {
     clear_events();
@@ -101,5 +107,23 @@ fn outline(num: String) {
         assert_eq!(events.as_slice(), ["precondition", "action", "result"]);
     });
     assert!(num == "1" || num == "2");
+    clear_events();
+}
+
+#[scenario("tests/features/background.feature", index = 0)]
+#[serial]
+fn background_first() {
+    with_locked_events(|events| {
+        assert_eq!(events.as_slice(), ["background", "action", "result"]);
+    });
+    clear_events();
+}
+
+#[scenario("tests/features/background.feature", index = 1)]
+#[serial]
+fn background_second() {
+    with_locked_events(|events| {
+        assert_eq!(events.as_slice(), ["background", "action", "result"]);
+    });
     clear_events();
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -102,7 +102,7 @@ improves the developer experience.
 
 - [ ] **Advanced Gherkin Constructs**
 
-  - [ ] Implement support for `Background` steps, ensuring they are executed
+  - [x] Implement support for `Background` steps, ensuring they are executed
     before each `Scenario`.
 
   - [ ] Implement support for `Data Tables`, making the data available to the

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -250,10 +250,8 @@ To achieve feature parity with modern BDD tools, the framework will support
 other essential Gherkin constructs.
 
 - **Background:** Steps defined in a `Background` section are executed before
-  each `Scenario` in a feature file.[^10] This maps naturally to common setup
-  logic and will be handled automatically by the
-
-  `#[scenario]` macro.
+  each `Scenario` in a feature file.[^10] The parser prepends these steps to
+  the scenario's step list so the `#[scenario]` macro runs them first.
 
 - **Data Tables:** A Gherkin data table provides a way to pass a structured
   block of data to a single step. `rstest-bdd` will make this data available as
@@ -646,8 +644,8 @@ incrementally.
 
 - **Phase 3: Advanced Gherkin Features & Ergonomics**
 
-- Add support for `Background` steps, Data Tables, and Docstrings, passing them
-  as special arguments to step functions.
+- Add support for Data Tables and Docstrings, passing them as special
+  arguments to step functions.
 
 - Implement robust compile-time error handling. The `#[scenario]` macro should
   emit clear compiler errors if a feature file cannot be parsed or if no

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -46,8 +46,9 @@ same type for readability.
 
 Scenarios follow the simple `Given‑When‑Then` pattern. Support for **Scenario
 Outline** is available, enabling a single scenario to run with multiple sets of
-data from an `Examples` table. Other advanced constructs such as
-**Background**, data tables and docstrings are not yet implemented.
+data from an `Examples` table. A `Background` section may define steps that run
+before each scenario. Other advanced constructs such as data tables and
+docstrings are not yet implemented.
 
 ### Example feature file
 
@@ -207,14 +208,9 @@ Best practices for writing effective scenarios include:
 The `rstest‑bdd` project is evolving. Several features described in the design
 document and README remain unimplemented in the current codebase:
 
-- **Scenario outlines and example tables.** Parameterised scenarios using
-  `Scenario Outline` with an `Examples` table are proposed, but there is no
-  support for expanding multiple runs from a single template. Use explicit
-  scenarios instead.
-
-- **Background sections, data tables and docstrings.** The design notes plans
-  to support shared `Background` steps and to supply data tables and docstrings
-  as arguments to step functions. These are currently not implemented.
+- **Data tables and docstrings.** The design notes plans to supply data tables
+  and docstrings as arguments to step functions. These are currently not
+  implemented.
 
 - **Selecting scenarios by name.** The README hints at a `name` argument for
   the `#[scenario]` macro, but the macro only accepts `path` and optional


### PR DESCRIPTION
## Summary
- run feature-level `Background` steps before each scenario
- document shared setup design and mark roadmap entry complete
- cover background execution with unit and behavioural tests

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: too many arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68927e728d0483229c8f996922367f00