### PR TITLE
Add DocString support for Gherkin steps

### DIFF
--- a/crates/rstest-bdd-macros/src/macros/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/mod.rs
@@ -23,7 +23,7 @@ fn step_attr(
     let pattern = syn::parse_macro_input!(attr as syn::LitStr);
     let mut func = syn::parse_macro_input!(item as syn::ItemFn);
 
-    let (fixtures, step_args, datatable) = match extract_args(&mut func) {
+    let (fixtures, step_args, datatable, docstring) = match extract_args(&mut func) {
         Ok(args) => args,
         Err(err) => return error_to_tokens(&err),
     };
@@ -35,6 +35,7 @@ fn step_attr(
         fixtures: &fixtures,
         step_args: &step_args,
         datatable: datatable.as_ref(),
+        docstring: docstring.as_ref(),
         pattern: &pattern,
         keyword,
     };

--- a/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
@@ -7,11 +7,12 @@ use crate::parsing::examples::ExampleTable;
 use crate::utils::errors::error_to_tokens;
 use crate::validation::examples::validate_examples_in_feature_text;
 
-/// Step extracted from a scenario with an optional data table.
+/// Step extracted from a scenario with optional arguments.
 #[derive(Debug, PartialEq)]
 pub(crate) struct ParsedStep {
     pub keyword: rstest_bdd::StepKeyword,
     pub text: String,
+    pub docstring: Option<String>,
     pub table: Option<Vec<Vec<String>>>,
 }
 
@@ -30,9 +31,11 @@ fn map_step(step: &Step) -> ParsedStep {
         _ => step.ty.into(),
     };
     let table = step.table.as_ref().map(|t| t.rows.clone());
+    let docstring = step.docstring.clone();
     ParsedStep {
         keyword,
         text: step.value.clone(),
+        docstring,
         table,
     }
 }

--- a/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
@@ -44,6 +44,23 @@ fn mk_step_with_table(ty: StepType, value: &str, rows: Vec<Vec<&str>>) -> Step {
     }
 }
 
+fn mk_step_with_docstring(ty: StepType, value: &str, doc: &str) -> Step {
+    Step {
+        keyword: match ty {
+            StepType::Given => "Given",
+            StepType::When => "When",
+            StepType::Then => "Then",
+        }
+        .to_string(),
+        ty,
+        value: value.to_string(),
+        docstring: Some(doc.to_string()),
+        table: None,
+        span: Span { start: 0, end: 0 },
+        position: LineCol { line: 0, col: 0 },
+    }
+}
+
 #[test]
 fn prepends_background_steps() {
     let feature = gherkin::Feature {
@@ -86,16 +103,19 @@ fn prepends_background_steps() {
             ParsedStep {
                 keyword: rstest_bdd::StepKeyword::Given,
                 text: "a background step".to_string(),
+                docstring: None,
                 table: None,
             },
             ParsedStep {
                 keyword: rstest_bdd::StepKeyword::When,
                 text: "an action".to_string(),
+                docstring: None,
                 table: None,
             },
             ParsedStep {
                 keyword: rstest_bdd::StepKeyword::Then,
                 text: "a result".to_string(),
+                docstring: None,
                 table: None,
             },
         ]
@@ -137,10 +157,52 @@ fn extracts_data_table() {
         vec![ParsedStep {
             keyword: rstest_bdd::StepKeyword::Given,
             text: "numbers".to_string(),
+            docstring: None,
             table: Some(vec![
                 vec!["1".to_string(), "2".to_string()],
                 vec!["3".to_string(), "4".to_string()],
             ]),
+        }]
+    );
+}
+
+#[test]
+fn extracts_docstring() {
+    let feature = gherkin::Feature {
+        keyword: "Feature".into(),
+        name: "example".into(),
+        description: None,
+        background: None,
+        scenarios: vec![Scenario {
+            keyword: "Scenario".into(),
+            name: "doc".into(),
+            description: None,
+            steps: vec![mk_step_with_docstring(
+                StepType::Given,
+                "text",
+                "line1\nline2",
+            )],
+            examples: Vec::new(),
+            tags: Vec::new(),
+            span: Span { start: 0, end: 0 },
+            position: LineCol { line: 0, col: 0 },
+        }],
+        rules: Vec::new(),
+        tags: Vec::new(),
+        span: Span { start: 0, end: 0 },
+        position: LineCol { line: 0, col: 0 },
+        path: None,
+    };
+
+    let ScenarioData { steps, .. } = extract_scenario_steps(&feature, Some(0))
+        .unwrap_or_else(|_| panic!("scenario extraction failed"));
+    assert_eq!(
+        steps,
+        vec![ParsedStep {
+            keyword: rstest_bdd::StepKeyword::Given,
+            text: "text".to_string(),
+            docstring: Some("line1\nline2".to_string()),
+            table: None,
         }]
     );
 }

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -358,7 +358,8 @@ fn extract_captured_values(re: &Regex, text: &str) -> Option<Vec<String>> {
 }
 
 /// Type alias for the stored step function pointer.
-pub type StepFn = for<'a> fn(&StepContext<'a>, &str, Option<&[&[&str]]>) -> Result<(), String>;
+pub type StepFn =
+    for<'a> fn(&StepContext<'a>, &str, Option<&str>, Option<&[&[&str]]>) -> Result<(), String>;
 
 /// Represents a single step definition registered with the framework.
 ///

