### PR TITLE
Add diagnostic cargo-bdd subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-bdd"
+version = "0.1.0"
+dependencies = [
+ "assert_cmd",
+ "clap",
+ "eyre",
+ "gherkin",
+ "inventory",
+ "predicates",
+ "rstest-bdd",
+ "rstest-bdd-macros",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,9 +130,12 @@ dependencies = [
  "eyre",
  "gherkin",
  "inventory",
+ "once_cell",
  "predicates",
+ "regex",
  "rstest-bdd",
  "rstest-bdd-macros",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/rstest-bdd",
     "crates/rstest-bdd-macros",
+    "crates/cargo-bdd",
     "examples/todo-cli",
 ]
 
@@ -31,6 +32,7 @@ trybuild = "1"
 once_cell = "1.18"
 serial_test = "2"
 rstest-bdd = { version = "0.1.0", path = "crates/rstest-bdd" }
+rstest-bdd-macros = { path = "crates/rstest-bdd-macros" }
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ categories = ["development-tools::testing"]
 gherkin = { version = "0.14", default-features = false, features = ["parser"] }
 inventory = "0.3"
 regex = "1.11.1"
+walkdir = "2.5.0"
 thiserror = "1.0"
 proc-macro2 = "1"
 quote = "1"

--- a/crates/cargo-bdd/Cargo.toml
+++ b/crates/cargo-bdd/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "cargo-bdd"
+edition.workspace = true
+version.workspace = true
+publish = false
+
+[features]
+# Include example step definitions for tests
+"test-steps" = ["rstest-bdd-macros"]
+
+[dependencies]
+clap = { version = "4.5", features = ["derive"] }
+eyre = "0.6"
+gherkin.workspace = true
+inventory.workspace = true
+rstest-bdd.workspace = true
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
+
+[dependencies.rstest-bdd-macros]
+workspace = true
+optional = true

--- a/crates/cargo-bdd/Cargo.toml
+++ b/crates/cargo-bdd/Cargo.toml
@@ -14,6 +14,9 @@ eyre = "0.6"
 gherkin.workspace = true
 inventory.workspace = true
 rstest-bdd.workspace = true
+once_cell.workspace = true
+regex.workspace = true
+walkdir.workspace = true
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/cargo-bdd/src/lib.rs
+++ b/crates/cargo-bdd/src/lib.rs
@@ -1,0 +1,125 @@
+//! Diagnostic helpers for inspecting `rstest-bdd` step definitions.
+//!
+//! This library powers the `cargo-bdd` command and exposes utilities
+//! to enumerate registered steps, detect duplicates, and flag
+//! definitions that are not referenced by any provided feature files.
+
+use eyre::Result;
+use rstest_bdd::{Step, StepKeyword, StepText, extract_placeholders};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Gather all registered steps sorted by source location.
+#[must_use]
+pub fn steps() -> Vec<&'static Step> {
+    let mut out: Vec<&'static Step> = inventory::iter::<Step>.into_iter().collect();
+    out.sort_by_key(|s| (s.file, s.line));
+    out
+}
+
+/// Group step definitions that share the same keyword and pattern.
+#[must_use]
+pub fn duplicates() -> Vec<Vec<&'static Step>> {
+    let mut map: HashMap<(StepKeyword, &str), Vec<&'static Step>> = HashMap::new();
+    for step in steps() {
+        map.entry((step.keyword, step.pattern.as_str()))
+            .or_default()
+            .push(step);
+    }
+    map.into_values().filter(|v| v.len() > 1).collect()
+}
+
+/// Identify step definitions that are unused in the given feature paths.
+///
+/// `paths` may point to either `.feature` files or directories containing them.
+///
+/// # Errors
+/// Returns an error if any path cannot be read or parsed.
+pub fn unused(paths: &[PathBuf]) -> Result<Vec<&'static Step>> {
+    let feature_steps = collect_feature_steps(paths)?;
+    let mut used: HashSet<*const Step> = HashSet::new();
+    for (kw, text) in feature_steps {
+        for step in steps() {
+            if step.keyword == kw
+                && extract_placeholders(step.pattern, StepText::from(text.as_str())).is_ok()
+            {
+                used.insert(step as *const Step);
+            }
+        }
+    }
+    Ok(steps()
+        .into_iter()
+        .filter(|s| !used.contains(&(*s as *const Step)))
+        .collect())
+}
+
+fn collect_feature_steps(paths: &[PathBuf]) -> Result<Vec<(StepKeyword, String)>> {
+    let mut files = Vec::new();
+    for path in paths {
+        gather_features(path, &mut files)?;
+    }
+    let mut out = Vec::new();
+    for file in files {
+        let feature = gherkin::Feature::parse_path(&file, gherkin::GherkinEnv::default())?;
+        if let Some(bg) = &feature.background {
+            out.extend(bg.steps.iter().map(map_step));
+        }
+        for scenario in &feature.scenarios {
+            out.extend(scenario.steps.iter().map(map_step));
+        }
+    }
+    Ok(out)
+}
+
+fn gather_features(path: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    let meta = fs::metadata(path)?;
+    if meta.is_file() {
+        if path.extension().is_some_and(|e| e == "feature") {
+            out.push(path.to_path_buf());
+        }
+        return Ok(());
+    }
+    let mut dirs = VecDeque::from([path.to_path_buf()]);
+    while let Some(dir) = dirs.pop_front() {
+        for entry in fs::read_dir(&dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                dirs.push_back(path);
+            } else if path.extension().is_some_and(|e| e == "feature") {
+                out.push(path);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn map_step(step: &gherkin::Step) -> (StepKeyword, String) {
+    let kw = match step.keyword.as_str() {
+        "And" => StepKeyword::And,
+        "But" => StepKeyword::But,
+        _ => step.ty.into(),
+    };
+    (kw, step.value.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn detects_duplicates() {
+        assert!(!duplicates().is_empty());
+    }
+
+    #[test]
+    fn finds_unused_steps() {
+        let unused = unused(&[PathBuf::from("tests/features")]).unwrap();
+        assert!(unused.iter().any(|s| s.pattern.as_str() == "unused step"));
+    }
+}
+
+#[cfg(feature = "test-steps")]
+mod test_steps;

--- a/crates/cargo-bdd/src/lib.rs
+++ b/crates/cargo-bdd/src/lib.rs
@@ -47,23 +47,18 @@ fn normalise_pattern(pat: &str) -> String {
 ///
 /// # Errors
 /// Returns an error if any path cannot be read or parsed.
+///
+/// ```
+/// # use std::path::PathBuf;
+/// # fn demo() -> eyre::Result<()> {
+/// let unused = unused(&[PathBuf::from("tests/features")])?;
+/// assert!(!unused.is_empty());
+/// # Ok(())
+/// # }
+/// ```
 pub fn unused(paths: &[PathBuf]) -> Result<Vec<&'static Step>> {
     let feature_steps = collect_feature_steps(paths)?;
-    let mut by_kw: HashMap<StepKeyword, Vec<&'static Step>> = HashMap::new();
-    for step in steps() {
-        by_kw.entry(step.keyword).or_default().push(step);
-    }
-
-    let mut used: HashSet<*const Step> = HashSet::new();
-    for (kw, text) in feature_steps {
-        if let Some(candidates) = by_kw.get(&kw) {
-            for step in candidates {
-                if extract_placeholders(step.pattern, StepText::from(text.as_str())).is_ok() {
-                    used.insert(*step as *const Step);
-                }
-            }
-        }
-    }
+    let used = find_used_steps(feature_steps);
 
     Ok(steps()
         .into_iter()
@@ -71,48 +66,170 @@ pub fn unused(paths: &[PathBuf]) -> Result<Vec<&'static Step>> {
         .collect())
 }
 
+/// Determine which registered steps are referenced by the feature steps.
+///
+/// ```
+/// use rstest_bdd::StepKeyword;
+/// let used = find_used_steps(vec![(StepKeyword::Given, "step".into())]);
+/// assert!(used.is_empty());
+/// ```
+fn find_used_steps(feature_steps: Vec<(StepKeyword, String)>) -> HashSet<*const Step> {
+    let by_kw = group_steps_by_keyword();
+    let mut used = HashSet::new();
+    for (kw, text) in feature_steps {
+        if let Some(candidates) = by_kw.get(&kw) {
+            find_matching_steps(candidates, &text, &mut used);
+        }
+    }
+    used
+}
+
+/// Group registered steps by keyword for faster lookup.
+///
+/// ```
+/// let map = group_steps_by_keyword();
+/// assert!(map.keys().next().is_some());
+/// ```
+fn group_steps_by_keyword() -> HashMap<StepKeyword, Vec<&'static Step>> {
+    let mut map: HashMap<StepKeyword, Vec<&'static Step>> = HashMap::new();
+    for step in steps() {
+        map.entry(step.keyword).or_default().push(step);
+    }
+    map
+}
+
+/// Record steps that match the provided text.
+///
+/// ```
+/// # use rstest_bdd::Step;
+/// # use std::collections::HashSet;
+/// # fn demo(step: &Step, text: &str) {
+/// let mut used = HashSet::new();
+/// find_matching_steps(&[step], text, &mut used);
+/// # }
+/// ```
+fn find_matching_steps(candidates: &[&'static Step], text: &str, used: &mut HashSet<*const Step>) {
+    for step in candidates {
+        if matches_step_pattern(step, text) {
+            used.insert(*step as *const Step);
+        }
+    }
+}
+
+/// Check if a step pattern matches the provided text.
+///
+/// ```
+/// # use rstest_bdd::Step;
+/// # fn demo(step: &Step, text: &str) {
+/// let _ = matches_step_pattern(step, text);
+/// # }
+/// ```
+fn matches_step_pattern(step: &Step, text: &str) -> bool {
+    extract_placeholders(step.pattern, StepText::from(text)).is_ok()
+}
+
+/// Gather steps referenced in the supplied feature paths.
+///
+/// ```
+/// # use std::path::PathBuf;
+/// # fn demo() -> eyre::Result<()> {
+/// let steps = collect_feature_steps(&[PathBuf::from("tests/features")])?;
+/// assert!(!steps.is_empty());
+/// # Ok(())
+/// # }
+/// ```
 fn collect_feature_steps(paths: &[PathBuf]) -> Result<Vec<(StepKeyword, String)>> {
+    let files = collect_unique_feature_files(paths)?;
+    let mut out = Vec::new();
+    for file in files {
+        out.extend(extract_steps_from_feature(&file)?);
+    }
+    Ok(out)
+}
+
+/// Collect unique, sorted feature files from the provided paths.
+///
+/// ```
+/// # use std::path::PathBuf;
+/// # fn demo() -> eyre::Result<()> {
+/// let files = collect_unique_feature_files(&[PathBuf::from("tests/features")])?;
+/// assert!(!files.is_empty());
+/// # Ok(())
+/// # }
+/// ```
+fn collect_unique_feature_files(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
     let mut files = HashSet::new();
     for path in paths {
         for file in gather_features(path)? {
             files.insert(file);
         }
     }
-
     let mut files: Vec<PathBuf> = files.into_iter().collect();
     files.sort();
+    Ok(files)
+}
 
+/// Parse a single feature file and extract its steps.
+///
+/// ```
+/// # use std::path::Path;
+/// # fn demo(path: &Path) -> eyre::Result<()> {
+/// let steps = extract_steps_from_feature(path)?;
+/// assert!(!steps.is_empty());
+/// # Ok(())
+/// # }
+/// ```
+fn extract_steps_from_feature(file: &Path) -> Result<Vec<(StepKeyword, String)>> {
+    let feature = gherkin::Feature::parse_path(file, gherkin::GherkinEnv::default())?;
     let mut out = Vec::new();
-    for file in files {
-        let feature = gherkin::Feature::parse_path(&file, gherkin::GherkinEnv::default())?;
-        if let Some(bg) = &feature.background {
-            out.extend(bg.steps.iter().map(map_step));
-        }
-        for scenario in &feature.scenarios {
-            out.extend(scenario.steps.iter().map(map_step));
-        }
+    if let Some(bg) = &feature.background {
+        out.extend(bg.steps.iter().map(map_step));
+    }
+    for scenario in &feature.scenarios {
+        out.extend(scenario.steps.iter().map(map_step));
     }
     Ok(out)
 }
 
+/// Recursively collect `.feature` files from the given path.
+///
+/// ```
+/// # use std::path::Path;
+/// # fn demo(path: &Path) -> eyre::Result<()> {
+/// let files = gather_features(path)?;
+/// assert!(files.iter().all(|p| p.extension().is_some()));
+/// # Ok(())
+/// # }
+/// ```
 fn gather_features(path: &Path) -> Result<Vec<PathBuf>> {
     let meta = fs::metadata(path)?;
     if meta.is_file() {
-        return if path.extension().is_some_and(|e| e == "feature") {
+        return if is_feature_file(path) {
             Ok(vec![fs::canonicalize(path)?])
         } else {
             Ok(Vec::new())
         };
     }
-    let mut out = Vec::new();
-    for entry in WalkDir::new(path).into_iter().filter_map(Result::ok) {
-        let p = entry.path();
-        if entry.file_type().is_file() && p.extension().is_some_and(|e| e == OsStr::new("feature"))
-        {
-            out.push(fs::canonicalize(p)?);
-        }
-    }
-    Ok(out)
+
+    let files = WalkDir::new(path)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.file_type().is_file())
+        .map(|e| e.path().to_path_buf())
+        .filter(|p| is_feature_file(p))
+        .map(fs::canonicalize)
+        .collect::<std::io::Result<Vec<_>>>()?;
+    Ok(files)
+}
+
+/// Check whether the supplied path has a `.feature` extension.
+///
+/// ```
+/// # use std::path::Path;
+/// assert!(is_feature_file(Path::new("foo.feature")));
+/// ```
+fn is_feature_file(path: &Path) -> bool {
+    path.extension().is_some_and(|e| e == OsStr::new("feature"))
 }
 
 fn map_step(step: &gherkin::Step) -> (StepKeyword, String) {

--- a/crates/cargo-bdd/src/main.rs
+++ b/crates/cargo-bdd/src/main.rs
@@ -1,6 +1,6 @@
 //! Command-line interface for `rstest-bdd` diagnostics.
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 use eyre::Result;
 use std::path::PathBuf;
 
@@ -11,7 +11,7 @@ use cargo_bdd::{duplicates, steps, unused};
 #[command(version, about)]
 struct Cli {
     #[command(subcommand)]
-    command: Commands,
+    command: Option<Commands>,
 }
 
 #[derive(Subcommand)]
@@ -30,7 +30,7 @@ enum Commands {
 fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
-        Commands::Steps => {
+        Some(Commands::Steps) => {
             for step in steps() {
                 println!(
                     "{} {} ({}:{})",
@@ -41,7 +41,7 @@ fn main() -> Result<()> {
                 );
             }
         }
-        Commands::Duplicates => {
+        Some(Commands::Duplicates) => {
             for group in duplicates() {
                 let first = group[0];
                 println!("{} {}", first.keyword.as_str(), first.pattern.as_str());
@@ -50,7 +50,7 @@ fn main() -> Result<()> {
                 }
             }
         }
-        Commands::Unused { paths } => {
+        Some(Commands::Unused { paths }) => {
             for step in unused(&paths)? {
                 println!(
                     "{} {} ({}:{})",
@@ -60,6 +60,10 @@ fn main() -> Result<()> {
                     step.line
                 );
             }
+        }
+        None => {
+            Cli::command().print_help()?;
+            println!();
         }
     }
     Ok(())

--- a/crates/cargo-bdd/src/main.rs
+++ b/crates/cargo-bdd/src/main.rs
@@ -1,0 +1,70 @@
+//! Command-line interface for `rstest-bdd` diagnostics.
+
+use clap::{Parser, Subcommand};
+use eyre::Result;
+use std::path::PathBuf;
+
+use cargo_bdd::{duplicates, steps, unused};
+
+/// Inspect `rstest-bdd` step definitions in the current crate.
+#[derive(Parser)]
+#[command(version, about)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// List all registered step definitions.
+    #[command(name = "list-steps")]
+    Steps,
+    /// Report duplicate step definitions.
+    #[command(name = "list-duplicates")]
+    Duplicates,
+    /// Show step definitions unused by the supplied feature files.
+    #[command(name = "list-unused")]
+    Unused { paths: Vec<PathBuf> },
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Steps => {
+            for step in steps() {
+                println!(
+                    "{} {} ({}:{})",
+                    step.keyword.as_str(),
+                    step.pattern.as_str(),
+                    step.file,
+                    step.line
+                );
+            }
+        }
+        Commands::Duplicates => {
+            for group in duplicates() {
+                let first = group[0];
+                println!("{} {}", first.keyword.as_str(), first.pattern.as_str());
+                for step in group {
+                    println!("  {}:{}", step.file, step.line);
+                }
+            }
+        }
+        Commands::Unused { paths } => {
+            for step in unused(&paths)? {
+                println!(
+                    "{} {} ({}:{})",
+                    step.keyword.as_str(),
+                    step.pattern.as_str(),
+                    step.file,
+                    step.line
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+// Sample steps for tests; gated behind feature.
+#[cfg(feature = "test-steps")]
+mod test_steps;

--- a/crates/cargo-bdd/src/main.rs
+++ b/crates/cargo-bdd/src/main.rs
@@ -27,46 +27,91 @@ enum Commands {
     Unused { paths: Vec<PathBuf> },
 }
 
-fn main() -> Result<()> {
-    let cli = Cli::parse();
-    match cli.command {
-        Some(Commands::Steps) => {
-            for step in steps() {
-                println!(
-                    "{} {} ({}:{})",
-                    step.keyword.as_str(),
-                    step.pattern.as_str(),
-                    step.file,
-                    step.line
-                );
-            }
-        }
-        Some(Commands::Duplicates) => {
-            for group in duplicates() {
-                let first = group[0];
-                println!("{} {}", first.keyword.as_str(), first.pattern.as_str());
-                for step in group {
-                    println!("  {}:{}", step.file, step.line);
-                }
-            }
-        }
-        Some(Commands::Unused { paths }) => {
-            for step in unused(&paths)? {
-                println!(
-                    "{} {} ({}:{})",
-                    step.keyword.as_str(),
-                    step.pattern.as_str(),
-                    step.file,
-                    step.line
-                );
-            }
-        }
-        None => {
-            Cli::command().print_help()?;
-            println!();
+/// Execute the `list-steps` command.
+///
+/// ```
+/// # fn try_it() -> eyre::Result<()> {
+/// execute_steps_command()?;
+/// # Ok(())
+/// # }
+/// ```
+fn execute_steps_command() -> Result<()> {
+    for step in steps() {
+        println!(
+            "{} {} ({}:{})",
+            step.keyword.as_str(),
+            step.pattern.as_str(),
+            step.file,
+            step.line
+        );
+    }
+    Ok(())
+}
+
+/// Execute the `list-duplicates` command.
+///
+/// ```
+/// # fn try_it() -> eyre::Result<()> {
+/// execute_duplicates_command()?;
+/// # Ok(())
+/// # }
+/// ```
+fn execute_duplicates_command() -> Result<()> {
+    for group in duplicates() {
+        let first = group[0];
+        println!("{} {}", first.keyword.as_str(), first.pattern.as_str());
+        for step in group {
+            println!("  {}:{}", step.file, step.line);
         }
     }
     Ok(())
+}
+
+/// Execute the `list-unused` command for the given feature paths.
+///
+/// ```
+/// # use std::path::PathBuf;
+/// # fn try_it() -> eyre::Result<()> {
+/// let paths: Vec<PathBuf> = Vec::new();
+/// execute_unused_command(&paths)?;
+/// # Ok(())
+/// # }
+/// ```
+fn execute_unused_command(paths: &[PathBuf]) -> Result<()> {
+    for step in unused(paths)? {
+        println!(
+            "{} {} ({}:{})",
+            step.keyword.as_str(),
+            step.pattern.as_str(),
+            step.file,
+            step.line
+        );
+    }
+    Ok(())
+}
+
+/// Display help information when no subcommand is supplied.
+///
+/// ```
+/// # fn try_it() -> eyre::Result<()> {
+/// execute_help_command()?;
+/// # Ok(())
+/// # }
+/// ```
+fn execute_help_command() -> Result<()> {
+    Cli::command().print_help()?;
+    println!();
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Some(Commands::Steps) => execute_steps_command(),
+        Some(Commands::Duplicates) => execute_duplicates_command(),
+        Some(Commands::Unused { paths }) => execute_unused_command(&paths),
+        None => execute_help_command(),
+    }
 }
 
 // Sample steps for tests; gated behind feature.

--- a/crates/cargo-bdd/src/test_steps.rs
+++ b/crates/cargo-bdd/src/test_steps.rs
@@ -1,0 +1,19 @@
+use rstest_bdd_macros::{given, then, when};
+
+#[given("I have cukes")]
+fn have_cukes() {}
+
+#[when("I eat them")]
+fn eat_them() {}
+
+#[then("I should be satisfied")]
+fn satisfied() {}
+
+#[given("unused step")]
+fn unused() {}
+
+#[given("duplicate step")]
+fn dup_one() {}
+
+#[given("duplicate step")]
+fn dup_two() {}

--- a/crates/cargo-bdd/tests/cli.rs
+++ b/crates/cargo-bdd/tests/cli.rs
@@ -1,0 +1,34 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn list_steps_outputs_registered_steps() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("cargo-bdd")?;
+    cmd.arg("list-steps");
+    cmd.assert().success().stdout(
+        predicate::str::contains("Given I have cukes")
+            .and(predicate::str::contains("When I eat them"))
+            .and(predicate::str::contains("Then I should be satisfied")),
+    );
+    Ok(())
+}
+
+#[test]
+fn list_duplicates_reports_duplicates() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("cargo-bdd")?;
+    cmd.arg("list-duplicates");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("duplicate step"));
+    Ok(())
+}
+
+#[test]
+fn list_unused_shows_unused_definitions() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("cargo-bdd")?;
+    cmd.args(["list-unused", "tests/features"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("unused step"));
+    Ok(())
+}

--- a/crates/cargo-bdd/tests/cli.rs
+++ b/crates/cargo-bdd/tests/cli.rs
@@ -2,6 +2,15 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 
 #[test]
+fn no_args_prints_help() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("cargo-bdd")?;
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("list-steps"));
+    Ok(())
+}
+
+#[test]
 fn list_steps_outputs_registered_steps() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("cargo-bdd")?;
     cmd.arg("list-steps");

--- a/crates/cargo-bdd/tests/features/sample.feature
+++ b/crates/cargo-bdd/tests/features/sample.feature
@@ -1,0 +1,5 @@
+Feature: Cukes
+  Scenario: Eating cucumbers
+    Given I have cukes
+    When I eat them
+    Then I should be satisfied

--- a/crates/rstest-bdd-macros/Cargo.toml
+++ b/crates/rstest-bdd-macros/Cargo.toml
@@ -25,7 +25,7 @@ quote.workspace = true
 syn.workspace = true
 rstest-bdd.workspace = true
 gherkin.workspace = true
-walkdir = "2.5.0"
+walkdir.workspace = true
 
 [dev-dependencies]
 trybuild.workspace = true

--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -87,6 +87,19 @@ impl StepKeyword {
             Self::But => "But",
         }
     }
+
+    /// Shared parsing logic normalising case and whitespace.
+    /// Returns `None` when the input does not match a known keyword.
+    fn parse_keyword_impl(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "given" => Some(Self::Given),
+            "when" => Some(Self::When),
+            "then" => Some(Self::Then),
+            "and" => Some(Self::And),
+            "but" => Some(Self::But),
+            _ => None,
+        }
+    }
 }
 
 /// Error returned when parsing a `StepKeyword` from a string fails.
@@ -98,27 +111,13 @@ impl FromStr for StepKeyword {
     type Err = StepKeywordParseError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value.trim().to_ascii_lowercase().as_str() {
-            "given" => Ok(Self::Given),
-            "when" => Ok(Self::When),
-            "then" => Ok(Self::Then),
-            "and" => Ok(Self::And),
-            "but" => Ok(Self::But),
-            _ => Err(StepKeywordParseError(value.to_string())),
-        }
+        Self::parse_keyword_impl(value).ok_or_else(|| StepKeywordParseError(value.to_string()))
     }
 }
 
 impl From<&str> for StepKeyword {
     fn from(value: &str) -> Self {
-        match value.trim().to_ascii_lowercase().as_str() {
-            "given" => Self::Given,
-            "when" => Self::When,
-            "then" => Self::Then,
-            "and" => Self::And,
-            "but" => Self::But,
-            _ => panic!("invalid step keyword: {value}"),
-        }
+        Self::parse_keyword_impl(value).unwrap_or_else(|| panic!("invalid step keyword: {value}"))
     }
 }
 

--- a/crates/rstest-bdd/tests/step_keyword_parsing.rs
+++ b/crates/rstest-bdd/tests/step_keyword_parsing.rs
@@ -1,0 +1,38 @@
+//! Tests for `StepKeyword` parsing behaviour.
+
+use std::str::FromStr;
+
+use rstest::rstest;
+use rstest_bdd::{StepKeyword, panic_message};
+
+#[rstest]
+#[case("Given", StepKeyword::Given)]
+#[case("given", StepKeyword::Given)]
+#[case(" WHEN ", StepKeyword::When)]
+#[case("then", StepKeyword::Then)]
+#[case("and", StepKeyword::And)]
+#[case("But", StepKeyword::But)]
+fn parses_valid_keywords(#[case] input: &str, #[case] expected: StepKeyword) {
+    match StepKeyword::from_str(input) {
+        Ok(kw) => assert_eq!(kw, expected),
+        Err(err) => panic!("unexpected error: {}", err.0),
+    }
+    assert_eq!(StepKeyword::from(input), expected);
+}
+
+#[test]
+fn rejects_invalid_keyword() {
+    match StepKeyword::from_str("unknown") {
+        Ok(_) => panic!("expected an error"),
+        Err(err) => assert_eq!(err.0, "unknown"),
+    }
+}
+
+#[test]
+fn panics_on_invalid_keyword() {
+    if let Err(err) = std::panic::catch_unwind(|| StepKeyword::from("unknown")) {
+        assert_eq!(panic_message(err.as_ref()), "invalid step keyword: unknown");
+    } else {
+        panic!("expected a panic");
+    }
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -131,21 +131,21 @@ improves the developer experience.
 These tasks can be addressed after the core framework is stable and are aimed
 at improving maintainability and IDE integration.
 
-- [ ] **Diagnostic Tooling**
+- [x] **Diagnostic Tooling**
 
-  - [ ] Create a helper binary or `cargo` subcommand (`cargo bdd`).
+  - [x] Create a helper binary or `cargo` subcommand (`cargo bdd`).
 
-  - [ ] Implement a `list-steps` command to print the entire registered step
-    registry.
+  - [x] Implement a `list-steps` command to print the entire registered step
+     registry.
 
-  - [ ] Implement commands to identify unused or duplicate step definitions.
+  - [x] Implement commands to identify unused or duplicate step definitions.
 
 - [ ] **IDE Integration**
 
-  - [ ] Investigate creating a `rust-analyzer` procedural macro server to
+- [ ] Investigate creating a `rust-analyzer` procedural macro server to
     provide autocompletion and "Go to Definition" from `.feature` files.
 
-  - [ ] Alternatively, develop a dedicated VS Code extension to provide this
+- [ ] Alternatively, develop a dedicated VS Code extension to provide this
     functionality.
 
 - [ ] **Advanced Hooks**

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1200,6 +1200,22 @@ Public APIs are re‑exported from `lib.rs` so consumers continue to import from
 
 All modules use en‑GB spelling and include `//!` module‑level documentation.
 
+### 3.11 Diagnostic Tooling
+
+To help library users understand which step definitions are available and to
+spot possible dead code, the workspace now includes a `cargo-bdd` helper
+binary. It uses `inventory` to iterate over the registry and Clap for the
+command-line interface. Three subcommands are provided:
+
+- `list-steps` prints every registered step with its source location.
+- `list-duplicates` groups steps by keyword and pattern to surface duplicate
+  definitions.
+- `list-unused` parses one or more feature paths with the `gherkin` crate and
+  reports steps that are never referenced.
+
+The binary is intentionally lightweight and delegates all heavy lifting to the
+`cargo-bdd` library, making it easy to reuse the logic in other tools.
+
 ## **Works cited**
 
 [^1]: A Complete Guide To Behavior-Driven Testing With Pytest BDD, accessed on

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1213,6 +1213,13 @@ command-line interface. Three subcommands are provided:
 - `list-unused` parses one or more feature paths with the `gherkin` crate and
   reports steps that are never referenced.
 
+Feature paths are traversed with the `walkdir` crate, which skips symlinked
+directories by default and gracefully handles permission errors. Paths are
+canonicalised and deduplicated before parsing to avoid repeated work. Duplicate
+detection normalises whitespace and placeholder names so semantically identical
+steps are grouped together. Unused-step detection indexes the registry by
+keyword to minimise repeated comparisons.
+
 The binary is intentionally lightweight and delegates all heavy lifting to the
 `cargo-bdd` library, making it easy to reuse the logic in other tools.
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -244,6 +244,40 @@ Best practices for writing effective scenarios include:
   text must match exactly. Unknown type hints are treated as generic
   placeholders and capture any non-newline text greedily.
 
+## Diagnostic tooling
+
+The `cargo-bdd` subcommand provides insight into the compiled step registry. It
+is available once the workspace binary is built and can be invoked through
+Cargo directly.
+
+### Listing registered steps
+
+Print every known step with its source location:
+
+```sh
+cargo bdd list-steps
+```
+
+### Identifying duplicates
+
+Find conflicting step definitions grouped by keyword and pattern:
+
+```sh
+cargo bdd list-duplicates
+```
+
+### Detecting unused steps
+
+Pass one or more paths to search for `.feature` files. Any registered steps
+that do not match the parsed scenarios are reported:
+
+```sh
+cargo bdd list-unused tests/features
+```
+
+These diagnostics help keep the test suite tidy by removing dead code and
+ensuring that each feature file has a corresponding step implementation.
+
 ## Data tables and Docstrings
 
 Steps may supply structured or free-form data via a trailing argument. A data


### PR DESCRIPTION
## Summary
- add `cargo-bdd` helper with commands to list, deduplicate, and audit step definitions
- document diagnostic tooling in the design guide, user guide, and roadmap

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68ae1a058ecc8322b3ccb06b792953c4

## Summary by Sourcery

Add diagnostic tooling for rstest-bdd by introducing the `cargo-bdd` subcommand, updating documentation, and registering the new crate in the workspace

New Features:
- Introduce a new `cargo-bdd` helper binary with `list-steps`, `list-duplicates`, and `list-unused` subcommands for inspecting step definitions

Build:
- Add the `cargo-bdd` crate to the workspace manifest

Documentation:
- Document the diagnostic tooling in the user guide, design guide, and roadmap

Tests:
- Add library tests for duplicate detection and unused step identification
- Add CLI integration tests for the `cargo-bdd` commands