### PR TITLE
Document typed data table support

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -106,7 +106,8 @@ improves the developer experience.
     before each `Scenario`.
 
   - [x] Implement support for `Data Tables`, initially making the data
-    available to the step function as a `Vec<Vec<String>>`.
+    available to the step function as a `Vec<Vec<String>>` (legacy baseline;
+    typed support is planned below).
 
   - [x] Implement support for `Docstring`, making the content available as a
     `String` argument named `docstring`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -105,8 +105,8 @@ improves the developer experience.
   - [x] Implement support for `Background` steps, ensuring they are executed
     before each `Scenario`.
 
-  - [x] Implement support for `Data Tables`, making the data available to the
-    step function as a `Vec<Vec<String>>`.
+  - [x] Implement support for `Data Tables`, initially making the data
+    available to the step function as a `Vec<Vec<String>>`.
 
   - [x] Implement support for `Docstring`, making the content available as a
     `String` argument named `docstring`.
@@ -119,6 +119,29 @@ improves the developer experience.
   - [x] The `#[scenario]` macro must perform a compile-time check to ensure a
     matching step definition exists for every Gherkin step in the target
     scenario, emitting a `compile_error!` if any are missing.
+
+- [ ] **Typed Data Table Support**
+
+  - [ ] Add a `datatable` runtime module exposing `DataTableError`,
+    `HeaderSpec`, `RowSpec`, `Rows<T>`, and convenience parsers such as
+    `truthy_bool` and `trimmed<T: FromStr>`.
+
+  - [ ] Implement `TryFrom<Vec<Vec<String>>> for Rows<T>` (with `T:
+    DataTableRow`) to split optional headers, build index maps, and surface row
+    and column context on errors.
+
+  - [ ] Provide `#[derive(DataTableRow)]` and `#[derive(DataTable)]` macros with
+    field- and struct-level attributes for column mapping, optional or default
+    cells, trimming, tolerant booleans, custom parsers, and row aggregation
+    hooks.
+
+  - [ ] Update generated wrappers to forward conversion failures by formatting
+    the `DataTableError` into the emitted `StepError`, ensuring diagnostics
+    reach recorders.
+
+  - [ ] Extend documentation (users guide, design document) and add integration
+    tests plus compile-fail fixtures covering headered/headerless tables,
+    optional columns, tolerant booleans, and invalid attribute combinations.
 
 - [ ] **Tag Filtering**
 

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -280,38 +280,39 @@ other essential Gherkin constructs.
   steps to the scenario's step list so the `#[scenario]` macro runs them first.
 
 - Data Tables: A Gherkin data table provides a way to pass a structured block
-  of data to a single step. The step function continues to declare a single
-  optional parameter annotated with `#[datatable]` or named `datatable`. Legacy
-  code may keep using `Vec<Vec<String>>`, but the runtime now exposes a
-  `datatable` module for ergonomic typed parsing.
+  of data to a single step. The step function declares a single optional
+  parameter annotated with `#[datatable]` or named `datatable`. Legacy code may
+  keep using `Vec<Vec<String>>`. A future `datatable` module will expose typed
+  parsing once implemented.
 
-  - `datatable::Rows<T>` wraps a `Vec<T>` and implements `IntoIterator`,
+  - `datatable::Rows<T>` will wrap a `Vec<T>` and implement `IntoIterator`,
     `AsRef<[T]>`, and helper adapters so steps can iterate or collect without
-    ceremony. `TryFrom<Vec<Vec<String>>> for Rows<T>` splits optional headers,
-    builds an index map, and invokes `T::parse_row`, annotating failures with
-    row and column indices.
-  - `DataTableError` (via `thiserror`) covers header mismatches, missing
-    columns, uneven rows, and per-cell parse failures. The wrapper surfaces the
-    error's `Display` output through `StepError` so CLI recorders receive
+    ceremony. `TryFrom<Vec<Vec<String>>> for Rows<T>` will split optional
+    headers, build an index map, and invoke `T::parse_row`, annotating failures
+    with row and column indices.
+  - `DataTableError` (via `thiserror`) will cover header mismatches, missing
+    columns, uneven rows, and per-cell parse failures. The wrapper will surface
+    the error's `Display` output through `StepError` so CLI recorders receive
     precise diagnostics.
