### PR TITLE
Use specialization for step result conversions

### DIFF
--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -111,11 +111,15 @@ impl FromStr for StepKeyword {
 }
 
 impl From<&str> for StepKeyword {
+    #[expect(
+        unused_attributes,
+        reason = "deprecated trait conversion remains for compatibility"
+    )]
+    #[expect(useless_deprecated, reason = "trait impl deprecation has no effect")]
     #[deprecated(
         since = "0.1.0",
         note = "Use StepKeyword::try_from(...) or StepKeyword::from_str(...) instead"
     )]
-    #[expect(useless_deprecated, reason = "trait impl deprecation has no effect")]
     #[expect(
         clippy::expect_used,
         reason = "deprecated shim for backward compatibility"


### PR DESCRIPTION
## Summary
- enable nightly specialization support and mark `IntoStepResult` for specialization
- replace the negative auto-trait conversion logic with explicit specialisations for `()`, `Result<(), E>`, and `Result<T, E>`
- silence the deprecated `StepKeyword` shim lint with scoped `#[expect]` attributes

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68cbeb81fd2c8322a09793e755463611