### PR TITLE
Remove runtime dependency from macros crate

### DIFF
--- a/crates/rstest-bdd-macros/Cargo.toml
+++ b/crates/rstest-bdd-macros/Cargo.toml
@@ -23,7 +23,6 @@ proc-macro = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
-rstest-bdd.workspace = true
 gherkin.workspace = true
 walkdir = "2.5.0"
 
@@ -32,3 +31,4 @@ trybuild.workspace = true
 once_cell.workspace = true
 rstest.workspace = true
 serial_test.workspace = true
+rstest-bdd = { path = "../rstest-bdd" }

--- a/crates/rstest-bdd-macros/src/codegen/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/mod.rs
@@ -7,12 +7,12 @@ pub(crate) mod scenario;
 pub(crate) mod wrapper;
 
 /// Convert a [`StepKeyword`] into a quoted token.
-pub(crate) fn keyword_to_token(keyword: rstest_bdd::StepKeyword) -> TokenStream2 {
+pub(crate) fn keyword_to_token(keyword: crate::StepKeyword) -> TokenStream2 {
     match keyword {
-        rstest_bdd::StepKeyword::Given => quote! { rstest_bdd::StepKeyword::Given },
-        rstest_bdd::StepKeyword::When => quote! { rstest_bdd::StepKeyword::When },
-        rstest_bdd::StepKeyword::Then => quote! { rstest_bdd::StepKeyword::Then },
-        rstest_bdd::StepKeyword::And => quote! { rstest_bdd::StepKeyword::And },
-        rstest_bdd::StepKeyword::But => quote! { rstest_bdd::StepKeyword::But },
+        crate::StepKeyword::Given => quote! { ::rstest_bdd::StepKeyword::Given },
+        crate::StepKeyword::When => quote! { ::rstest_bdd::StepKeyword::When },
+        crate::StepKeyword::Then => quote! { ::rstest_bdd::StepKeyword::Then },
+        crate::StepKeyword::And => quote! { ::rstest_bdd::StepKeyword::And },
+        crate::StepKeyword::But => quote! { ::rstest_bdd::StepKeyword::But },
     }
 }

--- a/crates/rstest-bdd-macros/src/codegen/scenario.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario.rs
@@ -80,7 +80,7 @@ fn generate_table_tokens(table: Option<&[Vec<String>]>) -> TokenStream2 {
 ///
 /// # Examples
 /// ```rust,ignore
-/// use rstest_bdd::StepKeyword;
+/// use crate::StepKeyword;
 /// use crate::parsing::feature::ParsedStep;
 /// let steps = vec![ParsedStep { keyword: StepKeyword::Given, text: "x".into(), table: None }];
 /// let (k, v, t) = process_steps(&steps);
@@ -175,10 +175,10 @@ fn generate_test_tokens(
 
     quote! {
         let steps = [#((#keywords, #values, #docstrings, #tables)),*];
-        let mut ctx = rstest_bdd::StepContext::default();
+        let mut ctx = ::rstest_bdd::StepContext::default();
         #(#ctx_inserts)*
         for (index, (keyword, text, docstring, table)) in steps.iter().enumerate() {
-            if let Some(f) = rstest_bdd::find_step(*keyword, (*text).into()) {
+            if let Some(f) = ::rstest_bdd::find_step(*keyword, (*text).into()) {
                 if let Err(err) = f(&ctx, *text, *docstring, *table) {
                     panic!(
                         "Step failed at index {}: {} {} - {}\n(feature: {}, scenario: {})",

--- a/crates/rstest-bdd-macros/src/lib.rs
+++ b/crates/rstest-bdd-macros/src/lib.rs
@@ -3,8 +3,11 @@
 mod codegen;
 mod macros;
 mod parsing;
+mod step_keyword;
 mod utils;
 mod validation;
+
+pub(crate) use step_keyword::StepKeyword;
 
 use proc_macro::TokenStream;
 

--- a/crates/rstest-bdd-macros/src/macros/given.rs
+++ b/crates/rstest-bdd-macros/src/macros/given.rs
@@ -4,5 +4,5 @@ use proc_macro::TokenStream;
 
 /// Macro for defining a Given step that registers with the step inventory.
 pub(crate) fn given(attr: TokenStream, item: TokenStream) -> TokenStream {
-    super::step_attr(attr, item, rstest_bdd::StepKeyword::Given)
+    super::step_attr(attr, item, crate::StepKeyword::Given)
 }

--- a/crates/rstest-bdd-macros/src/macros/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/mod.rs
@@ -17,11 +17,7 @@ pub(crate) use when::when;
 use crate::codegen::wrapper::{WrapperConfig, extract_args, generate_wrapper_code};
 use crate::utils::errors::error_to_tokens;
 
-fn step_attr(
-    attr: TokenStream,
-    item: TokenStream,
-    keyword: rstest_bdd::StepKeyword,
-) -> TokenStream {
+fn step_attr(attr: TokenStream, item: TokenStream, keyword: crate::StepKeyword) -> TokenStream {
     let pattern = syn::parse_macro_input!(attr as syn::LitStr);
     let mut func = syn::parse_macro_input!(item as syn::ItemFn);
 

--- a/crates/rstest-bdd-macros/src/macros/then.rs
+++ b/crates/rstest-bdd-macros/src/macros/then.rs
@@ -4,5 +4,5 @@ use proc_macro::TokenStream;
 
 /// Macro for defining a Then step that registers with the step inventory.
 pub(crate) fn then(attr: TokenStream, item: TokenStream) -> TokenStream {
-    super::step_attr(attr, item, rstest_bdd::StepKeyword::Then)
+    super::step_attr(attr, item, crate::StepKeyword::Then)
 }

--- a/crates/rstest-bdd-macros/src/macros/when.rs
+++ b/crates/rstest-bdd-macros/src/macros/when.rs
@@ -4,5 +4,5 @@ use proc_macro::TokenStream;
 
 /// Macro for defining a When step that registers with the step inventory.
 pub(crate) fn when(attr: TokenStream, item: TokenStream) -> TokenStream {
-    super::step_attr(attr, item, rstest_bdd::StepKeyword::When)
+    super::step_attr(attr, item, crate::StepKeyword::When)
 }

--- a/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
@@ -10,7 +10,7 @@ use crate::validation::examples::validate_examples_in_feature_text;
 /// Step extracted from a scenario with optional arguments (data table and doc string).
 #[derive(Debug, PartialEq)]
 pub(crate) struct ParsedStep {
-    pub keyword: rstest_bdd::StepKeyword,
+    pub keyword: crate::StepKeyword,
     pub text: String,
     pub docstring: Option<String>,
     pub table: Option<Vec<Vec<String>>>,
@@ -26,8 +26,8 @@ pub(crate) struct ScenarioData {
 /// Convert a Gherkin step to a `ParsedStep`.
 fn map_step(step: &Step) -> ParsedStep {
     let keyword = match step.keyword.as_str() {
-        "And" => rstest_bdd::StepKeyword::And,
-        "But" => rstest_bdd::StepKeyword::But,
+        "And" => crate::StepKeyword::And,
+        "But" => crate::StepKeyword::But,
         _ => step.ty.into(),
     };
     let table = step.table.as_ref().map(|t| t.rows.clone());

--- a/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
@@ -152,19 +152,19 @@ fn prepends_background_steps() {
         &feature,
         &[
             ParsedStep {
-                keyword: rstest_bdd::StepKeyword::Given,
+                keyword: crate::StepKeyword::Given,
                 text: "a background step".to_string(),
                 docstring: None,
                 table: None,
             },
             ParsedStep {
-                keyword: rstest_bdd::StepKeyword::When,
+                keyword: crate::StepKeyword::When,
                 text: "an action".to_string(),
                 docstring: None,
                 table: None,
             },
             ParsedStep {
-                keyword: rstest_bdd::StepKeyword::Then,
+                keyword: crate::StepKeyword::Then,
                 text: "a result".to_string(),
                 docstring: None,
                 table: None,
@@ -189,7 +189,7 @@ fn extracts_data_table() {
     assert_extracted_steps(
         &feature,
         &[ParsedStep {
-            keyword: rstest_bdd::StepKeyword::Given,
+            keyword: crate::StepKeyword::Given,
             text: "numbers".to_string(),
             docstring: None,
             table: Some(vec![
@@ -216,7 +216,7 @@ fn extracts_docstring() {
     assert_extracted_steps(
         &feature,
         &[ParsedStep {
-            keyword: rstest_bdd::StepKeyword::Given,
+            keyword: crate::StepKeyword::Given,
             text: "text".to_string(),
             docstring: Some("line1\nline2".to_string()),
             table: None,
@@ -242,13 +242,13 @@ fn background_steps_with_docstring_are_extracted() {
         &feature,
         &[
             ParsedStep {
-                keyword: rstest_bdd::StepKeyword::Given,
+                keyword: crate::StepKeyword::Given,
                 text: "setup".to_string(),
                 docstring: Some("bg line1\nbg line2".to_string()),
                 table: None,
             },
             ParsedStep {
-                keyword: rstest_bdd::StepKeyword::When,
+                keyword: crate::StepKeyword::When,
                 text: "an action".to_string(),
                 docstring: None,
                 table: None,

--- a/crates/rstest-bdd-macros/src/step_keyword.rs
+++ b/crates/rstest-bdd-macros/src/step_keyword.rs
@@ -1,0 +1,32 @@
+//! Local representation of step keywords used during macro expansion.
+//!
+//! This lightweight enum mirrors the variants provided by `rstest-bdd` but
+//! avoids a compile-time dependency on that crate.  It is only used internally
+//! for parsing feature files and generating code.
+
+use gherkin::StepType;
+
+/// Keyword used to categorise a step definition.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum StepKeyword {
+    /// Setup preconditions for a scenario.
+    Given,
+    /// Perform an action when testing behaviour.
+    When,
+    /// Assert the expected outcome of a scenario.
+    Then,
+    /// Additional conditions that share context with the previous step.
+    And,
+    /// Negative or contrasting conditions.
+    But,
+}
+
+impl From<StepType> for StepKeyword {
+    fn from(value: StepType) -> Self {
+        match value {
+            StepType::Given => Self::Given,
+            StepType::When => Self::When,
+            StepType::Then => Self::Then,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- remove rstest-bdd as a compile-time dependency of the macros crate
- introduce a local `StepKeyword` enum
- emit fully-qualified `::rstest_bdd` paths from generated code

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ae3f0e67d4832287ee759d9f13f8d1