### PR TITLE
Inline step keyword parsing and remove helpers

### DIFF
--- a/crates/rstest-bdd-macros/src/codegen/scenario.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario.rs
@@ -1,6 +1,5 @@
 //! Code generation for scenario tests.
 
-use crate::parsing::feature::resolve_conjunction_keyword;
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{ToTokens, quote};
@@ -101,7 +100,12 @@ fn process_steps(
     let keywords = steps
         .iter()
         .map(|s| {
-            let kw = resolve_conjunction_keyword(&mut prev, s.keyword);
+            let kw = if matches!(s.keyword, crate::StepKeyword::And | crate::StepKeyword::But) {
+                prev.unwrap_or(s.keyword)
+            } else {
+                prev = Some(s.keyword);
+                s.keyword
+            };
             kw.to_token_stream()
         })
         .collect();


### PR DESCRIPTION
## Summary
- inline parsing of step keywords to resolve conjunctions
- remove unused conjunction helpers

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68b16fa803488322961775018ed6c3a2