### PR TITLE
Gate compile-time validation and improve step diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -326,7 +326,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -388,7 +388,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.104",
  "textwrap",
  "thiserror",
  "typed-builder",
@@ -675,6 +675,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,12 +799,13 @@ dependencies = [
  "gherkin",
  "once_cell",
  "proc-macro-crate",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "rstest",
  "rstest-bdd",
  "serial_test",
- "syn",
+ "syn 2.0.104",
  "trybuild",
  "walkdir",
 ]
@@ -798,7 +823,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.104",
  "unicode-ident",
 ]
 
@@ -874,7 +899,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -920,7 +945,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -946,6 +971,16 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1020,7 +1055,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1126,7 +1161,7 @@ checksum = "29a3151c41d0b13e3d011f98adc24434560ef06673a155a6c7f66b9879eecce2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1152,6 +1187,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,6 +771,7 @@ dependencies = [
 name = "rstest-bdd-macros"
 version = "0.1.0-alpha2"
 dependencies = [
+ "cfg-if",
  "gherkin",
  "once_cell",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ gherkin = { version = "0.14", default-features = false, features = ["parser"] }
 inventory = "0.3"
 regex = "1.11.2"
 thiserror = "1.0"
-proc-macro2 = { version = "1", features = ["span-locations"] }
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
 rstest = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ gherkin = { version = "0.14", default-features = false, features = ["parser"] }
 inventory = "0.3"
 regex = "1.11.2"
 thiserror = "1.0"
-proc-macro2 = "1"
+proc-macro2 = { version = "1", features = ["span-locations"] }
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
 rstest = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ regex = "1.11.2"
 thiserror = "1.0"
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
+cfg-if = "1"
 rstest = "0.18"
 trybuild = "1"
 once_cell = "1.18"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ builds on the excellent `rstest` fixture and parametrisation model:
 - **Pytest‑bdd vibes**: explicit `#[scenario]` binding from test code to a
   named scenario.
 
+  The attribute now requires a `path` argument pointing to the `.feature` file;
+  index-only usage is no longer supported.
+
 Think of it as *courgette‑driven* development: crisp, versatile, and it plays
 nicely with everything else on your plate.
 
@@ -57,6 +60,14 @@ Feature flags:
 
 - `strict-compile-time-validation` — fails compilation when steps are missing
   or ambiguous; implies `compile-time-validation`.
+
+Both features are disabled by default and apply only to the `rstest-bdd-macros`
+crate. Enable them in your `Cargo.toml` with:
+
+```toml
+[dependencies]
+rstest-bdd-macros = { version = "0.1.0-alpha2", features = ["compile-time-validation"] }
+```
 
 ______________________________________________________________________
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ Feature flags:
 - `no-inventory` — fallback code‑gen registry for platforms where
   linker‑section collection is unwieldy.
 
+- `compile-time-validation` — registers steps at compile time and reports
+  missing or ambiguous steps with spans.
+
+- `strict-compile-time-validation` — fails compilation when steps are missing
+  or ambiguous; implies `compile-time-validation`.
+
 ______________________________________________________________________
 
 ## Quick start (end‑to‑end “Web Search”)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ builds on the excellent `rstest` fixture and parametrisation model:
   The attribute now requires a `path` argument pointing to the `.feature` file;
   index-only usage is no longer supported.
 
+  Migration:
+
+  ```rust
+  // Before
+  #[scenario(index = 0)]
+  // After
+  #[scenario(path = "tests/features/example.feature", index = 0)]
+  ```
+
 Think of it as *courgette‑driven* development: crisp, versatile, and it plays
 nicely with everything else on your plate.
 
@@ -56,10 +65,10 @@ Feature flags:
   linker‑section collection is unwieldy.
 
 - `compile-time-validation` — registers steps at compile time and reports
-  missing or ambiguous steps with spans.
+  missing or ambiguous steps with spans. (Disabled by default.)
 
 - `strict-compile-time-validation` — fails compilation when steps are missing
-  or ambiguous; implies `compile-time-validation`.
+  or ambiguous; implies `compile-time-validation`. (Disabled by default.)
 
 Both features are disabled by default and apply only to the `rstest-bdd-macros`
 crate. Enable them in your `Cargo.toml` with:
@@ -67,6 +76,13 @@ crate. Enable them in your `Cargo.toml` with:
 ```toml
 [dependencies]
 rstest-bdd-macros = { version = "0.1.0-alpha2", features = ["compile-time-validation"] }
+```
+
+Or via CLI:
+
+```bash
+cargo test --features "rstest-bdd-macros/compile-time-validation"
+cargo test --features "rstest-bdd-macros/strict-compile-time-validation"
 ```
 
 ______________________________________________________________________

--- a/crates/rstest-bdd-macros/Cargo.toml
+++ b/crates/rstest-bdd-macros/Cargo.toml
@@ -20,7 +20,8 @@ proc-macro = true
 
 [features]
 default = []
-strict-compile-time-validation = []
+compile-time-validation = []
+strict-compile-time-validation = ["compile-time-validation"]
 
 
 [dependencies]

--- a/crates/rstest-bdd-macros/Cargo.toml
+++ b/crates/rstest-bdd-macros/Cargo.toml
@@ -25,7 +25,7 @@ strict-compile-time-validation = ["compile-time-validation"]
 
 
 [dependencies]
-proc-macro2.workspace = true
+proc-macro2 = { version = "1", features = ["span-locations"] }
 quote.workspace = true
 syn.workspace = true
 gherkin.workspace = true

--- a/crates/rstest-bdd-macros/Cargo.toml
+++ b/crates/rstest-bdd-macros/Cargo.toml
@@ -32,9 +32,14 @@ gherkin.workspace = true
 walkdir = "2.5.0"
 proc-macro-crate = "3"
 rstest-bdd.workspace = true
+cfg-if = "1"
 
 [dev-dependencies]
 trybuild.workspace = true
 once_cell.workspace = true
 rstest.workspace = true
 serial_test.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/rstest-bdd-macros/Cargo.toml
+++ b/crates/rstest-bdd-macros/Cargo.toml
@@ -33,6 +33,7 @@ walkdir = "2.5.0"
 proc-macro-crate = "3"
 rstest-bdd.workspace = true
 cfg-if = "1"
+proc-macro-error = "1"
 
 [dev-dependencies]
 trybuild.workspace = true

--- a/crates/rstest-bdd-macros/README.md
+++ b/crates/rstest-bdd-macros/README.md
@@ -28,6 +28,9 @@ builds on the excellent `rstest` fixture and parametrisation model:
 - **Pytest‑bdd vibes**: explicit `#[scenario]` binding from test code to a
   named scenario.
 
+  The attribute now requires a `path` argument pointing to the `.feature` file;
+  index-only usage is no longer supported.
+
 Think of it as *courgette‑driven* development: crisp, versatile, and it plays
 nicely with everything else on your plate.
 
@@ -57,6 +60,13 @@ Feature flags:
 
 - `strict-compile-time-validation` — fails compilation when steps are missing
   or ambiguous; implies `compile-time-validation`.
+
+Both features are disabled by default. Enable them with:
+
+```toml
+[dependencies]
+rstest-bdd-macros = { version = "0.1.0-alpha2", features = ["compile-time-validation"] }
+```
 
 ______________________________________________________________________
 

--- a/crates/rstest-bdd-macros/README.md
+++ b/crates/rstest-bdd-macros/README.md
@@ -31,6 +31,15 @@ builds on the excellent `rstest` fixture and parametrisation model:
   The attribute now requires a `path` argument pointing to the `.feature` file;
   index-only usage is no longer supported.
 
+  Migration:
+
+  ```rust
+  // Before
+  #[scenario(index = 0)]
+  // After
+  #[scenario(path = "tests/features/example.feature", index = 0)]
+  ```
+
 Think of it as *courgette‑driven* development: crisp, versatile, and it plays
 nicely with everything else on your plate.
 
@@ -56,16 +65,23 @@ Feature flags:
   linker‑section collection is unwieldy.
 
 - `compile-time-validation` — registers steps at compile time and reports
-  missing or ambiguous steps with spans.
+  missing or ambiguous steps with spans. (Disabled by default.)
 
 - `strict-compile-time-validation` — fails compilation when steps are missing
-  or ambiguous; implies `compile-time-validation`.
+  or ambiguous; implies `compile-time-validation`. (Disabled by default.)
 
 Both features are disabled by default. Enable them with:
 
 ```toml
 [dependencies]
 rstest-bdd-macros = { version = "0.1.0-alpha2", features = ["compile-time-validation"] }
+```
+
+Or via CLI:
+
+```bash
+cargo test --features "rstest-bdd-macros/compile-time-validation"
+cargo test --features "rstest-bdd-macros/strict-compile-time-validation"
 ```
 
 ______________________________________________________________________

--- a/crates/rstest-bdd-macros/README.md
+++ b/crates/rstest-bdd-macros/README.md
@@ -52,6 +52,12 @@ Feature flags:
 - `no-inventory` — fallback code‑gen registry for platforms where
   linker‑section collection is unwieldy.
 
+- `compile-time-validation` — registers steps at compile time and reports
+  missing or ambiguous steps with spans.
+
+- `strict-compile-time-validation` — fails compilation when steps are missing
+  or ambiguous; implies `compile-time-validation`.
+
 ______________________________________________________________________
 
 ## Quick start (end‑to‑end “Web Search”)

--- a/crates/rstest-bdd-macros/src/codegen/scenario.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario.rs
@@ -83,6 +83,7 @@ fn generate_table_tokens(table: Option<&[Vec<String>]>) -> TokenStream2 {
 /// use crate::StepKeyword;
 /// use crate::parsing::feature::ParsedStep;
 /// // Note: `span` is available only with the `compile-time-validation` feature.
+/// #[cfg_attr(docsrs, doc(cfg(feature = "compile-time-validation")))]
 /// let steps = vec![ParsedStep {
 ///     keyword: StepKeyword::Given,
 ///     text: "x".into(),

--- a/crates/rstest-bdd-macros/src/codegen/scenario.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario.rs
@@ -82,7 +82,14 @@ fn generate_table_tokens(table: Option<&[Vec<String>]>) -> TokenStream2 {
 /// ```rust,ignore
 /// use crate::StepKeyword;
 /// use crate::parsing::feature::ParsedStep;
-/// let steps = vec![ParsedStep { keyword: StepKeyword::Given, text: "x".into(), docstring: None, table: None, span: proc_macro2::Span::call_site(), }];
+/// // Note: `span` is available only with the `compile-time-validation` feature.
+/// let steps = vec![ParsedStep {
+///     keyword: StepKeyword::Given,
+///     text: "x".into(),
+///     docstring: None,
+///     table: None,
+///     span: proc_macro2::Span::call_site(),
+/// }];
 /// let (k, v, t) = process_steps(&steps);
 /// assert_eq!(v.len(), 1);
 /// ```

--- a/crates/rstest-bdd-macros/src/codegen/scenario.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario.rs
@@ -83,7 +83,6 @@ fn generate_table_tokens(table: Option<&[Vec<String>]>) -> TokenStream2 {
 /// use crate::StepKeyword;
 /// use crate::parsing::feature::ParsedStep;
 /// // Note: `span` is available only with the `compile-time-validation` feature.
-/// #[cfg_attr(docsrs, doc(cfg(feature = "compile-time-validation")))]
 /// let steps = vec![ParsedStep {
 ///     keyword: StepKeyword::Given,
 ///     text: "x".into(),

--- a/crates/rstest-bdd-macros/src/codegen/scenario.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario.rs
@@ -82,7 +82,7 @@ fn generate_table_tokens(table: Option<&[Vec<String>]>) -> TokenStream2 {
 /// ```rust,ignore
 /// use crate::StepKeyword;
 /// use crate::parsing::feature::ParsedStep;
-/// let steps = vec![ParsedStep { keyword: StepKeyword::Given, text: "x".into(), table: None }];
+/// let steps = vec![ParsedStep { keyword: StepKeyword::Given, text: "x".into(), docstring: None, table: None, span: proc_macro2::Span::call_site(), }];
 /// let (k, v, t) = process_steps(&steps);
 /// assert_eq!(v.len(), 1);
 /// ```

--- a/crates/rstest-bdd-macros/src/lib.rs
+++ b/crates/rstest-bdd-macros/src/lib.rs
@@ -1,4 +1,10 @@
 //! Attribute macros enabling Behaviour-Driven testing with `rstest`.
+//!
+//! # Feature flags
+//! - `compile-time-validation`: registers steps at compile time and attaches
+//!   spans for diagnostics.
+//! - `strict-compile-time-validation`: escalates missing or ambiguous steps to
+//!   compile errors; implies `compile-time-validation`.
 
 mod codegen;
 mod macros;

--- a/crates/rstest-bdd-macros/src/lib.rs
+++ b/crates/rstest-bdd-macros/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
 //! Attribute macros enabling Behaviour-Driven testing with `rstest`.
 //!
 //! # Feature flags
@@ -5,6 +6,8 @@
 //!   spans for diagnostics.
 //! - `strict-compile-time-validation`: escalates missing or ambiguous steps to
 //!   compile errors; implies `compile-time-validation`.
+//!
+//! Both features are disabled by default.
 
 mod codegen;
 mod macros;

--- a/crates/rstest-bdd-macros/src/lib.rs
+++ b/crates/rstest-bdd-macros/src/lib.rs
@@ -17,6 +17,7 @@ mod step_keyword;
 mod utils;
 mod validation;
 
+
 pub(crate) use step_keyword::StepKeyword;
 
 use proc_macro::TokenStream;

--- a/crates/rstest-bdd-macros/src/lib.rs
+++ b/crates/rstest-bdd-macros/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(proc_macro_diagnostic)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 //! Attribute macros enabling Behaviour-Driven testing with `rstest`.
 //!
@@ -17,26 +16,30 @@ mod step_keyword;
 mod utils;
 mod validation;
 
-
 pub(crate) use step_keyword::StepKeyword;
 
 use proc_macro::TokenStream;
+use proc_macro_error::proc_macro_error;
 
+#[proc_macro_error]
 #[proc_macro_attribute]
 pub fn given(attr: TokenStream, item: TokenStream) -> TokenStream {
     macros::given(attr, item)
 }
 
+#[proc_macro_error]
 #[proc_macro_attribute]
 pub fn when(attr: TokenStream, item: TokenStream) -> TokenStream {
     macros::when(attr, item)
 }
 
+#[proc_macro_error]
 #[proc_macro_attribute]
 pub fn then(attr: TokenStream, item: TokenStream) -> TokenStream {
     macros::then(attr, item)
 }
 
+#[proc_macro_error]
 #[proc_macro_attribute]
 pub fn scenario(attr: TokenStream, item: TokenStream) -> TokenStream {
     macros::scenario(attr, item)
@@ -68,6 +71,7 @@ pub fn scenario(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// Errors:
 /// - Emits a compile error if the directory does not exist, contains no
 ///   `.feature` files, or if parsing fails.
+#[proc_macro_error]
 #[proc_macro]
 pub fn scenarios(input: TokenStream) -> TokenStream {
     macros::scenarios(input)

--- a/crates/rstest-bdd-macros/src/lib.rs
+++ b/crates/rstest-bdd-macros/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(proc_macro_diagnostic)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 //! Attribute macros enabling Behaviour-Driven testing with `rstest`.
 //!

--- a/crates/rstest-bdd-macros/src/macros/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/mod.rs
@@ -19,6 +19,7 @@ use crate::utils::errors::error_to_tokens;
 
 fn step_attr(attr: TokenStream, item: TokenStream, keyword: crate::StepKeyword) -> TokenStream {
     let pattern = syn::parse_macro_input!(attr as syn::LitStr);
+    #[cfg(feature = "compile-time-validation")]
     crate::validation::steps::register_step(keyword, &pattern);
     let mut func = syn::parse_macro_input!(item as syn::ItemFn);
 

--- a/crates/rstest-bdd-macros/src/macros/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/mod.rs
@@ -35,13 +35,17 @@ fn step_attr(attr: TokenStream, item: TokenStream, keyword: crate::StepKeyword) 
                 crate::StepKeyword::And => "and",
                 crate::StepKeyword::But => "but",
             };
+            // `proc_macro::Diagnostic` is unstable on stable toolchains, so we
+            // emit a second error with guidance instead of a help-level note.
             let mut enriched = syn::Error::new(
                 err.span(),
                 format!("invalid step function signature: {err}"),
             );
             enriched.combine(syn::Error::new(
                 err.span(),
-                format!("use `#[{kw_name}] fn name(ctx: &StepContext, ...)` and valid fixtures"),
+                format!(
+                    "help: use `#[{kw_name}] fn name(ctx: &StepContext, ...)` and valid fixtures"
+                ),
             ));
             return error_to_tokens(&enriched).into();
         }

--- a/crates/rstest-bdd-macros/src/macros/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/mod.rs
@@ -34,13 +34,16 @@ fn step_attr(attr: TokenStream, item: TokenStream, keyword: crate::StepKeyword) 
                 crate::StepKeyword::And => "and",
                 crate::StepKeyword::But => "but",
             };
-            let span = err.span().unwrap();
-            span.error(format!("invalid step function signature: {err}"))
-                .help(format!(
-                    "use `#[{kw_name}] fn name(ctx: &StepContext, ...)` and valid fixtures"
-                ))
-                .emit();
-            return TokenStream::new();
+            let span = err.span();
+            let mut enriched =
+                syn::Error::new(span, format!("invalid step function signature: {err}"));
+            enriched.combine(syn::Error::new(
+                span,
+                format!(
+                    "help: use `#[{kw_name}] fn name(ctx: &StepContext, ...)` and valid fixtures"
+                ),
+            ));
+            return enriched.into_compile_error().into();
         }
     };
 

--- a/crates/rstest-bdd-macros/src/macros/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/mod.rs
@@ -34,16 +34,10 @@ fn step_attr(attr: TokenStream, item: TokenStream, keyword: crate::StepKeyword) 
                 crate::StepKeyword::And => "and",
                 crate::StepKeyword::But => "but",
             };
-            let span = err.span();
-            let mut enriched =
-                syn::Error::new(span, format!("invalid step function signature: {err}"));
-            enriched.combine(syn::Error::new(
-                span,
-                format!(
-                    "help: use `#[{kw_name}] fn name(ctx: &StepContext, ...)` and valid fixtures"
-                ),
-            ));
-            return enriched.into_compile_error().into();
+            let help = format!(
+                "use `#[{kw_name}] fn name(ctx: &rstest_bdd::StepContext, ...)` and valid fixtures"
+            );
+            proc_macro_error::abort!(err.span(), "invalid step function signature: {}", err; help = help);
         }
     };
 

--- a/crates/rstest-bdd-macros/src/macros/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/mod.rs
@@ -21,6 +21,7 @@ use crate::utils::errors::error_to_tokens;
 fn step_attr(attr: TokenStream, item: TokenStream, keyword: crate::StepKeyword) -> TokenStream {
     let pattern = syn::parse_macro_input!(attr as syn::LitStr);
     #[cfg(feature = "compile-time-validation")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "compile-time-validation")))]
     crate::validation::steps::register_step(keyword, &pattern);
     let mut func = syn::parse_macro_input!(item as syn::ItemFn);
 

--- a/crates/rstest-bdd-macros/src/macros/scenario.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenario.rs
@@ -114,8 +114,15 @@ pub(crate) fn scenario(attr: TokenStream, item: TokenStream) -> TokenStream {
         Err(err) => return err.into(),
     };
 
-    let strict_validation = cfg!(feature = "strict-compile-time-validation");
-    if let Err(err) = crate::validation::steps::validate_steps_exist(&steps, strict_validation) {
+    #[cfg(feature = "strict-compile-time-validation")]
+    if let Err(err) = crate::validation::steps::validate_steps_exist(&steps, true) {
+        return err.into_compile_error().into();
+    }
+    #[cfg(all(
+        feature = "compile-time-validation",
+        not(feature = "strict-compile-time-validation")
+    ))]
+    if let Err(err) = crate::validation::steps::validate_steps_exist(&steps, false) {
         return err.into_compile_error().into();
     }
 

