### PR TITLE
Add dedicated placeholder syntax error and brace tests

### DIFF
--- a/crates/rstest-bdd/src/internal_tests.rs
+++ b/crates/rstest-bdd/src/internal_tests.rs
@@ -4,9 +4,8 @@
 //! behaviour remains stable while allowing private access from a child module.
 
 use crate::placeholder::{
-    RegexBuilder, is_double_brace, is_empty_type_hint, is_escaped_brace, is_placeholder_start,
-    parse_double_brace, parse_escaped_brace, parse_literal, parse_placeholder,
-    parse_placeholder_name,
+    RegexBuilder, is_double_brace, is_escaped_brace, is_placeholder_start, parse_double_brace,
+    parse_escaped_brace, parse_literal, parse_placeholder,
 };
 
 #[test]
@@ -22,15 +21,6 @@ fn predicates_detect_expected_tokens() {
     // Placeholder start
     assert!(is_placeholder_start(s, 8)); // "{a"
     assert!(is_placeholder_start(s, 11)); // "{_"
-}
-
-#[test]
-fn empty_type_hint_is_detected() {
-    let pat = "{n:   }";
-    let st = RegexBuilder::new(pat);
-    // name_end just after "n" (index 2)
-    let (name_end, _name) = parse_placeholder_name(&st, 1);
-    assert!(is_empty_type_hint(&st, name_end));
 }
 
 #[test]

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -65,7 +65,7 @@ pub fn panic_message(e: &(dyn std::any::Any + Send)) -> String {
 
 /// Error type produced by step wrappers.
 ///
-/// The variants categorise the possible failure modes when invoking a step.
+/// The variants categorize the possible failure modes when invoking a step.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum StepError {

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -30,8 +30,8 @@ pub use pattern::StepPattern;
 pub use placeholder::extract_placeholders;
 pub use registry::{Step, find_step, lookup_step};
 pub use types::{
-    PatternStr, PlaceholderError, StepFn, StepKeyword, StepKeywordParseError, StepPatternError,
-    StepText,
+    PatternStr, PlaceholderError, PlaceholderSyntaxError, StepFn, StepKeyword,
+    StepKeywordParseError, StepPatternError, StepText,
 };
 
 /// Extracts a panic payload into a human-readable message.

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -30,7 +30,8 @@ pub use pattern::StepPattern;
 pub use placeholder::extract_placeholders;
 pub use registry::{Step, find_step, lookup_step};
 pub use types::{
-    PatternStr, PlaceholderError, StepFn, StepKeyword, StepKeywordParseError, StepText,
+    PatternStr, PlaceholderError, StepFn, StepKeyword, StepKeywordParseError, StepPatternError,
+    StepText,
 };
 
 /// Extracts a panic payload into a human-readable message.

--- a/crates/rstest-bdd/src/pattern.rs
+++ b/crates/rstest-bdd/src/pattern.rs
@@ -59,6 +59,9 @@ impl StepPattern {
     /// - This method is thread-safe; concurrent calls may race to build a
     ///   `Regex`, but only the first successful value is cached.
     pub fn compile(&self) -> Result<(), StepPatternError> {
+        if self.regex.get().is_some() {
+            return Ok(());
+        }
         let src = crate::placeholder::build_regex_from_pattern(self.text)?;
         let regex = Regex::new(&src)?;
         let _ = self.regex.set(regex);
@@ -71,9 +74,12 @@ impl StepPattern {
     /// Panics if `compile()` was not called before this accessor.
     #[must_use]
     pub fn regex(&self) -> &Regex {
-        self.regex
-            .get()
-            .unwrap_or_else(|| panic!("step pattern regex must be precompiled"))
+        self.regex.get().unwrap_or_else(|| {
+            panic!(
+                "step pattern regex must be precompiled; call compile() first on pattern '{}'",
+                self.text
+            )
+        })
     }
 }
 

--- a/crates/rstest-bdd/src/pattern.rs
+++ b/crates/rstest-bdd/src/pattern.rs
@@ -2,6 +2,7 @@
 //! This module defines `StepPattern`, a lightweight wrapper around a pattern
 //! literal that compiles lazily to a regular expression.
 
+use crate::types::StepPatternError;
 use regex::Regex;
 use std::hash::{Hash, Hasher};
 use std::sync::OnceLock;
@@ -49,10 +50,11 @@ impl StepPattern {
     /// Compile the pattern into a regular expression, caching the result.
     ///
     /// # Errors
-    /// Returns an error if the pattern cannot be converted into a valid regex.
-    pub fn compile(&self) -> Result<(), regex::Error> {
+    /// Returns an error if the pattern contains invalid placeholders or the
+    /// generated regex fails to compile.
+    pub fn compile(&self) -> Result<(), StepPatternError> {
         let src = crate::placeholder::build_regex_from_pattern(self.text)?;
-        let regex = Regex::new(&src)?;
+        let regex = Regex::new(&src).map_err(StepPatternError::Regex)?;
         let _ = self.regex.set(regex);
         Ok(())
     }

--- a/crates/rstest-bdd/src/pattern.rs
+++ b/crates/rstest-bdd/src/pattern.rs
@@ -69,11 +69,6 @@ impl StepPattern {
             .get()
             .unwrap_or_else(|| panic!("step pattern regex must be precompiled"))
     }
-
-    /// Return the cached regex if available.
-    pub(crate) fn try_regex(&self) -> Option<&Regex> {
-        self.regex.get()
-    }
 }
 
 impl From<&'static str> for StepPattern {

--- a/crates/rstest-bdd/src/pattern.rs
+++ b/crates/rstest-bdd/src/pattern.rs
@@ -54,7 +54,7 @@ impl StepPattern {
     /// generated regex fails to compile.
     pub fn compile(&self) -> Result<(), StepPatternError> {
         let src = crate::placeholder::build_regex_from_pattern(self.text)?;
-        let regex = Regex::new(&src).map_err(StepPatternError::Regex)?;
+        let regex = Regex::new(&src)?;
         let _ = self.regex.set(regex);
         Ok(())
     }

--- a/crates/rstest-bdd/src/pattern.rs
+++ b/crates/rstest-bdd/src/pattern.rs
@@ -52,6 +52,12 @@ impl StepPattern {
     /// # Errors
     /// Returns an error if the pattern contains invalid placeholders or the
     /// generated regex fails to compile.
+    ///
+    /// # Notes
+    /// - This operation is idempotent. Subsequent calls after a successful
+    ///   compilation are no-ops.
+    /// - This method is thread-safe; concurrent calls may race to build a
+    ///   `Regex`, but only the first successful value is cached.
     pub fn compile(&self) -> Result<(), StepPatternError> {
         let src = crate::placeholder::build_regex_from_pattern(self.text)?;
         let regex = Regex::new(&src)?;

--- a/crates/rstest-bdd/src/placeholder.rs
+++ b/crates/rstest-bdd/src/placeholder.rs
@@ -141,12 +141,13 @@ pub(crate) fn parse_escape_sequence(state: &mut RegexBuilder<'_>) {
     debug_assert!(matches!(state.bytes.get(state.position), Some(b'\\')));
     debug_assert!(!is_escaped_brace(state.bytes, state.position));
     debug_assert!(state.bytes.get(state.position + 1).is_some());
-    if let Some(&next) = state.bytes.get(state.position + 1) {
-        state.push_literal_byte(next);
-        state.advance(2);
-    } else if try_parse_common_sequences(state) {
-        // Trailing backslash handled by common sequences.
-    }
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "preceding debug_assert ensures bound"
+    )]
+    let next = state.bytes[state.position + 1];
+    state.push_literal_byte(next);
+    state.advance(2);
 }
 
 pub(crate) fn parse_double_brace(state: &mut RegexBuilder<'_>) {

--- a/crates/rstest-bdd/src/placeholder.rs
+++ b/crates/rstest-bdd/src/placeholder.rs
@@ -228,6 +228,14 @@ pub(crate) fn validate_placeholder_whitespace(
     Ok(())
 }
 
+/// Returns `true` if the type hint is empty, contains whitespace, or braces.
+fn is_invalid_type_hint(ty: &str) -> bool {
+    ty.is_empty()
+        || ty.chars().any(|c| c.is_ascii_whitespace())
+        || ty.contains('{')
+        || ty.contains('}')
+}
+
 /// Ensures the raw type hint is well-formed, rejecting empty,
 /// whitespace-padded, or brace-containing hints.
 pub(crate) fn validate_type_hint(
@@ -236,11 +244,7 @@ pub(crate) fn validate_type_hint(
     name: &str,
 ) -> Result<Option<String>, StepPatternError> {
     if let Some(ty) = ty_raw {
-        if ty.is_empty()
-            || ty.chars().any(|c| c.is_ascii_whitespace())
-            || ty.contains('{')
-            || ty.contains('}')
-        {
+        if is_invalid_type_hint(&ty) {
             return Err(PlaceholderSyntaxError::new(
                 "invalid placeholder in step pattern",
                 start,

--- a/crates/rstest-bdd/src/placeholder.rs
+++ b/crates/rstest-bdd/src/placeholder.rs
@@ -284,7 +284,7 @@ pub(crate) fn parse_placeholder(state: &mut RegexBuilder<'_>) -> Result<(), Step
     if ty_opt.is_none() {
         after = find_closing_brace(state.bytes, name_end).ok_or_else(|| {
             PlaceholderSyntaxError::new(
-                "unbalanced braces in step pattern",
+                "missing closing '}' for placeholder",
                 start,
                 Some(name.clone()),
             )
@@ -292,7 +292,7 @@ pub(crate) fn parse_placeholder(state: &mut RegexBuilder<'_>) -> Result<(), Step
     }
     if !matches!(state.bytes.get(after), Some(b'}')) {
         return Err(PlaceholderSyntaxError::new(
-            "unbalanced braces in step pattern",
+            "missing closing '}' for placeholder",
             start,
             Some(name),
         )

--- a/crates/rstest-bdd/src/placeholder.rs
+++ b/crates/rstest-bdd/src/placeholder.rs
@@ -20,12 +20,7 @@ pub fn extract_placeholders(
     pattern: &StepPattern,
     text: StepText<'_>,
 ) -> Result<Vec<String>, PlaceholderError> {
-    pattern.compile().map_err(|e| match e {
-        StepPatternError::PlaceholderSyntax(err) => {
-            PlaceholderError::InvalidPlaceholder(err.user_message())
-        }
-        StepPatternError::Regex(e) => PlaceholderError::InvalidPattern(e.to_string()),
-    })?;
+    pattern.compile()?;
     let re = pattern.regex();
     extract_captured_values(re, text.as_str()).ok_or(PlaceholderError::PatternMismatch)
 }

--- a/crates/rstest-bdd/src/placeholder.rs
+++ b/crates/rstest-bdd/src/placeholder.rs
@@ -184,22 +184,11 @@ pub(crate) fn parse_type_hint(state: &RegexBuilder<'_>, start: usize) -> (usize,
     }
     i += 1;
     let ty_start = i;
-    let mut nest = 0usize;
     while let Some(&b) = state.bytes.get(i) {
-        match b {
-            b'{' => {
-                nest += 1;
-                i += 1;
-            }
-            b'}' => {
-                if nest == 0 {
-                    break;
-                }
-                nest -= 1;
-                i += 1;
-            }
-            _ => i += 1,
+        if b == b'}' {
+            break;
         }
+        i += 1;
     }
     #[expect(clippy::string_slice, reason = "ASCII region delimited by braces")]
     let ty = state.pattern[ty_start..i].to_string();
@@ -318,7 +307,7 @@ pub(crate) fn parse_placeholder(state: &mut RegexBuilder<'_>) -> Result<(), Step
 }
 
 /// Parses sequences common to all contexts: doubled braces, escaped braces, or
-/// backslash escapes. Returns `true` if a recognised sequence was consumed.
+/// backslash escapes. Returns `true` if a recognized sequence was consumed.
 #[inline]
 pub(crate) fn try_parse_common_sequences(st: &mut RegexBuilder<'_>) -> bool {
     if is_double_brace(st.bytes, st.position) {

--- a/crates/rstest-bdd/src/placeholder.rs
+++ b/crates/rstest-bdd/src/placeholder.rs
@@ -8,14 +8,14 @@ use crate::types::{PlaceholderError, PlaceholderSyntaxError, StepPatternError, S
 use regex::Regex;
 
 /// Extract placeholder values from a step string using a pattern.
-/// See crate-level docs for the accepted syntax and error cases.
+/// See crate-level docs for accepted syntax and error cases.
 ///
 /// # Errors
-/// Returns [`PlaceholderError::InvalidPlaceholder`] if the pattern contains
-/// malformed placeholders, [`PlaceholderError::InvalidPattern`] if the
-/// generated regex fails to compile, and
-/// [`PlaceholderError::PatternMismatch`] when the text does not satisfy the
-/// pattern.
+/// - [`PlaceholderError::InvalidPlaceholder`]: pattern contains malformed
+///   placeholders
+/// - [`PlaceholderError::InvalidPattern`]: generated regular expression failed
+///   to compile
+/// - [`PlaceholderError::PatternMismatch`]: text does not match the pattern
 pub fn extract_placeholders(
     pattern: &StepPattern,
     text: StepText<'_>,

--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -191,6 +191,17 @@ pub enum PlaceholderError {
     InvalidPattern(String),
 }
 
+impl From<StepPatternError> for PlaceholderError {
+    fn from(e: StepPatternError) -> Self {
+        match e {
+            StepPatternError::PlaceholderSyntax(err) => {
+                Self::InvalidPlaceholder(err.user_message())
+            }
+            StepPatternError::Regex(re) => Self::InvalidPattern(re.to_string()),
+        }
+    }
+}
+
 /// Type alias for the stored step function pointer.
 pub type StepFn = for<'a> fn(
     &crate::context::StepContext<'a>,

--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -124,7 +124,7 @@ impl From<StepType> for StepKeyword {
 }
 
 /// Detailed information about placeholder parsing failures.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlaceholderSyntaxError {
     /// Human‑readable reason for the failure.
     pub message: String,
@@ -166,6 +166,7 @@ impl std::error::Error for PlaceholderSyntaxError {}
 
 /// Errors that may occur when compiling a [`StepPattern`].
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum StepPatternError {
     /// Placeholder syntax in the pattern is invalid.
     #[error(transparent)]
@@ -187,9 +188,6 @@ pub enum PlaceholderError {
     /// The step pattern could not be compiled into a regular expression.
     #[error("invalid step pattern: {0}")]
     InvalidPattern(String),
-    /// The step pattern was not compiled before use.
-    #[error("uncompiled step pattern")]
-    Uncompiled,
 }
 
 /// Type alias for the stored step function pointer.

--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -121,12 +121,26 @@ impl From<StepType> for StepKeyword {
     }
 }
 
+/// Errors that may occur when compiling a [`StepPattern`].
+#[derive(Debug, Error)]
+pub enum StepPatternError {
+    /// Placeholder syntax in the pattern is invalid.
+    #[error("invalid placeholder syntax: {0}")]
+    PlaceholderSyntax(String),
+    /// The generated regular expression failed to compile.
+    #[error("{0}")]
+    Regex(#[from] regex::Error),
+}
+
 /// Error conditions that may arise when extracting placeholders.
 #[derive(Debug, Error)]
 pub enum PlaceholderError {
     /// The supplied text did not match the step pattern.
     #[error("pattern mismatch")]
     PatternMismatch,
+    /// The step pattern contained invalid placeholder syntax.
+    #[error("invalid placeholder syntax: {0}")]
+    InvalidPlaceholder(String),
     /// The step pattern could not be compiled into a regular expression.
     #[error("invalid step pattern: {0}")]
     InvalidPattern(String),

--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -173,7 +173,7 @@ pub enum StepPatternError {
     PlaceholderSyntax(#[from] PlaceholderSyntaxError),
     /// The generated regular expression failed to compile.
     #[error("{0}")]
-    Regex(#[from] regex::Error),
+    InvalidPattern(#[from] regex::Error),
 }
 
 /// Error conditions that may arise when extracting placeholders.
@@ -197,7 +197,7 @@ impl From<StepPatternError> for PlaceholderError {
             StepPatternError::PlaceholderSyntax(err) => {
                 Self::InvalidPlaceholder(err.user_message())
             }
-            StepPatternError::Regex(re) => Self::InvalidPattern(re.to_string()),
+            StepPatternError::InvalidPattern(re) => Self::InvalidPattern(re.to_string()),
         }
     }
 }

--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -128,7 +128,7 @@ impl From<StepType> for StepKeyword {
 pub struct PlaceholderSyntaxError {
     /// Human‑readable reason for the failure.
     pub message: String,
-    /// Byte index in the original pattern where parsing failed.
+    /// Zero-based byte offset in the original pattern where parsing failed.
     pub position: usize,
     /// Name of the placeholder, when known.
     pub placeholder: Option<String>,
@@ -148,7 +148,7 @@ impl PlaceholderSyntaxError {
     /// Return the user‑facing message without the "invalid placeholder syntax" prefix.
     #[must_use]
     pub fn user_message(&self) -> String {
-        let mut msg = format!("{} at position {}", self.message, self.position);
+        let mut msg = format!("{} at byte {} (zero-based)", self.message, self.position);
         if let Some(name) = &self.placeholder {
             let _ = write!(msg, " for placeholder `{name}`");
         }

--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -178,6 +178,7 @@ pub enum StepPatternError {
 
 /// Error conditions that may arise when extracting placeholders.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum PlaceholderError {
     /// The supplied text did not match the step pattern.
     #[error("pattern mismatch")]

--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -57,7 +57,7 @@ impl<'a> From<&'a str> for StepText<'a> {
     }
 }
 
-/// Keyword used to categorise a step definition.
+/// Keyword used to categorize a step definition.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum StepKeyword {
     /// Setup preconditions for a scenario.

--- a/crates/rstest-bdd/tests/placeholder_parsing.rs
+++ b/crates/rstest-bdd/tests/placeholder_parsing.rs
@@ -272,17 +272,38 @@ fn handles_nested_braces() {
 }
 
 #[rstest]
-#[case("before {outer {inner} after")]
-#[case("{unbalanced start text")]
-#[case("text with unbalanced end}")]
-#[case("text {with {multiple unbalanced")]
-#[case("text} with} multiple unbalanced")]
-#[case("start {middle text} end}")]
-fn compile_fails_on_unbalanced_braces(#[case] pattern: &'static str) {
+#[case(
+    "before {outer {inner} after",
+    "nested unbalanced opening brace should error"
+)]
+#[case(
+    "{unbalanced start text",
+    "unbalanced opening brace at start should error"
+)]
+#[case(
+    "text with unbalanced end}",
+    "unbalanced closing brace at end should error"
+)]
+#[case(
+    "text {with {multiple unbalanced",
+    "multiple unbalanced opening braces should error"
+)]
+#[case(
+    "text} with} multiple unbalanced",
+    "multiple unbalanced closing braces should error"
+)]
+#[case(
+    "start {middle text} end}",
+    "unbalanced closing brace in middle should error"
+)]
+fn compile_fails_on_unbalanced_braces(
+    #[case] pattern: &'static str,
+    #[case] description: &'static str,
+) {
     let pat = StepPattern::from(pattern);
     assert!(
         matches!(pat.compile(), Err(StepPatternError::PlaceholderSyntax(_))),
-        "unbalanced braces should error: {pattern}"
+        "{description}"
     );
 }
 

--- a/crates/rstest-bdd/tests/placeholder_parsing.rs
+++ b/crates/rstest-bdd/tests/placeholder_parsing.rs
@@ -137,6 +137,22 @@ fn malformed_type_hint_is_error() {
 }
 
 #[test]
+fn whitespace_before_closing_brace_is_error() {
+    for pattern in ["value {n }", "value {n   }"] {
+        let pat = StepPattern::from(pattern);
+        #[expect(clippy::expect_used, reason = "test asserts error")]
+        let err = pat
+            .compile()
+            .expect_err("whitespace before closing brace should error");
+        let StepPatternError::PlaceholderSyntax(e) = err else {
+            panic!("unexpected error variant");
+        };
+        assert_eq!(e.position, 6);
+        assert_eq!(e.placeholder.as_deref(), Some("n"));
+    }
+}
+
+#[test]
 fn extraction_reports_invalid_placeholder_error() {
     let pat = StepPattern::from("value {n:}");
     #[expect(clippy::expect_used, reason = "test asserts error variant")]

--- a/crates/rstest-bdd/tests/placeholder_parsing.rs
+++ b/crates/rstest-bdd/tests/placeholder_parsing.rs
@@ -166,6 +166,22 @@ fn extraction_reports_invalid_placeholder_error() {
 }
 
 #[test]
+fn invalid_pattern_error_display() {
+    #[expect(
+        clippy::invalid_regex,
+        clippy::expect_used,
+        reason = "deliberate invalid regex to test error display"
+    )]
+    let regex_err = regex::Regex::new("(").expect_err("invalid regex should error");
+    let err: PlaceholderError = StepPatternError::from(regex_err.clone()).into();
+    assert!(matches!(err, PlaceholderError::InvalidPattern(_)));
+    assert_eq!(
+        err.to_string(),
+        format!("invalid step pattern: {regex_err}"),
+    );
+}
+
+#[test]
 fn handles_escaped_braces() {
     let pat = StepPattern::from(r"literal \{ brace {v} \}");
     pat.compile()

--- a/crates/rstest-bdd/tests/placeholder_parsing.rs
+++ b/crates/rstest-bdd/tests/placeholder_parsing.rs
@@ -239,50 +239,18 @@ fn handles_nested_braces() {
     assert_eq!(caps, vec!["value"]);
 }
 
-#[test]
-fn compile_fails_on_unbalanced_braces() {
-    let pat = StepPattern::from("before {outer {inner} after");
+#[rstest]
+#[case("before {outer {inner} after")]
+#[case("{unbalanced start text")]
+#[case("text with unbalanced end}")]
+#[case("text {with {multiple unbalanced")]
+#[case("text} with} multiple unbalanced")]
+#[case("start {middle text} end}")]
+fn compile_fails_on_unbalanced_braces(#[case] pattern: &'static str) {
+    let pat = StepPattern::from(pattern);
     assert!(
         matches!(pat.compile(), Err(StepPatternError::PlaceholderSyntax(_))),
-        "unbalanced braces should error"
-    );
-}
-
-#[test]
-fn compile_fails_on_multiple_unbalanced_braces() {
-    // Unbalanced opening at start
-    let pat1 = StepPattern::from("{unbalanced start text");
-    assert!(
-        matches!(pat1.compile(), Err(StepPatternError::PlaceholderSyntax(_))),
-        "unbalanced opening brace at start should error",
-    );
-
-    // Unbalanced closing at end
-    let pat2 = StepPattern::from("text with unbalanced end}");
-    assert!(
-        matches!(pat2.compile(), Err(StepPatternError::PlaceholderSyntax(_))),
-        "unbalanced closing brace at end should error",
-    );
-
-    // Multiple unbalanced opening braces
-    let pat3 = StepPattern::from("text {with {multiple unbalanced");
-    assert!(
-        matches!(pat3.compile(), Err(StepPatternError::PlaceholderSyntax(_))),
-        "multiple unbalanced opening braces should error",
-    );
-
-    // Multiple unbalanced closing braces
-    let pat4 = StepPattern::from("text} with} multiple unbalanced");
-    assert!(
-        matches!(pat4.compile(), Err(StepPatternError::PlaceholderSyntax(_))),
-        "multiple unbalanced closing braces should error",
-    );
-
-    // Unbalanced braces in the middle
-    let pat5 = StepPattern::from("start {middle text} end}");
-    assert!(
-        matches!(pat5.compile(), Err(StepPatternError::PlaceholderSyntax(_))),
-        "unbalanced closing brace in the middle should error",
+        "unbalanced braces should error: {pattern}"
     );
 }
 

--- a/crates/rstest-bdd/tests/placeholder_parsing.rs
+++ b/crates/rstest-bdd/tests/placeholder_parsing.rs
@@ -132,7 +132,14 @@ fn malformed_type_hint_is_error() {
     let pat4 = StepPattern::from("value {n:f64 }");
     assert!(
         matches!(pat4.compile(), Err(StepPatternError::PlaceholderSyntax(_))),
-        "whitespace around type hint is invalid"
+        "whitespace after type hint is invalid",
+    );
+
+    // Whitespace on both sides of the type hint is invalid.
+    let pat5 = StepPattern::from("value {n: f64 }");
+    assert!(
+        matches!(pat5.compile(), Err(StepPatternError::PlaceholderSyntax(_))),
+        "whitespace around type hint is invalid",
     );
 }
 
@@ -170,15 +177,13 @@ fn invalid_pattern_error_display() {
     #[expect(
         clippy::invalid_regex,
         clippy::expect_used,
-        reason = "deliberate invalid regex to test error display"
+        reason = "deliberate invalid regex to test error display",
     )]
     let regex_err = regex::Regex::new("(").expect_err("invalid regex should error");
-    let err: PlaceholderError = StepPatternError::from(regex_err.clone()).into();
+    let expected = format!("invalid step pattern: {regex_err}");
+    let err: PlaceholderError = StepPatternError::from(regex_err).into();
     assert!(matches!(err, PlaceholderError::InvalidPattern(_)));
-    assert_eq!(
-        err.to_string(),
-        format!("invalid step pattern: {regex_err}"),
-    );
+    assert_eq!(err.to_string(), expected);
 }
 
 #[test]

--- a/crates/rstest-bdd/tests/placeholder_parsing.rs
+++ b/crates/rstest-bdd/tests/placeholder_parsing.rs
@@ -185,9 +185,9 @@ fn unknown_escape_is_literal(
 
 #[test]
 fn trailing_backslash_is_literal() {
-    let pat = compiled(r"foo\");
+    let pat = compiled("foo\\");
     #[expect(clippy::expect_used, reason = "test asserts literal match")]
-    let caps = extract_placeholders(&pat, StepText::from(r"foo\"))
+    let caps = extract_placeholders(&pat, StepText::from("foo\\"))
         .expect("literal backslash should match");
     assert!(caps.is_empty(), "no placeholders expected");
     assert!(

--- a/crates/rstest-bdd/tests/placeholder_parsing.rs
+++ b/crates/rstest-bdd/tests/placeholder_parsing.rs
@@ -145,7 +145,7 @@ fn extraction_reports_invalid_placeholder_error() {
     assert!(matches!(err, PlaceholderError::InvalidPlaceholder(_)));
     assert_eq!(
         err.to_string(),
-        "invalid placeholder syntax: invalid placeholder in step pattern at position 6 for placeholder `n`"
+        "invalid placeholder syntax: invalid placeholder in step pattern at byte 6 (zero-based) for placeholder `n`"
     );
 }
 

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1035,7 +1035,8 @@ enum PlaceholderError {
     capture manifests as a mismatch because the entire text must match the
     compiled regular expression for the pattern.
   - InvalidPlaceholder(String): the pattern contained malformed placeholder
-    syntax and could not be parsed. No additional metadata is captured.
+    syntax and could not be parsed. The message includes the byte position and,
+    when available, the offending placeholder name.
   - InvalidPattern(String): carries the underlying `regex::Error` string coming
     from the regular expression engine during compilation of the pattern. No
     additional metadata (placeholder name, position, or line info) is captured.
@@ -1045,7 +1046,12 @@ enum PlaceholderError {
 
 - Example error strings (exact `Display` output):
   - Pattern mismatch: `"pattern mismatch"`
-  - Invalid placeholder: `"invalid placeholder syntax: reason"`
+  - Invalid placeholder:
+
+    ```text
+    "invalid placeholder syntax: invalid placeholder in step pattern at position 6 for placeholder `n`"
+    ```
+
   - Invalid pattern: `"invalid step pattern: regex parse error: error message"`
   - Uncompiled: `"uncompiled step pattern"`
 
@@ -1054,17 +1060,25 @@ enum PlaceholderError {
   to JSON at an API boundary:
 
 ```json
-// Pattern mismatch
-{"code":"pattern_mismatch","message":"pattern mismatch"}
+{
+  "code": "pattern_mismatch",
+  "message": "pattern mismatch"
+}
 
-// Invalid placeholder
-{"code":"invalid_placeholder","message":"invalid placeholder syntax: reason"}
+{
+  "code": "invalid_placeholder",
+  "message": "invalid placeholder syntax: invalid placeholder in step pattern at position 6 for placeholder `n`"
+}
 
-// Invalid pattern
-{"code":"invalid_pattern","message":"invalid step pattern: <regex_error>"}
+{
+  "code": "invalid_pattern",
+  "message": "invalid step pattern: <regex_error>"
+}
 
-// Uncompiled pattern
-{"code":"uncompiled","message":"uncompiled step pattern"}
+{
+  "code": "uncompiled",
+  "message": "uncompiled step pattern"
+}
 ```
 
 Step wrapper functions parse the returned strings and convert them with

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1060,7 +1060,7 @@ enum PlaceholderError {
 
 {
   "code": "invalid_placeholder",
-  "message": "invalid placeholder syntax: invalid placeholder in step pattern at position 6 for placeholder `n`"
+  "message": "invalid placeholder syntax: invalid placeholder in step pattern at byte 6 (zero-based) for placeholder `n`"
 }
 
 {
@@ -1117,18 +1117,23 @@ Public APIs are re‑exported from `lib.rs` so consumers continue to import from
   - `StepKeyword` (+ `FromStr`), `StepKeywordParseError`.
   - `PlaceholderError`: semantic error enum returned by parsing helpers.
   - `StepFn`: type alias for the step function pointer.
+
 - `pattern.rs`: Step pattern wrapper.
   - `StepPattern::new`, `compile`, `regex`.
+
 - `placeholder.rs`: Placeholder extraction and scanner.
   - `extract_placeholders` (public) and the single‑pass scanner
     `build_regex_from_pattern` with small parsing predicates and helpers.
+
 - `context.rs`: Fixture context.
   - `StepContext`: simple type‑indexed store used to pass fixtures into steps.
+
 - `registry.rs`: Registration and lookup.
   - `Step` record, `step!` macro, global registry map, `lookup_step`,
     `find_step`.
+
 - `lib.rs`: Public API facade.
-  - Re‑exports public items and keeps the `greet()` example function.
+  - Re-exports public items and keeps the `greet()` example function.
 
 All modules use en‑GB spelling and include `//!` module‑level documentation.
 

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1032,8 +1032,8 @@ enum PlaceholderError {
     capture manifests as a mismatch because the entire text must match the
     compiled regular expression for the pattern.
   - InvalidPlaceholder(String): the pattern contained malformed placeholder
-    syntax and could not be parsed. The message includes the byte position and,
-    when available, the offending placeholder name.
+    syntax and could not be parsed. The message includes the zero-based byte
+    offset and, when available, the offending placeholder name.
   - InvalidPattern(String): carries the underlying `regex::Error` string coming
     from the regular expression engine during compilation of the pattern. No
     additional metadata (placeholder name, position, or line info) is captured.
@@ -1043,15 +1043,14 @@ enum PlaceholderError {
   - Invalid placeholder:
 
     ```text
-    "invalid placeholder syntax: invalid placeholder in step pattern at position 6 for placeholder `n`"
+    "invalid placeholder syntax: invalid placeholder in step pattern at byte 6 (zero-based) for placeholder `n`"
     ```
 
   - Invalid pattern: `"invalid step pattern: regex parse error: error message"`
 
   - Example JSON mapping (for consumers that serialize errors). Note: this is
-    not
-  emitted by the library; it is a suggested shape if you need to map the enum
-  to JSON at an API boundary:
+    not emitted by the library; it is a suggested shape if you need to map the
+    enum to JSON at an API boundary:
 
 ```json
 {

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1048,7 +1048,8 @@ enum PlaceholderError {
 
   - Invalid pattern: `"invalid step pattern: regex parse error: error message"`
 
-- Example JSON mapping (for consumers that serialise errors). Note: this is not
+  - Example JSON mapping (for consumers that serialize errors). Note: this is
+    not
   emitted by the library; it is a suggested shape if you need to map the enum
   to JSON at an API boundary:
 

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1133,11 +1133,10 @@ Public APIs are re‑exported from `lib.rs` so consumers continue to import from
   - `StepContext`
 
 - `registry.rs` — Registration and lookup:
-  - `Step`
-  - `step!` macro
-  - global registry map
-  - `lookup_step`
-  - `find_step.`
+- `step!` macro
+- global registry map
+- `lookup_step`
+- `find_step`.
 
 - `lib.rs` — Public API facade:
   - Re-exports public items

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1018,6 +1018,9 @@ enum PlaceholderError {
   // Display: "pattern mismatch"
   PatternMismatch,
 
+  // Display: "invalid placeholder syntax: <reason>"
+  InvalidPlaceholder(String),
+
   // Display: "invalid step pattern: <regex_error>"
   InvalidPattern(String),
 
@@ -1031,6 +1034,8 @@ enum PlaceholderError {
     pattern. There is no separate “missing capture” error; a missing or extra
     capture manifests as a mismatch because the entire text must match the
     compiled regular expression for the pattern.
+  - InvalidPlaceholder(String): the pattern contained malformed placeholder
+    syntax and could not be parsed. No additional metadata is captured.
   - InvalidPattern(String): carries the underlying `regex::Error` string coming
     from the regular expression engine during compilation of the pattern. No
     additional metadata (placeholder name, position, or line info) is captured.
@@ -1040,6 +1045,7 @@ enum PlaceholderError {
 
 - Example error strings (exact `Display` output):
   - Pattern mismatch: `"pattern mismatch"`
+  - Invalid placeholder: `"invalid placeholder syntax: reason"`
   - Invalid pattern: `"invalid step pattern: regex parse error: error message"`
   - Uncompiled: `"uncompiled step pattern"`
 
@@ -1050,6 +1056,9 @@ enum PlaceholderError {
 ```json
 // Pattern mismatch
 {"code":"pattern_mismatch","message":"pattern mismatch"}
+
+// Invalid placeholder
+{"code":"invalid_placeholder","message":"invalid placeholder syntax: reason"}
 
 // Invalid pattern
 {"code":"invalid_pattern","message":"invalid step pattern: <regex_error>"}

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1112,28 +1112,36 @@ To keep responsibilities cohesive the runtime is split into focused modules.
 Public APIs are re‑exported from `lib.rs` so consumers continue to import from
 `rstest_bdd::*` as before.
 
-- `types.rs`: Core types and errors.
-  - `PatternStr`, `StepText`: light wrappers for pattern keys and step text.
-  - `StepKeyword` (+ `FromStr`), `StepKeywordParseError`.
-  - `PlaceholderError`: semantic error enum returned by parsing helpers.
-  - `StepFn`: type alias for the step function pointer.
+- types.rs — Core types and errors:
+  - PatternStr
+  - StepText
+  - StepKeyword
+  - StepKeywordParseError
+  - PlaceholderError
+  - StepFn
 
-- `pattern.rs`: Step pattern wrapper.
-  - `StepPattern::new`, `compile`, `regex`.
+- pattern.rs — Step pattern wrapper:
+  - StepPattern.new
+  - compile
+  - regex
 
-- `placeholder.rs`: Placeholder extraction and scanner.
-  - `extract_placeholders` (public) and the single‑pass scanner
-    `build_regex_from_pattern` with small parsing predicates and helpers.
+- placeholder.rs — Placeholder extraction and scanner:
+  - extract_placeholders
+  - build_regex_from_pattern
 
-- `context.rs`: Fixture context.
-  - `StepContext`: simple type‑indexed store used to pass fixtures into steps.
+- context.rs — Fixture context:
+  - StepContext
 
-- `registry.rs`: Registration and lookup.
-  - `Step` record, `step!` macro, global registry map, `lookup_step`,
-    `find_step`.
+- registry.rs — Registration and lookup:
+  - Step
+  - step! macro
+  - global registry map
+  - lookup_step
+  - find_step
 
-- `lib.rs`: Public API facade.
-  - Re-exports public items and keeps the `greet()` example function.
+- lib.rs — Public API facade:
+  - Re-exports public items
+  - greet example function
 
 All modules use en‑GB spelling and include `//!` module‑level documentation.
 

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1112,36 +1112,36 @@ To keep responsibilities cohesive the runtime is split into focused modules.
 Public APIs are re‑exported from `lib.rs` so consumers continue to import from
 `rstest_bdd::*` as before.
 
-- types.rs — Core types and errors:
-  - PatternStr
-  - StepText
-  - StepKeyword
-  - StepKeywordParseError
-  - PlaceholderError
-  - StepFn
+- `types.rs` — Core types and errors:
+  - `PatternStr`
+  - `StepText`
+  - `StepKeyword`
+  - `StepKeywordParseError`
+  - `PlaceholderError`
+  - `StepFn`
 
-- pattern.rs — Step pattern wrapper:
-  - StepPattern.new
-  - compile
-  - regex
+- `pattern.rs` — Step pattern wrapper:
+  - `StepPattern::new`
+  - `compile`
+  - `regex`
 
-- placeholder.rs — Placeholder extraction and scanner:
-  - extract_placeholders
-  - build_regex_from_pattern
+- `placeholder.rs` — Placeholder extraction and scanner:
+  - `extract_placeholders`
+  - `build_regex_from_pattern`
 
-- context.rs — Fixture context:
-  - StepContext
+- `context.rs` — Fixture context:
+  - `StepContext`
 
-- registry.rs — Registration and lookup:
-  - Step
-  - step! macro
+- `registry.rs` — Registration and lookup:
+  - `Step`
+  - `step!` macro
   - global registry map
-  - lookup_step
-  - find_step
+  - `lookup_step`
+  - `find_step.`
 
-- lib.rs — Public API facade:
+- `lib.rs` — Public API facade:
   - Re-exports public items
-  - greet example function
+  - `greet` example function
 
 All modules use en‑GB spelling and include `//!` module‑level documentation.
 

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -581,10 +581,10 @@ fn test_my_scenario(my_fixture: MyFixture) { /\* final assertion \*/ }
 2. It uses a Gherkin parser crate (such as `gherkin` [^26]) to parse the feature
    file content into an Abstract Syntax Tree (AST).
 3. It traverses the AST to find the `Scenario` with the name "My Scenario".
-4. It iterates through the global step registry (`inventory::iter`) *at compile
-   time* to check if a matching step exists for every Gherkin step. If a step
-   is missing, it emits a `compile_error!` with a helpful message, failing the
-   build early.
+4. The macro cannot access the link-time step registry during compilation, so
+   it cannot verify step existence. Generated tests perform lookup at runtime
+   via `inventory::iter::<Step>()` and report a clear runtime error when no
+   matching pattern is found.
 5. Using the `quote!` macro [^28], it generates a completely new Rust function.
    This generated function replaces the original
 
@@ -1184,14 +1184,13 @@ All modules use en‑GB spelling and include `//!` module‑level documentation.
 [^14]: la10736/rstest: Fixture-based test framework for Rust - GitHub, accessed
        on July 20, 2025, <https://github.com/la10736/rstest>
 
-[^15]: rstest crate documentation for `#[case]` parameterisation, accessed on
+[^15]: rstest crate documentation for `#[case]` parameterization, accessed on
        July 20, 2025, <https://docs.rs/rstest/latest/rstest/attr.case.html>
 [^20]: Rust Reference: procedural macros operate without shared state, accessed
        on July 20, 2025,
        <https://doc.rust-lang.org/reference/procedural-macros.html>
 [^22]: Why macros cannot discover other macros, discussion on
-       users.rust-lang.org,
-       accessed on July 20, 2025,
+       users.rust-lang.org, accessed on July 20, 2025,
        <https://users.rust-lang.org/t/why-cant-macros-discover-other-macros/3574>
 [^23]: cucumber crate documentation for `World::run`, accessed on July 20,
        2025, <https://docs.rs/cucumber>

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1133,10 +1133,10 @@ Public APIs are re‑exported from `lib.rs` so consumers continue to import from
   - `StepContext`
 
 - `registry.rs` — Registration and lookup:
-- `step!` macro
-- global registry map
-- `lookup_step`
-- `find_step`.
+  - `step!` macro
+  - global registry map
+  - `lookup_step`
+  - `find_step`.
 
 - `lib.rs` — Public API facade:
   - Re-exports public items

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -31,8 +31,8 @@ eliminates the need for a separate test runner, reducing CI/CD configuration
 complexity and lowering the barrier to adoption for teams already invested in
 the Rust testing ecosystem.[^3]
 
-The design is heavily modeled on `pytest-bdd`, a successful plugin for Python's
-`pytest` framework.[^4]
+The design is heavily modelled on `pytest-bdd`, a successful plugin for
+Python's `pytest` framework.[^4]
 
 `pytest-bdd`'s success stems from its ability to leverage the full power of its
 host framework—including fixtures, parameterization, and a vast plugin
@@ -111,7 +111,6 @@ async fn browser() -> WebDriverResult<WebDriver> {
 // The test attribute (e.g., #[tokio::test]) would be configured via
 // feature flags in Cargo.toml to support different async runtimes.
 #[tokio::test]
-#
 async fn test_simple_search(#[future] browser: WebDriver) {
     // The body of this function runs *after* all Gherkin steps have passed.
     // It can be used for final assertions or complex cleanup.[6]
@@ -121,7 +120,6 @@ async fn test_simple_search(#[future] browser: WebDriver) {
 
 // Step definitions are just decorated functions.
 // The #[from(fixture_name)] attribute injects the fixture into the step.
-#
 async fn go_to_home(#[from(browser)] driver: &mut WebDriver) {
     driver.goto("https://duckduckgo.com/").await.unwrap();
 }
@@ -377,13 +375,13 @@ macro has a distinct role in the compile-time orchestration of the BDD tests.
 
 The most significant technical hurdle in this design is the inherent nature of
 Rust's procedural macros. Each macro invocation is executed by the compiler in
-an isolated, stateless environment.20. This means that when the
+an isolated, stateless environment.[^20] This means that when the
 
 `#[scenario]` macro is expanding, it has no direct way to discover the
 functions that have been decorated with `#[given]`, `#[when]`, or `#[then]`. It
 cannot scan the project's source code, reflect on other modules, or access a
-shared compile-time state to build a map of available steps.22. This stands in
-stark contrast to
+shared compile-time state to build a map of available steps.[^22] This stands
+in stark contrast to
 
 `pytest`, which provides a rich runtime plugin system that `pytest-bdd` hooks
 into to discover tests and steps dynamically during a collection phase.[^7]
@@ -463,7 +461,7 @@ step keywords are surfaced early.
 The [`StepPattern`](../crates/rstest-bdd/src/pattern.rs) wrapper encapsulates
 the pattern text so that step lookups cannot accidentally mix arbitrary strings
 with registered patterns. Each pattern is compiled into a regular expression
-when the step registry is initialised, surfacing invalid syntax immediately.
+when the step registry is initialized, surfacing invalid syntax immediately.
 Equality and hashing rely solely on the pattern text. Transient fields like the
 cached `Regex` are ignored to preserve identity-by-source-text semantics. The
 global registry stores `(StepKeyword, &'static StepPattern)` keys in a
@@ -573,9 +571,6 @@ fn given_i_am_a_user(mut user_context: UserContext) { /\*... \*/ }
 - **Input Code:**
 
 ```rust
-
-#
-
 fn test_my_scenario(my_fixture: MyFixture) { /\* final assertion \*/ }
 ```
 
@@ -583,14 +578,14 @@ fn test_my_scenario(my_fixture: MyFixture) { /\* final assertion \*/ }
 
 1. The `#[scenario]` proc-macro performs file I/O to read the contents of
    `f.feature`.
-2. It uses a Gherkin parser crate (such as `gherkin` 26) to parse the feature
+2. It uses a Gherkin parser crate (such as `gherkin` [^26]) to parse the feature
    file content into an Abstract Syntax Tree (AST).
 3. It traverses the AST to find the `Scenario` with the name "My Scenario".
 4. It iterates through the global step registry (`inventory::iter`) *at compile
    time* to check if a matching step exists for every Gherkin step. If a step
    is missing, it emits a `compile_error!` with a helpful message, failing the
    build early.
-5. Using the `quote!` macro 28, it generates a completely new Rust function.
+5. Using the `quote!` macro [^28], it generates a completely new Rust function.
    This generated function replaces the original
 
    `test_my_scenario` function.
@@ -826,16 +821,16 @@ unit/integration tests.
 
 The following table summarizes the key differences:
 
-| Feature          | rstest-bdd (Proposed)                                                                                                        | cucumber                                                                       |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| Test Runner      | Standard cargo test (via rstest expansion)                                                                                   | Custom runner invoked from a main function (World::run(…)) 23                  |
-| State Management | rstest fixtures; dependency injection model 1                                                                                | Mandatory World struct; a central state object per scenario 11                 |
-| Step Discovery   | Automatic via compile-time registration (inventory) and runtime matching                                                     | Explicit collection in the test runner setup (World::cucumber().steps(…)) 37   |
-| Parameterization | Gherkin Scenario Outline maps to rstest's #[case] parameterization 15                                                        | Handled internally by the cucumber runner                                      |
-| Async Support    | Runtime-agnostic via feature flags (e.g., tokio, async-std) which emit the appropriate test attribute (#[tokio::test], etc.) | Built-in; requires specifying an async runtime 11                              |
-| Ecosystem        | Seamless integration with rstest and cargo features                                                                          | Self-contained framework; can use any Rust library within steps                |
-| Ergonomics       | pytest-bdd-like; explicit #[scenario] binding links test code to features 6                                                  | cucumber-jvm/js-like; feature-driven, with a central test runner               |
-| Core Philosophy  | BDD as an extension of the existing rstest framework                                                                         | A native Rust implementation of the Cucumber framework standard                |
+| Feature          | rstest-bdd (Proposed)                                                                                                        | cucumber                                                                          |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Test Runner      | Standard cargo test (via rstest expansion)                                                                                   | Custom runner invoked from a main function (World::run(…)) [^23]                  |
+| State Management | rstest fixtures; dependency injection model [^1]                                                                             | Mandatory World struct; a central state object per scenario [^11]                 |
+| Step Discovery   | Automatic via compile-time registration (inventory) and runtime matching                                                     | Explicit collection in the test runner setup (World::cucumber().steps(…)) [^37]   |
+| Parameterization | Gherkin Scenario Outline maps to rstest's #[case] parameterization [^15]                                                     | Handled internally by the cucumber runner                                         |
+| Async Support    | Runtime-agnostic via feature flags (e.g., tokio, async-std) which emit the appropriate test attribute (#[tokio::test], etc.) | Built-in; requires specifying an async runtime [^11]                              |
+| Ecosystem        | Seamless integration with rstest and cargo features                                                                          | Self-contained framework; can use any Rust library within steps                   |
+| Ergonomics       | pytest-bdd-like; explicit #[scenario] binding links test code to features [^6]                                               | cucumber-jvm/js-like; feature-driven, with a central test runner                  |
+| Core Philosophy  | BDD as an extension of the existing rstest framework                                                                         | A native Rust implementation of the Cucumber framework standard                   |
 
 ### 3.5 Potential Extensions
 
@@ -1188,3 +1183,21 @@ All modules use en‑GB spelling and include `//!` module‑level documentation.
     <https://www.florianreinhard.de/cucumber-in-rust-beginners-tutorial/>
 [^14]: la10736/rstest: Fixture-based test framework for Rust - GitHub, accessed
        on July 20, 2025, <https://github.com/la10736/rstest>
+
+[^15]: rstest crate documentation for `#[case]` parameterisation, accessed on
+       July 20, 2025, <https://docs.rs/rstest/latest/rstest/attr.case.html>
+[^20]: Rust Reference: procedural macros operate without shared state, accessed
+       on July 20, 2025,
+       <https://doc.rust-lang.org/reference/procedural-macros.html>
+[^22]: Why macros cannot discover other macros, discussion on
+       users.rust-lang.org,
+       accessed on July 20, 2025,
+       <https://users.rust-lang.org/t/why-cant-macros-discover-other-macros/3574>
+[^23]: cucumber crate documentation for `World::run`, accessed on July 20,
+       2025, <https://docs.rs/cucumber>
+[^26]: gherkin crate on crates.io, accessed on July 20, 2025,
+       <https://crates.io/crates/gherkin>
+[^28]: quote crate macros, accessed on July 20, 2025,
+       <https://docs.rs/quote>
+[^37]: cucumber crate step collection API, accessed on July 20, 2025,
+       <https://docs.rs/cucumber/latest/cucumber/struct.World.html#method.steps>


### PR DESCRIPTION
## Summary
- add `StepPatternError` for placeholder parsing
- distinguish placeholder syntax errors from regex compilation
- verify nested and escaped braces via tests

## Testing
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_68aba75b26648322b787153c42936c05

## Summary by Sourcery

Introduce a dedicated StepPatternError type for placeholder syntax issues, map these errors through the compilation and extraction pipelines, and add comprehensive tests for nested, escaped, and malformed braces

New Features:
- Add StepPatternError enum to distinguish placeholder syntax errors from regex compilation errors
- Add InvalidPlaceholder variant to PlaceholderError for reporting malformed placeholder syntax

Enhancements:
- Update placeholder parsing and StepPattern::compile to return and propagate StepPatternError
- Refine extract_placeholders to map StepPatternError variants into appropriate PlaceholderError cases

Documentation:
- Update design documentation to include InvalidPlaceholder error variant and its JSON representation

Tests:
- Add tests for malformed placeholders, escaped braces, nested braces, and stray/unbalanced braces
- Add extraction test to assert InvalidPlaceholder error is returned for invalid placeholders