### PR TITLE
Document internationalisation roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -189,6 +189,10 @@ diagnostic messages.
 - [ ] **Localization of Library Messages with Fluent**
 
   - [ ] Integrate the `i18n-embed`, `rust-embed`, and `fluent` crates.
+  - [ ] Enable required features:
+        `i18n-embed = { features = ["fluent-system", "desktop-requester"] }`.
+  - [ ] Pin minimum supported versions in `Cargo.toml`.
+  - [ ] Add a minimal `Cargo.toml` example to the docs.
 
   - [ ] Create `.ftl` resource files under an `i18n/` directory for all
     user-facing diagnostic messages. If the macros crate also emits messages,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -167,15 +167,15 @@ improves the developer experience.
     discover all `.feature` files in a directory and generate a test module
     containing a test function for every `Scenario` found.
 
-## Phase 4: Internationalisation and Localisation
+## Phase 4: Internationalization and Localization
 
-This phase introduces full internationalisation (i18n) and localisation (l10n)
+This phase introduces full internationalization (i18n) and localization (l10n)
 support, enabling the use of non-English Gherkin and providing translated
 diagnostic messages.
 
-- [ ] **Foundational Gherkin Internationalisation**
+- [ ] **Foundational Gherkin Internationalization**
 
-  - [ ] Implement language detection in the feature file parser by recognising
+  - [ ] Implement language detection in the feature file parser by recognizing
     and respecting the `# language: <lang>` declaration.
 
   - [ ] Refactor keyword parsing to be language-aware, relying on the
@@ -183,29 +183,34 @@ diagnostic messages.
 
   - [ ] Add a comprehensive test suite with `.feature` files in multiple
     languages (e.g., French, German, Spanish) to validate correct parsing and
-    execution.
+    execution. These tests run in CI to maintain coverage as languages are
+    added.
 
-- [ ] **Localisation of Library Messages with Fluent**
+- [ ] **Localization of Library Messages with Fluent**
 
   - [ ] Integrate the `i18n-embed`, `rust-embed`, and `fluent` crates.
 
   - [ ] Create `.ftl` resource files under an `i18n/` directory for all
-    user-facing diagnostic messages.
+    user-facing diagnostic messages. If the macros crate also emits messages,
+    maintain a separate `i18n/` in `rstest-bdd-macros` or introduce a shared
+    `rstest-bdd-i18n` crate to host common assets.
 
-  - [ ] Use `rust-embed` to bundle the localisation resources directly into the
+  - [ ] Use `rust-embed` to bundle the localization resources directly into the
     library binary.
+
+  - [ ] Missing translation keys or unsupported locales fall back to English.
 
   - [ ] Implement the `I18nAssets` trait on a dedicated struct to make Fluent
     resources discoverable.
 
-  - [ ] Replace all hardcoded error and warning strings in procedural macros
-    with calls to a `FluentLanguageLoader`, which will be initialised at
-    compile time based on the user's environment.
+  - [ ] Keep procedural macro diagnostics in English for deterministic builds.
+    Localize user-facing runtime messages using a `FluentLanguageLoader` at
+    runtime.
 
 - [ ] **Documentation and User Guidance**
 
   - [ ] Update `README.md` and `docs/users-guide.md` with a new section
-    detailing how to use the internationalisation features.
+    detailing how to use the internationalization features.
 
   - [ ] Add a new example crate to demonstrate writing and running a BDD test
     suite using a non-English language.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -167,7 +167,53 @@ improves the developer experience.
     discover all `.feature` files in a directory and generate a test module
     containing a test function for every `Scenario` found.
 
-## Phase 4: Ergonomics and Developer Experience
+## Phase 4: Internationalisation and Localisation
+
+This phase introduces full internationalisation (i18n) and localisation (l10n)
+support, enabling the use of non-English Gherkin and providing translated
+diagnostic messages.
+
+- [ ] **Foundational Gherkin Internationalisation**
+
+  - [ ] Implement language detection in the feature file parser by recognising
+    and respecting the `# language: <lang>` declaration.
+
+  - [ ] Refactor keyword parsing to be language-aware, relying on the
+    `gherkin` crate's `StepType` rather than hardcoded English strings.
+
+  - [ ] Add a comprehensive test suite with `.feature` files in multiple
+    languages (e.g., French, German, Spanish) to validate correct parsing and
+    execution.
+
+- [ ] **Localisation of Library Messages with Fluent**
+
+  - [ ] Integrate the `i18n-embed`, `rust-embed`, and `fluent` crates.
+
+  - [ ] Create `.ftl` resource files under an `i18n/` directory for all
+    user-facing diagnostic messages.
+
+  - [ ] Use `rust-embed` to bundle the localisation resources directly into the
+    library binary.
+
+  - [ ] Implement the `I18nAssets` trait on a dedicated struct to make Fluent
+    resources discoverable.
+
+  - [ ] Replace all hardcoded error and warning strings in procedural macros
+    with calls to a `FluentLanguageLoader`, which will be initialised at
+    compile time based on the user's environment.
+
+- [ ] **Documentation and User Guidance**
+
+  - [ ] Update `README.md` and `docs/users-guide.md` with a new section
+    detailing how to use the internationalisation features.
+
+  - [ ] Add a new example crate to demonstrate writing and running a BDD test
+    suite using a non-English language.
+
+  - [ ] Update `CONTRIBUTING.md` with guidelines for adding and maintaining
+    translations for new diagnostic messages.
+
+## Phase 5: Ergonomics and Developer Experience
 
 This phase focuses on reducing boilerplate and improving the developer
 experience by introducing more powerful and intuitive APIs.
