### PR TITLE
Update slab dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"


### PR DESCRIPTION
## Summary
- update slab to 0.4.11 to avoid yanked 0.4.10

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b0ef51e20c8322ab33a283cab6c2e5

## Summary by Sourcery

Chores:
- Update Cargo.lock to reflect slab 0.4.11