-  - `RowSpec` and `HeaderSpec` describe header metadata and provide indexed or
-    named cell access, including trimmed views, to keep parsing logic
-    declarative.
-  - Convenience helpers such as `truthy_bool` and `trimmed<T: FromStr>` support
-    tolerant boolean parsing and whitespace handling without bespoke loops.
-  - `#[derive(DataTableRow)]` generates `DataTableRow` implementations for
+  - `RowSpec` and `HeaderSpec` will describe header metadata and provide
+    indexed or named cell access, including trimmed views, to keep parsing
+    logic declarative.
+  - Convenience helpers such as `truthy_bool` and `trimmed<T: FromStr>` will
+    support tolerant boolean parsing and whitespace handling without bespoke
+    loops.
+  - `#[derive(DataTableRow)]` will generate `DataTableRow` implementations for
     structs and tuple structs. Field attributes like
     `#[datatable(column = "Task name")]`, `#[datatable(optional)]`,
     `#[datatable(parse_with = "path::to_fn")]`, and struct-level
-    `#[datatable(rename_all = "...")]` cover column mapping, optional cells,
-    trimming, and custom parsers. The derive sets `REQUIRES_HEADER` when any
-    field depends on header lookup.
-  - `#[derive(DataTable)]` targets tuple structs that wrap collections. It
-    composes parsed rows with optional `map` or `convert` hooks so steps can
-    expose domain-specific containers without manual loops.
+    `#[datatable(rename_all = "...")]` will cover column mapping, optional
+    cells, trimming, and custom parsers. The derive will set `REQUIRES_HEADER`
+    when any field depends on header lookup.
+  - `#[derive(DataTable)]` will target tuple structs that wrap collections. It
+    will compose parsed rows with optional `map` or `convert` hooks so steps
+    can expose domain-specific containers without manual loops.
 
-  Existing custom `TryFrom<Vec<Vec<String>>>` implementations continue to work,
-  letting projects adopt typed tables gradually.
+  Existing custom `TryFrom<Vec<Vec<String>>>` implementations will continue to
+  work, letting projects adopt typed tables gradually.
 
   **Feature File:**
 
@@ -487,16 +488,15 @@ macro has a distinct role in the compile-time orchestration of the BDD tests.
 
 - Data Tables: Step functions may include a single optional parameter declared
   either by annotating it with `#[datatable]` or by naming it `datatable`.
-  Legacy consumers can continue to request a `Vec<Vec<String>>`, but the
-  runtime now encourages the `datatable::Rows<T>` newtype. When a feature step
-  includes a table, the wrapper clones the runtime `&[&[&str]]` payload into
-  `Vec<Vec<String>>` and invokes `TryFrom<Vec<Vec<String>>>`. The standard
-  implementation covers `Rows<T>` where `T: DataTableRow`. Conversion failures
-  yield a `DataTableError`, and the generated wrapper formats the error's
-  `Display` output into the resulting `StepError`, preserving row and column
-  diagnostics. The data table parameter must precede any Doc String argument,
-  must not be combined with `#[from]`, and a missing table triggers a runtime
-  error.
+  Legacy consumers can continue to request a `Vec<Vec<String>>`. A future
+  `datatable::Rows<T>` newtype will be supported. When implemented, the wrapper
+  will materialise the runtime `&[&[&str]]` payload into `Vec<Vec<String>>` and
+  invoke `TryFrom<Vec<Vec<String>>>`. The planned implementation will cover
+  `Rows<T>` where `T: DataTableRow`. Conversion failures will yield a
+  `DataTableError`, and the generated wrapper will format the error's `Display`
+  output into the resulting `StepError`, preserving row and column diagnostics.
+  The data table parameter must precede any Doc String argument, must not be
+  combined with `#[from]`, and a missing table triggers a runtime error.
 
 - Docstrings: A multi-line text block immediately following a step is
   exposed to the step function through an optional `docstring` parameter of
@@ -1578,10 +1578,10 @@ supporting type‑safe parameters in steps. The parser handles escaped braces,
 nested brace pairs, and treats other backslash escapes literally, preventing
 greedy captures while still requiring well‑formed placeholders.
 
-When a table parameter implements `TryFrom<Vec<Vec<String>>>`, the wrapper runs
-the conversion after materialising the nested vectors. The `datatable::Rows<T>`
-path maps any `DataTableError` into the `StepError` returned to the runner,
-preserving the formatted message alongside its row and column context.
+When available, if a table parameter implements `TryFrom<Vec<Vec<String>>>`,
+the wrapper will run the conversion after materialising the nested vectors. The
+`datatable::Rows<T>` path will map any `DataTableError` into `StepError`,
+preserving formatted row and column context.
 
 The runner forwards the raw doc string as `Option<&str>` and the wrapper
 converts it into an owned `String` before invoking the step function. The

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -279,51 +279,73 @@ other essential Gherkin constructs.
   before each `Scenario` in a feature file.[^10] The parser prepends these
   steps to the scenario's step list so the `#[scenario]` macro runs them first.
 
