### PR TITLE
Add structured StepError and improve panic handling

### DIFF
--- a/crates/rstest-bdd-macros/tests/fixtures/step_macros.rs
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_macros.rs
@@ -2,16 +2,23 @@
 //!
 //! This module declares dummy Given/When/Then functions so the
 //! procedural macros can register steps for compile tests.
+use rstest_bdd::StepError;
 use rstest_bdd_macros::{given, when, then};
 
 #[given("a precondition")]
-fn precondition() {}
+fn precondition() -> Result<(), StepError> {
+    Ok(())
+}
 
 #[when("an action occurs")]
-fn action() {}
+fn action() -> Result<(), StepError> {
+    Ok(())
+}
 
 #[then("a result is produced")]
-fn result() {}
+fn result() -> Result<(), StepError> {
+    Ok(())
+}
 
 
 fn main() {}

--- a/crates/rstest-bdd-macros/tests/inventory.rs
+++ b/crates/rstest-bdd-macros/tests/inventory.rs
@@ -1,16 +1,35 @@
 //! Tests for step registration via macros
 
+use rstest_bdd::StepError;
 use rstest_bdd::{Step, iter};
 use rstest_bdd_macros::{given, then, when};
 
 #[given("a precondition")]
-fn precondition() {}
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn precondition() -> Result<(), StepError> {
+    Ok(())
+}
 
 #[when("an action")]
-fn action() {}
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn action() -> Result<(), StepError> {
+    Ok(())
+}
 
 #[then("a result")]
-fn result() {}
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn result() -> Result<(), StepError> {
+    Ok(())
+}
 
 #[test]
 fn macros_register_steps() {

--- a/crates/rstest-bdd-macros/tests/scenario.rs
+++ b/crates/rstest-bdd-macros/tests/scenario.rs
@@ -1,6 +1,7 @@
 //! Behavioural tests covering the `#[scenario]` macro
 
 use rstest::rstest;
+use rstest_bdd::StepError;
 use rstest_bdd_macros::{given, scenario, then, when};
 use serial_test::serial;
 use std::sync::{LazyLock, Mutex, MutexGuard};
@@ -38,29 +39,54 @@ where
 }
 
 #[given("a background step")]
