### PR TITLE
Cache canonical feature path lookups

### DIFF
--- a/crates/rstest-bdd-macros/src/macros/scenario.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenario.rs
@@ -188,9 +188,10 @@ fn canonical_feature_path(path: &Path) -> String {
         return cached;
     }
 
-    let canonical = std::env::var("CARGO_MANIFEST_DIR")
-        .ok()
-        .map(PathBuf::from)
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").ok().map(PathBuf::from);
+
+    let canonical = manifest_dir
+        .as_ref()
         .map(|d| d.join(path))
         .and_then(|p| std::fs::canonicalize(&p).ok())
         .unwrap_or_else(|| PathBuf::from(path))


### PR DESCRIPTION
## Summary
- cache canonical feature paths to avoid repeated filesystem lookups
- test canonical path caching

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b8ddb57f1c8322af8c8301fc9a4d5b

## Summary by Sourcery

Cache canonical feature paths to reduce filesystem lookups and add tests for the caching behavior.

Enhancements:
- Introduce a mutex-protected in-memory cache for canonical_feature_path to reuse computed paths

Tests:
- Import serial_test and add a test to verify that canonical_feature_path caches results across calls even after the source file is removed