### PR TITLE
Refactor pattern parsing with regex

### DIFF
--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -281,11 +281,16 @@ fn build_regex_from_pattern(pat: &str) -> String {
         }
         let ty = cap.get(2).map(|m| m.as_str().trim());
         let delta = process_match(m.as_str(), ty, depth, &mut regex);
-        let delta_u = delta.unsigned_abs() as usize;
         if delta >= 0 {
-            depth = depth.saturating_add(delta_u);
+            #[expect(clippy::expect_used, reason = "delta is non-negative")]
+            {
+                depth = depth.saturating_add(usize::try_from(delta).expect("delta is non-negative"));
+            }
         } else {
-            depth = depth.saturating_sub(delta_u);
+            #[expect(clippy::expect_used, reason = "delta is negative")]
+            {
+                depth = depth.saturating_sub(usize::try_from(-delta).expect("delta is negative"));
+            }
         }
         last = m.end();
     }

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -282,15 +282,9 @@ fn build_regex_from_pattern(pat: &str) -> String {
         let ty = cap.name("ty").map(|m| m.as_str().trim());
         let delta = process_match(m.as_str(), ty, depth, &mut regex);
         if delta >= 0 {
-            #[expect(clippy::cast_sign_loss, reason = "delta sign is checked")]
-            {
-                depth = depth.saturating_add(delta as usize);
-            }
+            depth = depth.saturating_add(delta.unsigned_abs() as usize);
         } else {
-            #[expect(clippy::cast_sign_loss, reason = "delta sign is checked")]
-            {
-                depth = depth.saturating_sub((-delta) as usize);
-            }
+            depth = depth.saturating_sub(delta.unsigned_abs() as usize);
         }
         last = m.end();
     }

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -284,7 +284,8 @@ fn build_regex_from_pattern(pat: &str) -> String {
         if delta >= 0 {
             #[expect(clippy::expect_used, reason = "delta is non-negative")]
             {
-                depth = depth.saturating_add(usize::try_from(delta).expect("delta is non-negative"));
+                depth =
+                    depth.saturating_add(usize::try_from(delta).expect("delta is non-negative"));
             }
         } else {
             #[expect(clippy::expect_used, reason = "delta is negative")]

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -26,8 +26,12 @@ use std::sync::{LazyLock, OnceLock};
 
 // Compile once: used by `build_regex_from_pattern` for splitting pattern text.
 static PLACEHOLDER_RE: LazyLock<Regex> = LazyLock::new(|| {
+    #[expect(
+        clippy::expect_used,
+        reason = "pattern is verified; invalid regex indicates programmer error"
+    )]
     Regex::new(r"\{\{|\}\}|\{([A-Za-z_][A-Za-z0-9_]*)(?::([^}]+))?\}")
-        .unwrap_or_else(|e| panic!("invalid placeholder regex: {e}"))
+        .expect("invalid placeholder regex")
 });
 
 /// Wrapper for step pattern strings used in matching logic

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -244,10 +244,11 @@ impl<'a> StepContext<'a> {
 ///
 /// The pattern supports `format!`-style placeholders such as `{count:u32}`.
 /// Placeholders follow `{name[:type]}`; `name` must start with a letter or
-/// underscore and may contain letters, digits, or underscores. Surrounding
-/// whitespace around the type hint is ignored, though the compact `{name:type}`
-/// form is preferred. Literal braces may be escaped by doubling them: `{{` or
-/// `}}`. Nested braces inside placeholders are not supported.
+/// underscore and may contain letters, digits, or underscores. Whitespace
+/// within the type hint is ignored (for example, `{n: f64}` and `{n:f64}` are
+/// equivalent), but whitespace is not allowed between the name and the colon.
+/// Literal braces may be escaped by doubling them: `{{` or `}}`. Nested braces
+/// inside placeholders are not supported.
 ///
 /// Type hints:
 /// - Integers (`u*`/`i*`): decimal digits with an optional sign for signed

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -266,6 +266,7 @@ pub fn extract_placeholders(pattern: &StepPattern, text: StepText<'_>) -> Option
 }
 
 /// Update unmatched brace depth by scanning ASCII brace bytes.
+#[inline]
 fn update_brace_depth(text: &str, mut depth: usize) -> usize {
     for b in text.bytes() {
         match b {

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -27,7 +27,7 @@ use std::sync::{LazyLock, OnceLock};
 // Compile once: used by `build_regex_from_pattern` for splitting pattern text.
 static PLACEHOLDER_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"\{\{|}}|\{([A-Za-z_][A-Za-z0-9_]*)(?::([^}]+))?\}")
-        .unwrap_or_else(|e| panic!("invalid placeholder regex: {e}"))
+        .expect("invalid placeholder regex")
 });
 
 /// Wrapper for step pattern strings used in matching logic
@@ -263,6 +263,7 @@ fn build_regex_from_pattern(pat: &str) -> String {
         }
         let ty = cap.get(2).map(|m| m.as_str().trim());
         depth += process_match(m.as_str(), ty, depth, &mut regex);
+        depth = depth.max(0);
         last = m.end();
     }
     if let Some(tail) = pat.get(last..) {

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -323,13 +323,10 @@ fn build_regex_from_pattern(pat: &str) -> String {
     for cap in ph_re.captures_iter(pat) {
         #[expect(clippy::expect_used, reason = "placeholder regex guarantees a capture")]
         let m = cap.get(0).expect("placeholder capture missing");
-        #[expect(
-            clippy::expect_used,
-            reason = "placeholder regex guarantees UTF-8 bounds"
-        )]
-        let literal = pat.get(last..m.start()).expect("placeholder bounds");
-        regex.push_str(&regex::escape(literal));
-        depth = update_brace_depth(literal, depth);
+        if let Some(literal) = pat.get(last..m.start()) {
+            regex.push_str(&regex::escape(literal));
+            depth = update_brace_depth(literal, depth);
+        }
 
         let mat = m.as_str();
         let ty = cap.name("ty").map(|m| m.as_str().trim());
@@ -339,12 +336,9 @@ fn build_regex_from_pattern(pat: &str) -> String {
         }
         last = m.end();
     }
