### PR TITLE
Skip failing test targets during step discovery

### DIFF
--- a/crates/cargo-bdd/src/main.rs
+++ b/crates/cargo-bdd/src/main.rs
@@ -217,7 +217,7 @@ fn build_test_target(package: &Package, target: &Target) -> Result<Vec<PathBuf>>
         "test",
         "--no-run",
         "--message-format=json",
-        "--all-features",
+        "--all-features", // include optional diagnostics
         "--package",
         &package.name,
         "--test",
@@ -243,11 +243,12 @@ fn build_test_target(package: &Package, target: &Target) -> Result<Vec<PathBuf>>
         )
     })?;
     if !status.success() {
-        bail!(
-            "cargo test failed for target {} in package {}",
-            target.name,
-            package.name
+        // Ignore failing targets so incompatible crates do not break step discovery
+        eprintln!(
+            "warning: cargo test failed for target {} in package {}; skipping",
+            target.name, package.name
         );
+        return Ok(Vec::new());
     }
     Ok(bins)
 }


### PR DESCRIPTION
## Summary
- skip test targets that fail to compile so step discovery survives incompatible crates

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b782c7d0408322b6d8bc6ca229f2ba

## Summary by Sourcery

Skip failing test targets during step discovery to prevent incompatible crates from breaking the process

Enhancements:
- Log a warning and return an empty list when a test target fails to compile instead of bailing out
- Annotate the "--all-features" flag to indicate inclusion of optional diagnostics