### PR TITLE
Remove runtime crate dependency from macros

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         with:
           output-path: lcov.info
           format: lcov
+      - name: Publish dry run
+        run: make publish-check
       - name: Upload coverage data to CodeScene
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rstest = "0.18"
 trybuild = "1"
 once_cell = "1.18"
 serial_test = "2"
-rstest-bdd = "0.1.0-alpha1"
+rstest-bdd = "0.1.0-alpha2"
 rstest-bdd-macros = "0.1.0-alpha2"
 
 [workspace.lints.clippy]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie
+.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie publish-check
 
 SHELL := bash
 APP ?= rstest-bdd
@@ -36,6 +36,15 @@ markdownlint: ## Lint Markdown files
 
 nixie: ## Render Mermaid diagrams from .mmd files (writes .svg next to sources)
 	@bash scripts/nixie.sh
+publish-check: ## Dry-run cargo publish for all crates
+	@tmp=$$(mktemp -d); \
+	git archive --format=tar HEAD | tar -C $$tmp -xf -; \
+	sed -i '/^\[patch.crates-io\]/,$$d' $$tmp/Cargo.toml; \
+	for crate in $$tmp/crates/*; do \
+		(cd $$crate && $(CARGO) publish --dry-run --allow-dirty --no-verify); \
+	done; \
+	rm -rf $$tmp
+
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \

--- a/crates/rstest-bdd-macros/Cargo.toml
+++ b/crates/rstest-bdd-macros/Cargo.toml
@@ -32,4 +32,4 @@ trybuild.workspace = true
 once_cell.workspace = true
 rstest.workspace = true
 serial_test.workspace = true
-rstest-bdd = { path = "../rstest-bdd" }
+rstest-bdd.workspace = true

--- a/crates/rstest-bdd-macros/Cargo.toml
+++ b/crates/rstest-bdd-macros/Cargo.toml
@@ -32,4 +32,4 @@ trybuild.workspace = true
 once_cell.workspace = true
 rstest.workspace = true
 serial_test.workspace = true
-rstest-bdd.workspace = true
+rstest-bdd = { path = "../rstest-bdd" }

--- a/crates/rstest-bdd-macros/tests/fixtures/Cargo.toml
+++ b/crates/rstest-bdd-macros/tests/fixtures/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 publish = false
 
 [dependencies]
-rstest-bdd = { path = "../../../rstest-bdd" }
-rstest-bdd-macros = { path = "../.." }
+rstest-bdd = { version = "0.1.0-alpha2", path = "../../../rstest-bdd" }
+rstest-bdd-macros = { version = "0.1.0-alpha2", path = "../.." }

--- a/crates/rstest-bdd-macros/tests/fixtures/Cargo.toml
+++ b/crates/rstest-bdd-macros/tests/fixtures/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rstest-bdd-macros-fixtures"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+rstest-bdd = { path = "../../../rstest-bdd" }
+rstest-bdd-macros = { path = "../.." }

--- a/crates/rstest-bdd-macros/tests/ui/Cargo.toml
+++ b/crates/rstest-bdd-macros/tests/ui/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rstest-bdd-macros-ui"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+rstest-bdd = { path = "../../../rstest-bdd" }
+rstest-bdd-macros = { path = "../.." }

--- a/crates/rstest-bdd-macros/tests/ui/Cargo.toml
+++ b/crates/rstest-bdd-macros/tests/ui/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 publish = false
 
 [dependencies]
-rstest-bdd = { path = "../../../rstest-bdd" }
-rstest-bdd-macros = { path = "../.." }
+rstest-bdd = { version = "0.1.0-alpha2", path = "../../../rstest-bdd" }
+rstest-bdd-macros = { version = "0.1.0-alpha2", path = "../.." }


### PR DESCRIPTION
## Summary
- remove runtime crate from macro crate dependencies
- rely on fully-qualified `::rstest_bdd` paths when generating code

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b0e6711a5c8322be740651a087c1e6