### PR TITLE
Clarify compile-time registry and tighten user guide punctuation

### DIFF
--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -501,7 +501,7 @@ fragility of build scripts, and allows for fully decoupled step definitions.
 
 To surface missing steps earlier, the macros crate now maintains a small,
 compile‑time registry, and each `#[given]`, `#[when]`, and `#[then]` invocation
-records its keyword and pattern there. When `#[scenario]` expands it consults
+records its keyword and pattern there. When `#[scenario]` expands, it consults
 this registry and emits a `compile_error!` for any Gherkin step that lacks a
 unique definition. Because the registry only sees steps from the current
 compilation unit, each entry stores the originating crate’s identifier to avoid

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -215,9 +215,10 @@ scenario runs its steps sequentially in the order defined in the feature file.
 By default, missing steps emit a compile‑time warning and are checked again at
 runtime, so steps can live in other crates. Enabling the
 `strict-compile-time-validation` feature on `rstest-bdd-macros` turns those
-warnings into `compile_error!`s when all step definitions are local, preventing
-behaviour specifications from silently drifting from the code while still
-permitting cross‑crate step sharing.
+warnings into `compile_error!`s for any step not defined in the current crate,
+preventing behaviour specifications from silently drifting from the code.
+Scenarios that rely on step definitions from other crates will therefore fail
+to compile.
 
 To enable strict checking add the feature to your `dev-dependencies`:
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -85,11 +85,11 @@ a global registry. The wrapper captures the step keyword, pattern string and
 associated fixtures and uses the `inventory` crate to publish them for later
 lookup.
 
-> **Ordering note:** Step macros expand as the compiler parses the module. A
-> `#[scenario]` must therefore appear after all of its referenced step
-> definitions in the same module; otherwise the validation pass will not see
-> those steps and compilation will fail. The [`scenario_out_of_order` UI
-> test](../crates/rstest-bdd-macros/tests/fixtures/scenario_out_of_order.rs)
+> **Ordering note:** Step macros expand as the compiler parses the module.
+> Therefore, a `#[scenario]` must appear after all of its referenced step
+> definitions in the same module; otherwise, the validation pass will not see
+> those steps and compilation will fail. The
+> [`scenario_out_of_order` UI test](../crates/rstest-bdd-macros/tests/fixtures/scenario_out_of_order.rs)
 > demonstrates this constraint.
 
 ### Fixtures and the `#[from]` attribute
@@ -167,9 +167,9 @@ the following steps:
 2. For each step in the scenario (according to the `Given‑When‑Then` sequence),
    look up a matching step function by `(keyword, pattern)` in the registry. A
    missing step causes the macro to emit a compile‑time error such as
-   `No matching step definition found for: Given ""`, allowing detection of
-   incomplete implementations before tests run. Multiple matching definitions
-   likewise produce an error.
+   `No matching step definition found for: Given an undefined step`, allowing
+   detection of incomplete implementations before tests run. Multiple matching
+   definitions likewise produce an error.
 
 3. Invoke the registered step function with the `StepContext` so that fixtures
    are available inside the step.
@@ -213,11 +213,11 @@ behave like other `rstest` tests; they honour `#[tokio::test]` or
 `#[async_std::test]` attributes if applied to the original function. Each
 scenario runs its steps sequentially in the order defined in the feature file.
 By default, missing steps emit a compile‑time warning and are checked again at
-runtime so steps can live in other crates. Enabling the
+runtime, so steps can live in other crates. Enabling the
 `strict-compile-time-validation` feature on `rstest-bdd-macros` turns those
-warnings into `compile_error!`s when all step definitions are local. This
-prevents behaviour specifications from silently drifting from the code while
-still permitting cross‑crate step sharing.
+warnings into `compile_error!`s when all step definitions are local, preventing
+behaviour specifications from silently drifting from the code while still
+permitting cross‑crate step sharing.
 
 To enable strict checking add the feature to your `dev-dependencies`:
 


### PR DESCRIPTION
## Summary
- clarify local compile-time registry and inventory's runtime role
- smooth ordering and validation notes in the user guide
- document exact missing-step diagnostic and strict validation behaviour

## Testing
- `make fmt`
- `make markdownlint`
- `make nixie`
- `make lint`
- `make test` *(fails: validation::steps::tests::errors_when_step_ambiguous)*
- `RUSTFLAGS="-D warnings" cargo test --workspace --all-targets --all-features -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_68b4819dfcb88322bb730c73381dd8e6

## Summary by Sourcery

Improve documentation to clarify the compile-time registry mechanics and strict validation feature, tighten user guide phrasing and punctuation, and standardize missing-step diagnostic messages

Documentation:
- Clarify compile-time registry behavior, metadata storage, and its separation from runtime inventory usage
- Describe strict-compile-time-validation feature that converts missing-step warnings into errors for local definitions while retaining cross-crate workflows
- Refine user guide wording and punctuation in ordering and validation notes for improved readability
- Update diagnostic examples to show exact error messages for undefined or ambiguous steps