### PR TITLE
Introduce structured StepError and test wrappers

### DIFF
--- a/crates/rstest-bdd-macros/src/codegen/wrapper/emit.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/emit.rs
@@ -341,29 +341,7 @@ fn assemble_wrapper_function(
                 rstest_bdd::IntoStepResult::into_step_result(#ident(#(#arg_idents),*))
             }))
                 .map_err(|e| {
-                    let message = if let Some(s) = e.downcast_ref::<&str>() {
-                        s.to_string()
-                    } else if let Some(s) = e.downcast_ref::<String>() {
-                        s.clone()
-                    } else if let Some(i) = e.downcast_ref::<i32>() {
-                        i.to_string()
-                    } else if let Some(i) = e.downcast_ref::<u32>() {
-                        i.to_string()
-                    } else if let Some(i) = e.downcast_ref::<i64>() {
-                        i.to_string()
-                    } else if let Some(i) = e.downcast_ref::<u64>() {
-                        i.to_string()
-                    } else if let Some(i) = e.downcast_ref::<isize>() {
-                        i.to_string()
-                    } else if let Some(i) = e.downcast_ref::<usize>() {
-                        i.to_string()
-                    } else if let Some(f) = e.downcast_ref::<f64>() {
-                        f.to_string()
-                    } else if let Some(f) = e.downcast_ref::<f32>() {
-                        f.to_string()
-                    } else {
-                        format!("{e:?}")
-                    };
+                    let message = rstest_bdd::panic_message(e.as_ref());
                     #panic_err
                 })
                 .and_then(|res| res.map_err(|message| #exec_err))

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/emit.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/emit.rs
@@ -362,7 +362,7 @@ fn assemble_wrapper_function(
                     } else if let Some(f) = e.downcast_ref::<f32>() {
                         f.to_string()
                     } else {
-                        "non-string panic payload".to_string()
+                        format!("{e:?}")
                     };
                     #panic_err
                 })

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/emit.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/emit.rs
@@ -16,14 +16,13 @@ struct StepMeta<'a> {
 /// Quote construction for [`StepError`] variants sharing `pattern`,
 /// `function` and `message` fields.
 fn step_error_tokens(
-    variant: &str,
+    variant: &syn::Ident,
     pattern: &syn::LitStr,
     ident: &syn::Ident,
     message: &TokenStream2,
 ) -> TokenStream2 {
-    let variant_ident = format_ident!("{}", variant);
     quote! {
-        rstest_bdd::StepError::#variant_ident {
+        rstest_bdd::StepError::#variant {
             pattern: #pattern.to_string(),
             function: stringify!(#ident).to_string(),
             message: #message,
@@ -306,7 +305,7 @@ fn assemble_wrapper_function(
 ) -> TokenStream2 {
     let (declares, step_arg_parses, datatable_decl, docstring_decl) = arg_processing;
     let placeholder_err = step_error_tokens(
-        "ExecutionError",
+        &format_ident!("ExecutionError"),
         pattern,
         ident,
         &quote! {
@@ -318,8 +317,18 @@ fn assemble_wrapper_function(
             )
         },
     );
-    let panic_err = step_error_tokens("PanicError", pattern, ident, &quote! { message });
-    let exec_err = step_error_tokens("ExecutionError", pattern, ident, &quote! { message });
+    let panic_err = step_error_tokens(
+        &format_ident!("PanicError"),
+        pattern,
+        ident,
+        &quote! { message },
+    );
+    let exec_err = step_error_tokens(
+        &format_ident!("ExecutionError"),
+        pattern,
+        ident,
+        &quote! { message },
+    );
     quote! {
         fn #wrapper_ident(
             ctx: &rstest_bdd::StepContext<'_>,

--- a/crates/rstest-bdd/Cargo.toml
+++ b/crates/rstest-bdd/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 gherkin.workspace = true
 inventory.workspace = true
 regex.workspace = true
-thiserror = { version = "1.0", default-features = false }
+thiserror = { version = "1.0", default-features = false, features = ["std"] }
 hashbrown = "0.15"
 
 [dev-dependencies]

--- a/crates/rstest-bdd/Cargo.toml
+++ b/crates/rstest-bdd/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 gherkin.workspace = true
 inventory.workspace = true
 regex.workspace = true
-thiserror.workspace = true
+thiserror = { version = "1.0", default-features = false }
 hashbrown = "0.15"
 
 [dev-dependencies]

--- a/crates/rstest-bdd/Cargo.toml
+++ b/crates/rstest-bdd/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 gherkin.workspace = true
 inventory.workspace = true
 regex.workspace = true
-thiserror = { version = "1.0", default-features = false, features = ["std"] }
+thiserror.workspace = true
 hashbrown = "0.15"
 
 [dev-dependencies]

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -85,11 +85,15 @@ pub trait IntoStepResult {
 }
 
 impl IntoStepResult for () {
-    fn into_step_result(self) -> Result<(), String> { Ok(()) }
+    fn into_step_result(self) -> Result<(), String> {
+        Ok(())
+    }
 }
 
 impl IntoStepResult for Result<(), String> {
-    fn into_step_result(self) -> Result<(), String> { self }
+    fn into_step_result(self) -> Result<(), String> {
+        self
+    }
 }
 
 #[cfg(test)]

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -17,6 +17,7 @@ pub fn greet() -> &'static str {
 }
 
 pub use inventory::{iter, submit};
+use thiserror::Error;
 
 mod context;
 mod pattern;
@@ -31,6 +32,65 @@ pub use registry::{Step, find_step, lookup_step};
 pub use types::{
     PatternStr, PlaceholderError, StepFn, StepKeyword, StepKeywordParseError, StepText,
 };
+
+/// Error type produced by step wrappers.
+///
+/// The variants categorise the possible failure modes when invoking a step.
+#[derive(Debug, Error, Clone, PartialEq)]
+pub enum StepError {
+    /// Raised when a required fixture is absent from the [`StepContext`].
+    #[error("Missing fixture '{name}' of type '{ty}' for step function '{step}'")]
+    MissingFixture {
+        /// Name of the missing fixture.
+        name: String,
+        /// Type of the missing fixture.
+        ty: String,
+        /// Step function that requested the fixture.
+        step: String,
+    },
+    /// Raised when the invoked step function returns an [`Err`] variant.
+    #[error("Error executing step '{pattern}' via function '{function}': {message}")]
+    ExecutionError {
+        /// Pattern text used when invoking the step.
+        pattern: String,
+        /// Name of the step function.
+        function: String,
+        /// Error message produced by the step function.
+        message: String,
+    },
+    /// Raised when the step function panics during execution.
+    #[error("Panic in step '{pattern}', function '{function}': {message}")]
+    PanicError {
+        /// Pattern text used when invoking the step.
+        pattern: String,
+        /// Name of the step function.
+        function: String,
+        /// Panic payload converted to a string.
+        message: String,
+    },
+}
+
+/// Convert step function outputs into a standard result type.
+///
+/// Step functions may return either `()` to signal success or
+/// `Result<(), String>` for explicit failure. This trait normalises both
+/// forms into a `Result<(), String>` for wrapper processing.
+pub trait IntoStepResult {
+    /// Convert the value into a `Result` understood by the wrapper.
+    ///
+    /// # Errors
+    ///
+    /// Returns any error produced by the step function as a `String`.
+    fn into_step_result(self) -> Result<(), String>;
+}
+
+impl IntoStepResult for () {
+    fn into_step_result(self) -> Result<(), String> { Ok(()) }
+}
+
+impl IntoStepResult for Result<(), String> {
+    fn into_step_result(self) -> Result<(), String> { self }
+}
 
 #[cfg(test)]
 mod internal_tests;

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -58,7 +58,8 @@ pub fn panic_message(e: &(dyn std::any::Any + Send)) -> String {
     }
 
     try_downcast!(&str, String, i32, u32, i64, u64, isize, usize, f32, f64);
-    format!("{e:?}")
+    let ty = std::any::type_name_of_val(e);
+    format!("<non-debug panic payload of type {ty}>")
 }
 
 /// Error type produced by step wrappers.

--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -141,4 +141,4 @@ pub type StepFn = for<'a> fn(
     &str,
     Option<&str>,
     Option<&[&[&str]]>,
-) -> Result<(), String>;
+) -> Result<(), crate::StepError>;

--- a/crates/rstest-bdd/tests/fixture_context.rs
+++ b/crates/rstest-bdd/tests/fixture_context.rs
@@ -3,6 +3,7 @@
 use rstest_bdd::{StepContext, StepError, StepKeyword};
 use rstest_bdd_macros::given;
 
+/// Step that asserts the injected `number` fixture equals 42.
 #[given("a value")]
 #[expect(
     clippy::trivially_copy_pass_by_ref,

--- a/crates/rstest-bdd/tests/fixture_context.rs
+++ b/crates/rstest-bdd/tests/fixture_context.rs
@@ -12,6 +12,16 @@ fn needs_value(#[from(number)] number: &u32) {
     assert_eq!(*number, 42);
 }
 
+#[given("a panicking value step")]
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "fixture requires reference"
+)]
+fn panicking_value_step(#[from(number)] number: &u32) -> Result<(), String> {
+    let _ = number;
+    panic!("boom")
+}
+
 #[test]
 fn context_passes_fixture() {
     let number = 42u32;
@@ -33,11 +43,41 @@ fn context_missing_fixture_returns_error() {
         Ok(()) => panic!("expected error when fixture is missing"),
         Err(e) => e,
     };
+    let display = err.to_string();
     match err {
         StepError::MissingFixture { name, ty, step } => {
             assert_eq!(name, "number");
             assert_eq!(ty, "u32");
             assert_eq!(step, "needs_value");
+            assert!(
+                display.contains("Missing fixture 'number'"),
+                "unexpected Display: {display}"
+            );
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn fixture_step_panic_returns_panic_error() {
+    let number = 1u32;
+    let mut ctx = StepContext::default();
+    ctx.insert("number", &number);
+    let step_fn = rstest_bdd::lookup_step(StepKeyword::Given, "a panicking value step".into())
+        .unwrap_or_else(|| panic!("step 'a panicking value step' not found in registry"));
+    let err = match step_fn(&ctx, "a panicking value step", None, None) {
+        Ok(()) => panic!("expected panic error"),
+        Err(e) => e,
+    };
+    match err {
+        StepError::PanicError {
+            pattern,
+            function,
+            message,
+        } => {
+            assert_eq!(pattern, "a panicking value step");
+            assert_eq!(function, "panicking_value_step");
+            assert_eq!(message, "boom");
         }
         other => panic!("unexpected error: {other:?}"),
     }

--- a/crates/rstest-bdd/tests/pattern_mismatch.rs
+++ b/crates/rstest-bdd/tests/pattern_mismatch.rs
@@ -34,7 +34,11 @@ fn returns_error_on_pattern_mismatch() {
         panic!("expected mismatch to error");
     };
     match err {
-        StepError::ExecutionError { pattern, function, message } => {
+        StepError::ExecutionError {
+            pattern,
+            function,
+            message,
+        } => {
             assert_eq!(pattern, "number {value:u32}");
             assert_eq!(function, "number");
             assert!(message.contains("does not match pattern"));

--- a/crates/rstest-bdd/tests/pattern_mismatch.rs
+++ b/crates/rstest-bdd/tests/pattern_mismatch.rs
@@ -2,7 +2,7 @@
 
 use std::sync::atomic::{AtomicU32, Ordering};
 
-use rstest_bdd::{StepContext, StepKeyword, lookup_step};
+use rstest_bdd::{StepContext, StepError, StepKeyword, lookup_step};
 use rstest_bdd_macros::given;
 
 static CAPTURED: AtomicU32 = AtomicU32::new(0);
@@ -33,7 +33,14 @@ fn returns_error_on_pattern_mismatch() {
     let Err(err) = step_fn(&ctx, "unrelated text", None, None) else {
         panic!("expected mismatch to error");
     };
-    assert!(err.contains("does not match pattern"), "{err}");
-    assert!(err.contains("unrelated text"), "{err}");
-    assert!(err.contains("number {value:u32}"), "{err}");
+    match err {
+        StepError::ExecutionError { pattern, function, message } => {
+            assert_eq!(pattern, "number {value:u32}");
+            assert_eq!(function, "number");
+            assert!(message.contains("does not match pattern"));
+            assert!(message.contains("unrelated text"));
+            assert!(message.contains("number {value:u32}"));
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
 }

--- a/crates/rstest-bdd/tests/step_error.rs
+++ b/crates/rstest-bdd/tests/step_error.rs
@@ -1,39 +1,33 @@
 //! Unit tests for `StepError` display formatting
 
+use rstest::rstest;
 use rstest_bdd::StepError;
 
-#[test]
-fn missing_fixture_formats() {
-    let err = StepError::MissingFixture {
+#[rstest]
+#[case(
+    StepError::MissingFixture {
         name: "n".into(),
         ty: "u32".into(),
         step: "s".into(),
-    };
-    assert_eq!(
-        err.to_string(),
-        "Missing fixture 'n' of type 'u32' for step function 's'"
-    );
-}
-
-#[test]
-fn execution_error_formats() {
-    let err = StepError::ExecutionError {
+    },
+    "Missing fixture 'n' of type 'u32' for step function 's'",
+)]
+#[case(
+    StepError::ExecutionError {
         pattern: "p".into(),
         function: "f".into(),
         message: "m".into(),
-    };
-    assert_eq!(
-        err.to_string(),
-        "Error executing step 'p' via function 'f': m"
-    );
-}
-
-#[test]
-fn panic_error_formats() {
-    let err = StepError::PanicError {
+    },
+    "Error executing step 'p' via function 'f': m",
+)]
+#[case(
+    StepError::PanicError {
         pattern: "p".into(),
         function: "f".into(),
         message: "boom".into(),
-    };
-    assert_eq!(err.to_string(), "Panic in step 'p', function 'f': boom");
+    },
+    "Panic in step 'p', function 'f': boom",
+)]
+fn step_error_display_formats(#[case] err: StepError, #[case] expected: &str) {
+    assert_eq!(err.to_string(), expected);
 }

--- a/crates/rstest-bdd/tests/step_error.rs
+++ b/crates/rstest-bdd/tests/step_error.rs
@@ -1,0 +1,39 @@
+//! Unit tests for `StepError` display formatting
+
+use rstest_bdd::StepError;
+
+#[test]
+fn missing_fixture_formats() {
+    let err = StepError::MissingFixture {
+        name: "n".into(),
+        ty: "u32".into(),
+        step: "s".into(),
+    };
+    assert_eq!(
+        err.to_string(),
+        "Missing fixture 'n' of type 'u32' for step function 's'"
+    );
+}
+
+#[test]
+fn execution_error_formats() {
+    let err = StepError::ExecutionError {
+        pattern: "p".into(),
+        function: "f".into(),
+        message: "m".into(),
+    };
+    assert_eq!(
+        err.to_string(),
+        "Error executing step 'p' via function 'f': m"
+    );
+}
+
+#[test]
+fn panic_error_formats() {
+    let err = StepError::PanicError {
+        pattern: "p".into(),
+        function: "f".into(),
+        message: "boom".into(),
+    };
+    assert_eq!(err.to_string(), "Panic in step 'p', function 'f': boom");
+}

--- a/crates/rstest-bdd/tests/step_error_behaviour.rs
+++ b/crates/rstest-bdd/tests/step_error_behaviour.rs
@@ -13,6 +13,26 @@ fn panicking_step() -> Result<(), String> {
     panic!("kaboom")
 }
 
+#[given("a non-string panicking step")]
+fn non_string_panicking_step() -> Result<(), String> {
+    std::panic::panic_any(123_i32)
+}
+
+#[given("a successful step")]
+fn successful_step() {}
+
+#[given("a step requiring a table")]
+#[expect(clippy::needless_pass_by_value, reason = "step consumes the table")]
+fn step_needing_table(datatable: Vec<Vec<String>>) {
+    let _ = datatable;
+}
+
+#[given("a step requiring a docstring")]
+#[expect(clippy::needless_pass_by_value, reason = "step consumes docstring")]
+fn step_needing_docstring(docstring: String) {
+    let _ = docstring;
+}
+
 #[test]
 fn execution_error_is_reported() {
     let ctx = StepContext::default();
@@ -54,6 +74,93 @@ fn panic_is_captured() {
             assert_eq!(pattern, "a panicking step");
             assert_eq!(function, "panicking_step");
             assert_eq!(message, "kaboom");
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn non_string_panic_is_captured() {
+    let ctx = StepContext::default();
+    let step_fn = rstest_bdd::lookup_step(StepKeyword::Given, "a non-string panicking step".into())
+        .unwrap_or_else(|| panic!("step 'a non-string panicking step' not found in registry"));
+    let err = match step_fn(&ctx, "a non-string panicking step", None, None) {
+        Ok(()) => panic!("expected error"),
+        Err(e) => e,
+    };
+    match err {
+        StepError::PanicError {
+            pattern,
+            function,
+            message,
+        } => {
+            assert_eq!(pattern, "a non-string panicking step");
+            assert_eq!(function, "non_string_panicking_step");
+            assert_eq!(message, "123");
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn ok_is_returned() {
+    let ctx = StepContext::default();
+    let step_fn = rstest_bdd::lookup_step(StepKeyword::Given, "a successful step".into())
+        .unwrap_or_else(|| panic!("step 'a successful step' not found in registry"));
+    let res = step_fn(&ctx, "a successful step", None, None);
+    if let Err(e) = res {
+        panic!("unexpected error: {e:?}");
+    }
+}
+
+#[test]
+fn missing_datatable_is_reported() {
+    let ctx = StepContext::default();
+    let step_fn = rstest_bdd::lookup_step(StepKeyword::Given, "a step requiring a table".into())
+        .unwrap_or_else(|| panic!("step 'a step requiring a table' not found in registry"));
+    let err = match step_fn(&ctx, "a step requiring a table", None, None) {
+        Ok(()) => panic!("expected error"),
+        Err(e) => e,
+    };
+    match err {
+        StepError::ExecutionError {
+            pattern,
+            function,
+            message,
+        } => {
+            assert_eq!(pattern, "a step requiring a table");
+            assert_eq!(function, "step_needing_table");
+            assert_eq!(
+                message,
+                "Step 'a step requiring a table' requires a data table",
+            );
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn missing_docstring_is_reported() {
+    let ctx = StepContext::default();
+    let step_fn =
+        rstest_bdd::lookup_step(StepKeyword::Given, "a step requiring a docstring".into())
+            .unwrap_or_else(|| panic!("step 'a step requiring a docstring' not found in registry"));
+    let err = match step_fn(&ctx, "a step requiring a docstring", None, None) {
+        Ok(()) => panic!("expected error"),
+        Err(e) => e,
+    };
+    match err {
+        StepError::ExecutionError {
+            pattern,
+            function,
+            message,
+        } => {
+            assert_eq!(pattern, "a step requiring a docstring");
+            assert_eq!(function, "step_needing_docstring");
+            assert_eq!(
+                message,
+                "Step 'a step requiring a docstring' requires a doc string",
+            );
         }
         other => panic!("unexpected error: {other:?}"),
     }

--- a/crates/rstest-bdd/tests/step_error_behaviour.rs
+++ b/crates/rstest-bdd/tests/step_error_behaviour.rs
@@ -135,3 +135,28 @@ fn successful_step_execution() {
         panic!("unexpected error: {e:?}");
     }
 }
+
+#[test]
+fn datatable_is_passed_and_executes() {
+    let ctx = StepContext::default();
+    let step_fn = rstest_bdd::lookup_step(StepKeyword::Given, "a step requiring a table".into())
+        .unwrap_or_else(|| panic!("step 'a step requiring a table' not found in registry"));
+
+    // Minimal 2×2 data table
+    let table: &[&[&str]] = &[&["a", "b"], &["c", "d"]];
+    if let Err(e) = step_fn(&ctx, "a step requiring a table", None, Some(table)) {
+        panic!("unexpected error passing datatable: {e:?}");
+    }
+}
+
+#[test]
+fn docstring_is_passed_and_executes() {
+    let ctx = StepContext::default();
+    let step_fn =
+        rstest_bdd::lookup_step(StepKeyword::Given, "a step requiring a docstring".into())
+            .unwrap_or_else(|| panic!("step 'a step requiring a docstring' not found in registry"));
+
+    if let Err(e) = step_fn(&ctx, "a step requiring a docstring", Some("content"), None) {
+        panic!("unexpected error passing docstring: {e:?}");
+    }
+}

--- a/crates/rstest-bdd/tests/step_error_behaviour.rs
+++ b/crates/rstest-bdd/tests/step_error_behaviour.rs
@@ -1,5 +1,6 @@
 //! Behavioural tests for `StepError` propagation in wrappers
 
+use rstest::rstest;
 use rstest_bdd::{StepContext, StepError, StepKeyword};
 use rstest_bdd_macros::given;
 
@@ -33,135 +34,104 @@ fn step_needing_docstring(docstring: String) {
     let _ = docstring;
 }
 
-#[test]
-fn execution_error_is_reported() {
+#[rstest]
+#[case(
+    "a failing step",
+    "failing_step",
+    StepError::ExecutionError {
+        pattern: "a failing step".into(),
+        function: "failing_step".into(),
+        message: "boom".into(),
+    },
+)]
+#[case(
+    "a panicking step",
+    "panicking_step",
+    StepError::PanicError {
+        pattern: "a panicking step".into(),
+        function: "panicking_step".into(),
+        message: "kaboom".into(),
+    },
+)]
+#[case(
+    "a non-string panicking step",
+    "non_string_panicking_step",
+    StepError::PanicError {
+        pattern: "a non-string panicking step".into(),
+        function: "non_string_panicking_step".into(),
+        message: "123".into(),
+    },
+)]
+#[case(
+    "a step requiring a table",
+    "step_needing_table",
+    StepError::ExecutionError {
+        pattern: "a step requiring a table".into(),
+        function: "step_needing_table".into(),
+        message: "Step 'a step requiring a table' requires a data table".into(),
+    },
+)]
+#[case(
+    "a step requiring a docstring",
+    "step_needing_docstring",
+    StepError::ExecutionError {
+        pattern: "a step requiring a docstring".into(),
+        function: "step_needing_docstring".into(),
+        message: "Step 'a step requiring a docstring' requires a doc string".into(),
+    },
+)]
+fn step_error_scenarios(
+    #[case] step_pattern: &str,
+    #[case] expected_function: &str,
+    #[case] expected_error: StepError,
+) {
     let ctx = StepContext::default();
-    let step_fn = rstest_bdd::lookup_step(StepKeyword::Given, "a failing step".into())
-        .unwrap_or_else(|| panic!("step 'a failing step' not found in registry"));
-    let err = match step_fn(&ctx, "a failing step", None, None) {
-        Ok(()) => panic!("expected error"),
+    let step_fn = rstest_bdd::lookup_step(StepKeyword::Given, step_pattern.into())
+        .unwrap_or_else(|| panic!("step '{step_pattern}' not found in registry"));
+    let err = match step_fn(&ctx, step_pattern, None, None) {
+        Ok(()) => panic!("expected error for '{step_pattern}'"),
         Err(e) => e,
     };
-    match err {
-        StepError::ExecutionError {
-            pattern,
-            function,
-            message,
-        } => {
-            assert_eq!(pattern, "a failing step");
-            assert_eq!(function, "failing_step");
-            assert_eq!(message, "boom");
+    match (err, expected_error) {
+        (
+            StepError::ExecutionError {
+                pattern,
+                function,
+                message,
+            },
+            StepError::ExecutionError {
+                message: expected_message,
+                ..
+            },
+        )
+        | (
+            StepError::PanicError {
+                pattern,
+                function,
+                message,
+            },
+            StepError::PanicError {
+                message: expected_message,
+                ..
+            },
+        ) => {
+            assert_eq!(pattern, step_pattern);
+            assert_eq!(function, expected_function);
+            assert_eq!(message, expected_message);
         }
-        other => panic!("unexpected error: {other:?}"),
+        (other_actual, other_expected) => panic!(
+            "unexpected error for '{step_pattern}': got {other_actual:?}, expected {other_expected:?}",
+        ),
     }
 }
 
 #[test]
-fn panic_is_captured() {
-    let ctx = StepContext::default();
-    let step_fn = rstest_bdd::lookup_step(StepKeyword::Given, "a panicking step".into())
-        .unwrap_or_else(|| panic!("step 'a panicking step' not found in registry"));
-    let err = match step_fn(&ctx, "a panicking step", None, None) {
-        Ok(()) => panic!("expected error"),
-        Err(e) => e,
-    };
-    match err {
-        StepError::PanicError {
-            pattern,
-            function,
-            message,
-        } => {
-            assert_eq!(pattern, "a panicking step");
-            assert_eq!(function, "panicking_step");
-            assert_eq!(message, "kaboom");
-        }
-        other => panic!("unexpected error: {other:?}"),
-    }
-}
-
-#[test]
-fn non_string_panic_is_captured() {
-    let ctx = StepContext::default();
-    let step_fn = rstest_bdd::lookup_step(StepKeyword::Given, "a non-string panicking step".into())
-        .unwrap_or_else(|| panic!("step 'a non-string panicking step' not found in registry"));
-    let err = match step_fn(&ctx, "a non-string panicking step", None, None) {
-        Ok(()) => panic!("expected error"),
-        Err(e) => e,
-    };
-    match err {
-        StepError::PanicError {
-            pattern,
-            function,
-            message,
-        } => {
-            assert_eq!(pattern, "a non-string panicking step");
-            assert_eq!(function, "non_string_panicking_step");
-            assert_eq!(message, "123");
-        }
-        other => panic!("unexpected error: {other:?}"),
-    }
-}
-
-#[test]
-fn ok_is_returned() {
+fn successful_step_execution() {
     let ctx = StepContext::default();
     let step_fn = rstest_bdd::lookup_step(StepKeyword::Given, "a successful step".into())
         .unwrap_or_else(|| panic!("step 'a successful step' not found in registry"));
     let res = step_fn(&ctx, "a successful step", None, None);
     if let Err(e) = res {
         panic!("unexpected error: {e:?}");
-    }
-}
-
-#[test]
-fn missing_datatable_is_reported() {
-    let ctx = StepContext::default();
-    let step_fn = rstest_bdd::lookup_step(StepKeyword::Given, "a step requiring a table".into())
-        .unwrap_or_else(|| panic!("step 'a step requiring a table' not found in registry"));
-    let err = match step_fn(&ctx, "a step requiring a table", None, None) {
-        Ok(()) => panic!("expected error"),
-        Err(e) => e,
-    };
-    match err {
-        StepError::ExecutionError {
-            pattern,
-            function,
-            message,
-        } => {
-            assert_eq!(pattern, "a step requiring a table");
-            assert_eq!(function, "step_needing_table");
-            assert_eq!(
-                message,
-                "Step 'a step requiring a table' requires a data table",
-            );
-        }
-        other => panic!("unexpected error: {other:?}"),
-    }
-}
-
-#[test]
-fn missing_docstring_is_reported() {
-    let ctx = StepContext::default();
-    let step_fn =
-        rstest_bdd::lookup_step(StepKeyword::Given, "a step requiring a docstring".into())
-            .unwrap_or_else(|| panic!("step 'a step requiring a docstring' not found in registry"));
-    let err = match step_fn(&ctx, "a step requiring a docstring", None, None) {
-        Ok(()) => panic!("expected error"),
-        Err(e) => e,
-    };
-    match err {
-        StepError::ExecutionError {
-            pattern,
-            function,
-            message,
-        } => {
-            assert_eq!(pattern, "a step requiring a docstring");
-            assert_eq!(function, "step_needing_docstring");
-            assert_eq!(
-                message,
-                "Step 'a step requiring a docstring' requires a doc string",
-            );
-        }
-        other => panic!("unexpected error: {other:?}"),
     }
 }

--- a/crates/rstest-bdd/tests/step_error_behaviour.rs
+++ b/crates/rstest-bdd/tests/step_error_behaviour.rs
@@ -1,0 +1,60 @@
+//! Behavioural tests for `StepError` propagation in wrappers
+
+use rstest_bdd::{StepContext, StepError, StepKeyword};
+use rstest_bdd_macros::given;
+
+#[given("a failing step")]
+fn failing_step() -> Result<(), String> {
+    Err("boom".into())
+}
+
+#[given("a panicking step")]
+fn panicking_step() -> Result<(), String> {
+    panic!("kaboom")
+}
+
+#[test]
+fn execution_error_is_reported() {
+    let ctx = StepContext::default();
+    let step_fn = rstest_bdd::lookup_step(StepKeyword::Given, "a failing step".into())
+        .unwrap_or_else(|| panic!("step 'a failing step' not found in registry"));
+    let err = match step_fn(&ctx, "a failing step", None, None) {
+        Ok(()) => panic!("expected error"),
+        Err(e) => e,
+    };
+    match err {
+        StepError::ExecutionError {
+            pattern,
+            function,
+            message,
+        } => {
+            assert_eq!(pattern, "a failing step");
+            assert_eq!(function, "failing_step");
+            assert_eq!(message, "boom");
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn panic_is_captured() {
+    let ctx = StepContext::default();
+    let step_fn = rstest_bdd::lookup_step(StepKeyword::Given, "a panicking step".into())
+        .unwrap_or_else(|| panic!("step 'a panicking step' not found in registry"));
+    let err = match step_fn(&ctx, "a panicking step", None, None) {
+        Ok(()) => panic!("expected error"),
+        Err(e) => e,
+    };
+    match err {
+        StepError::PanicError {
+            pattern,
+            function,
+            message,
+        } => {
+            assert_eq!(pattern, "a panicking step");
+            assert_eq!(function, "panicking_step");
+            assert_eq!(message, "kaboom");
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}

--- a/crates/rstest-bdd/tests/step_registry.rs
+++ b/crates/rstest-bdd/tests/step_registry.rs
@@ -9,7 +9,7 @@ fn sample() {}
     reason = "wrapper must match StepFn signature"
 )]
 fn wrapper(
-    ctx: &rstest_bdd::StepContext<'_>,
+    ctx: &StepContext<'_>,
     _text: &str,
     _docstring: Option<&str>,
     _table: Option<&[&[&str]]>,
@@ -125,6 +125,7 @@ fn wrapper_error_handling(
         Ok(()) => panic!("expected error from wrapper '{pattern}'"),
         Err(e) => e,
     };
+    let err_display = err.to_string();
     if is_execution_error {
         match err {
             StepError::ExecutionError {
@@ -140,7 +141,7 @@ fn wrapper_error_handling(
                 assert_eq!(step, function_name);
                 assert_eq!(name, "missing");
                 assert_eq!(ty, "u32");
-                assert_eq!(err.to_string(), expected_message);
+                assert_eq!(err_display, expected_message);
             }
             other => panic!("unexpected error for '{pattern}': {other:?}"),
         }

--- a/crates/rstest-bdd/tests/step_registry.rs
+++ b/crates/rstest-bdd/tests/step_registry.rs
@@ -42,6 +42,58 @@ step!(
     &[]
 );
 
+fn panicking_wrapper(
+    ctx: &StepContext<'_>,
+    _text: &str,
+    _docstring: Option<&str>,
+    _table: Option<&[&[&str]]>,
+) -> Result<(), StepError> {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+    let _ = ctx;
+    catch_unwind(AssertUnwindSafe(|| panic!("snap"))).map_err(|e| {
+        #[expect(
+            clippy::option_if_let_else,
+            reason = "sequential downcasts aid readability"
+        )]
+        let message = if let Some(s) = e.downcast_ref::<&str>() {
+            (*s).to_string()
+        } else if let Some(s) = e.downcast_ref::<String>() {
+            s.clone()
+        } else if let Some(i) = e.downcast_ref::<i32>() {
+            i.to_string()
+        } else if let Some(i) = e.downcast_ref::<u32>() {
+            i.to_string()
+        } else if let Some(i) = e.downcast_ref::<i64>() {
+            i.to_string()
+        } else if let Some(i) = e.downcast_ref::<u64>() {
+            i.to_string()
+        } else if let Some(i) = e.downcast_ref::<isize>() {
+            i.to_string()
+        } else if let Some(i) = e.downcast_ref::<usize>() {
+            i.to_string()
+        } else if let Some(f) = e.downcast_ref::<f64>() {
+            f.to_string()
+        } else if let Some(f) = e.downcast_ref::<f32>() {
+            f.to_string()
+        } else {
+            format!("{e:?}")
+        };
+        StepError::PanicError {
+            pattern: "panics".into(),
+            function: "panicking_wrapper".into(),
+            message,
+        }
+    })?;
+    Ok(())
+}
+
+step!(
+    rstest_bdd::StepKeyword::When,
+    "panics",
+    panicking_wrapper,
+    &[]
+);
+
 #[test]
 fn step_is_registered() {
     let found = iter::<Step>.into_iter().any(|step| {
@@ -73,6 +125,33 @@ fn wrapper_error_propagates() {
             assert_eq!(pattern, "fails");
             assert_eq!(function, "failing_wrapper");
             assert_eq!(message, "boom");
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn wrapper_panic_is_captured() {
+    let step_fn = iter::<Step>
+        .into_iter()
+        .find(|s| s.pattern.as_str() == "panics")
+        .map_or_else(
+            || panic!("step 'panics' not found in registry"),
+            |step| step.run,
+        );
+    let err = match step_fn(&StepContext::default(), "panics", None, None) {
+        Ok(()) => panic!("expected error from wrapper"),
+        Err(e) => e,
+    };
+    match err {
+        StepError::PanicError {
+            pattern,
+            function,
+            message,
+        } => {
+            assert_eq!(pattern, "panics");
+            assert_eq!(function, "panicking_wrapper");
+            assert_eq!(message, "snap");
         }
         other => panic!("unexpected error: {other:?}"),
     }


### PR DESCRIPTION
## Summary
- add `StepError` enum with helper trait for step return types
- convert wrapper generation to emit `StepError` variants
- test StepError formatting and propagation, including panic capture

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a9103f1a048322a0e1f82b77509fb8

## Summary by Sourcery

Introduce a structured StepError type and normalize step function results to improve error handling in step wrappers

New Features:
- Add StepError enum with MissingFixture, ExecutionError, and PanicError variants
- Introduce IntoStepResult trait to unify step function outputs into Result<(), String>

Enhancements:
- Update macro-generated wrappers to return Result<(), StepError> and emit appropriate StepError variants for missing fixtures, pattern mismatches, execution errors, and panics
- Change codegen helpers to use StepError instead of plain string errors

Tests:
- Adapt existing tests to assert on StepError variants instead of strings
- Add unit tests for StepError Display formatting
- Add behavioural tests to verify StepError propagation and panic capture