### PR TITLE
Check feature file existence

### DIFF
--- a/crates/rstest-bdd-macros/src/macros/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/mod.rs
@@ -25,7 +25,7 @@ fn step_attr(
 
     let (fixtures, step_args, datatable, docstring, call_order) = match extract_args(&mut func) {
         Ok(args) => args,
-        Err(err) => return error_to_tokens(&err),
+        Err(err) => return error_to_tokens(&err).into(),
     };
 
     let ident = &func.sig.ident;

--- a/crates/rstest-bdd-macros/src/macros/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/mod.rs
@@ -25,7 +25,7 @@ fn step_attr(
 
     let (fixtures, step_args, datatable, docstring, call_order) = match extract_args(&mut func) {
         Ok(args) => args,
-        Err(err) => return error_to_tokens(&err).into(),
+        Err(err) => return error_to_tokens(&err).into(), // convert proc_macro2 to proc_macro
     };
 
     let ident = &func.sig.ident;

--- a/crates/rstest-bdd-macros/src/macros/scenario.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenario.rs
@@ -97,7 +97,7 @@ pub(crate) fn scenario(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let feature = match parse_and_load_feature(&path) {
         Ok(f) => f,
-        Err(err) => return err,
+        Err(err) => return err.into(),
     };
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| String::new());
     let feature_path_str = PathBuf::from(manifest_dir)
@@ -111,11 +111,11 @@ pub(crate) fn scenario(attr: TokenStream, item: TokenStream) -> TokenStream {
         examples,
     } = match extract_scenario_steps(&feature, index) {
         Ok(res) => res,
-        Err(err) => return err,
+        Err(err) => return err.into(),
     };
 
     if let Err(err) = process_scenario_outline_examples(sig, examples.as_ref()) {
-        return err;
+        return err.into();
     }
 
     let (_args, ctx_inserts) = extract_function_fixtures(sig);

--- a/crates/rstest-bdd-macros/src/parsing/examples.rs
+++ b/crates/rstest-bdd-macros/src/parsing/examples.rs
@@ -4,6 +4,7 @@ use crate::utils::errors::error_to_tokens;
 use crate::validation::examples::{
     extract_and_validate_headers, flatten_and_validate_rows, validate_header_consistency,
 };
+use proc_macro2::TokenStream;
 
 /// Rows parsed from a `Scenario Outline` examples table.
 #[derive(Clone)]
@@ -18,7 +19,7 @@ fn should_process_outline(scenario: &gherkin::Scenario) -> bool {
 
 fn get_first_examples_table(
     scenario: &gherkin::Scenario,
-) -> Result<&gherkin::Table, proc_macro::TokenStream> {
+) -> Result<&gherkin::Table, TokenStream> {
     scenario
         .examples
         .first()
@@ -34,7 +35,7 @@ fn get_first_examples_table(
 /// Extract examples table data from a scenario if present.
 pub(crate) fn extract_examples(
     scenario: &gherkin::Scenario,
-) -> Result<Option<ExampleTable>, proc_macro::TokenStream> {
+) -> Result<Option<ExampleTable>, TokenStream> {
     if !should_process_outline(scenario) {
         return Ok(None);
     }

--- a/crates/rstest-bdd-macros/src/parsing/examples.rs
+++ b/crates/rstest-bdd-macros/src/parsing/examples.rs
@@ -17,9 +17,7 @@ fn should_process_outline(scenario: &gherkin::Scenario) -> bool {
     scenario.keyword == "Scenario Outline" || !scenario.examples.is_empty()
 }
 
-fn get_first_examples_table(
-    scenario: &gherkin::Scenario,
-) -> Result<&gherkin::Table, TokenStream> {
+fn get_first_examples_table(scenario: &gherkin::Scenario) -> Result<&gherkin::Table, TokenStream> {
     scenario
         .examples
         .first()

--- a/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
@@ -48,8 +48,16 @@ fn validate_feature_file_exists(feature_path: &Path) -> Result<(), syn::Error> {
             let msg = format!("feature path is not a file: {}", feature_path.display());
             Err(syn::Error::new(proc_macro2::Span::call_site(), msg))
         }
-        Err(_) => {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             let msg = format!("feature file not found: {}", feature_path.display());
+            Err(syn::Error::new(proc_macro2::Span::call_site(), msg))
+        }
+        Err(e) => {
+            let msg = format!(
+                "failed to access feature file ({}): {}",
+                feature_path.display(),
+                e
+            );
             Err(syn::Error::new(proc_macro2::Span::call_site(), msg))
         }
     }

--- a/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
@@ -272,7 +272,5 @@ fn errors_when_feature_unparseable() {
     let Err(err) = parse_and_load_feature(path) else {
         panic!("expected parse error");
     };
-    assert!(err
-        .to_string()
-        .contains("failed to parse feature file"));
+    assert!(err.to_string().contains("failed to parse feature file"));
 }

--- a/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
@@ -260,6 +260,7 @@ fn background_steps_with_docstring_are_extracted() {
 #[rstest]
 #[case("tests/features/does_not_exist.feature", "feature file not found")]
 #[case("tests/features/empty.feature", "failed to parse feature file")]
+#[case("tests/features", "feature path is not a file")]
 fn errors_when_feature_fails(#[case] rel_path: &str, #[case] expected_snippet: &str) {
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(rel_path);
     let Err(err) = parse_and_load_feature(&path) else {

--- a/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use gherkin::{Background, LineCol, Scenario, Span, Step, StepType};
-use std::path::Path;
+use rstest::rstest;
 
 #[expect(
     unreachable_patterns,
@@ -257,20 +257,13 @@ fn background_steps_with_docstring_are_extracted() {
     );
 }
 
-#[test]
-fn errors_when_feature_not_found() {
-    let path = Path::new("tests/features/does_not_exist.feature");
-    let Err(err) = parse_and_load_feature(path) else {
-        panic!("expected missing feature to error");
+#[rstest]
+#[case("tests/features/does_not_exist.feature", "feature file not found")]
+#[case("tests/features/empty.feature", "failed to parse feature file")]
+fn errors_when_feature_fails(#[case] rel_path: &str, #[case] expected_snippet: &str) {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(rel_path);
+    let Err(err) = parse_and_load_feature(&path) else {
+        panic!("expected failure for feature path: {rel_path}");
     };
-    assert!(err.to_string().contains("feature file not found"));
-}
-
-#[test]
-fn errors_when_feature_unparseable() {
-    let path = Path::new("tests/features/empty.feature");
-    let Err(err) = parse_and_load_feature(path) else {
-        panic!("expected parse error");
-    };
-    assert!(err.to_string().contains("failed to parse feature file"));
+    assert!(err.to_string().contains(expected_snippet));
 }

--- a/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 use gherkin::{Background, LineCol, Scenario, Span, Step, StepType};
+use std::path::Path;
 
 #[expect(
     unreachable_patterns,
@@ -254,4 +255,24 @@ fn background_steps_with_docstring_are_extracted() {
             },
         ],
     );
+}
+
+#[test]
+fn errors_when_feature_not_found() {
+    let path = Path::new("tests/features/does_not_exist.feature");
+    let Err(err) = parse_and_load_feature(path) else {
+        panic!("expected missing feature to error");
+    };
+    assert!(err.to_string().contains("feature file not found"));
+}
+
+#[test]
+fn errors_when_feature_unparseable() {
+    let path = Path::new("tests/features/empty.feature");
+    let Err(err) = parse_and_load_feature(path) else {
+        panic!("expected parse error");
+    };
+    assert!(err
+        .to_string()
+        .contains("failed to parse feature file"));
 }

--- a/crates/rstest-bdd-macros/src/utils/errors.rs
+++ b/crates/rstest-bdd-macros/src/utils/errors.rs
@@ -1,8 +1,8 @@
 //! Error handling helpers for macros.
 
-use proc_macro::TokenStream;
+use proc_macro2::TokenStream;
 
 /// Convert a `syn::Error` into a `TokenStream` for macro errors.
 pub(crate) fn error_to_tokens(err: &syn::Error) -> TokenStream {
-    err.to_compile_error().into()
+    err.to_compile_error()
 }

--- a/crates/rstest-bdd-macros/src/validation/examples.rs
+++ b/crates/rstest-bdd-macros/src/validation/examples.rs
@@ -1,7 +1,7 @@
 //! Validation routines for example tables in features.
 
 use crate::utils::errors::error_to_tokens;
-use proc_macro::TokenStream;
+use proc_macro2::TokenStream;
 
 /// Validate Examples table structure in feature file text.
 pub(crate) fn validate_examples_in_feature_text(text: &str) -> Result<(), TokenStream> {

--- a/crates/rstest-bdd-macros/src/validation/parameters.rs
+++ b/crates/rstest-bdd-macros/src/validation/parameters.rs
@@ -1,7 +1,7 @@
 //! Validation for function parameters against scenario outline headers.
 
 use crate::utils::errors::error_to_tokens;
-use proc_macro::TokenStream;
+use proc_macro2::TokenStream;
 
 fn parameter_matches_header(arg: &syn::FnArg, header: &str) -> bool {
     match arg {

--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_empty_file.rs
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_empty_file.rs
@@ -1,6 +1,0 @@
-use rstest_bdd_macros::scenario;
-
-#[scenario(path = "tests/features/empty.feature")]
-fn empty() {}
-
-fn main() {}

--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_empty_file.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_empty_file.stderr
@@ -1,7 +1,0 @@
-error: failed to parse feature file: Could not read path: $WORKSPACE/target/tests/trybuild/rstest-bdd-macros/tests/features/empty.feature
- --> tests/fixtures/scenario_empty_file.rs:3:1
-  |
-3 | #[scenario(path = "tests/features/empty.feature")]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_file.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_file.stderr
@@ -1,4 +1,4 @@
-error: failed to parse feature file: Could not read path: $WORKSPACE/target/tests/trybuild/rstest-bdd-macros/tests/features/does_not_exist.feature
+error: feature file not found: $WORKSPACE/target/tests/trybuild/rstest-bdd-macros/tests/features/does_not_exist.feature
  --> tests/fixtures/scenario_missing_file.rs:3:1
   |
 3 | #[scenario(path = "tests/features/does_not_exist.feature")]

--- a/crates/rstest-bdd-macros/tests/trybuild.rs
+++ b/crates/rstest-bdd-macros/tests/trybuild.rs
@@ -5,7 +5,6 @@ fn step_macros_compile() {
     let t = trybuild::TestCases::new();
     t.pass("tests/fixtures/step_macros.rs");
     t.compile_fail("tests/fixtures/scenario_missing_file.rs");
-    t.compile_fail("tests/fixtures/scenario_empty_file.rs");
     t.compile_fail("tests/fixtures/step_tuple_pattern.rs");
     t.compile_fail("tests/fixtures/step_struct_pattern.rs");
     t.compile_fail("tests/fixtures/step_nested_pattern.rs");

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -113,7 +113,7 @@ improves the developer experience.
 
 - [ ] **Robust Error Handling**
 
-  - [ ] The `#[scenario]` macro must emit a `compile_error!` if the specified
+  - [x] The `#[scenario]` macro must emit a `compile_error!` if the specified
     `.feature` file cannot be found or parsed.
 
   - [ ] The `#[scenario]` macro must perform a compile-time check to ensure a

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -683,7 +683,10 @@ incrementally.
 
 - Implement robust compile-time error handling. The `#[scenario]` macro should
   emit clear compiler errors if a feature file cannot be parsed or if no
-  matching step definition can be found for a Gherkin step.
+  matching step definition can be found for a Gherkin step. The macro now
+  validates that the referenced feature file exists before invoking the Gherkin
+  parser. Missing or malformed files cause `compile_error!` to be emitted,
+  failing fast during compilation.
 
 - Develop a `scenarios!` helper macro, analogous to the one in `pytest-bdd` 9,
   which can automatically bind all scenarios within one or more feature files,

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -142,6 +142,9 @@ scenario defined in a `.feature` file. It accepts two arguments:
 | `path: &str`   | Relative path to the feature file from the crate root. This is mandatory.                                    | **Implemented**: the macro resolves the path at compile time and parses the feature using the `gherkin` crate. |
 | `index: usize` | Optional zero‑based index selecting a scenario when the file contains multiple scenarios. Defaults to `0`.   | **Implemented**: the macro uses the index to pick the scenario.                                                |
 
+If the feature file cannot be found or contains invalid Gherkin, the macro
+emits a compile-time error with the offending path.
+
 The design document proposes a `name` argument to select scenarios by name, but
 only `path` and `index` are currently accepted.
 


### PR DESCRIPTION
## Summary
- emit compile-time error when feature file is missing
- document scenario error handling and update roadmap

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: FileNotFound: failed copying files from cache to destination for package lodash-es)*

------
https://chatgpt.com/codex/tasks/task_e_689e42d82e808322ba0f714d876d511a

## Summary by Sourcery

Implement robust compile-time errors for missing or malformed feature files in the #[scenario] macro and update related code, documentation, and tests.

New Features:
- Emit clear compile-time errors when a feature file is missing or contains invalid Gherkin

Enhancements:
- Check for feature file existence before parsing to fail fast and unify error return types to proc_macro2::TokenStream
- Update trybuild fixtures by removing the empty-file test and adding missing-file compile_fail cases

Documentation:
- Document compile-time error behavior for missing or malformed feature files in the user guide, design doc, and roadmap

Tests:
- Add unit tests and trybuild cases for missing and unparseable feature files