--- a/crates/rstest-bdd-macros/src/macros/scenario.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenario.rs
@@ -129,7 +129,7 @@ fn try_scenario(
 
 /// Canonicalise the feature path for stable diagnostics.
 ///
-/// ```rust
+/// ```rust,ignore
 /// # use std::path::{Path, PathBuf};
 /// # fn demo() {
 /// let path = PathBuf::from("features/example.feature");
@@ -149,7 +149,7 @@ fn canonical_feature_path(path: &Path) -> String {
 
 /// Validate registered steps when compile-time validation is enabled.
 ///
-/// ```rust,ignore
+/// ```rust,ignore,ignore
 /// let steps = Vec::new();
 /// let _ = validate_steps_compile_time(&steps);
 /// ```

--- a/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
@@ -30,6 +30,8 @@ impl PartialEq for ParsedStep {
     }
 }
 
+impl Eq for ParsedStep {}
+
 /// Name, steps, and optional examples extracted from a Gherkin scenario.
 pub(crate) struct ScenarioData {
     pub name: String,

--- a/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
@@ -8,12 +8,24 @@ use crate::utils::errors::error_to_tokens;
 use crate::validation::examples::validate_examples_in_feature_text;
 
 /// Step extracted from a scenario with optional arguments (data table and doc string).
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone)]
 pub(crate) struct ParsedStep {
     pub keyword: crate::StepKeyword,
     pub text: String,
     pub docstring: Option<String>,
     pub table: Option<Vec<Vec<String>>>,
+    #[cfg(feature = "compile-time-validation")]
+    /// Approximate span for diagnostics.
+    pub span: proc_macro2::Span,
+}
+
+impl PartialEq for ParsedStep {
+    fn eq(&self, other: &Self) -> bool {
+        self.keyword == other.keyword
+            && self.text == other.text
+            && self.docstring == other.docstring
+            && self.table == other.table
+    }
 }
 
 /// Name, steps, and optional examples extracted from a Gherkin scenario.
