### PR TITLE
Streamline step registration and expand ambiguity tests

### DIFF
--- a/crates/rstest-bdd-macros/src/validation/steps.rs
+++ b/crates/rstest-bdd-macros/src/validation/steps.rs
@@ -55,7 +55,7 @@ static CURRENT_CRATE_ID: LazyLock<Box<str>> =
 /// session, including those registered by tests.
 /// Patterns are leaked into static memory because macros require `'static` lifetimes.
 /// Registration occurs during macro expansion so the total leak is bounded.
-fn register_step_inner(keyword: StepKeyword, pattern: &syn::LitStr, crate_id: impl Into<String>) {
+fn register_step_inner(keyword: StepKeyword, pattern: &syn::LitStr, crate_id: impl AsRef<str>) {
     let leaked: &'static str = Box::leak(pattern.value().into_boxed_str());
     let step_pattern: &'static StepPattern = Box::leak(Box::new(StepPattern::new(leaked)));
     if let Err(e) = step_pattern.compile() {
@@ -71,7 +71,7 @@ fn register_step_inner(keyword: StepKeyword, pattern: &syn::LitStr, crate_id: im
         reason = "lock poisoning is unrecoverable; panic with clear message"
     )]
     let mut reg = REGISTERED.lock().expect("step registry poisoned");
-    let crate_id = normalise_crate_id(&crate_id.into());
+    let crate_id = normalise_crate_id(crate_id.as_ref());
     let defs = reg.entry(crate_id).or_default();
     defs.by_kw.entry(keyword).or_default().push(step_pattern);
 }

--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_step.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_step.stderr
@@ -1,11 +1,3 @@
-warning: step registry has no definitions for crate ID '$CRATE'. This may indicate a registry issue.
- --> tests/fixtures/scenario_missing_step.rs:3:1
-  |
-3 | #[scenario(path = "../../../../crates/rstest-bdd-macros/tests/features/unmatched.feature")]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: this warning originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error: No matching step definition found for 'Given an undefined step'
  --> tests/fixtures/scenario_missing_step.rs:3:1
   |

--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_out_of_order.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_out_of_order.stderr
@@ -1,11 +1,3 @@
-warning: step registry has no definitions for crate ID '$CRATE'. This may indicate a registry issue.
- --> tests/fixtures/scenario_out_of_order.rs:3:1
-  |
-3 | #[scenario(path = "../../../../crates/rstest-bdd-macros/tests/features/ambiguous.feature")]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: this warning originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error: No matching step definition found for 'Given a step'
  --> tests/fixtures/scenario_out_of_order.rs:3:1
   |


### PR DESCRIPTION
## Summary
- consolidate step registration into a single helper and wrappers
- inline step validation to remove redundant passes
- extend test helper to accept keywords and cover placeholder ambiguities

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bb6e9e62208322af0e891205af06bc

## Summary by Sourcery

Streamline step registration and validation, enhance ambiguity detection, and expand tests to cover placeholder ambiguities

Enhancements:
- Consolidate step registration into a single helper register_step_inner and update both public and test wrappers
- Inline and simplify step existence validation by merging missing and ambiguous pattern detection into validate_steps_exist
- Improve ambiguity detection by proactively scanning definitions and erroring on multiple placeholder matches

Tests:
- Refactor create_test_step to accept keywords and update registration tests accordingly
- Add parametrized cases for literal and placeholder ambiguity scenarios
- Simplify ambiguous error assertions by dynamically counting bullet matches