### PR TITLE
Inline step keyword parsing

### DIFF
--- a/crates/rstest-bdd-macros/src/codegen/scenario.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario.rs
@@ -1,7 +1,6 @@
 //! Code generation for scenario tests.
 
 use super::keyword_to_token;
-use crate::parsing::feature::resolve_conjunction_keyword;
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
@@ -99,7 +98,13 @@ fn process_steps(
     let keywords = steps
         .iter()
         .map(|s| {
-            let kw = resolve_conjunction_keyword(&mut prev, s.keyword);
+            let kw = match s.keyword {
+                crate::StepKeyword::And | crate::StepKeyword::But => prev.unwrap_or(s.keyword),
+                kw => {
+                    prev = Some(kw);
+                    kw
+                }
+            };
             keyword_to_token(kw)
         })
         .collect();

--- a/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
@@ -1,6 +1,6 @@
 //! Feature file loading and scenario extraction.
 
-use gherkin::{Feature, GherkinEnv, Step, StepType};
+use gherkin::{Feature, GherkinEnv, Step};
 use std::path::{Path, PathBuf};
 
 use crate::parsing::examples::ExampleTable;
@@ -23,38 +23,6 @@ pub(crate) struct ScenarioData {
     pub(crate) examples: Option<ExampleTable>,
 }
 
-/// Map a textual step keyword and `StepType` to a `StepKeyword`.
-///
-/// Conjunction keywords such as "And" and "But" inherit the semantic
-/// meaning of the preceding step but remain distinct for later resolution.
-/// Matching is case-insensitive to tolerate unusual source casing.
-pub(crate) fn parse_step_keyword(kw: &str, ty: StepType) -> crate::StepKeyword {
-    match kw.trim() {
-        s if s.eq_ignore_ascii_case("and") => crate::StepKeyword::And,
-        s if s.eq_ignore_ascii_case("but") => crate::StepKeyword::But,
-        _ => ty.into(),
-    }
-}
-
-/// Return `true` if the keyword is a connective such as "And" or "But".
-pub(crate) fn is_conjunction_keyword(kw: crate::StepKeyword) -> bool {
-    matches!(kw, crate::StepKeyword::And | crate::StepKeyword::But)
-}
-
-/// Replace "And"/"But" with the previous keyword, falling back to itself when
-/// no previous step exists.
-pub(crate) fn resolve_conjunction_keyword(
-    prev: &mut Option<crate::StepKeyword>,
-    kw: crate::StepKeyword,
-) -> crate::StepKeyword {
-    if is_conjunction_keyword(kw) {
-        prev.unwrap_or(kw)
-    } else {
-        *prev = Some(kw);
-        kw
-    }
-}
-
 /// Convert a Gherkin step to a `ParsedStep`.
 ///
 /// Uses the textual keyword when present to honour conjunctions
@@ -64,9 +32,14 @@ impl From<&Step> for ParsedStep {
         // The Gherkin parser exposes both a textual keyword (e.g. "And") and a
         // typed variant (Given/When/Then). We prioritise the textual value so
         // that conjunctions are preserved and can be used to improve
-        // diagnostics. Trimming avoids surprises from trailing spaces in
+        // diagnostics. Matching is case-insensitive to tolerate unusual source
+        // casing, and trimming avoids surprises from trailing spaces in
         // .feature files.
-        let keyword = parse_step_keyword(&step.keyword, step.ty);
+        let keyword = match step.keyword.trim() {
+            s if s.eq_ignore_ascii_case("and") => crate::StepKeyword::And,
+            s if s.eq_ignore_ascii_case("but") => crate::StepKeyword::But,
+            _ => step.ty.into(),
+        };
         let table = step.table.as_ref().map(|t| t.rows.clone());
         let docstring = step.docstring.clone();
         Self {


### PR DESCRIPTION
## Summary
- inline step keyword parsing into `ParsedStep` conversion
- resolve conjunction keywords during code generation without helper functions

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b0d9f384248322932dc1d6b7829329