@@ -83,6 +95,8 @@ impl From<&Step> for ParsedStep {
             text: step.value.clone(),
             docstring,
             table,
+            #[cfg(feature = "compile-time-validation")]
+            span: proc_macro2::Span::call_site(),
         }
     }
 }

--- a/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
@@ -50,19 +50,17 @@ pub(crate) struct ScenarioData {
 /// meaning of the preceding step but remain distinct for later resolution.
 /// Matching is case-insensitive to tolerate unusual source casing.
 pub(crate) fn parse_step_keyword(kw: &str, ty: StepType) -> crate::StepKeyword {
-    match kw.trim() {
-        s if s.eq_ignore_ascii_case("and") => crate::StepKeyword::And,
-        s if s.eq_ignore_ascii_case("but") => crate::StepKeyword::But,
-        _ =>
-        {
-            #[expect(unreachable_patterns, reason = "panic on future StepType variants")]
-            match ty {
-                StepType::Given => crate::StepKeyword::Given,
-                StepType::When => crate::StepKeyword::When,
-                StepType::Then => crate::StepKeyword::Then,
-                _ => panic!("unsupported step type: {ty:?}"),
-            }
-        }
+    let lower = kw.trim().to_ascii_lowercase();
+    if lower == "and" {
+        return crate::StepKeyword::And;
+    }
+    if lower == "but" {
+        return crate::StepKeyword::But;
+    }
+    match ty {
+        StepType::Given => crate::StepKeyword::Given,
+        StepType::When => crate::StepKeyword::When,
+        StepType::Then => crate::StepKeyword::Then,
     }
 }
 

--- a/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
@@ -15,10 +15,12 @@ pub(crate) struct ParsedStep {
     pub docstring: Option<String>,
     pub table: Option<Vec<Vec<String>>>,
     #[cfg(feature = "compile-time-validation")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "compile-time-validation")))]
     /// Approximate span for diagnostics.
-    pub span: proc_macro2::Span,
+    pub(crate) span: proc_macro2::Span,
 }
 
+// Equality intentionally ignores `span` to ease test comparisons.
 impl PartialEq for ParsedStep {
     fn eq(&self, other: &Self) -> bool {
         self.keyword == other.keyword

--- a/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
@@ -20,7 +20,8 @@ pub(crate) struct ParsedStep {
     pub(crate) span: proc_macro2::Span,
 }
 
-// Equality intentionally ignores `span` to ease test comparisons.
+// Equality intentionally ignores `span` as spans vary between compilations.
+// Compare only semantic fields to keep tests stable; update if new fields are added.
 impl PartialEq for ParsedStep {
     fn eq(&self, other: &Self) -> bool {
         self.keyword == other.keyword

--- a/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
@@ -168,18 +168,21 @@ fn assert_feature_extraction(
             text: "a background step".to_string(),
             docstring: None,
             table: None,
+            span: proc_macro2::Span::call_site(),
         },
         ParsedStep {
             keyword: crate::StepKeyword::When,
             text: "an action".to_string(),
             docstring: None,
             table: None,
+            span: proc_macro2::Span::call_site(),
         },
         ParsedStep {
             keyword: crate::StepKeyword::Then,
             text: "a result".to_string(),
             docstring: None,
             table: None,
+            span: proc_macro2::Span::call_site(),
         },
     ],
     None
@@ -201,6 +204,7 @@ fn assert_feature_extraction(
             vec!["1".to_string(), "2".to_string()],
             vec!["3".to_string(), "4".to_string()],
         ]),
+        span: proc_macro2::Span::call_site(),
     }],
     None
 )]