-- Data Tables: A Gherkin data table provides a way to pass a structured
-  block of data to a single step. Provide it to the step function via a single
-  optional parameter annotated with `#[datatable]` or named `datatable` of type
-  `Vec<Vec<String>>`, mirroring `pytest-bdd`'s `datatable` argument.[^11]
-  During expansion, the `#[datatable]` marker is removed, but the declared
-  parameter type is preserved and must implement `TryFrom<Vec<Vec<String>>>` to
-  accept the converted cells. The annotated parameter must precede any Doc
-  String argument and cannot combine `#[datatable]` with `#[from]`.
+- Data Tables: A Gherkin data table provides a way to pass a structured block
+  of data to a single step. The step function continues to declare a single
+  optional parameter annotated with `#[datatable]` or named `datatable`. Legacy
+  code may keep using `Vec<Vec<String>>`, but the runtime now exposes a
+  `datatable` module for ergonomic typed parsing.
+
+  - `datatable::Rows<T>` wraps a `Vec<T>` and implements `IntoIterator`,
+    `AsRef<[T]>`, and helper adapters so steps can iterate or collect without
+    ceremony. `TryFrom<Vec<Vec<String>>> for Rows<T>` splits optional headers,
+    builds an index map, and invokes `T::parse_row`, annotating failures with
+    row and column indices.
+  - `DataTableError` (via `thiserror`) covers header mismatches, missing
+    columns, uneven rows, and per-cell parse failures. The wrapper surfaces the
+    error's `Display` output through `StepError` so CLI recorders receive
+    precise diagnostics.
+  - `RowSpec` and `HeaderSpec` describe header metadata and provide indexed or
+    named cell access, including trimmed views, to keep parsing logic
+    declarative.
+  - Convenience helpers such as `truthy_bool` and `trimmed<T: FromStr>` support
+    tolerant boolean parsing and whitespace handling without bespoke loops.
+  - `#[derive(DataTableRow)]` generates `DataTableRow` implementations for
+    structs and tuple structs. Field attributes like
+    `#[datatable(column = "Task name")]`, `#[datatable(optional)]`,
+    `#[datatable(parse_with = "path::to_fn")]`, and struct-level
+    `#[datatable(rename_all = "...")]` cover column mapping, optional cells,
+    trimming, and custom parsers. The derive sets `REQUIRES_HEADER` when any
+    field depends on header lookup.
+  - `#[derive(DataTable)]` targets tuple structs that wrap collections. It
+    composes parsed rows with optional `map` or `convert` hooks so steps can
+    expose domain-specific containers without manual loops.
+
+  Existing custom `TryFrom<Vec<Vec<String>>>` implementations continue to work,
+  letting projects adopt typed tables gradually.
 
   **Feature File:**
 
 ```gherkin
   Given the following users exist:
 
-  | name  | email              |
-  | Alice | alice@example.com |
-  | Bob   | bob@example.com   |
+  | name  | email              | active |
+  | Alice | alice@example.com | yes    |
+  | Bob   | bob@example.com   | no     |
 ```
 
 **Step definition (`tests/steps/create_users.rs`):**
 
 ```rust
+use rstest_bdd::datatable::{self, Rows};
+use rstest_bdd_macros::DataTableRow;
+
+#[derive(DataTableRow)]
+#[datatable(rename_all = "kebab-case")]
+struct UserRow {
+    name: String,
+    #[datatable(parse_with = "datatable::truthy_bool")]
+    active: bool,
+    #[datatable(column = "email")]
+    email: String,
+}
+
 #[given("the following users exist:")]
 fn create_users(
     #[from(db)] conn: &mut DbConnection,
-    datatable: Vec<Vec<String>>,
+    #[datatable] users: Rows<UserRow>,
 ) {
-    let headers = &datatable[0];
-    let name_idx = headers
-        .iter()
-        .position(|h| h == "name")
-        .expect("missing 'name' column");
-    let email_idx = headers
-        .iter()
-        .position(|h| h == "email")
-        .expect("missing 'email' column");
-
-    for row in datatable.iter().skip(1) {
-        assert!(
-            row.len() > name_idx && row.len() > email_idx,
-            "Expected 'name' and 'email' columns",
-        );
-        let name = &row[name_idx];
-        let email = &row[email_idx];
-        conn.insert_user(name, email);
+    for row in users {
+        conn.insert_user(&row.name, &row.email, row.active);
     }
 }
 ```