-fn background_step() {
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn background_step() -> Result<(), StepError> {
     with_locked_events(|events| events.push("background"));
+    Ok(())
 }
 
 #[given("another background step")]
-fn another_background_step() {
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn another_background_step() -> Result<(), StepError> {
     with_locked_events(|events| events.push("another background"));
+    Ok(())
 }
 
 #[given("a precondition")]
-fn precondition() {
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn precondition() -> Result<(), StepError> {
     clear_events();
     with_locked_events(|events| events.push("precondition"));
+    Ok(())
 }
 
 #[when("an action occurs")]
-fn action() {
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn action() -> Result<(), StepError> {
     with_locked_events(|events| events.push("action"));
+    Ok(())
 }
 
 #[then("a result is produced")]
-fn result() {
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn result() -> Result<(), StepError> {
     with_locked_events(|events| events.push("result"));
+    Ok(())
 }
 
 #[scenario("tests/features/web_search.feature")]
@@ -142,15 +168,15 @@ fn background_second() {
 #[serial]
 fn multiple_background_steps_execute_in_order() {
     clear_events();
-    background_step();
-    another_background_step();
+    let _ = background_step();
+    let _ = another_background_step();
     with_locked_events(|events| {
         assert_eq!(events.as_slice(), ["background", "another background"]);
     });
 
     clear_events();
-    background_step();
-    another_background_step();
+    let _ = background_step();
+    let _ = another_background_step();
     with_locked_events(|events| {
         assert_eq!(events.as_slice(), ["background", "another background"]);
     });

--- a/crates/rstest-bdd-macros/tests/scenarios_macro.rs
+++ b/crates/rstest-bdd-macros/tests/scenarios_macro.rs
@@ -1,17 +1,42 @@
 //! Behavioural tests for the `scenarios!` macro.
 
+use rstest_bdd::StepError;
 use rstest_bdd_macros::{given, scenarios, then, when};
 
 #[given("a precondition")]
-fn precondition() {}
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn precondition() -> Result<(), StepError> {
+    Ok(())
+}
 
 #[when("an action occurs")]
-fn action() {}
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn action() -> Result<(), StepError> {
+    Ok(())
+}
 
 #[when("an action occurs with <num>")]
-fn action_with_num() {}
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn action_with_num() -> Result<(), StepError> {
+    Ok(())
+}
 
 #[then("events are recorded")]
-fn events_recorded() {}
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn events_recorded() -> Result<(), StepError> {
+    Ok(())
+}
 
 scenarios!("tests/features/auto");

--- a/crates/rstest-bdd/tests/argument_parsing.rs
+++ b/crates/rstest-bdd/tests/argument_parsing.rs
@@ -1,6 +1,7 @@
 //! Behavioural test for step argument parsing
 
 use rstest::fixture;
+use rstest_bdd::StepError;
 use rstest_bdd_macros::{given, scenario, then, when};
 use std::cell::RefCell;
 
@@ -10,18 +11,33 @@ fn account() -> RefCell<u32> {
 }
 
 #[given("I start with {amount:u32} dollars")]
-fn start_balance(#[from(account)] acc: &RefCell<u32>, amount: u32) {
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn start_balance(#[from(account)] acc: &RefCell<u32>, amount: u32) -> Result<(), StepError> {
     *acc.borrow_mut() = amount;
+    Ok(())
 }
 
 #[when("I deposit {amount:u32} dollars")]
-fn deposit_amount(#[from(account)] acc: &RefCell<u32>, amount: u32) {
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn deposit_amount(#[from(account)] acc: &RefCell<u32>, amount: u32) -> Result<(), StepError> {
     *acc.borrow_mut() += amount;
+    Ok(())
 }
 
 #[then("my balance is {expected:u32} dollars")]
-fn check_balance(#[from(account)] acc: &RefCell<u32>, expected: u32) {
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn check_balance(#[from(account)] acc: &RefCell<u32>, expected: u32) -> Result<(), StepError> {
     assert_eq!(*acc.borrow(), expected);
+    Ok(())
 }
 
 #[scenario(path = "tests/features/argument.feature")]

--- a/crates/rstest-bdd/tests/datatable.rs
+++ b/crates/rstest-bdd/tests/datatable.rs
@@ -1,10 +1,15 @@
 //! Behavioural test for data table support
 
+use rstest_bdd::StepError;
 use rstest_bdd_macros::{given, scenario};
 
 #[given("the following table:")]
 #[expect(clippy::needless_pass_by_value, reason = "step consumes the table")]
-fn check_table(datatable: Vec<Vec<String>>) {
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn check_table(datatable: Vec<Vec<String>>) -> Result<(), StepError> {
     assert_eq!(
         datatable,
         vec![
@@ -12,6 +17,7 @@ fn check_table(datatable: Vec<Vec<String>>) {
             vec!["gamma".to_string(), "delta".to_string()],
         ],
     );
+    Ok(())
 }
 
 #[scenario(path = "tests/features/datatable.feature")]
@@ -19,12 +25,17 @@ fn datatable_scenario() {}
 
 #[given("a table then value {word}:")]
 #[expect(clippy::needless_pass_by_value, reason = "step consumes the table")]
-fn table_then_value(datatable: Vec<Vec<String>>, value: String) {
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn table_then_value(datatable: Vec<Vec<String>>, value: String) -> Result<(), StepError> {
     assert_eq!(
         datatable,
         vec![vec!["a".to_string()], vec!["b".to_string()]],
     );
     assert_eq!(value, "beta");
+    Ok(())
 }
 
 #[scenario(path = "tests/features/datatable_arg_order.feature")]

--- a/crates/rstest-bdd/tests/docstring.rs
+++ b/crates/rstest-bdd/tests/docstring.rs
@@ -1,7 +1,12 @@
 //! Behavioural test for doc string support
+#![expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
 
 use std::cell::RefCell;
 
+use rstest_bdd::StepError;
 use rstest_bdd_macros::{given, scenario, then};
 
 thread_local! {
@@ -14,10 +19,15 @@ thread_local! {
 }
 
 #[given("the following message:")]
-fn capture_message(docstring: String) {
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn capture_message(docstring: String) -> Result<(), StepError> {
     CAPTURED.with(|m| {
         m.replace(Some(docstring));
     });
+    Ok(())
 }
 
 #[then("the captured message equals:")]
@@ -26,7 +36,11 @@ fn capture_message(docstring: String) {
     reason = "doc string is owned to mirror user API"
 )]
 #[expect(clippy::expect_used, reason = "test ensures a message was captured")]
-fn assert_message(docstring: String) {
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn assert_message(docstring: String) -> Result<(), StepError> {
     CAPTURED.with(|m| {
         let captured = m
             .borrow_mut()
@@ -34,6 +48,7 @@ fn assert_message(docstring: String) {
             .expect("message should be captured before assertion");
         assert_eq!(captured, docstring);
     });
+    Ok(())
 }
 
 #[given("message then value {int}:")]
@@ -41,9 +56,10 @@ fn assert_message(docstring: String) {
     clippy::needless_pass_by_value,
     reason = "doc string is owned to mirror user API"
 )]
-fn doc_then_value(docstring: String, value: i32) {
+fn doc_then_value(docstring: String, value: i32) -> Result<(), StepError> {
     assert_eq!(docstring.trim(), "alpha");
     assert_eq!(value, 5);
+    Ok(())
 }
 
 #[given("value then message {int}:")]
@@ -51,9 +67,10 @@ fn doc_then_value(docstring: String, value: i32) {
     clippy::needless_pass_by_value,
     reason = "doc string is owned to mirror user API"
 )]
-fn value_then_doc(value: i32, docstring: String) {
+fn value_then_doc(value: i32, docstring: String) -> Result<(), StepError> {
     assert_eq!(value, 5);
     assert_eq!(docstring.trim(), "alpha");
+    Ok(())
 }
 
 #[scenario(path = "tests/features/docstring.feature")]

--- a/crates/rstest-bdd/tests/e2e_scenario.rs
+++ b/crates/rstest-bdd/tests/e2e_scenario.rs
@@ -1,6 +1,7 @@
 //! End-to-end test verifying fixture injection across multiple steps
 
 use rstest::fixture;
+use rstest_bdd::StepError;
 use rstest_bdd_macros::{given, scenario, then, when};
 
 #[fixture]
@@ -14,18 +15,33 @@ fn multiplier() -> i32 {
 }
 
 #[given("number is available")]
-fn check_number(#[from(number)] n: i32) {
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn check_number(#[from(number)] n: i32) -> Result<(), StepError> {
     assert_eq!(n, 21);
+    Ok(())
 }
 
 #[when("the number is doubled")]
-fn multiply(#[from(number)] n: i32, #[from(multiplier)] m: i32) {
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn multiply(#[from(number)] n: i32, #[from(multiplier)] m: i32) -> Result<(), StepError> {
     assert_eq!(n * m, 42);
+    Ok(())
 }
 
 #[then("the number remains")]
-fn verify_number(#[from(number)] n: i32) {
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn verify_number(#[from(number)] n: i32) -> Result<(), StepError> {
     assert_eq!(n, 21);
+    Ok(())
 }
 
 #[scenario(path = "tests/features/context.feature")]

--- a/crates/rstest-bdd/tests/step_error.rs
+++ b/crates/rstest-bdd/tests/step_error.rs
@@ -1,0 +1,41 @@
+//! Unit tests for `StepError` formatting
+
+use rstest_bdd::StepError;
+
+#[test]
+fn missing_fixture_formats() {
+    let err = StepError::MissingFixture {
+        name: "item".to_string(),
+        ty: "u32".to_string(),
+        step: "my_step".to_string(),
+    };
+    assert_eq!(
+        err.to_string(),
+        "Missing fixture 'item' of type 'u32' for step function 'my_step'"
+    );
+}
+
+#[test]
+fn execution_error_formats() {
+    let err = StepError::ExecutionError {
+        step: "exec".to_string(),
+        message: "boom".to_string(),
+    };
+    assert_eq!(
+        err.to_string(),
+        "Execution error in step function 'exec': boom"
+    );
+}
+
+#[test]
+fn panic_error_formats() {
+    let err = StepError::PanicError {
+        pattern: "pattern".to_string(),
+        function: "func".to_string(),
+        message: "payload".to_string(),
+    };
+    assert_eq!(
+        err.to_string(),
+        "Panic in step 'pattern', function 'func': payload"
+    );
+}

--- a/crates/rstest-bdd/tests/step_registry.rs
+++ b/crates/rstest-bdd/tests/step_registry.rs
@@ -1,6 +1,6 @@
 //! Behavioural test for step registry
 
-use rstest_bdd::{Step, StepContext, iter, step};
+use rstest_bdd::{Step, StepContext, StepError, iter, step};
 
 fn sample() {}
 #[expect(
@@ -12,7 +12,7 @@ fn wrapper(
     _text: &str,
     _docstring: Option<&str>,
     _table: Option<&[&[&str]]>,
-) -> Result<(), String> {
+) -> Result<(), StepError> {
     // Adapter for zero-argument step functions
     let _ = ctx;
     sample();
@@ -26,9 +26,12 @@ fn failing_wrapper(
     _text: &str,
     _docstring: Option<&str>,
     _table: Option<&[&[&str]]>,
-) -> Result<(), String> {
+) -> Result<(), StepError> {
     let _ = ctx;
-    Err("boom".to_string())
+    Err(StepError::ExecutionError {
+        step: "failing_wrapper".to_string(),
+        message: "boom".to_string(),
+    })
 }
 
 step!(
@@ -60,5 +63,11 @@ fn wrapper_error_propagates() {
         Ok(()) => panic!("expected error from wrapper"),
         Err(e) => e,
     };
-    assert_eq!(err, "boom");
+    match err {
+        StepError::ExecutionError { step, message } => {
+            assert_eq!(step, "failing_wrapper");
+            assert_eq!(message, "boom");
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
 }

--- a/examples/todo-cli/tests/todo.rs
+++ b/examples/todo-cli/tests/todo.rs
@@ -3,6 +3,7 @@
 use std::cell::RefCell;
 
 use rstest::fixture;
+use rstest_bdd::StepError;
 use rstest_bdd_macros::{given, scenario, then, when};
 use todo_cli::TodoList;
 
@@ -12,12 +13,24 @@ fn todo_list() -> RefCell<TodoList> {
 }
 
 #[given("an empty to-do list")]
-fn empty_list(#[from(todo_list)] list: &RefCell<TodoList>) {
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn empty_list(#[from(todo_list)] list: &RefCell<TodoList>) -> Result<(), StepError> {
     assert!(list.borrow().is_empty(), "list should start empty");
+    Ok(())
 }
 
 #[when("I add the following tasks")]
-fn add_tasks(#[from(todo_list)] list: &RefCell<TodoList>, datatable: Vec<Vec<String>>) {
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn add_tasks(
+    #[from(todo_list)] list: &RefCell<TodoList>,
+    datatable: Vec<Vec<String>>,
+) -> Result<(), StepError> {
     for (i, row) in datatable.into_iter().enumerate() {
         assert_eq!(
             row.len(),
@@ -32,13 +45,22 @@ fn add_tasks(#[from(todo_list)] list: &RefCell<TodoList>, datatable: Vec<Vec<Str
             .expect("row.len() == 1 just asserted");
         list.borrow_mut().add(task);
     }
+    Ok(())
 }
 
 #[then("the list displays")]
-fn list_displays(#[from(todo_list)] list: &RefCell<TodoList>, docstring: String) {
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn list_displays(
+    #[from(todo_list)] list: &RefCell<TodoList>,
+    docstring: String,
+) -> Result<(), StepError> {
     // Normalise docstring indentation to prevent false negatives.
     let expected = dedent(&docstring);
     assert_eq!(list.borrow().display(), expected);
+    Ok(())
 }
 
 fn dedent(input: &str) -> String {
@@ -63,14 +85,30 @@ fn dedent(input: &str) -> String {
 }
 
 #[given("a to-do list with {first} and {second}")]
-fn list_with_two(#[from(todo_list)] list: &RefCell<TodoList>, first: String, second: String) {
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn list_with_two(
+    #[from(todo_list)] list: &RefCell<TodoList>,
+    first: String,
+    second: String,
+) -> Result<(), StepError> {
     let mut l = list.borrow_mut();
     l.add(first);
     l.add(second);
+    Ok(())
 }
 
 #[when("I complete {task}")]
-fn complete_task(#[from(todo_list)] list: &RefCell<TodoList>, task: String) {
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn complete_task(
+    #[from(todo_list)] list: &RefCell<TodoList>,
+    task: String,
+) -> Result<(), StepError> {
     let ok = list.borrow_mut().complete(&task);
     assert!(
         ok,
@@ -78,10 +116,18 @@ fn complete_task(#[from(todo_list)] list: &RefCell<TodoList>, task: String) {
         task,
         list.borrow().statuses()
     );
+    Ok(())
 }
 
 #[then("the task statuses should be")]
-fn assert_statuses(#[from(todo_list)] list: &RefCell<TodoList>, datatable: Vec<Vec<String>>) {
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step functions must return StepError"
+)]
+fn assert_statuses(
+    #[from(todo_list)] list: &RefCell<TodoList>,
+    datatable: Vec<Vec<String>>,
+) -> Result<(), StepError> {
     let expected: Vec<(String, bool)> = datatable
         .into_iter()
         .enumerate()
@@ -100,6 +146,7 @@ fn assert_statuses(#[from(todo_list)] list: &RefCell<TodoList>, datatable: Vec<V
         })
         .collect();
     assert_eq!(list.borrow().statuses(), expected);
+    Ok(())
 }
 
 #[allow(unused_variables)]


### PR DESCRIPTION
## Summary
- replace string errors with `StepError` carrying richer context
- harden wrapper against panics and missing data
- add regression tests for all `StepError` variants

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a835e80200832296a2c90a4595bbce