@@ -218,6 +222,7 @@ fn assert_feature_extraction(
         text: "text".to_string(),
         docstring: Some("line1\nline2".to_string()),
         table: None,
+        span: proc_macro2::Span::call_site(),
     }],
     None
 )]
@@ -238,12 +243,14 @@ fn assert_feature_extraction(
             text: "setup".to_string(),
             docstring: Some("bg line1\nbg line2".to_string()),
             table: None,
+            span: proc_macro2::Span::call_site(),
         },
         ParsedStep {
             keyword: crate::StepKeyword::When,
             text: "an action".to_string(),
             docstring: None,
             table: None,
+            span: proc_macro2::Span::call_site(),
         },
     ],
     None
@@ -267,18 +274,21 @@ fn assert_feature_extraction(
             text: "first".into(),
             docstring: None,
             table: None,
+            span: proc_macro2::Span::call_site(),
         },
         ParsedStep {
             keyword: crate::StepKeyword::And,
             text: "second".into(),
             docstring: None,
             table: None,
+            span: proc_macro2::Span::call_site(),
         },
         ParsedStep {
             keyword: crate::StepKeyword::But,
             text: "negated".into(),
             docstring: None,
             table: None,
+            span: proc_macro2::Span::call_site(),
         },
     ],
     None
@@ -299,12 +309,14 @@ fn assert_feature_extraction(
             text: "first".into(),
             docstring: None,
             table: None,
+            span: proc_macro2::Span::call_site(),
         },
         ParsedStep {
             keyword: crate::StepKeyword::Then,
             text: "result".into(),
             docstring: None,
             table: None,
+            span: proc_macro2::Span::call_site(),
         },
     ],
     None