@@ -463,15 +485,18 @@ macro has a distinct role in the compile-time orchestration of the BDD tests.
   call to `rstest_bdd::step!`, which internally uses `inventory::submit!` to
   add a `Step` to the registry.
 
-- Data Tables: Step functions may include a single optional parameter
-  declared in one of two ways: (a) annotated with `#[datatable]` and of any
-  type `T` where `T: TryFrom<Vec<Vec<String>>>`, or (b) named `datatable` with
-  concrete type `Vec<Vec<String>>`. When a feature step includes a data table,
-  the wrapper converts the cells to `Vec<Vec<String>>` and, for (a), performs a
-  `try_into()` to the declared type. The `#[datatable]` marker is removed
-  during expansion. The data table parameter must precede any Doc String
-  argument, must not be combined with `#[from]`, and the wrapper emits a
-  runtime error if the table is missing.
+- Data Tables: Step functions may include a single optional parameter declared
+  either by annotating it with `#[datatable]` or by naming it `datatable`.
+  Legacy consumers can continue to request a `Vec<Vec<String>>`, but the
+  runtime now encourages the `datatable::Rows<T>` newtype. When a feature step
+  includes a table, the wrapper clones the runtime `&[&[&str]]` payload into
+  `Vec<Vec<String>>` and invokes `TryFrom<Vec<Vec<String>>>`. The standard
+  implementation covers `Rows<T>` where `T: DataTableRow`. Conversion failures
+  yield a `DataTableError`, and the generated wrapper formats the error's
+  `Display` output into the resulting `StepError`, preserving row and column
+  diagnostics. The data table parameter must precede any Doc String argument,
+  must not be combined with `#[from]`, and a missing table triggers a runtime
+  error.
 
 - Docstrings: A multi-line text block immediately following a step is
   exposed to the step function through an optional `docstring` parameter of
@@ -1553,6 +1578,11 @@ supporting type‑safe parameters in steps. The parser handles escaped braces,
 nested brace pairs, and treats other backslash escapes literally, preventing
 greedy captures while still requiring well‑formed placeholders.
 
+When a table parameter implements `TryFrom<Vec<Vec<String>>>`, the wrapper runs
+the conversion after materialising the nested vectors. The `datatable::Rows<T>`
+path maps any `DataTableError` into the `StepError` returned to the runner,
+preserving the formatted message alongside its row and column context.
+
 The runner forwards the raw doc string as `Option<&str>` and the wrapper
 converts it into an owned `String` before invoking the step function. The
 sequence below summarizes how the runner locates and executes steps when
@@ -1575,7 +1605,7 @@ sequenceDiagram
     ScenarioRunner->>StepWrapper: call StepFn(ctx, text, docstring: Option<&str>, table: Option<&[&[&str]]>)
     StepWrapper->>StepWrapper: extract_placeholders(pattern, text)
     StepWrapper->>StepWrapper: parse captures with FromStr
-    StepWrapper->>StepFunction: call with typed args (docstring: String, datatable: Vec<Vec<String>>)
+    StepWrapper->>StepFunction: call with typed args (docstring: String, datatable: T)
     StepFunction-->>StepWrapper: returns
     StepWrapper-->>ScenarioRunner: returns
 ```


### PR DESCRIPTION
## Summary
- describe the new datatable module, derives, and error propagation approach in the design document
- refresh the roadmap with a typed data table milestone and clarify the baseline data table support entry

## Testing
- make fmt
- make markdownlint
- make nixie

------
https://chatgpt.com/codex/tasks/task_e_68caca1b8b0c8322ba8e51b4174828c5

## Summary by Sourcery

Document the typed data table support by expanding the design documentation and updating the project roadmap with a dedicated milestone.

Documentation:
- Add detailed design document section for the new datatable module covering Rows<T>, DataTableError, HeaderSpec/RowSpec, parse helpers, and derive macros for DataTableRow and DataTable
- Update roadmap to include a typed data table support milestone with tasks for runtime APIs, derive macros, error handling, documentation updates, and tests