### PR TITLE
Add macros for asserting step results

### DIFF
--- a/crates/rstest-bdd/CHANGELOG.md
+++ b/crates/rstest-bdd/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Helper macros `assert_step_ok!` and `assert_step_err!` for concise assertions
+  on `Result`-returning steps.
+
 ## [0.1.0-alpha3] - 2025-09-03
 
 ### Added

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -27,6 +27,63 @@ mod placeholder;
 mod registry;
 mod types;
 
+/// Assert that a [`Result`] is `Ok` and unwrap it.
+///
+/// Panics with a message including the error when the value is an `Err`.
+///
+/// # Examples
+/// ```
+/// use rstest_bdd::assert_step_ok;
+///
+/// let res: Result<(), &str> = Ok(());
+/// assert_step_ok!(res);
+/// ```
+#[macro_export]
+macro_rules! assert_step_ok {
+    ($expr:expr $(,)?) => {
+        match $expr {
+            Ok(value) => value,
+            Err(e) => panic!("step returned error: {e}"),
+        }
+    };
+}
+
+/// Assert that a [`Result`] is `Err` and unwrap the error.
+///
+/// Optionally asserts that the error's display contains a substring.
+///
+/// # Examples
+/// ```
+/// use rstest_bdd::assert_step_err;
+///
+/// let err: Result<(), &str> = Err("boom");
+/// let e = assert_step_err!(err, "boom");
+/// assert_eq!(e, "boom");
+/// ```
+#[macro_export]
+macro_rules! assert_step_err {
+    ($expr:expr $(,)?) => {
+        match $expr {
+            Ok(_) => panic!("step succeeded unexpectedly"),
+            Err(e) => e,
+        }
+    };
+    ($expr:expr, $msg:expr $(,)?) => {
+        match $expr {
+            Ok(_) => panic!("step succeeded unexpectedly"),
+            Err(e) => {
+                let display = e.to_string();
+                assert!(
+                    display.contains($msg),
+                    "error '{display}' does not contain '{msg}'",
+                    msg = $msg
+                );
+                e
+            }
+        }
+    };
+}
+
 pub use context::StepContext;
 pub use pattern::StepPattern;
 pub use placeholder::extract_placeholders;

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -76,6 +76,7 @@ macro_rules! assert_step_err {
                 assert!(
                     display.contains($msg),
                     "error '{display}' does not contain '{msg}'",
+                    display = display,
                     msg = $msg
                 );
                 e

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -31,21 +31,15 @@ mod types;
 ///
 /// Panics with a message including the error when the value is an `Err`.
 ///
+/// Note: Formatting the error in the panic message requires the error type to
+/// implement [`std::fmt::Display`].
+///
 /// # Examples
 /// ```
 /// use rstest_bdd::assert_step_ok;
 ///
 /// let res: Result<(), &str> = Ok(());
 /// assert_step_ok!(res);
-/// ```
-///
-/// Single-argument form:
-/// ```
-/// use rstest_bdd::assert_step_err;
-///
-/// let err: Result<(), &str> = Err("boom");
-/// let e = assert_step_err!(err);
-/// assert_eq!(e, "boom");
 /// ```
 #[macro_export]
 macro_rules! assert_step_ok {
@@ -95,11 +89,12 @@ macro_rules! assert_step_err {
             Ok(_) => panic!("step succeeded unexpectedly"),
             Err(e) => {
                 let __rstest_bdd_display = e.to_string();
+                let __rstest_bdd_msg: &str = $msg.as_ref();
                 assert!(
-                    __rstest_bdd_display.contains($msg),
+                    __rstest_bdd_display.contains(__rstest_bdd_msg),
                     "error '{display}' does not contain '{msg}'",
                     display = __rstest_bdd_display,
-                    msg = $msg
+                    msg = __rstest_bdd_msg
                 );
                 e
             }

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -52,6 +52,10 @@ macro_rules! assert_step_ok {
 ///
 /// Optionally asserts that the error's display contains a substring.
 ///
+/// Note: The `(expr, "substring")` form requires the error type to
+/// implement [`std::fmt::Display`] so it can be converted to a string for
+/// matching.
+///
 /// # Examples
 /// ```
 /// use rstest_bdd::assert_step_err;

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -38,6 +38,15 @@ mod types;
 /// let res: Result<(), &str> = Ok(());
 /// assert_step_ok!(res);
 /// ```
+///
+/// Single-argument form:
+/// ```
+/// use rstest_bdd::assert_step_err;
+///
+/// let err: Result<(), &str> = Err("boom");
+/// let e = assert_step_err!(err);
+/// assert_eq!(e, "boom");
+/// ```
 #[macro_export]
 macro_rules! assert_step_ok {
     ($expr:expr $(,)?) => {
@@ -64,6 +73,15 @@ macro_rules! assert_step_ok {
 /// let e = assert_step_err!(err, "boom");
 /// assert_eq!(e, "boom");
 /// ```
+///
+/// Single-argument form:
+/// ```
+/// use rstest_bdd::assert_step_err;
+///
+/// let err: Result<(), &str> = Err("boom");
+/// let e = assert_step_err!(err);
+/// assert_eq!(e, "boom");
+/// ```
 #[macro_export]
 macro_rules! assert_step_err {
     ($expr:expr $(,)?) => {
@@ -76,11 +94,11 @@ macro_rules! assert_step_err {
         match $expr {
             Ok(_) => panic!("step succeeded unexpectedly"),
             Err(e) => {
-                let display = e.to_string();
+                let __rstest_bdd_display = e.to_string();
                 assert!(
-                    display.contains($msg),
+                    __rstest_bdd_display.contains($msg),
                     "error '{display}' does not contain '{msg}'",
-                    display = display,
+                    display = __rstest_bdd_display,
                     msg = $msg
                 );
                 e

--- a/crates/rstest-bdd/tests/assert_macros.rs
+++ b/crates/rstest-bdd/tests/assert_macros.rs
@@ -31,6 +31,14 @@ fn assert_step_err_unwraps_error_without_substring() {
     let e = assert_step_err!(res);
     assert_eq!(e, "boom");
 }
+
+#[test]
+fn assert_step_err_accepts_owned_string_pattern() {
+    let res: Result<(), &str> = Err("boom");
+    let pat = "boom".to_string();
+    let e = assert_step_err!(res, pat);
+    assert_eq!(e, "boom");
+}
 #[test]
 #[should_panic(expected = "does not contain")]
 fn assert_step_err_panics_when_substring_absent() {

--- a/crates/rstest-bdd/tests/assert_macros.rs
+++ b/crates/rstest-bdd/tests/assert_macros.rs
@@ -7,19 +7,35 @@ fn assert_step_ok_unwraps_result() {
     let res: Result<(), &str> = Ok(());
     assert_step_ok!(res);
 }
-
+#[test]
+fn assert_step_ok_returns_value() {
+    let res: Result<u32, &str> = Ok(42);
+    let v = assert_step_ok!(res);
+    assert_eq!(v, 42);
+}
 #[test]
 #[should_panic(expected = "step returned error")]
 fn assert_step_ok_panics_on_err() {
     let res: Result<(), &str> = Err("boom");
     assert_step_ok!(res);
 }
-
 #[test]
 fn assert_step_err_unwraps_error() {
     let res: Result<(), &str> = Err("boom");
     let e = assert_step_err!(res, "boo");
     assert_eq!(e, "boom");
+}
+#[test]
+fn assert_step_err_unwraps_error_without_substring() {
+    let res: Result<(), &str> = Err("boom");
+    let e = assert_step_err!(res);
+    assert_eq!(e, "boom");
+}
+#[test]
+#[should_panic(expected = "does not contain")]
+fn assert_step_err_panics_when_substring_absent() {
+    let res: Result<(), &str> = Err("boom");
+    let _ = assert_step_err!(res, "absent");
 }
 
 #[test]

--- a/crates/rstest-bdd/tests/assert_macros.rs
+++ b/crates/rstest-bdd/tests/assert_macros.rs
@@ -1,0 +1,30 @@
+//! Unit tests for `assert_step_ok!` and `assert_step_err!`
+
+use rstest_bdd::{assert_step_err, assert_step_ok};
+
+#[test]
+fn assert_step_ok_unwraps_result() {
+    let res: Result<(), &str> = Ok(());
+    assert_step_ok!(res);
+}
+
+#[test]
+#[should_panic(expected = "step returned error")]
+fn assert_step_ok_panics_on_err() {
+    let res: Result<(), &str> = Err("boom");
+    assert_step_ok!(res);
+}
+
+#[test]
+fn assert_step_err_unwraps_error() {
+    let res: Result<(), &str> = Err("boom");
+    let e = assert_step_err!(res, "boo");
+    assert_eq!(e, "boom");
+}
+
+#[test]
+#[should_panic(expected = "step succeeded unexpectedly")]
+fn assert_step_err_panics_on_ok() {
+    let res: Result<(), &str> = Ok(());
+    let _ = assert_step_err!(res);
+}

--- a/crates/rstest-bdd/tests/fixture_context.rs
+++ b/crates/rstest-bdd/tests/fixture_context.rs
@@ -1,6 +1,8 @@
 //! Behavioural test for fixture context injection
 
-use rstest_bdd::{StepContext, StepError, StepKeyword, assert_step_err, assert_step_ok};
+use rstest_bdd::{
+    StepContext, StepError, StepKeyword, assert_step_err, assert_step_ok, lookup_step,
+};
 use rstest_bdd_macros::given;
 
 /// Step that asserts the injected `number` fixture equals 42.
@@ -29,7 +31,7 @@ fn context_passes_fixture() {
     let number = 42u32;
     let mut ctx = StepContext::default();
     ctx.insert("number", &number);
-    let step_fn = rstest_bdd::lookup_step(StepKeyword::Given, "a value".into())
+    let step_fn = lookup_step(StepKeyword::Given, "a value".into())
         .expect("step 'a value' not found in registry");
     assert_step_ok!(step_fn(&ctx, "a value", None, None));
 }
@@ -38,7 +40,7 @@ fn context_passes_fixture() {
 #[expect(clippy::expect_used, reason = "step lookup must succeed for test")]
 fn context_missing_fixture_returns_error() {
     let ctx = StepContext::default();
-    let step_fn = rstest_bdd::lookup_step(StepKeyword::Given, "a value".into())
+    let step_fn = lookup_step(StepKeyword::Given, "a value".into())
         .expect("step 'a value' not found in registry");
     let err = assert_step_err!(step_fn(&ctx, "a value", None, None));
     let display = err.to_string();
@@ -62,7 +64,7 @@ fn fixture_step_panic_returns_panic_error() {
     let number = 1u32;
     let mut ctx = StepContext::default();
     ctx.insert("number", &number);
-    let step_fn = rstest_bdd::lookup_step(StepKeyword::Given, "a panicking value step".into())
+    let step_fn = lookup_step(StepKeyword::Given, "a panicking value step".into())
         .expect("step 'a panicking value step' not found in registry");
     let err = assert_step_err!(step_fn(&ctx, "a panicking value step", None, None), "boom");
     match err {

--- a/crates/rstest-bdd/tests/fixture_context.rs
+++ b/crates/rstest-bdd/tests/fixture_context.rs
@@ -24,20 +24,22 @@ fn panicking_value_step(number: &u32) -> Result<(), String> {
 }
 
 #[test]
+#[expect(clippy::expect_used, reason = "step lookup must succeed for test")]
 fn context_passes_fixture() {
     let number = 42u32;
     let mut ctx = StepContext::default();
     ctx.insert("number", &number);
     let step_fn = rstest_bdd::lookup_step(StepKeyword::Given, "a value".into())
-        .unwrap_or_else(|| panic!("step 'a value' not found in registry"));
+        .expect("step 'a value' not found in registry");
     assert_step_ok!(step_fn(&ctx, "a value", None, None));
 }
 
 #[test]
+#[expect(clippy::expect_used, reason = "step lookup must succeed for test")]
 fn context_missing_fixture_returns_error() {
     let ctx = StepContext::default();
     let step_fn = rstest_bdd::lookup_step(StepKeyword::Given, "a value".into())
-        .unwrap_or_else(|| panic!("step 'a value' not found in registry"));
+        .expect("step 'a value' not found in registry");
     let err = assert_step_err!(step_fn(&ctx, "a value", None, None));
     let display = err.to_string();
     match err {
@@ -55,12 +57,13 @@ fn context_missing_fixture_returns_error() {
 }
 
 #[test]
+#[expect(clippy::expect_used, reason = "step lookup must succeed for test")]
 fn fixture_step_panic_returns_panic_error() {
     let number = 1u32;
     let mut ctx = StepContext::default();
     ctx.insert("number", &number);
     let step_fn = rstest_bdd::lookup_step(StepKeyword::Given, "a panicking value step".into())
-        .unwrap_or_else(|| panic!("step 'a panicking value step' not found in registry"));
+        .expect("step 'a panicking value step' not found in registry");
     let err = assert_step_err!(step_fn(&ctx, "a panicking value step", None, None), "boom");
     match err {
         StepError::PanicError {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,3 +4,5 @@
 
 - Deprecated `From<&str>` for `StepKeyword`; use `StepKeyword::try_from` or
   `StepKeyword::from_str` instead.
+- Helper macros `assert_step_ok!` and `assert_step_err!` to streamline tests for
+  `Result`-returning steps.

--- a/docs/ergonomics-and-developer-experience.md
+++ b/docs/ergonomics-and-developer-experience.md
@@ -352,7 +352,7 @@ Two helper macros are provided by the `rstest-bdd` crate and re-exported:
   substring.
 
 These simple declarative macros (`macro_rules!`) live in
-`rstest-bdd/src/lib.rs`.
+`crates/rstest-bdd/src/lib.rs`.
 
 ### 4.2. Step Scaffolding
 

--- a/docs/ergonomics-and-developer-experience.md
+++ b/docs/ergonomics-and-developer-experience.md
@@ -343,18 +343,15 @@ fn test_cli_command(cli_state: CliState) {
 **Goal:** Simplify the common pattern of asserting that a step returning a
 `Result` is either `Ok` or `Err`.
 
-Proposed Design:
+Two helper macros are provided by the `rstest-bdd` crate and re-exported:
 
-Two new macros will be added to the rstest-bdd crate and re-exported.
+- `assert_step_ok!(result)`: unwraps a `Result` value, panicking with a
+  formatted message when the value is `Err(e)`.
+- `assert_step_err!(result, expected_msg)`: asserts that the `Result` is an
+  `Err` and optionally checks that the error message contains a specific
+  substring.
 
-- `assert_step_ok!(result)`: This macro will take a `Result` value. If the
-  result is `Err(e)`, it will panic with a formatted message including the
-  error `e`.
-- `assert_step_err!(result, expected_msg)`: This macro will assert that the
-  `Result` is an `Err`. It can optionally take a second argument to assert that
-  the error message contains a specific substring.
-
-These will be simple declarative macros (`macro_rules!`) defined in
+These simple declarative macros (`macro_rules!`) live in
 `rstest-bdd/src/lib.rs`.
 
 ### 4.2. Step Scaffolding

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -239,7 +239,7 @@ experience by introducing more powerful and intuitive APIs.
     etc.) to be used without an explicit pattern string. The pattern will be
     inferred from the function's name (e.g., `fn user_logs_in()` becomes "user
     logs in"). [User’s guide](users-guide.md#inferred-step-patterns)
-  - [ ] **Streamlined **`Result`** Assertions:** Introduce helper macros like
+  - [x] **Streamlined **`Result`** Assertions:** Introduce helper macros like
     `assert_step_ok!` and `assert_step_err!` to reduce boilerplate when testing
     `Result`-returning steps.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -239,7 +239,7 @@ experience by introducing more powerful and intuitive APIs.
     etc.) to be used without an explicit pattern string. The pattern will be
     inferred from the function's name (e.g., `fn user_logs_in()` becomes "user
     logs in"). [User’s guide](users-guide.md#inferred-step-patterns)
-  - [x] **Streamlined **`Result`** Assertions:** Introduce helper macros like
+  - [x] **Streamlined `Result` Assertions:** Introduce helper macros like
     `assert_step_ok!` and `assert_step_err!` to reduce boilerplate when testing
     `Result`-returning steps.
 

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1547,6 +1547,18 @@ Public APIs are re‑exported from `lib.rs` so consumers continue to import from
 
 All modules use en‑GB spelling and include `//!` module‑level documentation.
 
+## Assertion helper macros
+
+To streamline tests for step functions returning `Result`, the crate exposes
+two helper macros:
+
+- `assert_step_ok!(expr)` unwraps an `Ok` value and panics with the error when
+  `expr` yields `Err`.
+- `assert_step_err!(expr, msg?)` unwraps the error and optionally checks that
+  its display contains `msg`.
+
+These macros keep test code succinct while still surfacing detailed diagnostics.
+
 ## Part 4: Internationalization and Localization Roadmap
 
 ### 4.1 Phase 1: Foundational Gherkin Internationalization (target v0.4)

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -371,6 +371,28 @@ added, patterns and examples may change. Meanwhile, adopting `rstest‑bdd` in
 its current form will be most effective when feature files remain simple and
 step definitions are explicit.
 
+## Assertion macros
+
+When step functions return `Result` values it is common to assert on their
+outcome. The `rstest-bdd` crate exports two helper macros to streamline these
+checks:
+
+```rust
+use rstest_bdd::{assert_step_err, assert_step_ok};
+
+let ok: Result<(), &str> = Ok(());
+assert_step_ok!(ok);
+
+let err: Result<(), &str> = Err("boom");
+let e = assert_step_err!(err, "boom");
+assert_eq!(e, "boom");
+```
+
+`assert_step_ok!` unwraps an `Ok` value and panics with the error message when
+the result is `Err`. `assert_step_err!` unwraps the error and optionally checks
+that its display contains a substring. Both macros return their unwrapped
+values, allowing further inspection when required.
+
 ## Diagnostic tooling
 
 `rstest-bdd` bundles a small helper binary exposed as the cargo subcommand


### PR DESCRIPTION
## Summary
- add `assert_step_ok!` and `assert_step_err!` macros for concise `Result` assertions
- document assertion macros in design doc, users' guide, and roadmap
- exercise assertion macros in fixture tests and dedicated unit tests

## Testing
- `make fmt`
- `make lint`
- `make test` *(failed: inconsistent output due to environment lock; partial tests run)*
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68c1c79c89f48322a55453da9cd16547

## Summary by Sourcery

Introduce assert_step_ok! and assert_step_err! macros for concise Result assertions, update tests to leverage them, and add comprehensive documentation and changelog entries

New Features:
- Add assert_step_ok! macro to assert and unwrap Ok results from step functions
- Add assert_step_err! macro to assert and unwrap Err results with optional substring matching

Documentation:
- Document the new assertion macros in the user guide, design doc, ergonomics guide, and roadmap
- Update CHANGELOG entries to announce the new macros

Tests:
- Refactor existing fixture tests to use the new macros and add dedicated unit tests covering various success and failure scenarios