-    #[expect(
-        clippy::expect_used,
-        reason = "placeholder regex guarantees UTF-8 bounds"
-    )]
-    let tail = pat.get(last..).expect("placeholder bounds");
-    regex.push_str(&regex::escape(tail));
+    if let Some(tail) = pat.get(last..) {
+        regex.push_str(&regex::escape(tail));
+    }
     regex.push('$');
     regex
 }

--- a/crates/rstest-bdd/tests/placeholder_parsing.rs
+++ b/crates/rstest-bdd/tests/placeholder_parsing.rs
@@ -3,10 +3,10 @@
 use rstest::rstest;
 use rstest_bdd::{StepPattern, StepText, extract_placeholders};
 
+#[expect(clippy::expect_used, reason = "test helper should fail loudly")]
 fn compiled(pattern: &'static str) -> StepPattern {
     let pat = StepPattern::from(pattern);
-    pat.compile()
-        .unwrap_or_else(|e| panic!("failed to compile pattern: {e}"));
+    pat.compile().expect("failed to compile pattern");
     pat
 }
 
@@ -101,8 +101,9 @@ fn unbalanced_braces_are_literals() {
         extract_placeholders(&pat, StepText::from("before value after")).is_none(),
         "text without literal brace should not match",
     );
+    #[expect(clippy::expect_used, reason = "test asserts exact match")]
     let caps = extract_placeholders(&pat, StepText::from("before {outer {inner} after"))
-        .unwrap_or_else(|| panic!("literal braces should match exactly"));
+        .expect("literal braces should match exactly");
     assert!(caps.is_empty(), "no placeholders expected");
 }
 
