### PR TITLE
Add tests for step result conversions and ambiguous fixtures

### DIFF
--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -1,10 +1,10 @@
-#![feature(auto_traits, negative_impls)]
 //! Core library for `rstest-bdd`.
 //!
 //! ⚠️ This crate currently requires the Rust nightly compiler because it
 //! relies on auto traits and negative impls to normalise step return values.
 //! This crate exposes helper utilities used by behaviour tests. It also defines
 //! the global step registry used to orchestrate behaviour-driven tests.
+#![feature(auto_traits, negative_impls)]
 
 /// Returns a greeting for the library.
 ///

--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -121,10 +121,10 @@ impl From<&str> for StepKeyword {
         reason = "deprecated shim for backward compatibility"
     )]
     fn from(value: &str) -> Self {
-        // Trait implementations cannot carry deprecation attributes. We retain
+        // Rust ignores `#[deprecated]` on trait implementations, so we keep
         // this shim for backward compatibility and rely on documentation to
-        // steer callers towards `StepKeyword::try_from` or
-        // `StepKeyword::from_str` instead.
+        // steer callers towards `StepKeyword::from_str` (or `str::parse`)
+        // instead.
         Self::from_str(value).expect("valid step keyword")
     }
 }

--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -121,6 +121,10 @@ impl From<&str> for StepKeyword {
         reason = "deprecated shim for backward compatibility"
     )]
     fn from(value: &str) -> Self {
+        // Trait implementations cannot carry deprecation attributes. We retain
+        // this shim for backward compatibility and rely on documentation to
+        // steer callers towards `StepKeyword::try_from` or
+        // `StepKeyword::from_str` instead.
         Self::from_str(value).expect("valid step keyword")
     }
 }

--- a/crates/rstest-bdd/tests/features/step_return.feature
+++ b/crates/rstest-bdd/tests/features/step_return.feature
@@ -3,3 +3,8 @@ Feature: Step return values
     Given base number is 1
     When it is incremented
     Then the result is 2
+
+  Scenario: Ambiguous fixtures ignore override
+    Given two competing fixtures
+    When a step returns a competing value
+    Then the fixtures remain unchanged

--- a/crates/rstest-bdd/tests/features/step_return_ambiguous.feature
+++ b/crates/rstest-bdd/tests/features/step_return_ambiguous.feature
@@ -1,5 +1,0 @@
-Feature: Step return ambiguity
-  Scenario: Ambiguous fixtures ignore override
-    Given two competing fixtures
-    When a step returns a competing value
-    Then the fixtures remain unchanged

--- a/crates/rstest-bdd/tests/features/step_return_ambiguous.feature
+++ b/crates/rstest-bdd/tests/features/step_return_ambiguous.feature
@@ -1,0 +1,5 @@
+Feature: Step return ambiguity
+  Scenario: Ambiguous fixtures ignore override
+    Given two competing fixtures
+    When a step returns a competing value
+    Then the fixtures remain unchanged

--- a/crates/rstest-bdd/tests/step_return.rs
+++ b/crates/rstest-bdd/tests/step_return.rs
@@ -3,13 +3,13 @@
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct Number(i32);
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct PrimaryValue(i32);
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct SecondaryValue(i32);
 
 #[fixture]

