### PR TITLE
Refine step keyword handling and code generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,6 +752,8 @@ dependencies = [
  "gherkin",
  "hashbrown 0.15.4",
  "inventory",
+ "proc-macro2",
+ "quote",
  "regex",
  "rstest",
  "rstest-bdd-macros",

--- a/crates/rstest-bdd-macros/src/codegen/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/mod.rs
@@ -1,18 +1,4 @@
 //! Code generation utilities for the proc macros.
 
-use proc_macro2::TokenStream as TokenStream2;
-use quote::quote;
-
 pub(crate) mod scenario;
 pub(crate) mod wrapper;
-
-/// Convert a [`StepKeyword`] into a quoted token.
-pub(crate) fn keyword_to_token(keyword: rstest_bdd::StepKeyword) -> TokenStream2 {
-    match keyword {
-        rstest_bdd::StepKeyword::Given => quote! { rstest_bdd::StepKeyword::Given },
-        rstest_bdd::StepKeyword::When => quote! { rstest_bdd::StepKeyword::When },
-        rstest_bdd::StepKeyword::Then => quote! { rstest_bdd::StepKeyword::Then },
-        rstest_bdd::StepKeyword::And => quote! { rstest_bdd::StepKeyword::And },
-        rstest_bdd::StepKeyword::But => quote! { rstest_bdd::StepKeyword::But },
-    }
-}

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/emit.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/emit.rs
@@ -1,7 +1,6 @@
 //! Code emission helpers for wrapper generation.
 
 use super::args::{ArgumentCollections, CallArg, DataTableArg, DocStringArg, FixtureArg, StepArg};
-use crate::codegen::keyword_to_token;
 use crate::utils::ident::sanitize_ident;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
@@ -460,12 +459,11 @@ fn generate_registration_code(
         })
         .collect();
     let fixture_len = fixture_names.len();
-    let keyword_token = keyword_to_token(*keyword);
     quote! {
         const #const_ident: [&'static str; #fixture_len] = [#(#fixture_names),*];
         const _: [(); #fixture_len] = [(); #const_ident.len()];
 
-        rstest_bdd::step!(@pattern #keyword_token, &#pattern_ident, #wrapper_ident, &#const_ident);
+        rstest_bdd::step!(@pattern #keyword, &#pattern_ident, #wrapper_ident, &#const_ident);
     }
 }
 

--- a/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
@@ -25,11 +25,7 @@ pub(crate) struct ScenarioData {
 
 /// Convert a Gherkin step to a `ParsedStep`.
 fn map_step(step: &Step) -> ParsedStep {
-    let keyword = match step.keyword.as_str() {
-        "And" => rstest_bdd::StepKeyword::And,
-        "But" => rstest_bdd::StepKeyword::But,
-        _ => step.ty.into(),
-    };
+    let keyword = step.keyword.as_str().trim_end().into();
     let table = step.table.as_ref().map(|t| t.rows.clone());
     let docstring = step.docstring.clone();
     ParsedStep {

--- a/crates/rstest-bdd/Cargo.toml
+++ b/crates/rstest-bdd/Cargo.toml
@@ -21,6 +21,8 @@ inventory.workspace = true
 regex.workspace = true
 thiserror.workspace = true
 hashbrown = "0.15"
+quote.workspace = true
+proc-macro2.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true

--- a/crates/rstest-bdd/tests/step_keyword.rs
+++ b/crates/rstest-bdd/tests/step_keyword.rs
@@ -1,0 +1,20 @@
+//! Tests for `StepKeyword` conversions.
+
+use gherkin::StepType;
+use rstest_bdd::StepKeyword;
+
+#[test]
+fn from_str_parses_all_keywords() {
+    assert_eq!(StepKeyword::from("Given"), StepKeyword::Given);
+    assert_eq!(StepKeyword::from("When"), StepKeyword::When);
+    assert_eq!(StepKeyword::from("Then"), StepKeyword::Then);
+    assert_eq!(StepKeyword::from("And"), StepKeyword::And);
+    assert_eq!(StepKeyword::from("But"), StepKeyword::But);
+}
+
+#[test]
+fn from_step_type_maps_primary_keywords() {
+    assert_eq!(StepKeyword::from(StepType::Given), StepKeyword::Given);
+    assert_eq!(StepKeyword::from(StepType::When), StepKeyword::When);
+    assert_eq!(StepKeyword::from(StepType::Then), StepKeyword::Then);
+}


### PR DESCRIPTION
## Summary
- derive token output directly from `StepKeyword`
- normalise continuation keywords during scenario generation
- tighten step keyword conversions and cover them with tests

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ae53b987ac832285cdf6fa834fa895

## Summary by Sourcery

Refine step keyword handling by normalizing continuation keywords to the preceding primary, deriving token output via a new ToTokens impl, unifying parsing and codegen, and improving test context initialization

Enhancements:
- Implement ToTokens for StepKeyword and remove the legacy keyword_to_token helper
- Normalize And/But to the last primary keyword during scenario code generation
- Switch parser and wrapper emission to use direct &str→StepKeyword conversion
- Conditionally initialize the generated test context only when inserts are present

Build:
- Add quote and proc-macro2 as workspace dependencies

Tests:
- Add tests for From<&str> and From<gherkin::StepType> conversions on StepKeyword