--- a/crates/rstest-bdd/tests/docstring.rs
+++ b/crates/rstest-bdd/tests/docstring.rs
@@ -1,0 +1,15 @@
+//! Behavioural test for doc string support
+
+use rstest_bdd_macros::{given, scenario};
+
+#[given("the following message:")]
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "doc string is owned to mirror user API"
+)]
+fn check_docstring(docstring: String) {
+    assert_eq!(docstring, "\nhello\nworld\n");
+}
+
+#[scenario(path = "tests/features/docstring.feature")]
+fn docstring_scenario() {}

--- a/crates/rstest-bdd/tests/features/docstring.feature
+++ b/crates/rstest-bdd/tests/features/docstring.feature
@@ -1,0 +1,7 @@
+Feature: DocString handling
+  Scenario: Capture docstring
+    Given the following message:
+      """
+      hello
+      world
+      """

--- a/crates/rstest-bdd/tests/fixture_context.rs
+++ b/crates/rstest-bdd/tests/fixture_context.rs
@@ -5,6 +5,7 @@ use rstest_bdd::{Step, StepContext, iter, step};
 fn needs_value(
     ctx: &StepContext<'_>,
     _text: &str,
+    _docstring: Option<&str>,
     _table: Option<&[&[&str]]>,
 ) -> Result<(), String> {
     let val = ctx.get::<u32>("number").ok_or_else(|| {
@@ -33,7 +34,7 @@ fn context_passes_fixture() {
             || panic!("step 'a value' not found in registry"),
             |step| step.run,
         );
-    let result = step_fn(&ctx, "a value", None);
+    let result = step_fn(&ctx, "a value", None, None);
     assert!(result.is_ok(), "step execution failed: {result:?}");
 }
 
@@ -47,7 +48,7 @@ fn context_missing_fixture_returns_error() {
             || panic!("step 'a value' not found in registry"),
             |step| step.run,
         );
-    let result = step_fn(&ctx, "a value", None);
+    let result = step_fn(&ctx, "a value", None, None);
     let err = match result {
         Ok(()) => panic!("expected error when fixture is missing"),
         Err(e) => e,

--- a/crates/rstest-bdd/tests/step_registry.rs
+++ b/crates/rstest-bdd/tests/step_registry.rs
@@ -10,6 +10,7 @@ fn sample() {}
 fn wrapper(
     ctx: &rstest_bdd::StepContext<'_>,
     _text: &str,
+    _docstring: Option<&str>,
     _table: Option<&[&[&str]]>,
 ) -> Result<(), String> {
     // Adapter for zero-argument step functions
@@ -23,6 +24,7 @@ step!(rstest_bdd::StepKeyword::When, "behavioural", wrapper, &[]);
 fn failing_wrapper(
     ctx: &StepContext<'_>,
     _text: &str,
+    _docstring: Option<&str>,
     _table: Option<&[&[&str]]>,
 ) -> Result<(), String> {
     let _ = ctx;
@@ -53,7 +55,7 @@ fn wrapper_error_propagates() {
             || panic!("step 'fails' not found in registry"),
             |step| step.run,
         );
-    let result = step_fn(&StepContext::default(), "fails", None);
+    let result = step_fn(&StepContext::default(), "fails", None, None);
     let err = match result {
         Ok(()) => panic!("expected error from wrapper"),
         Err(e) => e,

--- a/docs/gherkin-syntax.md
+++ b/docs/gherkin-syntax.md
@@ -268,7 +268,9 @@ run multiple times. Instead, pass the entire table to the step definition as a
 parameter named `datatable`. The argument holds the rows as a two-dimensional
 collection (rows and cells). Parse it in the target language as appropriate
 (for example, a list of lists in Python; a `Vec<Vec<String>>` in Rust) and use
-it to perform the necessary setup.[^16]
+it to perform the necessary setup.[^16] In `rstest-bdd`, a `Doc String` is
+retrieved in a similar fashion via a parameter named `docstring` of type
+`String`.
 
 ### Section 2.4: Incorporating Block Text with `Doc Strings`
 
@@ -295,9 +297,10 @@ Feature: API for creating blog posts
 ```
 
 In the step definition, the entire content of the `Doc String` is passed as a
-single string argument. Advanced Gherkin parsers also allow specifying a
-content type (e.g., `"""json`) after the opening delimiter, which can help
-tools with syntax highlighting and parsing.[^10]
+single string argument. In `rstest-bdd`, this is achieved by declaring an
+argument named `docstring` of type `String`. Advanced Gherkin parsers also
+allow specifying a content type (e.g., `"""json`) after the opening delimiter,
+which can help tools with syntax highlighting and parsing.[^10]
 
 ### Section 2.5: Grouping with the `Rule` Keyword
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -108,7 +108,7 @@ improves the developer experience.
   - [x] Implement support for `Data Tables`, making the data available to the
     step function as a `Vec<Vec<String>>`.
 
-  - [ ] Implement support for `DocStrings`, making the content available as a
+  - [x] Implement support for `DocStrings`, making the content available as a
     `String` argument.
 
 - [ ] **Robust Error Handling**

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -357,6 +357,12 @@ macro has a distinct role in the compile-time orchestration of the BDD tests.
   it to the function. The wrapper emits an error at runtime if the table is
   missing.
 
+- **Doc Strings:** A multi-line text block immediately following a step is
+  exposed to the step function through an optional `docstring` parameter of
+  type `String`. As with data tables, the parameter must use this exact name
+  and concrete type for detection. The wrapper copies the block text into the
+  argument and fails at runtime if the doc string is absent.
+
 ### 2.2 The Core Architectural Challenge: Stateless Step Discovery
 
 The most significant technical hurdle in this design is the inherent nature of
@@ -932,7 +938,7 @@ sequenceDiagram
         StepRegistry->>StepRegistry: extract_placeholders(pattern, text)
         StepRegistry-->>ScenarioRunner: StepFn
     end
-    ScenarioRunner->>StepWrapper: call StepFn(ctx, text, table: Option<&[&[&str]]>)
+    ScenarioRunner->>StepWrapper: call StepFn(ctx, text, docstring: Option<&str>, table: Option<&[&[&str]]>)
     StepWrapper->>StepWrapper: extract_placeholders(pattern, text)
     StepWrapper->>StepWrapper: parse captures with FromStr
     StepWrapper->>StepFunction: call with typed args

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -47,8 +47,8 @@ same type for readability.
 Scenarios follow the simple `Given‑When‑Then` pattern. Support for **Scenario
 Outline** is available, enabling a single scenario to run with multiple sets of
 data from an `Examples` table. A `Background` section may define steps that run
-before each scenario. Other advanced constructs such as data tables and
-docstrings are not yet implemented.
+before each scenario. Advanced constructs such as data tables and doc strings
+provide structured or free‑form arguments to steps.
 
 ### Example feature file
 
@@ -203,14 +203,20 @@ Best practices for writing effective scenarios include:
   Nested braces inside placeholders are permitted. When no placeholder is
   present, the text must match exactly.
 
+## Data tables and doc strings
+
+Steps may supply structured or free-form data via a trailing argument. A data
+table is received by including an argument named `datatable` of type
+`Vec<Vec<String>>`. A doc string is made available through an argument named
+`docstring` of type `String`. Both arguments must use these exact names and
+types to be detected by the procedural macros. At runtime the generated wrapper
+converts the table cells or copies the block text and passes them to the step
+function, panicking if the feature omits the expected content.
+
 ## Limitations and roadmap
 
 The `rstest‑bdd` project is evolving. Several features described in the design
 document and README remain unimplemented in the current codebase:
-
-- **Data tables and docstrings.** The design notes plans to supply data tables
-  and docstrings as arguments to step functions. These are currently not
-  implemented.
 
 - **Selecting scenarios by name.** The README hints at a `name` argument for
   the `#[scenario]` macro, but the macro only accepts `path` and optional


### PR DESCRIPTION
## Summary
- allow step functions to accept Doc String blocks via a `docstring` parameter
- pass Doc Strings through the generated scenario runner
- document Doc String usage and mark roadmap item complete

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: Error running command bun x --bun @mermaid-js/mermaid-cli mmdc -p /tmp/tmpht6okp_n.json ...)*

------
https://chatgpt.com/codex/tasks/task_e_6896701300a48322ad940e9e005da327