--- a/crates/rstest-bdd/tests/step_return.rs
+++ b/crates/rstest-bdd/tests/step_return.rs
@@ -46,6 +46,8 @@ fn two_competing(primary_value: i32, secondary_value: i32) {
 
 #[when("a step returns a competing value")]
 fn returns_competing_value(primary_value: i32, secondary_value: i32) -> i32 {
+    // The step context should prefer the fixture bindings when multiple values
+    // of the same type exist, so this return is intentionally ignored.
     primary_value + secondary_value
 }
 

--- a/crates/rstest-bdd/tests/step_return.rs
+++ b/crates/rstest-bdd/tests/step_return.rs
@@ -68,9 +68,9 @@ fn returns_competing_value(
     primary_value: PrimaryValue,
     secondary_value: SecondaryValue,
 ) -> PrimaryValue {
-    // The step context should prefer the fixture bindings when multiple values
-    // of the same type exist. The extra `competing_primary_value` fixture keeps
-    // this return intentionally ignored.
+    // When multiple fixtures of the same type exist, the step context cannot
+    // determine which fixture to override, so the return value is ignored.
+    // The `competing_primary_value` fixture creates this ambiguity intentionally.
     PrimaryValue(primary_value.0 + secondary_value.0)
 }
 

--- a/crates/rstest-bdd/tests/step_return.rs
+++ b/crates/rstest-bdd/tests/step_return.rs
@@ -27,3 +27,35 @@ fn check(number: i32) {
 fn scenario_step_return(number: i32) {
     let _ = number;
 }
+
+#[fixture]
+fn primary_value() -> i32 {
+    10
+}
+
+#[fixture]
+fn secondary_value() -> i32 {
+    20
+}
+
+#[given("two competing fixtures")]
+fn two_competing(primary_value: i32, secondary_value: i32) {
+    assert_eq!(primary_value, 10);
+    assert_eq!(secondary_value, 20);
+}
+
+#[when("a step returns a competing value")]
+fn returns_competing_value(primary_value: i32, secondary_value: i32) -> i32 {
+    primary_value + secondary_value
+}
+
+#[then("the fixtures remain unchanged")]
+fn fixtures_remain(primary_value: i32, secondary_value: i32) {
+    assert_eq!(primary_value, 10);
+    assert_eq!(secondary_value, 20);
+}
+
+#[scenario(path = "tests/features/step_return_ambiguous.feature")]
+fn scenario_step_return_ambiguous(primary_value: i32, secondary_value: i32) {
+    let _ = (primary_value, secondary_value);
+}

--- a/crates/rstest-bdd/tests/step_return.rs
+++ b/crates/rstest-bdd/tests/step_return.rs
@@ -85,7 +85,7 @@ fn fixtures_remain(
     assert_eq!(secondary_value.0, 20);
 }
 
-#[scenario(path = "tests/features/step_return_ambiguous.feature")]
+#[scenario(path = "tests/features/step_return.feature", index = 1)]
 fn scenario_step_return_ambiguous(
     primary_value: PrimaryValue,
     competing_primary_value: PrimaryValue,

--- a/crates/rstest-bdd/tests/step_return.rs
+++ b/crates/rstest-bdd/tests/step_return.rs
@@ -3,61 +3,93 @@
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct Number(i32);
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct PrimaryValue(i32);
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct SecondaryValue(i32);
+
 #[fixture]
-fn number() -> i32 {
-    1
+fn number() -> Number {
+    Number(1)
 }
 
 #[given("base number is 1")]
-fn base(number: i32) {
-    assert_eq!(number, 1);
+fn base(number: Number) {
+    assert_eq!(number.0, 1);
 }
 
 #[when("it is incremented")]
-fn increment(number: i32) -> i32 {
-    number + 1
+fn increment(number: Number) -> Number {
+    Number(number.0 + 1)
 }
 
 #[then("the result is 2")]
-fn check(number: i32) {
-    assert_eq!(number, 2);
+fn check(number: Number) {
+    assert_eq!(number.0, 2);
 }
 
 #[scenario(path = "tests/features/step_return.feature")]
-fn scenario_step_return(number: i32) {
+fn scenario_step_return(number: Number) {
     let _ = number;
 }
 
 #[fixture]
-fn primary_value() -> i32 {
-    10
+fn primary_value() -> PrimaryValue {
+    PrimaryValue(10)
 }
 
 #[fixture]
-fn secondary_value() -> i32 {
-    20
+fn competing_primary_value() -> PrimaryValue {
+    PrimaryValue(15)
+}
+
+#[fixture]
+fn secondary_value() -> SecondaryValue {
+    SecondaryValue(20)
 }
 
 #[given("two competing fixtures")]
-fn two_competing(primary_value: i32, secondary_value: i32) {
-    assert_eq!(primary_value, 10);
-    assert_eq!(secondary_value, 20);
+fn two_competing(
+    primary_value: PrimaryValue,
+    competing_primary_value: PrimaryValue,
+    secondary_value: SecondaryValue,
+) {
+    assert_eq!(primary_value.0, 10);
+    assert_eq!(competing_primary_value.0, 15);
+    assert_eq!(secondary_value.0, 20);
 }
 
 #[when("a step returns a competing value")]
-fn returns_competing_value(primary_value: i32, secondary_value: i32) -> i32 {
+fn returns_competing_value(
+    primary_value: PrimaryValue,
+    secondary_value: SecondaryValue,
+) -> PrimaryValue {
     // The step context should prefer the fixture bindings when multiple values
-    // of the same type exist, so this return is intentionally ignored.
-    primary_value + secondary_value
+    // of the same type exist. The extra `competing_primary_value` fixture keeps
+    // this return intentionally ignored.
+    PrimaryValue(primary_value.0 + secondary_value.0)
 }
 
 #[then("the fixtures remain unchanged")]
-fn fixtures_remain(primary_value: i32, secondary_value: i32) {
-    assert_eq!(primary_value, 10);
-    assert_eq!(secondary_value, 20);
+fn fixtures_remain(
+    primary_value: PrimaryValue,
+    competing_primary_value: PrimaryValue,
+    secondary_value: SecondaryValue,
+) {
+    assert_eq!(primary_value.0, 10);
+    assert_eq!(competing_primary_value.0, 15);
+    assert_eq!(secondary_value.0, 20);
 }
 
 #[scenario(path = "tests/features/step_return_ambiguous.feature")]
-fn scenario_step_return_ambiguous(primary_value: i32, secondary_value: i32) {
-    let _ = (primary_value, secondary_value);
+fn scenario_step_return_ambiguous(
+    primary_value: PrimaryValue,
+    competing_primary_value: PrimaryValue,
+    secondary_value: SecondaryValue,
+) {
+    let _ = (primary_value, competing_primary_value, secondary_value);
 }

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1448,7 +1448,8 @@ sequenceDiagram
   participant Then as Then Step
   participant Ctx as StepContext
 
-  Note over Ctx: fixtures: { name -> (&Any, TypeId) }<br/>values: { name -> Box<Any> }
+  Note over Ctx: fixtures: { name -> (&Any, TypeId) }<br/>
+    values: { name -> Box<Any> }
   Then->>Ctx: get::<T>("name")
   alt values has "name"
     Ctx-->>Then: &T from values

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1448,8 +1448,7 @@ sequenceDiagram
   participant Then as Then Step
   participant Ctx as StepContext
 
-  Note over Ctx: fixtures: { name -> (&Any, TypeId) }<br/>
-    values: { name -> Box<Any> }
+  Note over Ctx: fixtures: {name->(&Any, TypeId)}<br/>values: {name->Box<Any>}
   Then->>Ctx: get::<T>("name")
   alt values has "name"
     Ctx-->>Then: &T from values


### PR DESCRIPTION
## Summary
- expand the internal IntoStepResult unit tests to cover primitive, custom, alias, and Result conversions
- exercise the scenario runner with a new ambiguous fixture return flow and backing feature file
- wrap the Mermaid context note in the design docs to keep the text within the formatting limit

## Testing
- make fmt
- make markdownlint
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68caad98da2c8322a762b78285549a7f

## Summary by Sourcery

Expand test coverage for step result conversions and ambiguous fixtures, and adjust docs formatting

Documentation:
- Wrap Mermaid context note to comply with formatting limits

Tests:
- Add unit tests for IntoStepResult conversions covering primitives, custom structs, options, results, and type aliases
- Introduce BDD scenario tests for ambiguous fixture return flow with new fixtures, steps, and feature file

Chores:
- Reorder feature flags in lib.rs