### PR TITLE
Validate brace nesting in step patterns

### DIFF
--- a/crates/rstest-bdd/tests/placeholder_parsing.rs
+++ b/crates/rstest-bdd/tests/placeholder_parsing.rs
@@ -1,6 +1,6 @@
 //! Tests for placeholder extraction logic.
 
-use rstest_bdd::{StepPattern, StepText, extract_placeholders};
+use rstest_bdd::{StepPattern, StepPatternCompileError, StepText, extract_placeholders};
 
 #[test]
 fn type_hint_uses_specialised_fragment() {
@@ -86,12 +86,11 @@ fn handles_nested_braces() {
 }
 
 #[test]
-fn unbalanced_braces_are_literals() {
+fn unbalanced_braces_return_error() {
     let pat = StepPattern::from("before {outer {inner} after");
-    pat.compile()
-        .unwrap_or_else(|e| panic!("Failed to compile pattern: {e}"));
+    let result = pat.compile();
     assert!(
-        extract_placeholders(&pat, StepText::from("before value after")).is_none(),
-        "text without literal brace should not match",
+        matches!(result, Err(StepPatternCompileError::UnbalancedBraces)),
+        "unbalanced braces should return error",
     );
 }

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -993,7 +993,7 @@ step registry using `find_step`, which falls back to placeholder matching when
 no exact pattern is present. This approach keeps the macros lightweight while
 supporting type‑safe parameters in steps. The parser handles escaped braces and
 nested brace pairs, preventing greedy captures while still requiring
-well‑formed placeholders.
+well‑formed placeholders. Patterns with unbalanced braces fail to compile.
 
 The runner forwards the raw doc string as `Option<&str>` and the wrapper
 converts it into an owned `String` before invoking the step function. The

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -222,11 +222,11 @@ Best practices for writing effective scenarios include:
   and contribute to the feature files.
 
 - **Use placeholders for dynamic values.** Pattern strings may include
-  `format!`-style placeholders such as `{count:u32}`. Type hints narrow the
-  match. Numeric hints support all Rust primitives (`u8..u128`, `i8..i128`,
-  `usize`, `isize`, `f32`, `f64`). Escape literal braces with `\\{` and `\\}`.
-  Nested braces inside placeholders are permitted. When no placeholder is
-  present, the text must match exactly.
+`format!`-style placeholders such as `{count:u32}`. Type hints narrow the
+match. Numeric hints support all Rust primitives (`u8..u128`, `i8..i128`,
+`usize`, `isize`, `f32`, `f64`). Escape literal braces with `\\{` and `\\}`.
+Nested braces inside placeholders are permitted, but unbalanced braces cause a
+compile-time error. When no placeholder is present, the text must match exactly.
 
 ## Data tables and Doc Strings
 


### PR DESCRIPTION
## Summary
- add `StepPatternCompileError` and reject unbalanced braces during compilation
- document brace validation and extend placeholder parsing tests

closes #38

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68a508ce45948322b8fbc450fc2a2f61