### PR TITLE
Implement ToTokens for StepKeyword and normalise And/But

### DIFF
--- a/crates/rstest-bdd-macros/src/codegen/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/mod.rs
@@ -23,15 +23,3 @@ pub(crate) fn rstest_bdd_path() -> TokenStream2 {
     };
     quote! { ::#ident }
 }
-
-/// Convert a [`StepKeyword`] into a quoted token.
-pub(crate) fn keyword_to_token(keyword: crate::StepKeyword) -> TokenStream2 {
-    let path = rstest_bdd_path();
-    match keyword {
-        crate::StepKeyword::Given => quote! { #path::StepKeyword::Given },
-        crate::StepKeyword::When => quote! { #path::StepKeyword::When },
-        crate::StepKeyword::Then => quote! { #path::StepKeyword::Then },
-        crate::StepKeyword::And => quote! { #path::StepKeyword::And },
-        crate::StepKeyword::But => quote! { #path::StepKeyword::But },
-    }
-}

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/emit.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/emit.rs
@@ -1,7 +1,6 @@
 //! Code emission helpers for wrapper generation.
 
 use super::args::{ArgumentCollections, CallArg, DataTableArg, DocStringArg, FixtureArg, StepArg};
-use crate::codegen::keyword_to_token;
 use crate::utils::ident::sanitize_ident;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
@@ -453,10 +452,8 @@ fn generate_registration_code(
     wrapper_ident: &proc_macro2::Ident,
     const_ident: &proc_macro2::Ident,
 ) -> TokenStream2 {
-    let WrapperConfig {
-        fixtures, keyword, ..
-    } = config;
-    let fixture_names: Vec<_> = fixtures
+    let fixture_names: Vec<_> = config
+        .fixtures
         .iter()
         .map(|FixtureArg { name, .. }| {
             let s = name.to_string();
@@ -464,13 +461,13 @@ fn generate_registration_code(
         })
         .collect();
     let fixture_len = fixture_names.len();
-    let keyword_token = keyword_to_token(*keyword);
+    let keyword = config.keyword;
     let path = crate::codegen::rstest_bdd_path();
     quote! {
         const #const_ident: [&'static str; #fixture_len] = [#(#fixture_names),*];
         const _: [(); #fixture_len] = [(); #const_ident.len()];
 
-        #path::step!(@pattern #keyword_token, &#pattern_ident, #wrapper_ident, &#const_ident);
+        #path::step!(@pattern #keyword, &#pattern_ident, #wrapper_ident, &#const_ident);
     }
 }
 

--- a/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
@@ -32,7 +32,16 @@ pub(crate) fn parse_step_keyword(kw: &str, ty: StepType) -> crate::StepKeyword {
     match kw.trim() {
         s if s.eq_ignore_ascii_case("and") => crate::StepKeyword::And,
         s if s.eq_ignore_ascii_case("but") => crate::StepKeyword::But,
-        _ => ty.into(),
+        _ =>
+        {
+            #[expect(unreachable_patterns, reason = "panic on future StepType variants")]
+            match ty {
+                StepType::Given => crate::StepKeyword::Given,
+                StepType::When => crate::StepKeyword::When,
+                StepType::Then => crate::StepKeyword::Then,
+                _ => panic!("unsupported step type: {ty:?}"),
+            }
+        }
     }
 }
 

--- a/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
@@ -74,6 +74,9 @@ impl StepBuilder {
     }
 }
 
+// gherkin normalises "And"/"But" based on `ty`, but the parser under test
+// uses the `keyword` string instead. Hard-code `ty` to `Given` so tests can
+// verify keyword resolution without upstream interference.
 fn raw_step(keyword: &str, value: &str) -> Step {
     Step {
         keyword: keyword.to_string(),

--- a/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
@@ -78,6 +78,10 @@ impl StepBuilder {
 // uses the `keyword` string instead. Hard-code `ty` to `Given` so tests can
 // verify keyword resolution without upstream interference.
 fn raw_step(keyword: &str, value: &str) -> Step {
+    // Intentionally set `ty` to `Given` so tests can pass raw
+    // "And"/"But" via `keyword` without StepBuilder's auto-mapping
+    // altering them. The parser under test uses the `keyword` string
+    // (case-insensitive) and ignores `ty`.
     Step {
         keyword: keyword.to_string(),
         ty: StepType::Given,

--- a/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
@@ -328,3 +328,4 @@ fn errors_when_feature_fails(#[case] rel_path: &str, #[case] expected_snippet: &
     };
     assert!(err.to_string().contains(expected_snippet));
 }
+

--- a/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
@@ -74,25 +74,6 @@ impl StepBuilder {
     }
 }
 
-// gherkin normalises "And"/"But" based on `ty`, but the parser under test
-// uses the `keyword` string instead. Hard-code `ty` to `Given` so tests can
-// verify keyword resolution without upstream interference.
-fn raw_step(keyword: &str, value: &str) -> Step {
-    // Intentionally set `ty` to `Given` so tests can pass raw
-    // "And"/"But" via `keyword` without StepBuilder's auto-mapping
-    // altering them. The parser under test uses the `keyword` string
-    // (case-insensitive) and ignores `ty`.
-    Step {
-        keyword: keyword.to_string(),
-        ty: StepType::Given,
-        value: value.to_string(),
-        docstring: None,
-        table: None,
-        span: Span { start: 0, end: 0 },
-        position: LineCol { line: 0, col: 0 },
-    }
-}
-
 struct FeatureBuilder {
     name: String,
     background: Option<Vec<Step>>,
@@ -184,7 +165,6 @@ fn assert_feature_extraction(
     vec![
         ParsedStep {
             keyword: crate::StepKeyword::Given,
-<<<<<<< HEAD
             text: "a background step".to_string(),
             docstring: None,
             table: None,
@@ -193,197 +173,6 @@ fn assert_feature_extraction(
             keyword: crate::StepKeyword::When,
             text: "an action".to_string(),
             docstring: None,
-||||||| parent of ce4ff4d (Return Result from map_step and reset keyword context)
-            text: "numbers".to_string(),
-            docstring: None,
-            table: Some(vec![
-                vec!["1".to_string(), "2".to_string()],
-                vec!["3".to_string(), "4".to_string()],
-            ]),
-        }],
-    );
-}
-
-#[test]
-fn normalises_and_but_to_previous_keyword() {
-    use gherkin::{LineCol, Span};
-
-    fn raw_step(keyword: &str, value: &str) -> Step {
-        Step {
-            keyword: keyword.to_string(),
-            ty: StepType::Given,
-            value: value.to_string(),
-            docstring: None,
-            table: None,
-            span: Span { start: 0, end: 0 },
-            position: LineCol { line: 0, col: 0 },
-        }
-    }
-
-    let steps = vec![
-        StepBuilder::new(StepType::Given, "precondition").build(),
-        raw_step("And", "another"),
-        raw_step("But", "exception"),
-        StepBuilder::new(StepType::When, "action").build(),
-        raw_step("And", "also action"),
-        StepBuilder::new(StepType::Then, "result").build(),
-    ];
-
-    let feature = FeatureBuilder::new("example")
-        .with_scenario("case", steps)
-        .build();
-
-    assert_extracted_steps(
-        &feature,
-        &[
-            ParsedStep {
-                keyword: crate::StepKeyword::Given,
-                text: "precondition".to_string(),
-                docstring: None,
-                table: None,
-            },
-            ParsedStep {
-                keyword: crate::StepKeyword::Given,
-                text: "another".to_string(),
-                docstring: None,
-                table: None,
-            },
-            ParsedStep {
-                keyword: crate::StepKeyword::Given,
-                text: "exception".to_string(),
-                docstring: None,
-                table: None,
-            },
-            ParsedStep {
-                keyword: crate::StepKeyword::When,
-                text: "action".to_string(),
-                docstring: None,
-                table: None,
-            },
-            ParsedStep {
-                keyword: crate::StepKeyword::When,
-                text: "also action".to_string(),
-                docstring: None,
-                table: None,
-            },
-            ParsedStep {
-                keyword: crate::StepKeyword::Then,
-                text: "result".to_string(),
-                docstring: None,
-                table: None,
-            },
-        ],
-    );
-}
-
-#[test]
-fn extracts_docstring() {
-    let feature = FeatureBuilder::new("example")
-        .with_scenario(
-            "doc",
-            vec![
-                StepBuilder::new(StepType::Given, "text")
-                    .with_docstring("line1\nline2")
-                    .build(),
-            ],
-        )
-        .build();
-
-    assert_extracted_steps(
-        &feature,
-        &[ParsedStep {
-            keyword: crate::StepKeyword::Given,
-            text: "text".to_string(),
-            docstring: Some("line1\nline2".to_string()),
-=======
-            text: "numbers".to_string(),
-            docstring: None,
-            table: Some(vec![
-                vec!["1".to_string(), "2".to_string()],
-                vec!["3".to_string(), "4".to_string()],
-            ]),
-        }],
-    );
-}
-
-#[test]
-fn normalises_and_but_to_previous_keyword() {
-    let steps = vec![
-        StepBuilder::new(StepType::Given, "precondition").build(),
-        raw_step("And", "another"),
-        raw_step("But", "exception"),
-        StepBuilder::new(StepType::When, "action").build(),
-        raw_step("And", "also action"),
-        StepBuilder::new(StepType::Then, "result").build(),
-    ];
-
-    let feature = FeatureBuilder::new("example")
-        .with_scenario("case", steps)
-        .build();
-
-    assert_extracted_steps(
-        &feature,
-        &[
-            ParsedStep {
-                keyword: crate::StepKeyword::Given,
-                text: "precondition".to_string(),
-                docstring: None,
-                table: None,
-            },
-            ParsedStep {
-                keyword: crate::StepKeyword::Given,
-                text: "another".to_string(),
-                docstring: None,
-                table: None,
-            },
-            ParsedStep {
-                keyword: crate::StepKeyword::Given,
-                text: "exception".to_string(),
-                docstring: None,
-                table: None,
-            },
-            ParsedStep {
-                keyword: crate::StepKeyword::When,
-                text: "action".to_string(),
-                docstring: None,
-                table: None,
-            },
-            ParsedStep {
-                keyword: crate::StepKeyword::When,
-                text: "also action".to_string(),
-                docstring: None,
-                table: None,
-            },
-            ParsedStep {
-                keyword: crate::StepKeyword::Then,
-                text: "result".to_string(),
-                docstring: None,
-                table: None,
-            },
-        ],
-    );
-}
-
-#[test]
-fn extracts_docstring() {
-    let feature = FeatureBuilder::new("example")
-        .with_scenario(
-            "doc",
-            vec![
-                StepBuilder::new(StepType::Given, "text")
-                    .with_docstring("line1\nline2")
-                    .build(),
-            ],
-        )
-        .build();
-
-    assert_extracted_steps(
-        &feature,
-        &[ParsedStep {
-            keyword: crate::StepKeyword::Given,
-            text: "text".to_string(),
-            docstring: Some("line1\nline2".to_string()),
->>>>>>> ce4ff4d (Return Result from map_step and reset keyword context)
             table: None,
         },
         ParsedStep {
@@ -528,29 +317,6 @@ fn extracts_scenario_steps(
     assert_feature_extraction(feature, &expected, index);
 }
 
-#[test]
-fn rejects_leading_and_after_background() {
-    let feature = FeatureBuilder::new("example")
-        .with_background(vec![StepBuilder::new(StepType::Given, "setup").build()])
-        .with_scenario("case", vec![raw_step("And", "continuation")])
-        .build();
-
-    assert!(extract_scenario_steps(&feature, Some(0)).is_err());
-}
-
-#[rstest]
-#[case("And")]
-#[case("But")]
-fn rejects_leading_conjunction_without_background(#[case] kw: &str) {
-    // A Scenario that starts with And/But should be rejected because there is
-    // no preceding primary keyword to inherit from.
-    let feature = FeatureBuilder::new("example")
-        .with_scenario("case", vec![raw_step(kw, "start")])
-        .build();
-
-    assert!(extract_scenario_steps(&feature, Some(0)).is_err());
-}
-
 #[rstest]
 #[case("tests/features/does_not_exist.feature", "feature file not found")]
 #[case("tests/features/empty.feature", "failed to parse feature file")]
@@ -562,4 +328,3 @@ fn errors_when_feature_fails(#[case] rel_path: &str, #[case] expected_snippet: &
     };
     assert!(err.to_string().contains(expected_snippet));
 }
-

--- a/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
@@ -74,6 +74,18 @@ impl StepBuilder {
     }
 }
 
+fn raw_step(keyword: &str, value: &str) -> Step {
+    Step {
+        keyword: keyword.to_string(),
+        ty: StepType::Given,
+        value: value.to_string(),
+        docstring: None,
+        table: None,
+        span: Span { start: 0, end: 0 },
+        position: LineCol { line: 0, col: 0 },
+    }
+}
+
 struct FeatureBuilder {
     name: String,
     background: Option<Vec<Step>>,
@@ -165,6 +177,7 @@ fn assert_feature_extraction(
     vec![
         ParsedStep {
             keyword: crate::StepKeyword::Given,
+<<<<<<< HEAD
             text: "a background step".to_string(),
             docstring: None,
             table: None,
@@ -173,6 +186,197 @@ fn assert_feature_extraction(
             keyword: crate::StepKeyword::When,
             text: "an action".to_string(),
             docstring: None,
+||||||| parent of ce4ff4d (Return Result from map_step and reset keyword context)
+            text: "numbers".to_string(),
+            docstring: None,
+            table: Some(vec![
+                vec!["1".to_string(), "2".to_string()],
+                vec!["3".to_string(), "4".to_string()],
+            ]),
+        }],
+    );
+}
+
+#[test]
+fn normalises_and_but_to_previous_keyword() {
+    use gherkin::{LineCol, Span};
+
+    fn raw_step(keyword: &str, value: &str) -> Step {
+        Step {
+            keyword: keyword.to_string(),
+            ty: StepType::Given,
+            value: value.to_string(),
+            docstring: None,
+            table: None,
+            span: Span { start: 0, end: 0 },
+            position: LineCol { line: 0, col: 0 },
+        }
+    }
+
+    let steps = vec![
+        StepBuilder::new(StepType::Given, "precondition").build(),
+        raw_step("And", "another"),
+        raw_step("But", "exception"),
+        StepBuilder::new(StepType::When, "action").build(),
+        raw_step("And", "also action"),
+        StepBuilder::new(StepType::Then, "result").build(),
+    ];
+
+    let feature = FeatureBuilder::new("example")
+        .with_scenario("case", steps)
+        .build();
+
+    assert_extracted_steps(
+        &feature,
+        &[
+            ParsedStep {
+                keyword: crate::StepKeyword::Given,
+                text: "precondition".to_string(),
+                docstring: None,
+                table: None,
+            },
+            ParsedStep {
+                keyword: crate::StepKeyword::Given,
+                text: "another".to_string(),
+                docstring: None,
+                table: None,
+            },
+            ParsedStep {
+                keyword: crate::StepKeyword::Given,
+                text: "exception".to_string(),
+                docstring: None,
+                table: None,
+            },
+            ParsedStep {
+                keyword: crate::StepKeyword::When,
+                text: "action".to_string(),
+                docstring: None,
+                table: None,
+            },
+            ParsedStep {
+                keyword: crate::StepKeyword::When,
+                text: "also action".to_string(),
+                docstring: None,
+                table: None,
+            },
+            ParsedStep {
+                keyword: crate::StepKeyword::Then,
+                text: "result".to_string(),
+                docstring: None,
+                table: None,
+            },
+        ],
+    );
+}
+
+#[test]
+fn extracts_docstring() {
+    let feature = FeatureBuilder::new("example")
+        .with_scenario(
+            "doc",
+            vec![
+                StepBuilder::new(StepType::Given, "text")
+                    .with_docstring("line1\nline2")
+                    .build(),
+            ],
+        )
+        .build();
+
+    assert_extracted_steps(
+        &feature,
+        &[ParsedStep {
+            keyword: crate::StepKeyword::Given,
+            text: "text".to_string(),
+            docstring: Some("line1\nline2".to_string()),
+=======
+            text: "numbers".to_string(),
+            docstring: None,
+            table: Some(vec![
+                vec!["1".to_string(), "2".to_string()],
+                vec!["3".to_string(), "4".to_string()],
+            ]),
+        }],
+    );
+}
+
+#[test]
+fn normalises_and_but_to_previous_keyword() {
+    let steps = vec![
+        StepBuilder::new(StepType::Given, "precondition").build(),
+        raw_step("And", "another"),
+        raw_step("But", "exception"),
+        StepBuilder::new(StepType::When, "action").build(),
+        raw_step("And", "also action"),
+        StepBuilder::new(StepType::Then, "result").build(),
+    ];
+
+    let feature = FeatureBuilder::new("example")
+        .with_scenario("case", steps)
+        .build();
+
+    assert_extracted_steps(
+        &feature,
+        &[
+            ParsedStep {
+                keyword: crate::StepKeyword::Given,
+                text: "precondition".to_string(),
+                docstring: None,
+                table: None,
+            },
+            ParsedStep {
+                keyword: crate::StepKeyword::Given,
+                text: "another".to_string(),
+                docstring: None,
+                table: None,
+            },
+            ParsedStep {
+                keyword: crate::StepKeyword::Given,
+                text: "exception".to_string(),
+                docstring: None,
+                table: None,
+            },
+            ParsedStep {
+                keyword: crate::StepKeyword::When,
+                text: "action".to_string(),
+                docstring: None,
+                table: None,
+            },
+            ParsedStep {
+                keyword: crate::StepKeyword::When,
+                text: "also action".to_string(),
+                docstring: None,
+                table: None,
+            },
+            ParsedStep {
+                keyword: crate::StepKeyword::Then,
+                text: "result".to_string(),
+                docstring: None,
+                table: None,
+            },
+        ],
+    );
+}
+
+#[test]
+fn extracts_docstring() {
+    let feature = FeatureBuilder::new("example")
+        .with_scenario(
+            "doc",
+            vec![
+                StepBuilder::new(StepType::Given, "text")
+                    .with_docstring("line1\nline2")
+                    .build(),
+            ],
+        )
+        .build();
+
+    assert_extracted_steps(
+        &feature,
+        &[ParsedStep {
+            keyword: crate::StepKeyword::Given,
+            text: "text".to_string(),
+            docstring: Some("line1\nline2".to_string()),
+>>>>>>> ce4ff4d (Return Result from map_step and reset keyword context)
             table: None,
         },
         ParsedStep {
@@ -315,6 +519,16 @@ fn extracts_scenario_steps(
     #[case] index: Option<usize>,
 ) {
     assert_feature_extraction(feature, &expected, index);
+}
+
+#[test]
+fn rejects_leading_and_after_background() {
+    let feature = FeatureBuilder::new("example")
+        .with_background(vec![StepBuilder::new(StepType::Given, "setup").build()])
+        .with_scenario("case", vec![raw_step("And", "continuation")])
+        .build();
+
+    assert!(extract_scenario_steps(&feature, Some(0)).is_err());
 }
 
 #[rstest]

--- a/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
@@ -539,6 +539,19 @@ fn rejects_leading_and_after_background() {
 }
 
 #[rstest]
+#[case("And")]
+#[case("But")]
+fn rejects_leading_conjunction_without_background(#[case] kw: &str) {
+    // A Scenario that starts with And/But should be rejected because there is
+    // no preceding primary keyword to inherit from.
+    let feature = FeatureBuilder::new("example")
+        .with_scenario("case", vec![raw_step(kw, "start")])
+        .build();
+
+    assert!(extract_scenario_steps(&feature, Some(0)).is_err());
+}
+
+#[rstest]
 #[case("tests/features/does_not_exist.feature", "feature file not found")]
 #[case("tests/features/empty.feature", "failed to parse feature file")]
 #[case("tests/features", "feature path is not a file")]

--- a/crates/rstest-bdd-macros/src/step_keyword.rs
+++ b/crates/rstest-bdd-macros/src/step_keyword.rs
@@ -33,7 +33,8 @@ impl From<&str> for StepKeyword {
             "then" => Self::Then,
             "and" => Self::And,
             "but" => Self::But,
-            _ => panic!("invalid step keyword: {trimmed}"),
+            // Use the original, untrimmed `value` for clearer diagnostics.
+            _ => panic!("invalid step keyword: {value}"),
         }
     }
 }

--- a/crates/rstest-bdd-macros/src/step_keyword.rs
+++ b/crates/rstest-bdd-macros/src/step_keyword.rs
@@ -1,10 +1,14 @@
 //! Local representation of step keywords used during macro expansion.
 //!
 //! This lightweight enum mirrors the variants provided by `rstest-bdd` but
-//! avoids a compile-time dependency on that crate.  It is only used internally
-//! for parsing feature files and generating code.
+//! avoids a compile-time dependency on that crate. It is only used internally
+//! for parsing feature files and generating code. While the enum includes `And`
+//! and `But` for completeness, feature parsing normalises them to the preceding
+//! primary keyword.
 
 use gherkin::StepType;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{ToTokens, quote};
 
 /// Keyword used to categorise a step definition.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -23,10 +27,43 @@ pub(crate) enum StepKeyword {
 
 impl From<StepType> for StepKeyword {
     fn from(value: StepType) -> Self {
+        #[expect(unreachable_patterns, reason = "panic on future StepType variants")]
         match value {
             StepType::Given => Self::Given,
             StepType::When => Self::When,
             StepType::Then => Self::Then,
+            #[cfg(any())]
+            StepType::And => Self::And,
+            #[cfg(any())]
+            StepType::But => Self::But,
+            _ => panic!("unsupported step type: {value:?}"),
         }
+    }
+}
+
+impl From<&str> for StepKeyword {
+    fn from(value: &str) -> Self {
+        match value.trim() {
+            "Given" => Self::Given,
+            "When" => Self::When,
+            "Then" => Self::Then,
+            "And" => Self::And,
+            "But" => Self::But,
+            other => panic!("invalid step keyword: {other}"),
+        }
+    }
+}
+
+impl ToTokens for StepKeyword {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        let path = crate::codegen::rstest_bdd_path();
+        let variant = match self {
+            Self::Given => quote!(Given),
+            Self::When => quote!(When),
+            Self::Then => quote!(Then),
+            Self::And => quote!(And),
+            Self::But => quote!(But),
+        };
+        tokens.extend(quote! { #path::StepKeyword::#variant });
     }
 }

--- a/crates/rstest-bdd-macros/src/step_keyword.rs
+++ b/crates/rstest-bdd-macros/src/step_keyword.rs
@@ -9,7 +9,7 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{ToTokens, quote};
 
-/// Keyword used to categorise a step definition.
+/// Keyword used to categorize a step definition.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum StepKeyword {
     /// Setup preconditions for a scenario.

--- a/crates/rstest-bdd-macros/src/step_keyword.rs
+++ b/crates/rstest-bdd-macros/src/step_keyword.rs
@@ -60,6 +60,8 @@ mod tests {
     #[case("Given", StepKeyword::Given)]
     #[case("given", StepKeyword::Given)]
     #[case(" WhEn ", StepKeyword::When)]
+    #[case("AND", StepKeyword::And)]
+    #[case(" but ", StepKeyword::But)]
     fn parses_case_insensitively(#[case] input: &str, #[case] expected: StepKeyword) {
         assert_eq!(StepKeyword::from(input), expected);
     }

--- a/crates/rstest-bdd-macros/src/step_keyword.rs
+++ b/crates/rstest-bdd-macros/src/step_keyword.rs
@@ -3,7 +3,7 @@
 //! This lightweight enum mirrors the variants provided by `rstest-bdd` but
 //! avoids a compile-time dependency on that crate. It is only used internally
 //! for parsing feature files and generating code. While the enum includes `And`
-//! and `But` for completeness, feature parsing normalises them to the preceding
+//! and `But` for completeness, feature parsing normalizes them to the preceding
 //! primary keyword.
 
 use proc_macro2::TokenStream as TokenStream2;

--- a/crates/rstest-bdd-macros/src/step_keyword.rs
+++ b/crates/rstest-bdd-macros/src/step_keyword.rs
@@ -26,13 +26,14 @@ pub(crate) enum StepKeyword {
 
 impl From<&str> for StepKeyword {
     fn from(value: &str) -> Self {
-        match value.trim().to_ascii_lowercase().as_str() {
+        let trimmed = value.trim();
+        match trimmed.to_ascii_lowercase().as_str() {
             "given" => Self::Given,
             "when" => Self::When,
             "then" => Self::Then,
             "and" => Self::And,
             "but" => Self::But,
-            other => panic!("invalid step keyword: {other}"),
+            _ => panic!("invalid step keyword: {trimmed}"),
         }
     }
 }

--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -98,12 +98,12 @@ impl FromStr for StepKeyword {
     type Err = StepKeywordParseError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        let kw = match value.trim() {
-            "Given" => Self::Given,
-            "When" => Self::When,
-            "Then" => Self::Then,
-            "And" => Self::And,
-            "But" => Self::But,
+        let kw = match value.trim().to_ascii_lowercase().as_str() {
+            "given" => Self::Given,
+            "when" => Self::When,
+            "then" => Self::Then,
+            "and" => Self::And,
+            "but" => Self::But,
             other => return Err(StepKeywordParseError(other.to_string())),
         };
         Ok(kw)
@@ -129,6 +129,21 @@ impl From<StepType> for StepKeyword {
             StepType::But => Self::But,
             _ => panic!("unsupported step type: {ty:?}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("Given", StepKeyword::Given)]
+    #[case("given", StepKeyword::Given)]
+    #[case("\tThEn\n", StepKeyword::Then)]
+    fn parses_case_insensitively(#[case] input: &str, #[case] expected: StepKeyword) {
+        assert!(matches!(StepKeyword::from_str(input), Ok(val) if val == expected));
+        assert_eq!(StepKeyword::from(input), expected);
     }
 }
 

--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -118,13 +118,12 @@ impl From<&str> for StepKeyword {
 
 impl From<StepType> for StepKeyword {
     fn from(ty: StepType) -> Self {
-        // `gherkin::StepType` currently exposes only `Given`, `When`, and `Then`.
-        // If the upstream crate adds more variants, compilation will fail until
-        // they are handled explicitly here.
         match ty {
             StepType::Given => Self::Given,
             StepType::When => Self::When,
             StepType::Then => Self::Then,
+            #[expect(unreachable_patterns, reason = "panic on future StepType variants")]
+            _ => panic!("unsupported step type: {ty:?}"),
         }
     }
 }
@@ -132,6 +131,7 @@ impl From<StepType> for StepKeyword {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gherkin::StepType;
     use rstest::rstest;
 
     #[rstest]
@@ -142,6 +142,14 @@ mod tests {
     #[case(" but ", StepKeyword::But)]
     fn parses_case_insensitively(#[case] input: &str, #[case] expected: StepKeyword) {
         assert!(matches!(StepKeyword::from_str(input), Ok(val) if val == expected));
+        assert_eq!(StepKeyword::from(input), expected);
+    }
+
+    #[rstest]
+    #[case(StepType::Given, StepKeyword::Given)]
+    #[case(StepType::When, StepKeyword::When)]
+    #[case(StepType::Then, StepKeyword::Then)]
+    fn maps_step_type(#[case] input: StepType, #[case] expected: StepKeyword) {
         assert_eq!(StepKeyword::from(input), expected);
     }
 }

--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -116,6 +116,9 @@ impl From<&str> for StepKeyword {
     }
 }
 
+// And/But are not present in `gherkin::StepType`; they are resolved from the
+// raw `keyword` string during feature parsing. This mapping covers only primary
+// keywords emitted by the Gherkin parser.
 impl From<StepType> for StepKeyword {
     fn from(ty: StepType) -> Self {
         match ty {

--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -118,11 +118,14 @@ impl From<&str> for StepKeyword {
 
 impl From<StepType> for StepKeyword {
     fn from(ty: StepType) -> Self {
-        #[expect(unreachable_patterns, reason = "panic on future StepType variants")]
         match ty {
             StepType::Given => Self::Given,
             StepType::When => Self::When,
             StepType::Then => Self::Then,
+            #[expect(
+                unreachable_patterns,
+                reason = "keep a guard for future StepType variants"
+            )]
             _ => panic!("unsupported step type: {ty:?}"),
         }
     }

--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -57,7 +57,10 @@ impl<'a> From<&'a str> for StepText<'a> {
     }
 }
 
-/// Keyword used to categorize a step definition.
+/// Keyword used to categorise a step definition.
+///
+/// The enum includes `And` and `But` variants for completeness, but feature
+/// parsing resolves them against the preceding `Given`/`When`/`Then`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum StepKeyword {
     /// Setup preconditions for a scenario.
@@ -95,7 +98,7 @@ impl FromStr for StepKeyword {
     type Err = StepKeywordParseError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        let kw = match value {
+        let kw = match value.trim() {
             "Given" => Self::Given,
             "When" => Self::When,
             "Then" => Self::Then,
@@ -115,10 +118,16 @@ impl From<&str> for StepKeyword {
 
 impl From<StepType> for StepKeyword {
     fn from(ty: StepType) -> Self {
+        #[expect(unreachable_patterns, reason = "panic on future StepType variants")]
         match ty {
             StepType::Given => Self::Given,
             StepType::When => Self::When,
             StepType::Then => Self::Then,
+            #[cfg(any())]
+            StepType::And => Self::And,
+            #[cfg(any())]
+            StepType::But => Self::But,
+            _ => panic!("unsupported step type: {ty:?}"),
         }
     }
 }

--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -118,15 +118,13 @@ impl From<&str> for StepKeyword {
 
 impl From<StepType> for StepKeyword {
     fn from(ty: StepType) -> Self {
-        #[expect(unreachable_patterns, reason = "panic on future StepType variants")]
+        // `gherkin::StepType` currently exposes only `Given`, `When`, and `Then`.
+        // `And`/`But` steps are normalised from their string keywords earlier.
         match ty {
             StepType::Given => Self::Given,
             StepType::When => Self::When,
             StepType::Then => Self::Then,
-            #[cfg(any())]
-            StepType::And => Self::And,
-            #[cfg(any())]
-            StepType::But => Self::But,
+            #[expect(unreachable_patterns, reason = "panic on future StepType variants")]
             _ => panic!("unsupported step type: {ty:?}"),
         }
     }
@@ -141,6 +139,8 @@ mod tests {
     #[case("Given", StepKeyword::Given)]
     #[case("given", StepKeyword::Given)]
     #[case("\tThEn\n", StepKeyword::Then)]
+    #[case("AND", StepKeyword::And)]
+    #[case(" but ", StepKeyword::But)]
     fn parses_case_insensitively(#[case] input: &str, #[case] expected: StepKeyword) {
         assert!(matches!(StepKeyword::from_str(input), Ok(val) if val == expected));
         assert_eq!(StepKeyword::from(input), expected);

--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -118,11 +118,11 @@ impl From<&str> for StepKeyword {
 
 impl From<StepType> for StepKeyword {
     fn from(ty: StepType) -> Self {
+        #[expect(unreachable_patterns, reason = "panic on future StepType variants")]
         match ty {
             StepType::Given => Self::Given,
             StepType::When => Self::When,
             StepType::Then => Self::Then,
-            #[expect(unreachable_patterns, reason = "panic on future StepType variants")]
             _ => panic!("unsupported step type: {ty:?}"),
         }
     }

--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -57,7 +57,7 @@ impl<'a> From<&'a str> for StepText<'a> {
     }
 }
 
-/// Keyword used to categorise a step definition.
+/// Keyword used to categorize a step definition.
 ///
 /// The enum includes `And` and `But` variants for completeness, but feature
 /// parsing resolves them against the preceding `Given`/`When`/`Then`.
@@ -119,13 +119,12 @@ impl From<&str> for StepKeyword {
 impl From<StepType> for StepKeyword {
     fn from(ty: StepType) -> Self {
         // `gherkin::StepType` currently exposes only `Given`, `When`, and `Then`.
-        // `And`/`But` steps are normalised from their string keywords earlier.
+        // If the upstream crate adds more variants, compilation will fail until
+        // they are handled explicitly here.
         match ty {
             StepType::Given => Self::Given,
             StepType::When => Self::When,
             StepType::Then => Self::Then,
-            #[expect(unreachable_patterns, reason = "panic on future StepType variants")]
-            _ => panic!("unsupported step type: {ty:?}"),
         }
     }
 }

--- a/docs/gherkin-syntax.md
+++ b/docs/gherkin-syntax.md
@@ -370,7 +370,7 @@ a full "regression" suite, or tests specific to a certain feature or
 environment. `Tags` are Gherkin's mechanism for this kind of organisation. A
 tag is a simple annotation prefixed with an `@` symbol (e.g., `@smoke`, `@api`,
 `@ui`).[^13] Tags can be placed above `Feature`, `Scenario`,
-`Scenario Outline`, or even specific `Examples` tables to categorise them.[^10]
+`Scenario Outline`, or even specific `Examples` tables to categorize them.[^10]
 A single element can have multiple tags.
 
 ```gherkin

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -440,8 +440,9 @@ location information for generating clear error messages.
 // A simplified representation of the step metadata.
 #[derive(Debug)]
 pub struct Step {
-    pub keyword: StepKeyword, // e.g., Given, When or Then
-    pub pattern: &'static StepPattern, // The pattern string from the attribute, e.g., "A user has {count} cucumbers"
+    pub keyword: StepKeyword, // e.g., Given, When, Then, And or But
+    pub pattern: &'static StepPattern, // The pattern string from the attribute,
+                                       // e.g., "A user has {count} cucumbers"
     // A type-erased function pointer. Arguments will be wired up by the
     // scenario orchestrator in later phases.
     pub run: fn(),
@@ -456,7 +457,8 @@ inventory::collect!(Step);
 
 The [`StepKeyword`](../crates/rstest-bdd/src/types.rs) enum implements
 `FromStr`. Parsing failures return a `StepKeywordParseError` to ensure invalid
-step keywords are surfaced early.
+step keywords are surfaced early. All five Gherkin keywords are recognised and
+`And`/`But` are resolved to the preceding primary keyword during parsing.
 
 The [`StepPattern`](../crates/rstest-bdd/src/pattern.rs) wrapper encapsulates
 the pattern text so that step lookups cannot accidentally mix arbitrary strings

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -458,7 +458,7 @@ inventory::collect!(Step);
 The [`StepKeyword`](../crates/rstest-bdd/src/types.rs) enum implements
 `FromStr`. Parsing failures return a `StepKeywordParseError` to ensure invalid
 step keywords are surfaced early. Matching ignores case and surrounding
-whitespace. All five Gherkin keywords are recognised and `And`/`But` are
+whitespace. All five Gherkin keywords are recognized and `And`/`But` are
 resolved to the preceding primary keyword during parsing.
 
 The [`StepPattern`](../crates/rstest-bdd/src/pattern.rs) wrapper encapsulates
@@ -495,7 +495,7 @@ sequenceDiagram
   SP->>RB: build_regex_from_pattern(text)
   loop over pattern bytes
     RB->>TC: try_parse_common_sequences(...)
-    alt recognised sequence
+    alt recognized sequence
       TC-->>RB: consume
     else other character
       RB->>PC: parse_context_specific(...)

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -457,8 +457,9 @@ inventory::collect!(Step);
 
 The [`StepKeyword`](../crates/rstest-bdd/src/types.rs) enum implements
 `FromStr`. Parsing failures return a `StepKeywordParseError` to ensure invalid
-step keywords are surfaced early. All five Gherkin keywords are recognised and
-`And`/`But` are resolved to the preceding primary keyword during parsing.
+step keywords are surfaced early. Matching ignores case and surrounding
+whitespace. All five Gherkin keywords are recognised and `And`/`But` are
+resolved to the preceding primary keyword during parsing.
 
 The [`StepPattern`](../crates/rstest-bdd/src/pattern.rs) wrapper encapsulates
 the pattern text so that step lookups cannot accidentally mix arbitrary strings


### PR DESCRIPTION
## Summary
- implement `ToTokens` for `StepKeyword` and drop manual `keyword_to_token`
- normalise `And`/`But` to preceding keywords and trim inputs when parsing
- simplify scenario context setup to limit mutability

## Testing
- `make fmt`
- `make lint`
- `make markdownlint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68af76c4b12c8322b768c08aa9f9f86d

## Summary by Sourcery

Enable direct tokenization of step keywords and unify keyword parsing while simplifying code generation patterns

New Features:
- Add From<&str> implementation for StepKeyword to parse trimmed keyword strings
- Implement ToTokens trait for StepKeyword in the macros crate to generate tokens directly

Enhancements:
- Normalize And/But keywords to their preceding primary Given/When/Then variants during parsing
- Remove manual keyword_to_token helper and replace its usage with the ToTokens-based token stream
- Simplify scenario context construction in generated tests by reducing mutability

Documentation:
- Update StepKeyword documentation to include And and But variants and describe their resolution to preceding keywords