@@ -122,7 +123,8 @@ fn nested_brace_in_placeholder_is_literal() {
 #[test]
 fn stray_closing_brace_does_not_block_placeholders() {
     let pat = compiled("end} with {n:u32}");
+    #[expect(clippy::expect_used, reason = "test asserts placeholder match")]
     let caps = extract_placeholders(&pat, StepText::from("end} with 7"))
-        .unwrap_or_else(|| panic!("should match despite stray closing brace"));
+        .expect("should match despite stray closing brace");
     assert_eq!(caps, vec!["7"]);
 }

--- a/crates/rstest-bdd/tests/placeholder_parsing.rs
+++ b/crates/rstest-bdd/tests/placeholder_parsing.rs
@@ -66,6 +66,9 @@ fn type_hint_uses_specialised_fragment() {
         "value -1E-9",
         "value -.5",
         "value +3.0",
+        "value NaN",
+        "value inf",
+        "value Infinity",
     ] {
         assert!(
             extract_placeholders(&pat, StepText::from(sample)).is_some(),
@@ -114,4 +117,12 @@ fn nested_brace_in_placeholder_is_literal() {
         extract_placeholders(&pat, StepText::from("value")).is_none(),
         "missing closing brace should not match",
     );
+}
+
+#[test]
+fn stray_closing_brace_does_not_block_placeholders() {
+    let pat = compiled("end} with {n:u32}");
+    let caps = extract_placeholders(&pat, StepText::from("end} with 7"))
+        .unwrap_or_else(|| panic!("should match despite stray closing brace"));
+    assert_eq!(caps, vec!["7"]);
 }

--- a/crates/rstest-bdd/tests/placeholder_parsing.rs
+++ b/crates/rstest-bdd/tests/placeholder_parsing.rs
@@ -63,7 +63,7 @@ fn type_hint_uses_specialised_fragment() {
 
 #[test]
 fn handles_escaped_braces() {
-    let pat = StepPattern::from(r"literal \{ brace {v} \}");
+    let pat = StepPattern::from("literal {{ brace {v} }}");
     pat.compile()
         .unwrap_or_else(|e| panic!("Failed to compile pattern: {e}"));
     let text = StepText::from("literal { brace data }");
@@ -74,15 +74,15 @@ fn handles_escaped_braces() {
 }
 
 #[test]
-fn handles_nested_braces() {
-    let pat = StepPattern::from("before {outer {inner}} after");
+fn double_braces_without_placeholders() {
+    let pat = StepPattern::from("brace: {{}}");
     pat.compile()
         .unwrap_or_else(|e| panic!("Failed to compile pattern: {e}"));
-    let text = StepText::from("before value after");
+    let text = StepText::from("brace: {}");
     let Some(caps) = extract_placeholders(&pat, text) else {
         panic!("match expected");
     };
-    assert_eq!(caps, vec!["value"]);
+    assert!(caps.is_empty());
 }
 
 #[test]

--- a/crates/rstest-bdd/tests/placeholder_parsing.rs
+++ b/crates/rstest-bdd/tests/placeholder_parsing.rs
@@ -125,3 +125,18 @@ fn escaped_and_placeholder_adjacent() {
     };
     assert_eq!(caps, vec!["data"]);
 }
+
+#[test]
+fn nested_brace_in_placeholder_is_literal() {
+    let pat = StepPattern::from("{outer:{inner}}");
+    pat.compile()
+        .unwrap_or_else(|e| panic!("Failed to compile pattern: {e}"));
+    assert!(
+        extract_placeholders(&pat, StepText::from("value}")).is_some(),
+        "trailing brace should be matched literally",
+    );
+    assert!(
+        extract_placeholders(&pat, StepText::from("value")).is_none(),
+        "missing closing brace should not match",
+    );
+}

--- a/crates/rstest-bdd/tests/placeholder_parsing.rs
+++ b/crates/rstest-bdd/tests/placeholder_parsing.rs
@@ -75,6 +75,15 @@ fn type_hint_uses_specialised_fragment() {
             "{sample} should match f64",
         );
     }
+
+    // f32: special float values
+    let pat = compiled("value {n:f32}");
+    for sample in ["value NaN", "value inf", "value Infinity"] {
+        assert!(
+            extract_placeholders(&pat, StepText::from(sample)).is_some(),
+            "{sample} should match f32",
+        );
+    }
 }
 
 #[rstest]
@@ -99,6 +108,13 @@ fn malformed_type_hint_is_literal() {
     assert!(
         extract_placeholders(&pat, StepText::from("value 123")).is_none(),
         "malformed type hint should not capture",
+    );
+
+    // Whitespace between the name and colon makes it a literal placeholder.
+    let pat2 = compiled("value {n : f64}");
+    assert!(
+        extract_placeholders(&pat2, StepText::from("value 1.0")).is_none(),
+        "whitespace before colon should make the placeholder literal",
     );
 }
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -230,9 +230,12 @@ Best practices for writing effective scenarios include:
   `Infinity`. Matching is anchored: the entire step text must match the
   pattern; partial matches do not succeed. Escape literal braces with `{{` and
   `}}`. Nested braces inside placeholders are not supported. Placeholders
-  follow `{name[:type]}`; surrounding whitespace in the type hint is ignored
-  (for example, `{count:u32}` and `{count: u32}` are both accepted). Prefer the
-  compact form `{count:u32}` in new code.
+  follow `{name[:type]}`; `name` must start with a letter or underscore and may
+  contain letters, digits, or underscores (`[A-Za-z_][A-Za-z0-9_]*`).
+  Surrounding whitespace in the type hint is ignored (for example,
+  `{count:u32}` and `{count: u32}` are both accepted). Prefer the compact form
+  `{count:u32}` in new code. When a pattern contains no placeholders, the step
+  text must match exactly.
 
 ## Data tables and Doc Strings
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -225,10 +225,13 @@ Best practices for writing effective scenarios include:
   `format!`-style placeholders such as `{count:u32}`. Type hints narrow the
   match. Numeric hints support all Rust primitives (`u8..u128`, `i8..i128`,
   `usize`, `isize`, `f32`, `f64`). Floating-point hints accept integers,
-  decimal forms with optional leading or trailing digits, and scientific
-  notation (for example, `1e3`, `-1E-9`). Escape literal braces with `{{` and
-  `}}`. Nested braces inside placeholders are not supported. When no
-  placeholder is present, the text must match exactly.
+  decimal forms with optional leading or trailing digits, scientific notation
+  (for example, `1e3`, `-1E-9`), and the special values `NaN`, `inf`, and
+  `Infinity`. Matching is anchored: the entire step text must match the
+  pattern; partial matches do not succeed. Escape literal braces with `{{` and
+  `}}`. Nested braces inside placeholders are not supported. Placeholders
+  follow `{name[:type]}` with no whitespace around the colon (for example,
+  `{count:u32}`).
 
 ## Data tables and Doc Strings
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -232,10 +232,10 @@ Best practices for writing effective scenarios include:
   `}}`. Nested braces inside placeholders are not supported. Placeholders
   follow `{name[:type]}`; `name` must start with a letter or underscore and may
   contain letters, digits, or underscores (`[A-Za-z_][A-Za-z0-9_]*`).
-  Surrounding whitespace in the type hint is ignored (for example,
-  `{count:u32}` and `{count: u32}` are both accepted). Prefer the compact form
-  `{count:u32}` in new code. When a pattern contains no placeholders, the step
-  text must match exactly.
+  Whitespace within the type hint is ignored (for example, `{count: u32}` and
+  `{count:u32}` are both accepted), but whitespace is not allowed between the
+  name and the colon. Prefer the compact form `{count:u32}` in new code. When a
+  pattern contains no placeholders, the step text must match exactly.
 
 ## Data tables and Doc Strings
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -230,8 +230,9 @@ Best practices for writing effective scenarios include:
   `Infinity`. Matching is anchored: the entire step text must match the
   pattern; partial matches do not succeed. Escape literal braces with `{{` and
   `}}`. Nested braces inside placeholders are not supported. Placeholders
-  follow `{name[:type]}` with no whitespace around the colon (for example,
-  `{count:u32}`).
+  follow `{name[:type]}`; surrounding whitespace in the type hint is ignored
+  (for example, `{count:u32}` and `{count: u32}` are both accepted). Prefer the
+  compact form `{count:u32}` in new code.
 
 ## Data tables and Doc Strings
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -224,8 +224,11 @@ Best practices for writing effective scenarios include:
 - **Use placeholders for dynamic values.** Pattern strings may include
   `format!`-style placeholders such as `{count:u32}`. Type hints narrow the
   match. Numeric hints support all Rust primitives (`u8..u128`, `i8..i128`,
-  `usize`, `isize`, `f32`, `f64`). Escape literal braces with `{{` and `}}`.
-  When no placeholder is present, the text must match exactly.
+  `usize`, `isize`, `f32`, `f64`). Floating-point hints accept integers,
+  decimal forms with optional leading or trailing digits, and scientific
+  notation (for example, `1e3`, `-1E-9`). Escape literal braces with `{{` and
+  `}}`. Nested braces inside placeholders are not supported. When no
+  placeholder is present, the text must match exactly.
 
 ## Data tables and Doc Strings
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -224,9 +224,8 @@ Best practices for writing effective scenarios include:
 - **Use placeholders for dynamic values.** Pattern strings may include
   `format!`-style placeholders such as `{count:u32}`. Type hints narrow the
   match. Numeric hints support all Rust primitives (`u8..u128`, `i8..i128`,
-  `usize`, `isize`, `f32`, `f64`). Escape literal braces with `\\{` and `\\}`.
-  Nested braces inside placeholders are permitted. When no placeholder is
-  present, the text must match exactly.
+  `usize`, `isize`, `f32`, `f64`). Escape literal braces with `{{` and `}}`.
+  When no placeholder is present, the text must match exactly.
 
 ## Data tables and Doc Strings
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -227,15 +227,17 @@ Best practices for writing effective scenarios include:
   `usize`, `isize`, `f32`, `f64`). Floating-point hints accept integers,
   decimal forms with optional leading or trailing digits, scientific notation
   (for example, `1e3`, `-1E-9`), and the special values `NaN`, `inf`, and
