### PR TITLE
Add placeholder syntax error and brace parsing fixes

### DIFF
--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -127,6 +127,9 @@ pub enum PlaceholderError {
     /// The supplied text did not match the step pattern.
     #[error("pattern mismatch")]
     PatternMismatch,
+    /// The step pattern contained malformed placeholder syntax.
+    #[error("invalid placeholder syntax: {0}")]
+    PlaceholderSyntax(String),
     /// The step pattern could not be compiled into a regular expression.
     #[error("invalid step pattern: {0}")]
     InvalidPattern(String),

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1040,6 +1040,9 @@ enum PlaceholderError {
   // Display: "pattern mismatch"
   PatternMismatch,
 
+  // Display: "invalid placeholder syntax: <details>"
+  PlaceholderSyntax(String),
+
   // Display: "invalid step pattern: <regex_error>"
   InvalidPattern(String),
 
@@ -1053,6 +1056,8 @@ enum PlaceholderError {
     pattern. There is no separate “missing capture” error; a missing or extra
     capture manifests as a mismatch because the entire text must match the
     compiled regular expression for the pattern.
+  - PlaceholderSyntax(String): malformed placeholder or brace sequence in the
+    pattern. Carries a human-readable message describing the error.
   - InvalidPattern(String): carries the underlying `regex::Error` string coming
     from the regular expression engine during compilation of the pattern. No
     additional metadata (placeholder name, position, or line info) is captured.
@@ -1072,6 +1077,9 @@ enum PlaceholderError {
 ```json
 // Pattern mismatch
 {"code":"pattern_mismatch","message":"pattern mismatch"}
+
+// Invalid placeholder
+{"code":"invalid_placeholder","message":"invalid placeholder syntax: <details>"}
 
 // Invalid pattern
 {"code":"invalid_pattern","message":"invalid step pattern: <regex_error>"}

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -232,16 +232,17 @@ Best practices for writing effective scenarios include:
   (for example, `1e3`, `-1E-9`), and the special values `NaN`, `inf`, and
   `Infinity` (matched case-insensitively). Matching is anchored: the entire
   step text must match the pattern; partial matches do not succeed. Escape
-  literal braces with `{{` and `}}`. Unbalanced or unescaped braces produce a
-  compilation error. Nested braces inside placeholders are not supported.
-  Placeholders follow `{name[:type]}`; `name` must start with a letter or
-  underscore and may contain letters, digits, or underscores
-  (`[A-Za-z_][A-Za-z0-9_]*`). Whitespace within the type hint is ignored (for
-  example, `{count: u32}` and `{count:u32}` are both accepted), but whitespace
-  is not allowed between the name and the colon. Prefer the compact form
-  `{count:u32}` in new code. When a pattern contains no placeholders, the step
-  text must match exactly. Unknown type hints are treated as generic
-  placeholders and capture any non-newline text greedily.
+  literal braces with `{{` and `}}` or `\\{` and `\\}`. Unbalanced or unescaped
+  braces produce a compilation error. Nested or escaped braces inside
+  placeholders are treated literally when balanced. Placeholders follow
+  `{name[:type]}`; `name` must start with a letter or underscore and may
+  contain letters, digits, or underscores (`[A-Za-z_][A-Za-z0-9_]*`).
+  Whitespace within the type hint is ignored (for example, `{count: u32}` and
+  `{count:u32}` are both accepted), but whitespace is not allowed between the
+  name and the colon. Prefer the compact form `{count:u32}` in new code. When a
+  pattern contains no placeholders, the step text must match exactly. Unknown
+  type hints are treated as generic placeholders and capture any non-newline
+  text greedily.
 
 ## Data tables and Docstrings
 


### PR DESCRIPTION
## Summary
- add `PlaceholderSyntax` error variant to separate parse failures from regex compilation
- handle escaped and nested braces without rejecting valid patterns
- document placeholder syntax and error variant

## Testing
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68ab8c43aa388322a82d854bffeb58cb

## Summary by Sourcery

Add PlaceholderSyntax error variant and improve placeholder parsing to correctly handle escaped and nested braces, updating compile interfaces, documentation, and tests accordingly

New Features:
- Introduce PlaceholderSyntax error variant for malformed placeholder or brace sequences

Enhancements:
- Allow escaped braces (\{ \}) and double braces ({{ }}) inside placeholders without rejecting valid patterns
- Change compile and build functions to return PlaceholderError instead of regex::Error to surface syntax errors separately

Documentation:
- Document escaped and nested brace handling and the new PlaceholderSyntax error in the user guide and design docs

Tests:
- Add tests for escaped and nested braces inside placeholders and expect PlaceholderSyntax for unbalanced or stray braces