### PR TITLE
Document cap-std and camino for file access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,14 @@ project:
   }
   ```
 
+### File System Access
+
+- Use `cap-std` for all file system operations to enforce capability-based,
+  sandboxed access.
+- Use `camino` for path handling to ensure UTF-8 and cross-platform behaviour.
+- Avoid `std::fs` and `std::path::PathBuf` directly; wrap them with the
+  crates above.
+
 ### Testing
 
 - Write unit and behavioural tests for new functionality. Run both before and

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,5 +2,7 @@
 
 ## Unreleased
 
+- Mandated `cap-std` and `camino` for cross-platform file system access.
+
 - Deprecated `From<&str>` for `StepKeyword`; use `StepKeyword::try_from` or
   `StepKeyword::from_str` instead.


### PR DESCRIPTION
## Summary
- note cap-std and camino as the mandatory approach for file system access
- document the new guidance in the changelog

## Testing
- `make fmt`
- `make check-fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68c1c802de348322b606cbb3a7512fe9

## Summary by Sourcery

Document mandatory cap-std and camino usage for file system access and reflect the change in the changelog.

Documentation:
- Document mandatory use of cap-std for sandboxed file system operations and camino for UTF-8-safe, cross-platform path handling.
- Update changelog to record the new file system access guidelines.