-  `Infinity`. Matching is anchored: the entire step text must match the
-  pattern; partial matches do not succeed. Escape literal braces with `{{` and
-  `}}`. Nested braces inside placeholders are not supported. Placeholders
-  follow `{name[:type]}`; `name` must start with a letter or underscore and may
-  contain letters, digits, or underscores (`[A-Za-z_][A-Za-z0-9_]*`).
-  Whitespace within the type hint is ignored (for example, `{count: u32}` and
-  `{count:u32}` are both accepted), but whitespace is not allowed between the
-  name and the colon. Prefer the compact form `{count:u32}` in new code. When a
-  pattern contains no placeholders, the step text must match exactly.
+  `Infinity` (matched case-insensitively). Matching is anchored: the entire
+  step text must match the pattern; partial matches do not succeed. Escape
+  literal braces with `{{` and `}}`. Nested braces inside placeholders are not
+  supported. Placeholders follow `{name[:type]}`; `name` must start with a
+  letter or underscore and may contain letters, digits, or underscores
+  (`[A-Za-z_][A-Za-z0-9_]*`). Whitespace within the type hint is ignored (for
+  example, `{count: u32}` and `{count:u32}` are both accepted), but whitespace
+  is not allowed between the name and the colon. Prefer the compact form
+  `{count:u32}` in new code. When a pattern contains no placeholders, the step
+  text must match exactly. Unknown type hints are treated as generic
+  placeholders and capture any non-newline text greedily.
 
 ## Data tables and Doc Strings
 


