### PR TITLE
Parse step patterns for clearer errors

### DIFF
--- a/crates/rstest-bdd-macros/tests/fixtures/step_nested_pattern.rs
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_nested_pattern.rs
@@ -1,3 +1,6 @@
+//! Compile-fail fixture: nested destructuring in a step parameter must emit an
+//! "unsupported pattern" error, enforcing the single identifier rule.
+
 use rstest_bdd_macros::given;
 
 struct User {

--- a/crates/rstest-bdd-macros/tests/fixtures/step_nested_pattern.rs
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_nested_pattern.rs
@@ -1,0 +1,10 @@
+use rstest_bdd_macros::given;
+
+struct User {
+    coords: (i32, i32),
+}
+
+#[given("user coords")]
+fn step_nested(User { coords: (x, y) }: User) {}
+
+fn main() {}

--- a/crates/rstest-bdd-macros/tests/fixtures/step_nested_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_nested_pattern.stderr
@@ -1,0 +1,5 @@
+error: complex destructuring patterns are not yet supported - pattern resolves to 2 identifiers but a single bare identifier is required. Found pattern: `User { coords : (x, y) }`
+ --> tests/fixtures/step_nested_pattern.rs:8:16
+  |
+8 | fn step_nested(User { coords: (x, y) }: User) {}
+  |                ^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/rstest-bdd-macros/tests/fixtures/step_nested_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_nested_pattern.stderr
@@ -1,5 +1,5 @@
-error: complex destructuring patterns are not yet supported - pattern resolves to 2 identifiers but a single bare identifier is required. Found pattern: `User { coords : (x, y) }`
- --> tests/fixtures/step_nested_pattern.rs:8:16
-  |
-8 | fn step_nested(User { coords: (x, y) }: User) {}
-  |                ^^^^^^^^^^^^^^^^^^^^^^^
+error: unsupported pattern `User { coords : (x, y) }`; expected a single identifier
+  --> tests/fixtures/step_nested_pattern.rs:11:16
+   |
+11 | fn step_nested(User { coords: (x, y) }: User) {}
+   |                ^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/rstest-bdd-macros/tests/fixtures/step_struct_pattern.rs
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_struct_pattern.rs
@@ -1,0 +1,10 @@
+use rstest_bdd_macros::given;
+
+struct User {
+    name: String,
+}
+
+#[given("user data")]
+fn step_with_struct(User { name }: User) {}
+
+fn main() {}

--- a/crates/rstest-bdd-macros/tests/fixtures/step_struct_pattern.rs
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_struct_pattern.rs
@@ -1,3 +1,6 @@
+//! Compile-fail fixture: struct destructuring in a step parameter must emit an
+//! "unsupported pattern" error, enforcing the single identifier rule.
+
 use rstest_bdd_macros::given;
 
 struct User {

--- a/crates/rstest-bdd-macros/tests/fixtures/step_struct_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_struct_pattern.stderr
@@ -1,0 +1,5 @@
+error: complex destructuring patterns are not yet supported - pattern resolves to 1 identifiers but a single bare identifier is required
+ --> tests/fixtures/step_struct_pattern.rs:8:21
+  |
+8 | fn step_with_struct(User { name }: User) {}
+  |                     ^^^^^^^^^^^^^

--- a/crates/rstest-bdd-macros/tests/fixtures/step_struct_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_struct_pattern.stderr
@@ -1,5 +1,5 @@
-error: complex destructuring patterns are not yet supported - pattern resolves to 1 identifiers but a single bare identifier is required. Found pattern: `User { name }`
- --> tests/fixtures/step_struct_pattern.rs:8:21
-  |
-8 | fn step_with_struct(User { name }: User) {}
-  |                     ^^^^^^^^^^^^^
+error: unsupported pattern `User { name }`; expected a single identifier
+  --> tests/fixtures/step_struct_pattern.rs:11:21
+   |
+11 | fn step_with_struct(User { name }: User) {}
+   |                     ^^^^^^^^^^^^^

--- a/crates/rstest-bdd-macros/tests/fixtures/step_struct_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_struct_pattern.stderr
@@ -1,4 +1,4 @@
-error: complex destructuring patterns are not yet supported - pattern resolves to 1 identifiers but a single bare identifier is required
+error: complex destructuring patterns are not yet supported - pattern resolves to 1 identifiers but a single bare identifier is required. Found pattern: `User { name }`
  --> tests/fixtures/step_struct_pattern.rs:8:21
   |
 8 | fn step_with_struct(User { name }: User) {}

--- a/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.rs
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.rs
@@ -1,0 +1,6 @@
+use rstest_bdd_macros::given;
+
+#[given("coordinates")]
+fn step_with_tuple((x, y): (i32, i32)) {}
+
+fn main() {}

--- a/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.rs
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.rs
@@ -1,3 +1,6 @@
+//! Compile-fail fixture: tuple destructuring in a step parameter must emit an
+//! "unsupported pattern" error, enforcing the single identifier rule.
+
 use rstest_bdd_macros::given;
 
 #[given("coordinates")]

--- a/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.rs
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.rs
@@ -1,5 +1,6 @@
-//! Compile-fail fixture: tuple destructuring in a step parameter must emit an
-//! "unsupported pattern" error, enforcing the single identifier rule.
+//! Compile-fail fixture: tuple destructuring in a step parameter must emit a
+//! "complex destructuring patterns are not yet supported" error, enforcing the
+//! single bare identifier rule.
 
 use rstest_bdd_macros::given;
 

--- a/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.stderr
@@ -1,5 +1,5 @@
 error: unsupported pattern `(x, y)`; expected a single identifier
- --> tests/fixtures/step_tuple_pattern.rs:7:20
+ --> tests/fixtures/step_tuple_pattern.rs:8:20
   |
-7 | fn step_with_tuple((x, y): (i32, i32)) {}
+8 | fn step_with_tuple((x, y): (i32, i32)) {}
   |                    ^^^^^^

--- a/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.stderr
@@ -1,4 +1,4 @@
-error: complex destructuring patterns are not yet supported - pattern resolves to 2 identifiers but a single bare identifier is required
+error: complex destructuring patterns are not yet supported - pattern resolves to 2 identifiers but a single bare identifier is required. Found pattern: `(x, y)`
  --> tests/fixtures/step_tuple_pattern.rs:4:20
   |
 4 | fn step_with_tuple((x, y): (i32, i32)) {}

--- a/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.stderr
@@ -1,5 +1,5 @@
-error: complex destructuring patterns are not yet supported - pattern resolves to 2 identifiers but a single bare identifier is required. Found pattern: `(x, y)`
- --> tests/fixtures/step_tuple_pattern.rs:4:20
+error: unsupported pattern `(x, y)`; expected a single identifier
+ --> tests/fixtures/step_tuple_pattern.rs:7:20
   |
-4 | fn step_with_tuple((x, y): (i32, i32)) {}
+7 | fn step_with_tuple((x, y): (i32, i32)) {}
   |                    ^^^^^^

--- a/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.stderr
@@ -1,0 +1,5 @@
+error: complex destructuring patterns are not yet supported - pattern resolves to 2 identifiers but a single bare identifier is required
+ --> tests/fixtures/step_tuple_pattern.rs:4:20
+  |
+4 | fn step_with_tuple((x, y): (i32, i32)) {}
+  |                    ^^^^^^

--- a/crates/rstest-bdd-macros/tests/trybuild.rs
+++ b/crates/rstest-bdd-macros/tests/trybuild.rs
@@ -6,6 +6,8 @@ fn step_macros_compile() {
     t.pass("tests/fixtures/step_macros.rs");
     t.compile_fail("tests/fixtures/scenario_missing_file.rs");
     t.compile_fail("tests/fixtures/scenario_empty_file.rs");
+    t.compile_fail("tests/fixtures/step_tuple_pattern.rs");
+    t.compile_fail("tests/fixtures/step_struct_pattern.rs");
     t.compile_fail("tests/ui/outline_missing_examples.rs");
     t.compile_fail("tests/ui/outline_empty_examples.rs");
     t.compile_fail("tests/ui/outline_missing_column.rs");

--- a/crates/rstest-bdd-macros/tests/trybuild.rs
+++ b/crates/rstest-bdd-macros/tests/trybuild.rs
@@ -8,6 +8,7 @@ fn step_macros_compile() {
     t.compile_fail("tests/fixtures/scenario_empty_file.rs");
     t.compile_fail("tests/fixtures/step_tuple_pattern.rs");
     t.compile_fail("tests/fixtures/step_struct_pattern.rs");
+    t.compile_fail("tests/fixtures/step_nested_pattern.rs");
     t.compile_fail("tests/ui/outline_missing_examples.rs");
     t.compile_fail("tests/ui/outline_empty_examples.rs");
     t.compile_fail("tests/ui/outline_missing_column.rs");


### PR DESCRIPTION
## Summary
- parse step argument patterns recursively to report unsupported destructuring
- cover tuple and struct destructuring with compile-fail tests

## Testing
- `make fmt`
- `make lint`
- `make test`

closes #10

------
https://chatgpt.com/codex/tasks/task_e_689bb6784e0c8322b51534b8677da873

## Summary by Sourcery

Parse step argument patterns recursively to detect unsupported destructuring, enforce single bare identifiers, and provide clearer error messages, along with compile-fail tests for tuple and struct patterns.

Enhancements:
- Add extract_identifiers_from_pattern to recursively collect identifiers from nested patterns
- Enhance argument extraction to reject complex destructuring patterns with descriptive errors

Tests:
- Add compile-fail tests for tuple and struct destructuring in step functions