@@ -206,7 +252,7 @@ experience by introducing more powerful and intuitive APIs.
     macro to allow multiple placeholders from a step pattern to be parsed
     directly into the fields of a struct, simplifying step function signatures.
 
-### Post-Core Implementation: Extensions & Tooling
+## Phase 6: Extensions & Tooling
 
 These tasks can be addressed after the core framework is stable and are aimed
 at improving maintainability and IDE integration.

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1457,45 +1457,47 @@ Public APIs are re‑exported from `lib.rs` so consumers continue to import from
 
 All modules use en‑GB spelling and include `//!` module‑level documentation.
 
-## Part 4: Internationalisation and Localisation Roadmap
+## Part 4: Internationalization and Localization Roadmap
 
-### 4.1 Phase 1: Foundational Gherkin Internationalisation
+### 4.1 Phase 1: Foundational Gherkin Internationalization (target v0.4)
 
 - **Language detection:** Update the macro parser to honour the optional
   `# language: <lang>` declaration in feature files. The parser creates a
   language‑aware `gherkin::GherkinEnv` and defaults to English when the
   declaration is absent to preserve backwards compatibility.
 - **Language‑aware keyword parsing:** Refactor `StepKeyword` parsing to rely on
-  `gherkin::StepType`, allowing localised keywords such as `Étant donné` and
+  `gherkin::StepType`, allowing localized keywords such as `Étant donné` and
   `Gegeben sei` to map to the correct step types.
 - **Testing and validation:** Introduce multilingual feature files, including
   French, German, and Spanish, to validate that `Given`, `When`, `Then`, `And`,
-  and `But` are correctly recognised in each language.
+  and `But` are correctly recognized in each language. These scenarios will run
+  in CI to maintain coverage as new languages are added.
 
-### 4.2 Phase 2: Localisation of Library Messages with Fluent
+### 4.2 Phase 2: Localization of Library Messages with Fluent (target v0.5)
 
 - **Dependency integration:** Add `i18n-embed`, `rust-embed`, and `fluent` as
-  dependencies to supply localisation infrastructure.
-- **Localisation resource creation:** Create an `i18n/<locale>/` hierarchy in
+  dependencies to supply localization infrastructure.
+- **Localization resource creation:** Create an `i18n/<locale>/` hierarchy in
   the `rstest-bdd` crate containing Fluent translation files with identifiers
-  such as `error-missing-step`.
+  such as `error-missing-step`. If the macros crate also emits messages,
+  maintain a separate `i18n/` in `rstest-bdd-macros` or introduce a shared
+  `rstest-bdd-i18n` crate to host common assets.
 - **Resource embedding and loading:** Embed the `i18n` directory using
-  `rust-embed` and expose it through a `Localisations` struct implementing
-  `I18nAssets` so the Fluent loader can discover translations. The approach
-  follows the pattern in `docs/localizable-rust-libraries-with-fluent.md`.
-- **Refactor diagnostic messages:** Replace hard‑coded strings in the macros
-  with lookups via `FluentLanguageLoader`, initialised from the `LANG`
-  environment variable. For example,
-  `loader.lookup("error-missing-step", None)` retrieves translated diagnostics
-  at compile time.
+  `rust-embed` and expose it through a `Localizations` struct implementing
+  `I18nAssets` so the Fluent loader can discover translations. Missing keys or
+  unsupported locales fall back to English.
+- **Refactor diagnostic messages:** Keep proc‑macro diagnostics stable and in
+  English for deterministic builds. Localize user‑facing runtime messages in
+  the `rstest-bdd` crate using `FluentLanguageLoader` and `i18n-embed`'s locale
+  requesters. Avoid compile‑time locale switches in macros.
 
