### PR TITLE
Introduce structured StepError for step wrappers

### DIFF
--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -357,9 +357,35 @@ fn extract_captured_values(re: &Regex, text: &str) -> Option<Vec<String>> {
     Some(values)
 }
 
+/// Error type produced by step wrappers.
+///
+/// The variants categorise the possible failure modes when invoking a step.
+#[derive(Debug, thiserror::Error)]
+pub enum StepError {
+    /// Raised when a required fixture is absent from the [`StepContext`].
+    #[error("Missing fixture '{name}' of type '{ty}' for step function '{step}'")]
+    MissingFixture {
+        name: String,
+        ty: String,
+        step: String,
+    },
+
+    /// Wraps generic execution failures.
+    #[error("Step execution failed: {0}")]
+    ExecutionError(String),
+
+    /// Indicates a panic occurred inside the step function.
+    #[error("Panic in step '{pattern}', function '{function}': {message}")]
+    PanicError {
+        pattern: String,
+        function: String,
+        message: String,
+    },
+}
+
 /// Type alias for the stored step function pointer.
 pub type StepFn =
-    for<'a> fn(&StepContext<'a>, &str, Option<&str>, Option<&[&[&str]]>) -> Result<(), String>;
+    for<'a> fn(&StepContext<'a>, &str, Option<&str>, Option<&[&[&str]]>) -> Result<(), StepError>;
 
 /// Represents a single step definition registered with the framework.
 ///

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -996,9 +996,10 @@ nested brace pairs, preventing greedy captures while still requiring
 well‑formed placeholders.
 
 The runner forwards the raw doc string as `Option<&str>` and the wrapper
-converts it into an owned `String` before invoking the step function. The
-sequence below summarizes how the runner locates and executes steps when
-placeholders are present:
+converts it into an owned `String` before invoking the step function. Step
+wrappers return `Result<(), StepError>` so callers can categorise missing
+fixtures, execution failures, or panics. The sequence below summarises how the
+runner locates and executes steps when placeholders are present:
 
 ```mermaid
 sequenceDiagram
@@ -1018,8 +1019,8 @@ sequenceDiagram
     StepWrapper->>StepWrapper: extract_placeholders(pattern, text)
     StepWrapper->>StepWrapper: parse captures with FromStr
     StepWrapper->>StepFunction: call with typed args (docstring: String, datatable: Vec<Vec<String>>)
-    StepFunction-->>StepWrapper: returns
-    StepWrapper-->>ScenarioRunner: returns
+    StepFunction-->>StepWrapper: Result<(), StepError>
+    StepWrapper-->>ScenarioRunner: Result<(), StepError>
 ```
 
 ## **Works cited**


### PR DESCRIPTION
## Summary
- replace string-based step errors with structured `StepError`
- update wrapper generation and tests to use `StepError`
- document `StepError` in design guide

closes #35

## Testing
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68a5091ddcd4832281af0e70fd731641