--- a/crates/rstest-bdd-macros/src/validation/mod.rs
+++ b/crates/rstest-bdd-macros/src/validation/mod.rs
@@ -2,4 +2,6 @@
 
 pub(crate) mod examples;
 pub(crate) mod parameters;
+#[cfg(feature = "compile-time-validation")]
+#[cfg_attr(docsrs, doc(cfg(feature = "compile-time-validation")))]
 pub(crate) mod steps;

--- a/crates/rstest-bdd-macros/src/validation/steps.rs
+++ b/crates/rstest-bdd-macros/src/validation/steps.rs
@@ -39,8 +39,8 @@ pub(crate) fn register_step(keyword: StepKeyword, pattern: &syn::LitStr) {
 ///
 /// In strict mode, missing steps cause compilation to fail. In non-strict mode,
 /// the function emits warnings but allows compilation to continue so scenarios
-/// can reference steps from other crates. Ambiguous step definitions always
-/// produce an error.
+/// can reference steps from other crates. Ambiguous step definitions within
+/// this crate always produce an error.
 ///
 /// # Errors
 /// Returns a `syn::Error` when `strict` is `true` and a step lacks a matching
@@ -109,10 +109,14 @@ fn create_strict_mode_error(missing: &[(proc_macro2::Span, String)]) -> Result<(
 
 fn emit_non_strict_warnings(missing: &[(proc_macro2::Span, String)]) {
     for (span, msg) in missing {
-        let _ = span; // reserved for future spanned diagnostics
+        let loc = span.start();
         #[expect(clippy::print_stderr, reason = "proc_macro::Diagnostic is unstable")]
         {
-            eprintln!("warning: {msg} (will be checked at runtime)");
+            eprintln!(
+                "warning: {msg}\n  --> line {} column {}\n",
+                loc.line,
+                loc.column + 1
+            );
         }
     }
 }

--- a/crates/rstest-bdd-macros/src/validation/steps.rs
+++ b/crates/rstest-bdd-macros/src/validation/steps.rs
@@ -113,7 +113,7 @@ fn emit_non_strict_warnings(missing: &[(proc_macro2::Span, String)]) {
         #[expect(clippy::print_stderr, reason = "proc_macro::Diagnostic is unstable")]
         {
             eprintln!(
-                "warning: {msg}\n  --> line {} column {}\n",
+                "[rstest-bdd][non-strict] {msg}\n  --> line {} column {}\n",
                 loc.line,
                 loc.column + 1
             );

--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_ambiguous_step.rs
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_ambiguous_step.rs
@@ -1,3 +1,4 @@
+//! Compile-fail fixture asserting ambiguous step detection for duplicate `given` steps.
 use rstest_bdd_macros::{given, scenario};
 
 #[given("a step")]

--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_ambiguous_step.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_ambiguous_step.stderr
@@ -1,7 +1,7 @@
 error: Ambiguous step definition for 'a step'. Matches: a step, a step
- --> tests/fixtures/scenario_ambiguous_step.rs:9:1
-  |
-9 | #[scenario(path = "../../../../crates/rstest-bdd-macros/tests/features/ambiguous.feature")]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> tests/fixtures/scenario_ambiguous_step.rs:10:1
+   |
+10 | #[scenario(path = "../../../../crates/rstest-bdd-macros/tests/features/ambiguous.feature")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/rstest-bdd-macros/tests/fixtures/step_nested_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_nested_pattern.stderr
@@ -3,5 +3,8 @@ error: invalid step function signature: unsupported parameter pattern; use a sim
    |
 11 | fn step_nested(User { coords: (x, y) }: User) {}
    |                ^^^^^^^^^^^^^^^^^^^^^^^
+error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
+  --> tests/fixtures/step_nested_pattern.rs:11:16
    |
-   = help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
+11 | fn step_nested(User { coords: (x, y) }: User) {}
+   |                ^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/rstest-bdd-macros/tests/fixtures/step_nested_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_nested_pattern.stderr
@@ -4,7 +4,7 @@ error: invalid step function signature: unsupported parameter pattern; use a sim
 11 | fn step_nested(User { coords: (x, y) }: User) {}
    |                ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
+error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
   --> tests/fixtures/step_nested_pattern.rs:11:16
    |
 11 | fn step_nested(User { coords: (x, y) }: User) {}

--- a/crates/rstest-bdd-macros/tests/fixtures/step_nested_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_nested_pattern.stderr
@@ -3,9 +3,5 @@ error: invalid step function signature: unsupported parameter pattern; use a sim
    |
 11 | fn step_nested(User { coords: (x, y) }: User) {}
    |                ^^^^^^^^^^^^^^^^^^^^^^^
-
-error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
-  --> tests/fixtures/step_nested_pattern.rs:11:16
    |
-11 | fn step_nested(User { coords: (x, y) }: User) {}
-   |                ^^^^^^^^^^^^^^^^^^^^^^^
+   = help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures

--- a/crates/rstest-bdd-macros/tests/fixtures/step_nested_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_nested_pattern.stderr
@@ -3,8 +3,5 @@ error: invalid step function signature: unsupported parameter pattern; use a sim
    |
 11 | fn step_nested(User { coords: (x, y) }: User) {}
    |                ^^^^^^^^^^^^^^^^^^^^^^^
-error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
-  --> tests/fixtures/step_nested_pattern.rs:11:16
    |
-11 | fn step_nested(User { coords: (x, y) }: User) {}
-   |                ^^^^^^^^^^^^^^^^^^^^^^^
+   = help: use `#[given] fn name(ctx: &rstest_bdd::StepContext, ...)` and valid fixtures

--- a/crates/rstest-bdd-macros/tests/fixtures/step_nested_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_nested_pattern.stderr
@@ -1,4 +1,10 @@
-error: invalid step function signature: unsupported parameter pattern; use a simple identifier (e.g., `arg: T`). help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures.
+error: invalid step function signature: unsupported parameter pattern; use a simple identifier (e.g., `arg: T`)
+  --> tests/fixtures/step_nested_pattern.rs:11:16
+   |
+11 | fn step_nested(User { coords: (x, y) }: User) {}
+   |                ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
   --> tests/fixtures/step_nested_pattern.rs:11:16
    |
 11 | fn step_nested(User { coords: (x, y) }: User) {}

--- a/crates/rstest-bdd-macros/tests/fixtures/step_struct_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_struct_pattern.stderr
@@ -4,7 +4,7 @@ error: invalid step function signature: unsupported parameter pattern; use a sim
 11 | fn step_with_struct(User { name }: User) {}
    |                     ^^^^^^^^^^^^^
 
-error: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
+error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
   --> tests/fixtures/step_struct_pattern.rs:11:21
    |
 11 | fn step_with_struct(User { name }: User) {}

--- a/crates/rstest-bdd-macros/tests/fixtures/step_struct_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_struct_pattern.stderr
@@ -3,5 +3,8 @@ error: invalid step function signature: unsupported parameter pattern; use a sim
    |
 11 | fn step_with_struct(User { name }: User) {}
    |                     ^^^^^^^^^^^^^
+error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
+  --> tests/fixtures/step_struct_pattern.rs:11:21
    |
-   = help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
+11 | fn step_with_struct(User { name }: User) {}
+   |                     ^^^^^^^^^^^^^

--- a/crates/rstest-bdd-macros/tests/fixtures/step_struct_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_struct_pattern.stderr
@@ -3,8 +3,5 @@ error: invalid step function signature: unsupported parameter pattern; use a sim
    |
 11 | fn step_with_struct(User { name }: User) {}
    |                     ^^^^^^^^^^^^^
-error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
-  --> tests/fixtures/step_struct_pattern.rs:11:21
    |
-11 | fn step_with_struct(User { name }: User) {}
-   |                     ^^^^^^^^^^^^^
+   = help: use `#[given] fn name(ctx: &rstest_bdd::StepContext, ...)` and valid fixtures

--- a/crates/rstest-bdd-macros/tests/fixtures/step_struct_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_struct_pattern.stderr
@@ -1,4 +1,10 @@
-error: invalid step function signature: unsupported parameter pattern; use a simple identifier (e.g., `arg: T`). help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures.
+error: invalid step function signature: unsupported parameter pattern; use a simple identifier (e.g., `arg: T`)
+  --> tests/fixtures/step_struct_pattern.rs:11:21
+   |
+11 | fn step_with_struct(User { name }: User) {}
+   |                     ^^^^^^^^^^^^^
+
+error: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
   --> tests/fixtures/step_struct_pattern.rs:11:21
    |
 11 | fn step_with_struct(User { name }: User) {}

--- a/crates/rstest-bdd-macros/tests/fixtures/step_struct_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_struct_pattern.stderr
@@ -3,9 +3,5 @@ error: invalid step function signature: unsupported parameter pattern; use a sim
    |
 11 | fn step_with_struct(User { name }: User) {}
    |                     ^^^^^^^^^^^^^
-
-error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
-  --> tests/fixtures/step_struct_pattern.rs:11:21
    |
-11 | fn step_with_struct(User { name }: User) {}
-   |                     ^^^^^^^^^^^^^
+   = help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures

--- a/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.stderr
@@ -3,8 +3,5 @@ error: invalid step function signature: unsupported parameter pattern; use a sim
   |
 8 | fn step_with_tuple((x, y): (i32, i32)) {}
   |                    ^^^^^^
-error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
- --> tests/fixtures/step_tuple_pattern.rs:8:20
   |
-8 | fn step_with_tuple((x, y): (i32, i32)) {}
-  |                    ^^^^^^
+  = help: use `#[given] fn name(ctx: &rstest_bdd::StepContext, ...)` and valid fixtures

--- a/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.stderr
@@ -1,4 +1,10 @@
-error: invalid step function signature: unsupported parameter pattern; use a simple identifier (e.g., `arg: T`). help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures.
+error: invalid step function signature: unsupported parameter pattern; use a simple identifier (e.g., `arg: T`)
+ --> tests/fixtures/step_tuple_pattern.rs:8:20
+  |
+8 | fn step_with_tuple((x, y): (i32, i32)) {}
+  |                    ^^^^^^
+
+error: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
  --> tests/fixtures/step_tuple_pattern.rs:8:20
   |
 8 | fn step_with_tuple((x, y): (i32, i32)) {}

--- a/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.stderr
@@ -3,5 +3,8 @@ error: invalid step function signature: unsupported parameter pattern; use a sim
   |
 8 | fn step_with_tuple((x, y): (i32, i32)) {}
   |                    ^^^^^^
+error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
+ --> tests/fixtures/step_tuple_pattern.rs:8:20
   |
-  = help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
+8 | fn step_with_tuple((x, y): (i32, i32)) {}
+  |                    ^^^^^^

--- a/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.stderr
@@ -4,7 +4,7 @@ error: invalid step function signature: unsupported parameter pattern; use a sim
 8 | fn step_with_tuple((x, y): (i32, i32)) {}
   |                    ^^^^^^
 
-error: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
+error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
  --> tests/fixtures/step_tuple_pattern.rs:8:20
   |
 8 | fn step_with_tuple((x, y): (i32, i32)) {}

--- a/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/step_tuple_pattern.stderr
@@ -3,9 +3,5 @@ error: invalid step function signature: unsupported parameter pattern; use a sim
   |
 8 | fn step_with_tuple((x, y): (i32, i32)) {}
   |                    ^^^^^^
-
-error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
- --> tests/fixtures/step_tuple_pattern.rs:8:20
   |
-8 | fn step_with_tuple((x, y): (i32, i32)) {}
-  |                    ^^^^^^
+  = help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures

--- a/crates/rstest-bdd-macros/tests/ui/datatable_after_docstring.stderr
+++ b/crates/rstest-bdd-macros/tests/ui/datatable_after_docstring.stderr
@@ -1,4 +1,10 @@
-error: invalid step function signature: DataTable must be declared before DocString to match Gherkin ordering. help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures.
+error: invalid step function signature: DataTable must be declared before DocString to match Gherkin ordering
+ --> tests/ui/datatable_after_docstring.rs:6:41
+  |
+6 | fn step(docstring: String, #[datatable] table: Vec<Vec<String>>) {}
+  |                                         ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
  --> tests/ui/datatable_after_docstring.rs:6:41
   |
 6 | fn step(docstring: String, #[datatable] table: Vec<Vec<String>>) {}

--- a/crates/rstest-bdd-macros/tests/ui/datatable_after_docstring.stderr
+++ b/crates/rstest-bdd-macros/tests/ui/datatable_after_docstring.stderr
@@ -3,9 +3,5 @@ error: invalid step function signature: DataTable must be declared before DocStr
   |
 6 | fn step(docstring: String, #[datatable] table: Vec<Vec<String>>) {}
   |                                         ^^^^^^^^^^^^^^^^^^^^^^^
-
-error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
- --> tests/ui/datatable_after_docstring.rs:6:41
   |
-6 | fn step(docstring: String, #[datatable] table: Vec<Vec<String>>) {}
-  |                                         ^^^^^^^^^^^^^^^^^^^^^^^
+  = help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures

--- a/crates/rstest-bdd-macros/tests/ui/datatable_after_docstring.stderr
+++ b/crates/rstest-bdd-macros/tests/ui/datatable_after_docstring.stderr
@@ -3,8 +3,5 @@ error: invalid step function signature: DataTable must be declared before DocStr
   |
 6 | fn step(docstring: String, #[datatable] table: Vec<Vec<String>>) {}
   |                                         ^^^^^^^^^^^^^^^^^^^^^^^
-error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
- --> tests/ui/datatable_after_docstring.rs:6:41
   |
-6 | fn step(docstring: String, #[datatable] table: Vec<Vec<String>>) {}
-  |                                         ^^^^^^^^^^^^^^^^^^^^^^^
+  = help: use `#[given] fn name(ctx: &rstest_bdd::StepContext, ...)` and valid fixtures

--- a/crates/rstest-bdd-macros/tests/ui/datatable_after_docstring.stderr
+++ b/crates/rstest-bdd-macros/tests/ui/datatable_after_docstring.stderr
@@ -3,5 +3,8 @@ error: invalid step function signature: DataTable must be declared before DocStr
   |
 6 | fn step(docstring: String, #[datatable] table: Vec<Vec<String>>) {}
   |                                         ^^^^^^^^^^^^^^^^^^^^^^^
+error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
+ --> tests/ui/datatable_after_docstring.rs:6:41
   |
-  = help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
+6 | fn step(docstring: String, #[datatable] table: Vec<Vec<String>>) {}
+  |                                         ^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/rstest-bdd-macros/tests/ui/datatable_after_docstring.stderr
+++ b/crates/rstest-bdd-macros/tests/ui/datatable_after_docstring.stderr
@@ -4,7 +4,7 @@ error: invalid step function signature: DataTable must be declared before DocStr
 6 | fn step(docstring: String, #[datatable] table: Vec<Vec<String>>) {}
   |                                         ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
+error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
  --> tests/ui/datatable_after_docstring.rs:6:41
   |
 6 | fn step(docstring: String, #[datatable] table: Vec<Vec<String>>) {}

--- a/crates/rstest-bdd-macros/tests/ui/datatable_duplicate.stderr
+++ b/crates/rstest-bdd-macros/tests/ui/datatable_duplicate.stderr
@@ -3,5 +3,8 @@ error: invalid step function signature: only one DataTable parameter is permitte
   |
 6 | fn step(#[datatable] first: Vec<Vec<String>>, #[datatable] second: Vec<Vec<String>>) {}
   |                                                            ^^^^^^^^^^^^^^^^^^^^^^^^
+error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
+ --> tests/ui/datatable_duplicate.rs:6:60
   |
-  = help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
+6 | fn step(#[datatable] first: Vec<Vec<String>>, #[datatable] second: Vec<Vec<String>>) {}
+  |                                                            ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/rstest-bdd-macros/tests/ui/datatable_duplicate.stderr
+++ b/crates/rstest-bdd-macros/tests/ui/datatable_duplicate.stderr
@@ -3,9 +3,5 @@ error: invalid step function signature: only one DataTable parameter is permitte
   |
 6 | fn step(#[datatable] first: Vec<Vec<String>>, #[datatable] second: Vec<Vec<String>>) {}
   |                                                            ^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
- --> tests/ui/datatable_duplicate.rs:6:60
   |
-6 | fn step(#[datatable] first: Vec<Vec<String>>, #[datatable] second: Vec<Vec<String>>) {}
-  |                                                            ^^^^^^^^^^^^^^^^^^^^^^^^
+  = help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures

--- a/crates/rstest-bdd-macros/tests/ui/datatable_duplicate.stderr
+++ b/crates/rstest-bdd-macros/tests/ui/datatable_duplicate.stderr
@@ -3,8 +3,5 @@ error: invalid step function signature: only one DataTable parameter is permitte
   |
 6 | fn step(#[datatable] first: Vec<Vec<String>>, #[datatable] second: Vec<Vec<String>>) {}
   |                                                            ^^^^^^^^^^^^^^^^^^^^^^^^
-error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
- --> tests/ui/datatable_duplicate.rs:6:60
   |
-6 | fn step(#[datatable] first: Vec<Vec<String>>, #[datatable] second: Vec<Vec<String>>) {}
-  |                                                            ^^^^^^^^^^^^^^^^^^^^^^^^
+  = help: use `#[given] fn name(ctx: &rstest_bdd::StepContext, ...)` and valid fixtures

--- a/crates/rstest-bdd-macros/tests/ui/datatable_duplicate.stderr
+++ b/crates/rstest-bdd-macros/tests/ui/datatable_duplicate.stderr
@@ -1,4 +1,10 @@
-error: invalid step function signature: only one DataTable parameter is permitted. help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures.
+error: invalid step function signature: only one DataTable parameter is permitted
+ --> tests/ui/datatable_duplicate.rs:6:60
+  |
+6 | fn step(#[datatable] first: Vec<Vec<String>>, #[datatable] second: Vec<Vec<String>>) {}
+  |                                                            ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
  --> tests/ui/datatable_duplicate.rs:6:60
   |
 6 | fn step(#[datatable] first: Vec<Vec<String>>, #[datatable] second: Vec<Vec<String>>) {}

--- a/crates/rstest-bdd-macros/tests/ui/datatable_duplicate.stderr
+++ b/crates/rstest-bdd-macros/tests/ui/datatable_duplicate.stderr
@@ -4,7 +4,7 @@ error: invalid step function signature: only one DataTable parameter is permitte
 6 | fn step(#[datatable] first: Vec<Vec<String>>, #[datatable] second: Vec<Vec<String>>) {}
   |                                                            ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
+error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
  --> tests/ui/datatable_duplicate.rs:6:60
   |
 6 | fn step(#[datatable] first: Vec<Vec<String>>, #[datatable] second: Vec<Vec<String>>) {}

--- a/crates/rstest-bdd-macros/tests/ui/datatable_duplicate_attr.stderr
+++ b/crates/rstest-bdd-macros/tests/ui/datatable_duplicate_attr.stderr
@@ -3,8 +3,5 @@ error: invalid step function signature: duplicate `#[datatable]` attribute
   |
 6 | fn step(#[datatable] #[datatable] table: Vec<Vec<String>>) {}
   |                                   ^^^^^
-error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
- --> tests/ui/datatable_duplicate_attr.rs:6:35
   |
-6 | fn step(#[datatable] #[datatable] table: Vec<Vec<String>>) {}
-  |                                   ^^^^^
+  = help: use `#[given] fn name(ctx: &rstest_bdd::StepContext, ...)` and valid fixtures

--- a/crates/rstest-bdd-macros/tests/ui/datatable_duplicate_attr.stderr
+++ b/crates/rstest-bdd-macros/tests/ui/datatable_duplicate_attr.stderr
@@ -3,5 +3,8 @@ error: invalid step function signature: duplicate `#[datatable]` attribute
   |
 6 | fn step(#[datatable] #[datatable] table: Vec<Vec<String>>) {}
   |                                   ^^^^^
+error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
+ --> tests/ui/datatable_duplicate_attr.rs:6:35
   |
-  = help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
+6 | fn step(#[datatable] #[datatable] table: Vec<Vec<String>>) {}
+  |                                   ^^^^^

--- a/crates/rstest-bdd-macros/tests/ui/datatable_duplicate_attr.stderr
+++ b/crates/rstest-bdd-macros/tests/ui/datatable_duplicate_attr.stderr
@@ -3,9 +3,5 @@ error: invalid step function signature: duplicate `#[datatable]` attribute
   |
 6 | fn step(#[datatable] #[datatable] table: Vec<Vec<String>>) {}
   |                                   ^^^^^
-
-error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
- --> tests/ui/datatable_duplicate_attr.rs:6:35
   |
-6 | fn step(#[datatable] #[datatable] table: Vec<Vec<String>>) {}
-  |                                   ^^^^^
+  = help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures

--- a/crates/rstest-bdd-macros/tests/ui/datatable_duplicate_attr.stderr
+++ b/crates/rstest-bdd-macros/tests/ui/datatable_duplicate_attr.stderr
@@ -4,7 +4,7 @@ error: invalid step function signature: duplicate `#[datatable]` attribute
 6 | fn step(#[datatable] #[datatable] table: Vec<Vec<String>>) {}
   |                                   ^^^^^
 
-error: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
+error: help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
  --> tests/ui/datatable_duplicate_attr.rs:6:35
   |
 6 | fn step(#[datatable] #[datatable] table: Vec<Vec<String>>) {}

--- a/crates/rstest-bdd-macros/tests/ui/datatable_duplicate_attr.stderr
+++ b/crates/rstest-bdd-macros/tests/ui/datatable_duplicate_attr.stderr
@@ -1,4 +1,10 @@
-error: invalid step function signature: duplicate `#[datatable]` attribute. help: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures.
+error: invalid step function signature: duplicate `#[datatable]` attribute
+ --> tests/ui/datatable_duplicate_attr.rs:6:35
+  |
+6 | fn step(#[datatable] #[datatable] table: Vec<Vec<String>>) {}
+  |                                   ^^^^^
+
+error: use `#[given] fn name(ctx: &StepContext, ...)` and valid fixtures
  --> tests/ui/datatable_duplicate_attr.rs:6:35
   |
 6 | fn step(#[datatable] #[datatable] table: Vec<Vec<String>>) {}


### PR DESCRIPTION
## Summary
- add `compile-time-validation` feature and gate strict validation on top of it
- hide step registry and registration behind compile-time feature flags
- track Gherkin step spans for clearer diagnostics and fixture documentation

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b481861234832281c5927264db2c17

## Summary by Sourcery

Gate step validation behind new compile-time features, enhance diagnostics by tracking step spans, and update macros, parsing, validation logic, and tests to support the new configuration flags and span tracking

New Features:
- Add compile-time-validation feature to enable Gherkin step validation at compile time
- Add strict-compile-time-validation feature to enforce strict step validation

Enhancements:
- Record source spans in ParsedStep and use them to emit errors and warnings at the precise step location
- Guard step registry, registration, and validation code behind the compile-time-validation feature flags
- Replace runtime cfg! checks with compile-time cfg attributes in the scenario macro for clearer gating
- Update codegen example to include the new span field in ParsedStep
- Implement custom PartialEq for ParsedStep to exclude span from equality comparisons

Tests:
- Add serial attribute to validation tests to avoid registry conflicts
- Initialize span field in parsing and validation tests under the compile-time-validation feature