### PR TITLE
Add data table support

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,16 +213,26 @@ ______________________________________________________________________
 ## Background, tables, and docstrings
 
 - **Background** runs before every scenario in the feature.
-
-- **Data tables** arrive as structured values (e.g. `Vec<(String, String)>`).
+- **Data tables** arrive in a `datatable` parameter of type
+  `Vec<Vec<String>>`.
 
 - **Docstrings** arrive as a `String`.
 
 ```rust
 #[given("the following users exist:")]
-fn create_users(#[from(db)] conn: &mut DbConnection, users: Vec<(String, String)>) {
-    for (name, email) in users {
-        conn.insert_user(&name, &email);
+fn create_users(
+    #[from(db)] conn: &mut DbConnection,
+    datatable: Vec<Vec<String>>,
+) {
+    // Assume the first row is a header: ["name", "email", ...]
+    for row in datatable.into_iter().skip(1) {
+        assert!(
+            row.len() >= 2,
+            "Expected at least two columns: name and email",
+        );
+        let name = &row[0];
+        let email = &row[1];
+        conn.insert_user(name, email);
     }
 }
 ```

--- a/crates/rstest-bdd-macros/src/codegen/scenario.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario.rs
@@ -60,7 +60,7 @@ fn generate_table_tokens(table: Option<&[Vec<String>]>) -> TokenStream2 {
         || quote! { None },
         |rows| {
             if rows.is_empty() {
-                return quote! { Some(&[][..]) };
+                return quote! { Some(&[] as &[&[&str]]) };
             }
             let row_tokens = rows.iter().map(|row| {
                 let cells = row.iter().map(|cell| {

--- a/crates/rstest-bdd-macros/src/codegen/scenario.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario.rs
@@ -59,6 +59,9 @@ fn generate_table_tokens(table: Option<&[Vec<String>]>) -> TokenStream2 {
     table.map_or_else(
         || quote! { None },
         |rows| {
+            if rows.is_empty() {
+                return quote! { Some(&[][..]) };
+            }
             let row_tokens = rows.iter().map(|row| {
                 let cells = row.iter().map(|cell| {
                     let lit = syn::LitStr::new(cell, proc_macro2::Span::call_site());

--- a/crates/rstest-bdd-macros/src/codegen/wrapper.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper.rs
@@ -100,6 +100,10 @@ fn is_string_type(ty: &syn::Type) -> bool {
 
 /// Determines if a function parameter should be treated as a datatable argument.
 ///
+/// Detection relies on the parameter being named `datatable` and having the
+/// concrete type `Vec<Vec<String>>`. Renaming the parameter or using a type alias
+/// will prevent detection.
+///
 /// # Examples
 /// ```rust,ignore
 /// # use proc_macro2::Span;

--- a/crates/rstest-bdd-macros/src/macros/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/mod.rs
@@ -23,7 +23,7 @@ fn step_attr(
     let pattern = syn::parse_macro_input!(attr as syn::LitStr);
     let mut func = syn::parse_macro_input!(item as syn::ItemFn);
 
-    let (fixtures, step_args) = match extract_args(&mut func) {
+    let (fixtures, step_args, datatable) = match extract_args(&mut func) {
         Ok(args) => args,
         Err(err) => return error_to_tokens(&err),
     };
@@ -34,6 +34,7 @@ fn step_attr(
         ident,
         fixtures: &fixtures,
         step_args: &step_args,
+        datatable: datatable.as_ref(),
         pattern: &pattern,
         keyword,
     };

--- a/crates/rstest-bdd-macros/src/macros/scenario.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenario.rs
@@ -4,7 +4,7 @@ use proc_macro::TokenStream;
 use proc_macro2::Span;
 use std::path::PathBuf;
 
-use crate::codegen::scenario::generate_scenario_code;
+use crate::codegen::scenario::{ScenarioConfig, generate_scenario_code};
 use crate::parsing::feature::{ScenarioData, extract_scenario_steps, parse_and_load_feature};
 use crate::utils::fixtures::extract_function_fixtures;
 use crate::validation::parameters::process_scenario_outline_examples;
@@ -121,14 +121,16 @@ pub(crate) fn scenario(attr: TokenStream, item: TokenStream) -> TokenStream {
     let (_args, ctx_inserts) = extract_function_fixtures(sig);
 
     generate_scenario_code(
-        attrs,
-        vis,
-        sig,
-        block,
-        feature_path_str,
-        scenario_name,
-        steps,
-        examples,
+        ScenarioConfig {
+            attrs,
+            vis,
+            sig,
+            block,
+            feature_path: feature_path_str,
+            scenario_name,
+            steps,
+            examples,
+        },
         ctx_inserts,
     )
 }

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -358,7 +358,7 @@ fn extract_captured_values(re: &Regex, text: &str) -> Option<Vec<String>> {
 }
 
 /// Type alias for the stored step function pointer.
-pub type StepFn = for<'a> fn(&StepContext<'a>, &str) -> Result<(), String>;
+pub type StepFn = for<'a> fn(&StepContext<'a>, &str, Option<&[&[&str]]>) -> Result<(), String>;
 
 /// Represents a single step definition registered with the framework.
 ///

--- a/crates/rstest-bdd/tests/datatable.rs
+++ b/crates/rstest-bdd/tests/datatable.rs
@@ -1,0 +1,18 @@
+//! Behavioural test for data table support
+
+use rstest_bdd_macros::{given, scenario};
+
+#[given("the following table:")]
+#[expect(clippy::needless_pass_by_value, reason = "step consumes the table")]
+fn check_table(datatable: Vec<Vec<String>>) {
+    assert_eq!(
+        datatable,
+        vec![
+            vec!["alpha".to_string(), "beta".to_string()],
+            vec!["gamma".to_string(), "delta".to_string()],
+        ],
+    );
+}
+
+#[scenario(path = "tests/features/datatable.feature")]
+fn datatable_scenario() {}

--- a/crates/rstest-bdd/tests/features/datatable.feature
+++ b/crates/rstest-bdd/tests/features/datatable.feature
@@ -1,0 +1,6 @@
+Feature: Data table support
+  Scenario: pass data table to step
+    Given the following table:
+      | alpha | beta |
+      | gamma | delta |
+

--- a/crates/rstest-bdd/tests/fixture_context.rs
+++ b/crates/rstest-bdd/tests/fixture_context.rs
@@ -2,7 +2,11 @@
 
 use rstest_bdd::{Step, StepContext, iter, step};
 
-fn needs_value(ctx: &StepContext<'_>, _text: &str) -> Result<(), String> {
+fn needs_value(
+    ctx: &StepContext<'_>,
+    _text: &str,
+    _table: Option<&[&[&str]]>,
+) -> Result<(), String> {
     let val = ctx.get::<u32>("number").ok_or_else(|| {
         "Missing fixture 'number' of type 'u32' in step function 'needs_value'".to_string()
     })?;
@@ -29,7 +33,7 @@ fn context_passes_fixture() {
             || panic!("step 'a value' not found in registry"),
             |step| step.run,
         );
-    let result = step_fn(&ctx, "a value");
+    let result = step_fn(&ctx, "a value", None);
     assert!(result.is_ok(), "step execution failed: {result:?}");
 }
 
@@ -43,7 +47,7 @@ fn context_missing_fixture_returns_error() {
             || panic!("step 'a value' not found in registry"),
             |step| step.run,
         );
-    let result = step_fn(&ctx, "a value");
+    let result = step_fn(&ctx, "a value", None);
     let err = match result {
         Ok(()) => panic!("expected error when fixture is missing"),
         Err(e) => e,

--- a/crates/rstest-bdd/tests/step_registry.rs
+++ b/crates/rstest-bdd/tests/step_registry.rs
@@ -7,7 +7,11 @@ fn sample() {}
     clippy::unnecessary_wraps,
     reason = "wrapper must match StepFn signature"
 )]
-fn wrapper(ctx: &rstest_bdd::StepContext<'_>, _text: &str) -> Result<(), String> {
+fn wrapper(
+    ctx: &rstest_bdd::StepContext<'_>,
+    _text: &str,
+    _table: Option<&[&[&str]]>,
+) -> Result<(), String> {
     // Adapter for zero-argument step functions
     let _ = ctx;
     sample();
@@ -16,7 +20,11 @@ fn wrapper(ctx: &rstest_bdd::StepContext<'_>, _text: &str) -> Result<(), String>
 
 step!(rstest_bdd::StepKeyword::When, "behavioural", wrapper, &[]);
 
-fn failing_wrapper(ctx: &StepContext<'_>, _text: &str) -> Result<(), String> {
+fn failing_wrapper(
+    ctx: &StepContext<'_>,
+    _text: &str,
+    _table: Option<&[&[&str]]>,
+) -> Result<(), String> {
     let _ = ctx;
     Err("boom".to_string())
 }
@@ -45,7 +53,7 @@ fn wrapper_error_propagates() {
             || panic!("step 'fails' not found in registry"),
             |step| step.run,
         );
-    let result = step_fn(&StepContext::default(), "fails");
+    let result = step_fn(&StepContext::default(), "fails", None);
     let err = match result {
         Ok(()) => panic!("expected error from wrapper"),
         Err(e) => e,

--- a/docs/gherkin-syntax.md
+++ b/docs/gherkin-syntax.md
@@ -630,9 +630,10 @@ steps.
   arguments to the corresponding step functions. Their names must match the
   headers in the `Examples` table.[^25]
 - `Data Tables`**:** A step definition function can access a `Data Table` by
-  including a special argument named `datatable`. `pytest-bdd` will inject the
-  table's content into this argument as a list of lists, where each inner list
-  represents a row.[^16]
+  including a special argument named `datatable` of type `Vec<Vec<String>>`.
+  The name and type must match exactly; aliases or alternative names are not
+  recognised. `pytest-bdd` will inject the table's content into this argument
+  as a list of lists, where each inner list represents a row.[^16]
 - `Doc Strings`**:** Similarly, a `Doc String` can be accessed by including a
   special argument named `docstring`. This argument will receive the entire
   block text as a single, multi-line string.[^16]
@@ -793,7 +794,7 @@ into Rust types.
 
   The same principle applies to `Data Tables`, where `step.table.as_ref()`
   would be used to access the table data, which can then be iterated over.[^30]
-______________________________________________________________________
+  ______________________________________________________________________
 
 ## Part 6: Synthesis: Implementation Variations and Quirks
 

--- a/docs/gherkin-syntax.md
+++ b/docs/gherkin-syntax.md
@@ -264,10 +264,11 @@ Feature: User administration
 ```
 
 Unlike an `Examples` table, this `Data Table` does not cause the scenario to
-run multiple times. Instead, the entire table is passed as a single argument to
-the step definition for "Given the following users exist in the system:". The
-automation code can then parse this table (often as a list of lists or list of
-maps) and use it to perform the necessary setup.[^16]
+run multiple times. Instead, the entire table is passed as a single optional
+parameter named `datatable` of type `Vec<Vec<String>>` to the step definition
+for "Given the following users exist in the system:". The automation code can
+then parse this table (often as a list of lists or list of maps) and use it to
+perform the necessary setup.[^16]
 
 ### Section 2.4: Incorporating Block Text with `Doc Strings`
 

--- a/docs/gherkin-syntax.md
+++ b/docs/gherkin-syntax.md
@@ -264,11 +264,11 @@ Feature: User administration
 ```
 
 Unlike an `Examples` table, this `Data Table` does not cause the scenario to
-run multiple times. Instead, the entire table is passed as a single optional
-parameter named `datatable` of type `Vec<Vec<String>>` to the step definition
-for "Given the following users exist in the system:". The automation code can
-then parse this table (often as a list of lists or list of maps) and use it to
-perform the necessary setup.[^16]
+run multiple times. Instead, pass the entire table to the step definition as a
+parameter named `datatable`. The argument holds the rows as a two-dimensional
+collection (rows and cells). Parse it in the target language as appropriate
+(for example, a list of lists in Python; a `Vec<Vec<String>>` in Rust) and use
+it to perform the necessary setup.[^16]
 
 ### Section 2.4: Incorporating Block Text with `Doc Strings`
 
@@ -631,12 +631,9 @@ steps.
   arguments to the corresponding step functions. Their names must match the
   headers in the `Examples` table.[^25]
 - `Data Tables`**:** Step functions may include a single optional parameter
-  named `datatable` of type `Vec<Vec<String>>`. Detection relies on this exact
-  name and type; renaming the parameter or using a type alias prevents the
-  wrapper from recognizing it. When the feature file attaches a data table to a
-  step, the generated wrapper converts the table into this structure and passes
-  it to the function. The wrapper emits an error at runtime if the table is
-  missing.[^16]
+  named `datatable`. The argument receives the table as a list of lists (rows
+  and cells). `pytest-bdd` injects the table content into this argument, where
+  each inner list represents a row.[^16]
 - `Doc Strings`**:** Similarly, a `Doc String` can be accessed by including a
   special argument named `docstring`. This argument will receive the entire
   block text as a single, multi-line string.[^16]

--- a/docs/gherkin-syntax.md
+++ b/docs/gherkin-syntax.md
@@ -629,11 +629,13 @@ steps.
   values from the `Examples` table are automatically parsed and passed as
   arguments to the corresponding step functions. Their names must match the
   headers in the `Examples` table.[^25]
-- `Data Tables`**:** A step definition function can access a `Data Table` by
-  including a special argument named `datatable` of type `Vec<Vec<String>>`.
-  The name and type must match exactly; aliases or alternative names are not
-  recognised. `pytest-bdd` will inject the table's content into this argument
-  as a list of lists, where each inner list represents a row.[^16]
+- `Data Tables`**:** Step functions may include a single optional parameter
+  named `datatable` of type `Vec<Vec<String>>`. Detection relies on this exact
+  name and type; renaming the parameter or using a type alias prevents the
+  wrapper from recognizing it. When the feature file attaches a data table to a
+  step, the generated wrapper converts the table into this structure and passes
+  it to the function. The wrapper emits an error at runtime if the table is
+  missing.[^16]
 - `Doc Strings`**:** Similarly, a `Doc String` can be accessed by including a
   special argument named `docstring`. This argument will receive the entire
   block text as a single, multi-line string.[^16]

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -105,7 +105,7 @@ improves the developer experience.
   - [x] Implement support for `Background` steps, ensuring they are executed
     before each `Scenario`.
 
-  - [ ] Implement support for `Data Tables`, making the data available to the
+  - [x] Implement support for `Data Tables`, making the data available to the
     step function as a `Vec<Vec<String>>`.
 
   - [ ] Implement support for `DocStrings`, making the content available as a

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -253,10 +253,10 @@ other essential Gherkin constructs.
   before each `Scenario` in a feature file.[^10] The parser prepends these
   steps to the scenario's step list so the `#[scenario]` macro runs them first.
 
-- **Data Tables:** A Gherkin data table provides a way to pass a structured
-  block of data to a single step. `rstest-bdd` will make this data available as
-  a `Vec<Vec<String>>` argument to the step function, mirroring `pytest-bdd`'s
-  `datatable` argument.[^11]
+- **Data Tables:** A Gherkin data table provides a way to pass a
+  structured block of data to a single step. `rstest-bdd` will make this data
+  available as a `Vec<Vec<String>>` argument to the step function, mirroring
+  `pytest-bdd`'s `datatable` argument.[^11]
 
   **Feature File:**
 
@@ -335,11 +335,11 @@ macro has a distinct role in the compile-time orchestration of the BDD tests.
   call to `rstest_bdd::step!`, which internally uses `inventory::submit!` to
   add a `Step` to the registry.
 
-- **Data Tables:** Step functions may include a parameter named `datatable`
-  of type `Vec<Vec<String>>`. When the feature file attaches a data table to a
-  step, the generated wrapper converts the table into this structure and passes
-  it to the function. The wrapper emits an error at runtime if the table is
-  missing.
+- **Data Tables:** Step functions may include a parameter named
+  `datatable` of type `Vec<Vec<String>>`. When the feature file attaches a data
+  table to a step, the generated wrapper converts the table into this structure
+  and passes it to the function. The wrapper emits an error at runtime if the
+  table is missing.
 
 ### 2.2 The Core Architectural Challenge: Stateless Step Discovery
 

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -253,9 +253,9 @@ other essential Gherkin constructs.
   before each `Scenario` in a feature file.[^10] The parser prepends these
   steps to the scenario's step list so the `#[scenario]` macro runs them first.
 
-- **Data Tables:** A Gherkin data table provides a way to pass a
-  structured block of data to a single step. `rstest-bdd` will make this data
-  available as a `Vec<Vec<String>>` argument to the step function, mirroring
+- **Data Tables:** A Gherkin data table provides a way to pass a structured
+  block of data to a single step. Provide it to the step function via a single
+  optional parameter named `datatable` of type `Vec<Vec<String>>`, mirroring
   `pytest-bdd`'s `datatable` argument.[^11]
 
   **Feature File:**
@@ -923,7 +923,7 @@ sequenceDiagram
         StepRegistry->>StepRegistry: extract_placeholders(pattern, text)
         StepRegistry-->>ScenarioRunner: StepFn
     end
-    ScenarioRunner->>StepWrapper: call StepFn(ctx, text, table)
+    ScenarioRunner->>StepWrapper: call StepFn(ctx, text, table: Option<&[&[&str]]>)
     StepWrapper->>StepWrapper: extract_placeholders(pattern, text)
     StepWrapper->>StepWrapper: parse captures with FromStr
     StepWrapper->>StepFunction: call with typed args

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -340,7 +340,7 @@ macro has a distinct role in the compile-time orchestration of the BDD tests.
   call to `rstest_bdd::step!`, which internally uses `inventory::submit!` to
   add a `Step` to the registry.
 
-- **Data Tables:** Step functions may include a parameter named
+- **Data Tables:** Step functions may include a single optional parameter named
   `datatable` of type `Vec<Vec<String>>`. Detection relies on this exact name
   and type; renaming the parameter or using a type alias will prevent the
   wrapper from recognizing it. When the feature file attaches a data table to a

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -336,10 +336,12 @@ macro has a distinct role in the compile-time orchestration of the BDD tests.
   add a `Step` to the registry.
 
 - **Data Tables:** Step functions may include a parameter named
-  `datatable` of type `Vec<Vec<String>>`. When the feature file attaches a data
-  table to a step, the generated wrapper converts the table into this structure
-  and passes it to the function. The wrapper emits an error at runtime if the
-  table is missing.
+  `datatable` of type `Vec<Vec<String>>`. Detection relies on this exact name
+  and type; renaming the parameter or using a type alias will prevent the
+  wrapper from recognising it. When the feature file attaches a data table to a
+  step, the generated wrapper converts the table into this structure and passes
+  it to the function. The wrapper emits an error at runtime if the table is
+  missing.
 
 ### 2.2 The Core Architectural Challenge: Stateless Step Discovery
 

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -276,7 +276,12 @@ fn create_users(
     #[from(db)] conn: &mut DbConnection,
     datatable: Vec<Vec<String>>,
 ) {
-    for row in datatable {
+    // Assume the first row is a header: ["name", "email", ...]
+    for row in datatable.into_iter().skip(1) {
+        assert!(
+            row.len() >= 2,
+            "Expected at least two columns: name and email",
+        );
         let name = &row[0];
         let email = &row[1];
         conn.insert_user(name, email);

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -276,14 +276,23 @@ fn create_users(
     #[from(db)] conn: &mut DbConnection,
     datatable: Vec<Vec<String>>,
 ) {
-    // Assume the first row is a header: ["name", "email", ...]
-    for row in datatable.into_iter().skip(1) {
+    let headers = &datatable[0];
+    let name_idx = headers
+        .iter()
+        .position(|h| h == "name")
+        .expect("missing 'name' column");
+    let email_idx = headers
+        .iter()
+        .position(|h| h == "email")
+        .expect("missing 'email' column");
+
+    for row in datatable.iter().skip(1) {
         assert!(
-            row.len() >= 2,
-            "Expected at least two columns: name and email",
+            row.len() > name_idx && row.len() > email_idx,
+            "Expected 'name' and 'email' columns",
         );
-        let name = &row[0];
-        let email = &row[1];
+        let name = &row[name_idx];
+        let email = &row[email_idx];
         conn.insert_user(name, email);
     }
 }

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -343,7 +343,7 @@ macro has a distinct role in the compile-time orchestration of the BDD tests.
 - **Data Tables:** Step functions may include a parameter named
   `datatable` of type `Vec<Vec<String>>`. Detection relies on this exact name
   and type; renaming the parameter or using a type alias will prevent the
-  wrapper from recognising it. When the feature file attaches a data table to a
+  wrapper from recognizing it. When the feature file attaches a data table to a
   step, the generated wrapper converts the table into this structure and passes
   it to the function. The wrapper emits an error at runtime if the table is
   missing.


### PR DESCRIPTION
## Summary
- support Gherkin data tables as `Vec<Vec<String>>` in step functions
- parse data tables from feature files and feed them to generated steps
- document data table handling and mark roadmap item complete

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: error: too many arguments. Expected 0 arguments but got 1.)*

------
https://chatgpt.com/codex/tasks/task_e_6893d0ab187083228caf02623703e662

## Summary by Sourcery

Add end-to-end support for Gherkin data tables by parsing tables from feature files, extending the StepFn signature and wrapper generation to pass tables as Vec<Vec<String>> to step functions, and updating tests and documentation accordingly.

New Features:
- Parse Gherkin data tables into ParsedStep and pass them as Vec<Vec<String>> to step functions

Enhancements:
- Extend code generation to detect and propagate `datatable` parameters and adapt scenario runner to include table argument
- Change the core StepFn type and wrapper invocation signature to accept an optional table parameter

Documentation:
- Document data table handling in the design guide and mark roadmap item as complete

Tests:
- Add parsing unit tests and behavioural integration test with a feature file for data table support
- Update existing step and fixture tests to include the new table parameter