### PR TITLE
Speed up macro step lookup

### DIFF
--- a/crates/rstest-bdd-macros/src/validation/steps.rs
+++ b/crates/rstest-bdd-macros/src/validation/steps.rs
@@ -248,7 +248,8 @@ fn format_ambiguous_step_error(matches: &[&'static StepPattern], step: &ParsedSt
         step.text,
         patterns
             .iter()
-            .map(|p| format!("  - {p}"))
+            // Do not indent bullet lines to make matching consistent.
+            .map(|p| format!("- {p}"))
             .collect::<Vec<_>>()
             .join("\n")
     );

--- a/crates/rstest-bdd-macros/src/validation/steps.rs
+++ b/crates/rstest-bdd-macros/src/validation/steps.rs
@@ -41,8 +41,7 @@ impl CrateDefs {
 /// total allocation is bounded by the step definitions registered in the
 /// current compilation session. Entries are grouped by crate to enable
 /// fast, crate-scoped lookups during validation.
-static REGISTERED: LazyLock<Mutex<Registry>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+static REGISTERED: LazyLock<Mutex<Registry>> = LazyLock::new(|| Mutex::new(HashMap::new()));
 static CURRENT_CRATE_ID: LazyLock<Box<str>> =
     LazyLock::new(|| normalise_crate_id(&current_crate_id_raw()));
 

--- a/crates/rstest-bdd-macros/src/validation/steps.rs
+++ b/crates/rstest-bdd-macros/src/validation/steps.rs
@@ -191,7 +191,7 @@ fn create_strict_mode_error(missing: &[(proc_macro2::Span, String)]) -> Result<(
         }
         _ => missing
             .iter()
-            .map(|(_, m)| format!("• {m}"))
+            .map(|(_, m)| format!("  - {m}"))
             .collect::<Vec<_>>()
             .join("\n"),
     };
@@ -279,7 +279,7 @@ fn build_missing_step_message(
     possible_matches: &[&str],
 ) -> String {
     let mut msg = format!(
-        "No matching step definition found for: {} {}",
+        "No matching step definition found for '{} {}'",
         fmt_keyword(resolved),
         step.text
     );

--- a/crates/rstest-bdd-macros/src/validation/steps.rs
+++ b/crates/rstest-bdd-macros/src/validation/steps.rs
@@ -221,7 +221,6 @@ fn has_matching_step_definition(
     let matches: Vec<&'static StepPattern> = patterns
         .iter()
         .copied()
-        .filter(|p| p.regex().is_match(text))
         .filter(|p| extract_placeholders(p, text.into()).is_ok())
         .collect();
     match matches.len() {

--- a/crates/rstest-bdd-macros/src/validation/steps/tests.rs
+++ b/crates/rstest-bdd-macros/src/validation/steps/tests.rs
@@ -77,7 +77,7 @@ fn errors_when_step_ambiguous() {
         Ok(()) => panic!("expected ambiguous step error"),
     };
     assert!(err.contains("Ambiguous step definition"));
-    assert!(err.contains("Matches: a step"));
+    assert!(err.contains("- a step"));
     assert!(validate_steps_exist(&steps, true).is_err());
 }
 

--- a/crates/rstest-bdd-macros/src/validation/steps/tests.rs
+++ b/crates/rstest-bdd-macros/src/validation/steps/tests.rs
@@ -77,7 +77,8 @@ fn errors_when_step_ambiguous() {
     };
     assert!(err.contains("Ambiguous step definition"));
     assert!(err.contains("- a step"));
-    let bullet_count = err.lines().filter(|l| l.trim() == "- a step").count();
+    // Count only lines that begin with the bullet, ignoring indented/reformatted lines.
+    let bullet_count = err.lines().filter(|l| l.starts_with("- a step")).count();
     assert_eq!(bullet_count, 2, "expected two bullet matches");
     assert!(validate_steps_exist(&steps, true).is_err());
 }

--- a/crates/rstest-bdd-macros/src/validation/steps/tests.rs
+++ b/crates/rstest-bdd-macros/src/validation/steps/tests.rs
@@ -1,3 +1,4 @@
+//! Tests for step validation: basic success, strict-mode errors, ambiguity and invalid patterns.
 use super::*;
 use rstest::rstest;
 use serial_test::serial;
@@ -78,6 +79,8 @@ fn errors_when_step_ambiguous() {
     };
     assert!(err.contains("Ambiguous step definition"));
     assert!(err.contains("- a step"));
+    let bullet_count = err.lines().filter(|l| l.trim() == "- a step").count();
+    assert_eq!(bullet_count, 2, "expected two bullet matches");
     assert!(validate_steps_exist(&steps, true).is_err());
 }
 

--- a/crates/rstest-bdd-macros/src/validation/steps/tests.rs
+++ b/crates/rstest-bdd-macros/src/validation/steps/tests.rs
@@ -3,11 +3,9 @@ use super::*;
 use rstest::rstest;
 use serial_test::serial;
 
+#[expect(clippy::expect_used, reason = "registry lock must panic if poisoned")]
 fn clear_registry() {
-    REGISTERED
-        .lock()
-        .unwrap_or_else(|e| panic!("step registry poisoned: {e}"))
-        .clear();
+    REGISTERED.lock().expect("step registry poisoned").clear();
 }
 
 fn registry_cleared() {

--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_ambiguous_step.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_ambiguous_step.stderr
@@ -1,6 +1,6 @@
 error: Ambiguous step definition for 'a step'.
-         - a step
-         - a step
+       - a step
+       - a step
   --> tests/fixtures/scenario_ambiguous_step.rs:11:1
    |
 11 | #[scenario(path = "../../../../crates/rstest-bdd-macros/tests/features/ambiguous.feature")]

--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_ambiguous_step.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_ambiguous_step.stderr
@@ -1,4 +1,6 @@
-error: Ambiguous step definition for 'a step'. Matches: a step, a step
+error: Ambiguous step definition for 'a step'.
+         - a step
+         - a step
   --> tests/fixtures/scenario_ambiguous_step.rs:11:1
    |
 11 | #[scenario(path = "../../../../crates/rstest-bdd-macros/tests/features/ambiguous.feature")]

--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_step.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_step.stderr
@@ -1,4 +1,4 @@
-warning: Step registry does not contain definitions for crate_id '$CRATE:'. This may indicate a registry issue.
+warning: step registry has no definitions for crate ID '$CRATE'. This may indicate a registry issue.
  --> tests/fixtures/scenario_missing_step.rs:3:1
   |
 3 | #[scenario(path = "../../../../crates/rstest-bdd-macros/tests/features/unmatched.feature")]

--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_step.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_step.stderr
@@ -6,7 +6,7 @@ warning: Step registry does not contain definitions for crate_id '$CRATE:'. This
   |
   = note: this warning originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: No matching step definition found for: Given an undefined step
+error: No matching step definition found for 'Given an undefined step'
  --> tests/fixtures/scenario_missing_step.rs:3:1
   |
 3 | #[scenario(path = "../../../../crates/rstest-bdd-macros/tests/features/unmatched.feature")]

--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_step.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_step.stderr
@@ -1,3 +1,11 @@
+warning: Step registry does not contain definitions for crate_id '$CRATE:'. This may indicate a registry issue.
+ --> tests/fixtures/scenario_missing_step.rs:3:1
+  |
+3 | #[scenario(path = "../../../../crates/rstest-bdd-macros/tests/features/unmatched.feature")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this warning originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: No matching step definition found for: Given an undefined step
  --> tests/fixtures/scenario_missing_step.rs:3:1
   |

--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_out_of_order.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_out_of_order.stderr
@@ -1,3 +1,11 @@
+warning: Step registry does not contain definitions for crate_id '$CRATE:'. This may indicate a registry issue.
+ --> tests/fixtures/scenario_out_of_order.rs:3:1
+  |
+3 | #[scenario(path = "../../../../crates/rstest-bdd-macros/tests/features/ambiguous.feature")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this warning originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: No matching step definition found for: Given a step
  --> tests/fixtures/scenario_out_of_order.rs:3:1
   |

--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_out_of_order.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_out_of_order.stderr
@@ -1,4 +1,4 @@
-warning: Step registry does not contain definitions for crate_id '$CRATE:'. This may indicate a registry issue.
+warning: step registry has no definitions for crate ID '$CRATE'. This may indicate a registry issue.
  --> tests/fixtures/scenario_out_of_order.rs:3:1
   |
 3 | #[scenario(path = "../../../../crates/rstest-bdd-macros/tests/features/ambiguous.feature")]

--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_out_of_order.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_out_of_order.stderr
@@ -6,7 +6,7 @@ warning: Step registry does not contain definitions for crate_id '$CRATE:'. This
   |
   = note: this warning originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: No matching step definition found for: Given a step
+error: No matching step definition found for 'Given a step'
  --> tests/fixtures/scenario_out_of_order.rs:3:1
   |
 3 | #[scenario(path = "../../../../crates/rstest-bdd-macros/tests/features/ambiguous.feature")]

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -542,6 +542,11 @@ pattern‑matching logic during validation, introducing a build-time dependency.
 `inventory` is employed later for runtime, cross‑crate discovery and does not
 power this compile‑time registry.
 
+Step definitions are recorded per crate and grouped by keyword, allowing direct
+lookups without scanning unrelated patterns. When the current crate has no
+registered steps, non-strict validation emits a warning and continues so
+definitions from other crates can satisfy the scenario.
+
 The following sequence diagram illustrates the feature-gated step registration
 and scenario validation flow:
 

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -542,9 +542,9 @@ pattern‑matching logic during validation, introducing a build-time dependency.
 `inventory` is employed later for runtime, cross‑crate discovery and does not
 power this compile‑time registry.
 
-Step definitions are recorded per crate and grouped by keyword, allowing direct
+Step definitions are recorded per crate and grouped by keyword, enabling direct
 lookups without scanning unrelated patterns. When the current crate has no
-registered steps, non-strict validation emits a warning and continues so
+registered steps, non-strict validation emits a warning and continues, so that
 definitions from other crates can satisfy the scenario.
 
 The following sequence diagram illustrates the feature-gated step registration


### PR DESCRIPTION
## Summary
- group registered steps by crate and keyword for faster lookup

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ba100b26a48322ab3be20c7dd1ec6e

## Summary by Sourcery

Group step patterns by crate and keyword in a nested registry map to speed up macro step lookups and simplify validation logic.

Enhancements:
- Replace the global Vec-based registry with a nested HashMap<crate_id, HashMap<StepKeyword, Vec<&'static StepPattern>>> for faster lookup.
- Update step registration to insert patterns directly into the new nested registry.
- Refactor validation, missing/ambiguous matching, and error formatting to operate on the new registry structure.