### PR TITLE
Error on unbalanced step braces

### DIFF
--- a/crates/rstest-bdd/src/internal_tests.rs
+++ b/crates/rstest-bdd/src/internal_tests.rs
@@ -54,20 +54,22 @@ fn parse_placeholder_without_type_and_with_type() {
     let mut st = RegexBuilder::new("before {outer {inner}} after");
     // Advance to the '{'
     st.position = "before ".len();
-    parse_placeholder(&mut st);
+    #[expect(clippy::expect_used, reason = "test helper should fail loudly")]
+    parse_placeholder(&mut st).expect("placeholder should parse");
     assert!(st.output.contains("(.+?)"));
 
     // With integer type
     let mut st2 = RegexBuilder::new("x {n:u32} y");
     st2.position = 2; // at '{'
-    parse_placeholder(&mut st2);
+    #[expect(clippy::expect_used, reason = "test helper should fail loudly")]
+    parse_placeholder(&mut st2).expect("placeholder should parse");
     assert!(st2.output.contains(r"(\d+)"));
 }
 
 #[test]
-fn parse_literal_opens_stray_on_lone_open_brace() {
-    let mut st = RegexBuilder::new("{");
+fn parse_literal_writes_char() {
+    let mut st = RegexBuilder::new("a");
     parse_literal(&mut st);
-    assert_eq!(st.stray_depth, 1);
-    assert!(st.output.ends_with(r"\{"));
+    assert_eq!(st.position, 1);
+    assert!(st.output.ends_with('a'));
 }

--- a/crates/rstest-bdd/src/pattern.rs
+++ b/crates/rstest-bdd/src/pattern.rs
@@ -51,7 +51,7 @@ impl StepPattern {
     /// # Errors
     /// Returns an error if the pattern cannot be converted into a valid regex.
     pub fn compile(&self) -> Result<(), regex::Error> {
-        let src = crate::placeholder::build_regex_from_pattern(self.text);
+        let src = crate::placeholder::build_regex_from_pattern(self.text)?;
         let regex = Regex::new(&src)?;
         let _ = self.regex.set(regex);
         Ok(())

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -229,9 +229,10 @@ Best practices for writing effective scenarios include:
   (for example, `1e3`, `-1E-9`), and the special values `NaN`, `inf`, and
   `Infinity` (matched case-insensitively). Matching is anchored: the entire
   step text must match the pattern; partial matches do not succeed. Escape
-  literal braces with `{{` and `}}`. Nested braces inside placeholders are not
-  supported. Placeholders follow `{name[:type]}`; `name` must start with a
-  letter or underscore and may contain letters, digits, or underscores
+  literal braces with `{{` and `}}`. Unbalanced or unescaped braces produce a
+  compilation error. Nested braces inside placeholders are not supported.
+  Placeholders follow `{name[:type]}`; `name` must start with a letter or
+  underscore and may contain letters, digits, or underscores
   (`[A-Za-z_][A-Za-z0-9_]*`). Whitespace within the type hint is ignored (for
   example, `{count: u32}` and `{count:u32}` are both accepted), but whitespace
   is not allowed between the name and the colon. Prefer the compact form


### PR DESCRIPTION
## Summary
- validate brace nesting during step pattern compilation
- raise syntax error for malformed or unbalanced placeholders
- document brace validation rules

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`

closes #38

------
https://chatgpt.com/codex/tasks/task_e_68a910b4062c8322872a9038b33e6583

## Summary by Sourcery

Validate brace balancing and placeholder syntax during step pattern compilation by returning errors for unbalanced or malformed constructs and update the compile API and documentation accordingly.

Bug Fixes:
- Fail compilation on unbalanced or stray braces in step patterns instead of treating them as literals
- Reject placeholders with malformed or empty type hints and disallowed whitespace before the colon

Enhancements:
- Convert placeholder parser and regex builder to return Result and remove stray_depth tracking
- Update StepPattern.compile to propagate parsing errors from the regex builder

Documentation:
- Document that unbalanced or unescaped braces produce compilation errors in step patterns

Tests:
- Revise tests to expect compile-time errors for invalid brace usage and malformed placeholders