### PR TITLE
Refactor table cell literal creation in scenario codegen

### DIFF
--- a/crates/rstest-bdd-macros/src/codegen/scenario.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario.rs
@@ -60,11 +60,12 @@ fn generate_table_tokens(table: Option<&[Vec<String>]>) -> TokenStream2 {
         || quote! { None },
         |rows| {
             if rows.is_empty() {
+                // Explicitly type the empty slice to avoid inference pitfalls when no rows exist.
                 return quote! { Some(&[] as &[&[&str]]) };
             }
             let row_tokens = rows.iter().map(|row| {
                 let cells = row.iter().map(|cell| {
-                    let lit = syn::LitStr::new(cell, proc_macro2::Span::call_site());
+                    let lit = cell_to_lit(cell);
                     quote! { #lit }
                 });
                 quote! { &[#(#cells),*][..] }

--- a/crates/rstest-bdd-macros/src/codegen/scenario.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario.rs
@@ -61,16 +61,17 @@ fn generate_table_tokens(table: Option<&[Vec<String>]>) -> TokenStream2 {
         |rows| {
             if rows.is_empty() {
                 // Explicitly type the empty slice to avoid inference pitfalls when no rows exist.
-                return quote! { Some(&[] as &[&[&str]]) };
-            }
-            let row_tokens = rows.iter().map(|row| {
-                let cells = row.iter().map(|cell| {
-                    let lit = cell_to_lit(cell);
-                    quote! { #lit }
+                quote! { Some(&[] as &[&[&str]]) }
+            } else {
+                let row_tokens = rows.iter().map(|row| {
+                    let cells = row.iter().map(|cell| {
+                        let lit = cell_to_lit(cell);
+                        quote! { #lit }
+                    });
+                    quote! { &[#(#cells),*][..] }
                 });
-                quote! { &[#(#cells),*][..] }
-            });
-            quote! { Some(&[#(#row_tokens),*][..]) }
+                quote! { Some(&[#(#row_tokens),*][..]) }
+            }
         },
     )
 }
@@ -92,7 +93,7 @@ fn process_steps(
     let values = steps
         .iter()
         .map(|s| {
-            let lit = syn::LitStr::new(&s.text, proc_macro2::Span::call_site());
+            let lit = cell_to_lit(&s.text);
             quote! { #lit }
         })
         .collect();


### PR DESCRIPTION
## Summary
- reuse `cell_to_lit` when building table cell literals to centralise span handling
- retain explicit slice type for empty tables to avoid inference issues

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6896700c978c8322843a5f31c630c90d

## Summary by Sourcery

Refactor scenario codegen for tables by consolidating literal construction and improving empty table typing

Enhancements:
- Reuse the cell_to_lit helper for generating table cell literals to centralize span handling
- Add an explicit slice type for empty tables to prevent type inference issues