### PR TITLE
Document planned tag filtering support

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -120,6 +120,13 @@ improves the developer experience.
     matching step definition exists for every Gherkin step in the target
     scenario, emitting a `compile_error!` if any are missing.
 
+- [ ] **Tag Filtering**
+
+  - [ ] Allow the `#[scenario]` macro to select scenarios by tag expression.
+
+  - [ ] Extend the `scenarios!` macro to filter scenarios using the same tag
+    syntax.
+
 - [ ] **Boilerplate Reduction**
 
   - [x] Implement the `scenarios!("path/to/features/")` macro to automatically

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -304,6 +304,24 @@ fn create_users(
   to be passed to a step. This will be provided as a `String` argument to the
   step function, again mirroring `pytest-bdd`.[^11]
 
+#### 1.3.4 Filtering Scenarios with Tags
+
+Tags provide a convenient way to organise scenarios and control which tests
+run. The `#[scenario]` macro will accept an optional `tags` argument containing
+an expression such as `"@fast and not @wip"`. Only scenarios whose tags satisfy
+this expression will expand into test functions. The `scenarios!` macro will
+offer the same argument to filter an entire directory of feature files.
+
+**Example:**
+
+```rust
+#[scenario(path = "search.feature", tags = "@fast and not @wip")]
+fn search_fast() {}
+```
+
+The macro emits a test only when the matched scenario carries the `@fast` tag
+and lacks the `@wip` tag.
+
 ## Part 2: Architectural and API Specification
 
 This part transitions from the user's perspective to the technical


### PR DESCRIPTION
## Summary
- note roadmap tasks to add tag-based scenario filtering
- outline tag expression support in the design guide

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68b0fa43065883228d6f349455cbede8