### PR TITLE
Sanitize wrapper identifiers for non-ASCII names

### DIFF
--- a/crates/rstest-bdd-macros/src/codegen/wrapper/emit.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/emit.rs
@@ -2,6 +2,7 @@
 
 use super::args::{ArgumentCollections, CallArg, DataTableArg, DocStringArg, FixtureArg, StepArg};
 use crate::codegen::keyword_to_token;
+use crate::utils::ident::sanitize_ident;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -120,6 +121,10 @@ static COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 /// Generate unique identifiers for the wrapper components.
 ///
+/// The provided step function identifier may contain Unicode. It is
+/// sanitised to ASCII characters before constructing constant names to avoid
+/// emitting invalid identifiers.
+///
 /// Returns identifiers for the wrapper function, fixture array constant, and
 /// pattern constant.
 fn generate_wrapper_identifiers(
@@ -127,7 +132,7 @@ fn generate_wrapper_identifiers(
     id: usize,
 ) -> (proc_macro2::Ident, proc_macro2::Ident, proc_macro2::Ident) {
     let wrapper_ident = format_ident!("__rstest_bdd_wrapper_{}_{}", ident, id);
-    let ident_upper = ident.to_string().to_uppercase();
+    let ident_upper = sanitize_ident(&ident.to_string()).to_ascii_uppercase();
     let const_ident = format_ident!("__RSTEST_BDD_FIXTURES_{}_{}", ident_upper, id);
     let pattern_ident = format_ident!("__RSTEST_BDD_PATTERN_{}_{}", ident_upper, id);
     (wrapper_ident, const_ident, pattern_ident)
@@ -345,5 +350,29 @@ pub(crate) fn generate_wrapper_code(config: &WrapperConfig<'_>) -> TokenStream2 
     quote! {
         #body
         #registration
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::generate_wrapper_identifiers;
+    use quote::format_ident;
+    use syn::parse_str;
+
+    #[test]
+    fn sanitizes_constant_identifiers() {
+        let ident = match parse_str::<syn::Ident>("préférence") {
+            Ok(i) => i,
+            Err(e) => panic!("parse identifier: {e}"),
+        };
+        let (_, const_ident, pattern_ident) = generate_wrapper_identifiers(&ident, 3);
+        assert_eq!(
+            const_ident,
+            format_ident!("__RSTEST_BDD_FIXTURES_PR_F_RENCE_3")
+        );
+        assert_eq!(
+            pattern_ident,
+            format_ident!("__RSTEST_BDD_PATTERN_PR_F_RENCE_3")
+        );
     }
 }

--- a/crates/rstest-bdd-macros/src/macros/scenarios.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios.rs
@@ -9,31 +9,8 @@ use std::path::{Path, PathBuf};
 use crate::codegen::scenario::{ScenarioConfig, generate_scenario_code};
 use crate::parsing::feature::{extract_scenario_steps, parse_and_load_feature};
 use crate::utils::errors::error_to_tokens;
+use crate::utils::ident::sanitize_ident;
 use gherkin::Feature;
-
-/// Sanitize a string so it may be used as a Rust identifier.
-///
-/// Only ASCII alphanumeric characters are preserved; all other characters
-/// (including Unicode) are replaced with underscores. The result is lowercased.
-/// Identifiers starting with a digit gain a leading underscore.
-///
-/// Note: Unicode characters are not supported and will be replaced with
-/// underscores.
-/// TODO: Consider supporting Unicode normalization in the future.
-fn sanitize_ident(input: &str) -> String {
-    let mut ident = String::new();
-    for c in input.chars() {
-        if c.is_ascii_alphanumeric() {
-            ident.push(c.to_ascii_lowercase());
-        } else {
-            ident.push('_');
-        }
-    }
-    if ident.is_empty() || matches!(ident.chars().next(), Some(c) if c.is_ascii_digit()) {
-        ident.insert(0, '_');
-    }
-    ident
-}
 
 /// Recursively collect all `.feature` files under `base`.
 fn collect_feature_files(base: &Path) -> std::io::Result<Vec<PathBuf>> {
@@ -263,28 +240,8 @@ pub(crate) fn scenarios(input: TokenStream) -> TokenStream {
 
 #[cfg(test)]
 mod tests {
-    use super::{dedupe_name, sanitize_ident};
+    use super::dedupe_name;
     use std::collections::HashSet;
-
-    #[test]
-    fn sanitizes_invalid_identifiers() {
-        assert_eq!(sanitize_ident("Hello world!"), "hello_world_");
-    }
-
-    #[test]
-    fn sanitizes_leading_digit() {
-        assert_eq!(sanitize_ident("123abc"), "_123abc");
-    }
-
-    #[test]
-    fn sanitizes_empty_input() {
-        assert_eq!(sanitize_ident(""), "_");
-    }
-
-    #[test]
-    fn sanitizes_unicode() {
-        assert_eq!(sanitize_ident("Crème—brûlée"), "cr_me_br_l_e");
-    }
 
     #[test]
     fn deduplicates_duplicate_titles() {

--- a/crates/rstest-bdd-macros/src/utils/ident.rs
+++ b/crates/rstest-bdd-macros/src/utils/ident.rs
@@ -1,0 +1,53 @@
+//! Identifier utilities.
+
+/// Sanitize a string so it may be used as a Rust identifier.
+///
+/// Only ASCII alphanumeric characters are retained; all other characters
+/// (including Unicode) are replaced with underscores. The result is
+/// lowercased. Identifiers starting with a digit gain a leading underscore.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use crate::utils::ident::sanitize_ident;
+/// assert_eq!(sanitize_ident("Crème—brûlée"), "cr_me_br_l_e");
+/// ```
+pub(crate) fn sanitize_ident(input: &str) -> String {
+    let mut ident = String::new();
+    for c in input.chars() {
+        if c.is_ascii_alphanumeric() {
+            ident.push(c.to_ascii_lowercase());
+        } else {
+            ident.push('_');
+        }
+    }
+    if ident.is_empty() || matches!(ident.chars().next(), Some(c) if c.is_ascii_digit()) {
+        ident.insert(0, '_');
+    }
+    ident
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_ident;
+
+    #[test]
+    fn sanitizes_invalid_identifiers() {
+        assert_eq!(sanitize_ident("Hello world!"), "hello_world_");
+    }
+
+    #[test]
+    fn sanitizes_leading_digit() {
+        assert_eq!(sanitize_ident("123abc"), "_123abc");
+    }
+
+    #[test]
+    fn sanitizes_empty_input() {
+        assert_eq!(sanitize_ident(""), "_");
+    }
+
+    #[test]
+    fn sanitizes_unicode() {
+        assert_eq!(sanitize_ident("Crème—brûlée"), "cr_me_br_l_e");
+    }
+}

--- a/crates/rstest-bdd-macros/src/utils/mod.rs
+++ b/crates/rstest-bdd-macros/src/utils/mod.rs
@@ -2,3 +2,4 @@
 
 pub(crate) mod errors;
 pub(crate) mod fixtures;
+pub(crate) mod ident;

--- a/crates/rstest-bdd-macros/tests/fixtures/step_macros_unicode.rs
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_macros_unicode.rs
@@ -1,0 +1,13 @@
+//! Step definitions with Unicode identifiers used by trybuild tests.
+use rstest_bdd_macros::{given, when, then};
+
+#[given("précondition")]
+fn précondition() {}
+
+#[when("acción")]
+fn acción() {}
+
+#[then("résultat")]
+fn résultat() {}
+
+fn main() {}

--- a/crates/rstest-bdd-macros/tests/trybuild.rs
+++ b/crates/rstest-bdd-macros/tests/trybuild.rs
@@ -4,6 +4,7 @@
 fn step_macros_compile() {
     let t = trybuild::TestCases::new();
     t.pass("tests/fixtures/step_macros.rs");
+    t.pass("tests/fixtures/step_macros_unicode.rs");
     // `scenarios!` should succeed when the directory exists.
     // t.pass("tests/fixtures/scenarios_autodiscovery.rs");
     t.compile_fail("tests/fixtures/scenario_missing_file.rs");


### PR DESCRIPTION
## Summary
- sanitize strings before using them in wrapper constant identifiers
- add helper for identifier sanitization and reuse in scenario generation
- cover unicode step names with compile test

## Testing
- `make fmt`
- `make lint`
- `make test`

Closes #33

------
https://chatgpt.com/codex/tasks/task_e_68a50828f0ec83229f22d2f04c05e874