### PR DESCRIPTION
## Summary
- replace manual brace scanning with regex-based pattern parsing
- document double-brace escaping and simplify placeholder tests

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`

closes #24

------
https://chatgpt.com/codex/tasks/task_e_68a4286c6f5483228c27dcb7e51101a7

## Summary by Sourcery

Refactor the step pattern parser to use a single precompiled regex for splitting literal text and placeholders, replacing manual brace scanning with modular helper functions.

New Features:
- Replace manual brace scanning with regex-based pattern parsing
- Support double-brace escaping (‘{{’/’}}’) instead of backslash escapes
- Expand floating-point hints to accept decimals, scientific notation, and special values (NaN, inf, Infinity)

Enhancements:
- Split pattern builder into smaller functions (process_literal_segment, process_match, etc.) around a LazyLock placeholder regex
- Formalize placeholder syntax in code comments (name, type hint, whitespace rules, anchored matching)
- Update user guide to reflect the new escaping and placeholder rules

Documentation:
- Revise user-guide to document double-brace escaping, disallowed nested braces in placeholders, and updated type hint details

Tests:
- Convert placeholder tests to rstest parameterized cases
- Introduce helper `compiled` function to streamline pattern compilation in tests
- Add coverage for various float formats, brace-escaping scenarios, unbalanced/nested braces