-### 4.3 Phase 3: Documentation and User Guidance
+### 4.3 Phase 3: Documentation and User Guidance (target v0.6)
 
 - **Update user documentation:** Extend `README.md` and `docs/users-guide.md`
   with guidance on writing non‑English feature files and selecting locales for
-  compiler messages.
+  runtime diagnostics.
 - **Provide multilingual examples:** Add a new example test suite under
-  `/examples` showcasing a non‑English Gherkin file and its localised
+  `/examples` showcasing a non‑English Gherkin file and its localized
   diagnostics.
 - **Update contributor guidelines:** Amend `CONTRIBUTING.md` with instructions
   for updating translations when new user‑facing messages are introduced.

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1457,6 +1457,49 @@ Public APIs are re‑exported from `lib.rs` so consumers continue to import from
 
 All modules use en‑GB spelling and include `//!` module‑level documentation.
 
+## Part 4: Internationalisation and Localisation Roadmap
+
+### 4.1 Phase 1: Foundational Gherkin Internationalisation
+
+- **Language detection:** Update the macro parser to honour the optional
+  `# language: <lang>` declaration in feature files. The parser creates a
+  language‑aware `gherkin::GherkinEnv` and defaults to English when the
+  declaration is absent to preserve backwards compatibility.
+- **Language‑aware keyword parsing:** Refactor `StepKeyword` parsing to rely on
+  `gherkin::StepType`, allowing localised keywords such as `Étant donné` and
+  `Gegeben sei` to map to the correct step types.
+- **Testing and validation:** Introduce multilingual feature files, including
+  French, German, and Spanish, to validate that `Given`, `When`, `Then`, `And`,
+  and `But` are correctly recognised in each language.
+
+### 4.2 Phase 2: Localisation of Library Messages with Fluent
+
+- **Dependency integration:** Add `i18n-embed`, `rust-embed`, and `fluent` as
+  dependencies to supply localisation infrastructure.
+- **Localisation resource creation:** Create an `i18n/<locale>/` hierarchy in
+  the `rstest-bdd` crate containing Fluent translation files with identifiers
+  such as `error-missing-step`.
+- **Resource embedding and loading:** Embed the `i18n` directory using
+  `rust-embed` and expose it through a `Localisations` struct implementing
+  `I18nAssets` so the Fluent loader can discover translations. The approach
+  follows the pattern in `docs/localizable-rust-libraries-with-fluent.md`.
+- **Refactor diagnostic messages:** Replace hard‑coded strings in the macros
+  with lookups via `FluentLanguageLoader`, initialised from the `LANG`
+  environment variable. For example,
+  `loader.lookup("error-missing-step", None)` retrieves translated diagnostics
+  at compile time.
+
+### 4.3 Phase 3: Documentation and User Guidance
+
+- **Update user documentation:** Extend `README.md` and `docs/users-guide.md`
+  with guidance on writing non‑English feature files and selecting locales for
+  compiler messages.
+- **Provide multilingual examples:** Add a new example test suite under
+  `/examples` showcasing a non‑English Gherkin file and its localised
+  diagnostics.
+- **Update contributor guidelines:** Amend `CONTRIBUTING.md` with instructions
+  for updating translations when new user‑facing messages are introduced.
+
 ## **Works cited**
 
 [^1]: A Complete Guide to Behaviour-Driven Testing With Pytest BDD, accessed on

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1477,6 +1477,14 @@ All modules use en‑GB spelling and include `//!` module‑level documentation.
 
 - **Dependency integration:** Add `i18n-embed`, `rust-embed`, and `fluent` as
   dependencies to supply localization infrastructure.
+
+  ```toml
+  [dependencies]
+  i18n-embed = { version = "0.16", features = ["fluent-system", "desktop-requester"] }
+  rust-embed = "8"
+  fluent = "0.17"
+  ```
+
 - **Localization resource creation:** Create an `i18n/<locale>/` hierarchy in
   the `rstest-bdd` crate containing Fluent translation files with identifiers
   such as `error-missing-step`. If the macros crate also emits messages,


### PR DESCRIPTION
## Summary
- outline internationalisation and localisation strategy

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68b9e18aff108322adbb45de2eca5ec6

## Summary by Sourcery

Document a 3-phase internationalisation and localisation roadmap for rstest-bdd, covering multilingual Gherkin parsing, Fluent-based message localisation, and updated user guidance.

Documentation:
- Add Part 4 to rstest-bdd-design.md outlining Phase 1 for language-aware Gherkin parsing and multilingual feature tests
- Describe Phase 2 for integrating i18n-embed, rust-embed, and Fluent to embed and load localized diagnostics
- Detail Phase 3 for updating README, user guide, examples, and contributor guidelines to support non-English usage