### PR TITLE
Use array runner for nixie

### DIFF
--- a/scripts/nixie.sh
+++ b/scripts/nixie.sh
@@ -6,11 +6,26 @@ MERMAID_CLI_SPEC=${MERMAID_CLI_SPEC:-@mermaid-js/mermaid-cli}
 
 if command -v npx >/dev/null 2>&1; then
     run=(npx --yes "$MERMAID_CLI_SPEC")
+    if [ "${NIXIE_VERBOSE:-}" = "1" ]; then
+        echo "Using npx to run $MERMAID_CLI_SPEC"
+    fi
 elif command -v bun >/dev/null 2>&1; then
     run=(bun x "$MERMAID_CLI_SPEC")
+    if [ "${NIXIE_VERBOSE:-}" = "1" ]; then
+        echo "Using bun x to run $MERMAID_CLI_SPEC"
+    fi
 else
+    if [ "${NIXIE_VERBOSE:-}" = "1" ]; then
+        echo "No npx or bun found for $MERMAID_CLI_SPEC"
+    fi
     echo "nixie requires npx or bun. Install one to render Mermaid diagrams." >&2
     exit 1
+fi
+
+extra_flags=()
+if [ -n "${MERMAID_EXTRA_FLAGS:-}" ]; then
+    # Split MERMAID_EXTRA_FLAGS into an array for safe expansion.
+    read -r -a extra_flags <<<"${MERMAID_EXTRA_FLAGS}"
 fi
 
 failed=0
@@ -18,7 +33,7 @@ while IFS= read -r -d '' f; do
     d="$(dirname "$f")"
     base="$(basename "$f")"
     out="$d/${base%.*}.svg"
-    if ! "${run[@]}" -i "$f" -o "$out"; then
+    if ! "${run[@]}" "${extra_flags[@]}" -i "$f" -o "$out"; then
         echo "Mermaid render failed: $f" >&2
         failed=1
     fi


### PR DESCRIPTION
## Summary
- allow MERMAID_CLI_SPEC pinning and invoke runner via command array
- generate explicit output filenames when rendering diagrams

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68a26599c9088322b41884f8eae91983

## Summary by Sourcery

Allow customizing and safely executing the Mermaid CLI in nixie and generate explicit SVG output filenames

Enhancements:
- Introduce MERMAID_CLI_SPEC environment variable with a default to pin the Mermaid CLI version
- Switch runner invocation to an array to prevent word splitting and support custom specs
- Name output files explicitly by appending ".svg" to each input base filename when rendering diagrams