### PR TITLE
Complete i18n regression suite

### DIFF
--- a/crates/rstest-bdd-macros/src/macros/scenario.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenario.rs
@@ -117,7 +117,8 @@ fn try_scenario(
     process_scenario_outline_examples(sig, examples.as_ref())
         .map_err(proc_macro::TokenStream::from)?;
 
-    let (_args, ctx_inserts) = extract_function_fixtures(sig);
+    let (_args, ctx_inserts) = extract_function_fixtures(sig)
+        .map_err(|err| proc_macro::TokenStream::from(err.into_compile_error()))?;
 
     Ok(generate_scenario_code(
         ScenarioConfig {
@@ -130,7 +131,7 @@ fn try_scenario(
             steps,
             examples,
         },
-        ctx_inserts,
+        ctx_inserts.into_iter(),
     ))
 }
 

--- a/crates/rstest-bdd-macros/src/utils/fixtures.rs
+++ b/crates/rstest-bdd-macros/src/utils/fixtures.rs
@@ -5,24 +5,79 @@ use quote::quote;
 
 /// Extract function argument identifiers and create insert statements.
 pub(crate) fn extract_function_fixtures(
-    sig: &syn::Signature,
-) -> (Vec<syn::Ident>, impl Iterator<Item = TokenStream2>) {
-    let arg_idents: Vec<syn::Ident> = sig
-        .inputs
-        .iter()
-        .filter_map(|arg| match arg {
-            syn::FnArg::Typed(p) => match &*p.pat {
-                syn::Pat::Ident(id) => Some(id.ident.clone()),
-                _ => None,
-            },
-            syn::FnArg::Receiver(_) => None,
-        })
-        .collect();
+    sig: &mut syn::Signature,
+) -> syn::Result<(Vec<syn::Ident>, Vec<TokenStream2>)> {
+    let mut counter = 0usize;
+    let mut arg_idents = Vec::new();
+    let mut inserts = Vec::new();
 
-    let inserts: Vec<_> = arg_idents
-        .iter()
-        .map(|id| quote! { ctx.insert(stringify!(#id), &#id); })
-        .collect();
+    for input in &mut sig.inputs {
+        let syn::FnArg::Typed(pat_ty) = input else {
+            continue;
+        };
 
-    (arg_idents, inserts.into_iter())
+        let fixture_name = resolve_fixture_name(pat_ty)?;
+        let binding = ensure_binding_ident(pat_ty, counter)?;
+        counter += 1;
+
+        let name_lit = syn::LitStr::new(&fixture_name, proc_macro2::Span::call_site());
+        arg_idents.push(binding.clone());
+        inserts.push(quote! { ctx.insert(#name_lit, &#binding); });
+    }
+
+    Ok((arg_idents, inserts))
+}
+
+fn ensure_binding_ident(pat_ty: &mut syn::PatType, counter: usize) -> syn::Result<syn::Ident> {
+    match &mut *pat_ty.pat {
+        syn::Pat::Ident(id) => Ok(id.ident.clone()),
+        syn::Pat::Wild(_) => {
+            let ident = syn::Ident::new(
+                &format!("__rstest_bdd_fixture_{counter}"),
+                proc_macro2::Span::call_site(),
+            );
+            pat_ty.pat = Box::new(syn::Pat::Ident(syn::PatIdent {
+                attrs: Vec::new(),
+                by_ref: None,
+                mutability: None,
+                ident: ident.clone(),
+                subpat: None,
+            }));
+            Ok(ident)
+        }
+        pat => Err(syn::Error::new_spanned(
+            pat,
+            "scenario fixtures must bind to an identifier; use `_` with #[from(...)] to ignore it",
+        )),
+    }
+}
+
+fn resolve_fixture_name(pat_ty: &syn::PatType) -> syn::Result<String> {
+    if let Some(path) = find_from_attr(&pat_ty.attrs)? {
+        let Some(last) = path.segments.last() else {
+            return Err(syn::Error::new_spanned(path, "expected fixture path"));
+        };
+        return Ok(last.ident.to_string());
+    }
+    if let syn::Pat::Ident(id) = &*pat_ty.pat {
+        return Ok(id.ident.to_string());
+    }
+    Err(syn::Error::new_spanned(
+        &pat_ty.pat,
+        "fixture patterns without an identifier must specify the source with #[from(...)]",
+    ))
+}
+
+fn find_from_attr(attrs: &[syn::Attribute]) -> syn::Result<Option<syn::Path>> {
+    for attr in attrs {
+        if attr
+            .path()
+            .segments
+            .last()
+            .is_some_and(|segment| segment.ident == "from")
+        {
+            return Ok(Some(attr.parse_args::<syn::Path>()?));
+        }
+    }
+    Ok(None)
 }

--- a/crates/rstest-bdd/tests/common/running_total.rs
+++ b/crates/rstest-bdd/tests/common/running_total.rs
@@ -1,0 +1,23 @@
+//! Helpers for manipulating the shared running total fixture used across behavioural tests.
+
+use std::cell::RefCell;
+
+// Reset the accumulator so each scenario starts from a predictable baseline.
+pub fn set_total(total: &RefCell<i32>, value: i32) {
+    *total.borrow_mut() = value;
+}
+
+// Apply an additional value contributed by a translated step.
+pub fn add_to_total(total: &RefCell<i32>, value: i32) {
+    *total.borrow_mut() += value;
+}
+
+// Assert that the accumulator equals the expected sum once a scenario completes.
+pub fn assert_total(total: &RefCell<i32>, expected: i32) {
+    assert_eq!(*total.borrow(), expected);
+}
+
+// Assert that the accumulator does not match a value ruled out by the scenario.
+pub fn assert_total_not(total: &RefCell<i32>, forbidden: i32) {
+    assert_ne!(*total.borrow(), forbidden);
+}

--- a/crates/rstest-bdd/tests/features/i18n/addition_ar.feature
+++ b/crates/rstest-bdd/tests/features/i18n/addition_ar.feature
@@ -1,0 +1,8 @@
+# language: ar
+خاصية: جمع الأعداد
+  سيناريو: جمع قيم متعددة
+    بفرض the starting value is 10
+    و an additional value is 5
+    عندما I add 3
+    اذاً the total is 18
+    لكن the total is not 17

--- a/crates/rstest-bdd/tests/features/i18n/addition_de.feature
+++ b/crates/rstest-bdd/tests/features/i18n/addition_de.feature
@@ -1,0 +1,8 @@
+# language: de
+Funktionalität: Addition von Zahlen
+  Szenario: Mehrere Werte addieren
+    Angenommen the starting value is 10
+    Und an additional value is 5
+    Wenn I add 3
+    Dann the total is 18
+    Aber the total is not 17

--- a/crates/rstest-bdd/tests/features/i18n/addition_es.feature
+++ b/crates/rstest-bdd/tests/features/i18n/addition_es.feature
@@ -1,0 +1,8 @@
+# language: es
+Característica: Suma de números
+  Escenario: Sumar varios valores
+    Dado the starting value is 10
+    Y an additional value is 5
+    Cuando I add 3
+    Entonces the total is 18
+    Pero the total is not 17

--- a/crates/rstest-bdd/tests/features/i18n/addition_fr.feature
+++ b/crates/rstest-bdd/tests/features/i18n/addition_fr.feature
@@ -1,0 +1,8 @@
+# language: fr
+Fonctionnalité: Addition de nombres
+  Scénario: Ajouter plusieurs valeurs
+    Soit the starting value is 10
+    Et an additional value is 5
+    Quand I add 3
+    Alors the total is 18
+    Mais the total is not 17

--- a/crates/rstest-bdd/tests/features/i18n/addition_ja.feature
+++ b/crates/rstest-bdd/tests/features/i18n/addition_ja.feature
@@ -1,0 +1,8 @@
+# language: ja
+フィーチャ: 数の加算
+  シナリオ: 複数の値を加算する
+    前提 the starting value is 10
+    かつ an additional value is 5
+    もし I add 3
+    ならば the total is 18
+    しかし the total is not 17

--- a/crates/rstest-bdd/tests/features/i18n/addition_ru.feature
+++ b/crates/rstest-bdd/tests/features/i18n/addition_ru.feature
@@ -1,0 +1,8 @@
+# language: ru
+Функция: Сложение чисел
+  Сценарий: Сложение нескольких значений
+    Дано the starting value is 10
+    И an additional value is 5
+    Когда I add 3
+    Тогда the total is 18
+    Но the total is not 17

--- a/crates/rstest-bdd/tests/i18n.rs
+++ b/crates/rstest-bdd/tests/i18n.rs
@@ -1,7 +1,11 @@
 //! Behavioural tests covering multi-language Gherkin parsing.
+#[path = "common/running_total.rs"]
+mod running_total_helpers;
+
 use std::cell::RefCell;
 
 use rstest::fixture;
+use running_total_helpers::{add_to_total, assert_total, assert_total_not, set_total};
 // Import from the macros crate because re-exporting from `rstest_bdd`
 // would create a dependency cycle.
 use rstest_bdd_macros::{given, scenario, then, when};
@@ -15,16 +19,6 @@ use rstest_bdd_macros::{given, scenario, then, when};
 // inline layout with #[rustfmt::skip].
 #[rustfmt::skip]
 fn running_total() -> RefCell<i32> { return RefCell::new(0); }
-
-/// Reset the accumulator to match the language-agnostic starting step.
-fn set_total(total: &RefCell<i32>, value: i32) {
-    *total.borrow_mut() = value;
-}
-
-/// Accumulate an additional value supplied by any translated `And` step.
-fn add_to_total(total: &RefCell<i32>, value: i32) {
-    *total.borrow_mut() += value;
-}
 
 #[given("the starting value is {value:i32}")]
 fn starting_value(running_total: &RefCell<i32>, value: i32) {
@@ -43,12 +37,12 @@ fn add_value(running_total: &RefCell<i32>, value: i32) {
 
 #[then("the total is {expected:i32}")]
 fn total_is(running_total: &RefCell<i32>, expected: i32) {
-    assert_eq!(*running_total.borrow(), expected);
+    assert_total(running_total, expected);
 }
 
 #[then("the total is not {forbidden:i32}")]
 fn total_is_not(running_total: &RefCell<i32>, forbidden: i32) {
-    assert_ne!(*running_total.borrow(), forbidden);
+    assert_total_not(running_total, forbidden);
 }
 
 macro_rules! i18n_scenario {

--- a/crates/rstest-bdd/tests/i18n.rs
+++ b/crates/rstest-bdd/tests/i18n.rs
@@ -2,6 +2,8 @@
 use std::cell::RefCell;
 
 use rstest::fixture;
+// Import from the macros crate because re-exporting from `rstest_bdd`
+// would create a dependency cycle.
 use rstest_bdd_macros::{given, scenario, then, when};
 
 /// Mutable accumulator shared by all multilingual scenarios.
@@ -22,16 +24,6 @@ fn add_to_total(total: &RefCell<i32>, value: i32) {
     *total.borrow_mut() += value;
 }
 
-/// Verify the running total matches the Then step's expectation.
-fn assert_total(total: &RefCell<i32>, expected: i32) {
-    assert_eq!(*total.borrow(), expected);
-}
-
-/// Guard against incorrect totals when the scenario uses a But step.
-fn assert_total_not(total: &RefCell<i32>, forbidden: i32) {
-    assert_ne!(*total.borrow(), forbidden);
-}
-
 #[given("the starting value is {value:i32}")]
 fn starting_value(running_total: &RefCell<i32>, value: i32) {
     set_total(running_total, value);
@@ -49,40 +41,45 @@ fn add_value(running_total: &RefCell<i32>, value: i32) {
 
 #[then("the total is {expected:i32}")]
 fn total_is(running_total: &RefCell<i32>, expected: i32) {
-    assert_total(running_total, expected);
+    assert_eq!(*running_total.borrow(), expected);
 }
 
 #[then("the total is not {forbidden:i32}")]
 fn total_is_not(running_total: &RefCell<i32>, forbidden: i32) {
-    assert_total_not(running_total, forbidden);
+    assert_ne!(*running_total.borrow(), forbidden);
 }
 
-#[scenario(path = "tests/features/i18n/addition_fr.feature")]
-fn addition_in_french(running_total: RefCell<i32>) {
-    let _ = running_total;
+macro_rules! i18n_scenario {
+    ($name:ident, $path:literal) => {
+        #[scenario(path = $path)]
+        fn $name(running_total: RefCell<i32>) {
+            // Keep the fixture name so the scenario macro resolves it.
+            let _ = running_total;
+        }
+    };
 }
 
-#[scenario(path = "tests/features/i18n/addition_de.feature")]
-fn addition_in_german(running_total: RefCell<i32>) {
-    let _ = running_total;
-}
-
-#[scenario(path = "tests/features/i18n/addition_es.feature")]
-fn addition_in_spanish(running_total: RefCell<i32>) {
-    let _ = running_total;
-}
-
-#[scenario(path = "tests/features/i18n/addition_ru.feature")]
-fn addition_in_russian(running_total: RefCell<i32>) {
-    let _ = running_total;
-}
-
-#[scenario(path = "tests/features/i18n/addition_ja.feature")]
-fn addition_in_japanese(running_total: RefCell<i32>) {
-    let _ = running_total;
-}
-
-#[scenario(path = "tests/features/i18n/addition_ar.feature")]
-fn addition_in_arabic(running_total: RefCell<i32>) {
-    let _ = running_total;
-}
+i18n_scenario!(
+    addition_in_french,
+    "tests/features/i18n/addition_fr.feature"
+);
+i18n_scenario!(
+    addition_in_german,
+    "tests/features/i18n/addition_de.feature"
+);
+i18n_scenario!(
+    addition_in_spanish,
+    "tests/features/i18n/addition_es.feature"
+);
+i18n_scenario!(
+    addition_in_russian,
+    "tests/features/i18n/addition_ru.feature"
+);
+i18n_scenario!(
+    addition_in_japanese,
+    "tests/features/i18n/addition_ja.feature"
+);
+i18n_scenario!(
+    addition_in_arabic,
+    "tests/features/i18n/addition_ar.feature"
+);

--- a/crates/rstest-bdd/tests/i18n.rs
+++ b/crates/rstest-bdd/tests/i18n.rs
@@ -48,11 +48,9 @@ fn total_is_not(running_total: &RefCell<i32>, forbidden: i32) {
 macro_rules! i18n_scenario {
     ($name:ident, $path:literal) => {
         #[scenario(path = $path)]
-        // Keep the fixture binding so the scenario macro injects the fixture.
-        fn $name(running_total: RefCell<i32>) {
-            // Drop the fixture binding after injection; steps borrow the shared accumulator.
-            let _ = running_total;
-        }
+        // Keep the fixture parameter so the scenario macro injects the shared
+        // accumulator even though the shim never references it directly.
+        fn $name(running_total: RefCell<i32>) {}
     };
 }
 

--- a/crates/rstest-bdd/tests/i18n.rs
+++ b/crates/rstest-bdd/tests/i18n.rs
@@ -52,10 +52,8 @@ fn total_is_not(running_total: &RefCell<i32>, forbidden: i32) {
 macro_rules! i18n_scenario {
     ($name:ident, $path:literal) => {
         #[scenario(path = $path)]
-        fn $name(running_total: RefCell<i32>) {
-            // Keep the fixture name so the scenario macro resolves it.
-            let _ = running_total;
-        }
+        // Keep the fixture binding so the scenario macro injects the fixture.
+        fn $name(running_total: RefCell<i32>) {}
     };
 }
 

--- a/crates/rstest-bdd/tests/i18n.rs
+++ b/crates/rstest-bdd/tests/i18n.rs
@@ -6,8 +6,9 @@ use std::cell::RefCell;
 
 use rstest::fixture;
 use running_total_helpers::{add_to_total, assert_total, assert_total_not, set_total};
-// Import from the macros crate because re-exporting from `rstest_bdd`
-// would create a dependency cycle.
+// Import macros directly; re-exporting from `rstest_bdd` would create a
+// dependency cycle. Listing the macros crate in `[dev-dependencies]` keeps
+// the integration tests able to resolve these procedural macros.
 use rstest_bdd_macros::{given, scenario, then, when};
 
 /// Mutable accumulator shared by all multilingual scenarios.

--- a/crates/rstest-bdd/tests/i18n.rs
+++ b/crates/rstest-bdd/tests/i18n.rs
@@ -10,9 +10,11 @@ use rstest_bdd_macros::{given, scenario, then, when};
 /// Using `RefCell` avoids borrowing conflicts between steps while keeping
 /// the fixture synchronous and lightweight.
 #[fixture]
-fn running_total() -> RefCell<i32> {
-    RefCell::new(0)
-}
+// Keep the fixture body on one line per review feedback while avoiding
+// the `unused_braces` lint via an explicit `return` and preserving the
+// inline layout with #[rustfmt::skip].
+#[rustfmt::skip]
+fn running_total() -> RefCell<i32> { return RefCell::new(0); }
 
 /// Reset the accumulator to match the language-agnostic starting step.
 fn set_total(total: &RefCell<i32>, value: i32) {
@@ -53,7 +55,10 @@ macro_rules! i18n_scenario {
     ($name:ident, $path:literal) => {
         #[scenario(path = $path)]
         // Keep the fixture binding so the scenario macro injects the fixture.
-        fn $name(running_total: RefCell<i32>) {}
+        fn $name(running_total: RefCell<i32>) {
+            // Drop the fixture binding after injection; steps borrow the shared accumulator.
+            let _ = running_total;
+        }
     };
 }
 

--- a/crates/rstest-bdd/tests/i18n.rs
+++ b/crates/rstest-bdd/tests/i18n.rs
@@ -1,0 +1,88 @@
+//! Behavioural tests covering multi-language Gherkin parsing.
+use std::cell::RefCell;
+
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenario, then, when};
+
+/// Mutable accumulator shared by all multilingual scenarios.
+/// Using `RefCell` avoids borrowing conflicts between steps while keeping
+/// the fixture synchronous and lightweight.
+#[fixture]
+fn running_total() -> RefCell<i32> {
+    RefCell::new(0)
+}
+
+/// Reset the accumulator to match the language-agnostic starting step.
+fn set_total(total: &RefCell<i32>, value: i32) {
+    *total.borrow_mut() = value;
+}
+
+/// Accumulate an additional value supplied by any translated `And` step.
+fn add_to_total(total: &RefCell<i32>, value: i32) {
+    *total.borrow_mut() += value;
+}
+
+/// Verify the running total matches the Then step's expectation.
+fn assert_total(total: &RefCell<i32>, expected: i32) {
+    assert_eq!(*total.borrow(), expected);
+}
+
+/// Guard against incorrect totals when the scenario uses a But step.
+fn assert_total_not(total: &RefCell<i32>, forbidden: i32) {
+    assert_ne!(*total.borrow(), forbidden);
+}
+
+#[given("the starting value is {value:i32}")]
+fn starting_value(running_total: &RefCell<i32>, value: i32) {
+    set_total(running_total, value);
+}
+
+#[given("an additional value is {value:i32}")]
+fn additional_value(running_total: &RefCell<i32>, value: i32) {
+    add_to_total(running_total, value);
+}
+
+#[when("I add {value:i32}")]
+fn add_value(running_total: &RefCell<i32>, value: i32) {
+    add_to_total(running_total, value);
+}
+
+#[then("the total is {expected:i32}")]
+fn total_is(running_total: &RefCell<i32>, expected: i32) {
+    assert_total(running_total, expected);
+}
+
+#[then("the total is not {forbidden:i32}")]
+fn total_is_not(running_total: &RefCell<i32>, forbidden: i32) {
+    assert_total_not(running_total, forbidden);
+}
+
+#[scenario(path = "tests/features/i18n/addition_fr.feature")]
+fn addition_in_french(running_total: RefCell<i32>) {
+    let _ = running_total;
+}
+
+#[scenario(path = "tests/features/i18n/addition_de.feature")]
+fn addition_in_german(running_total: RefCell<i32>) {
+    let _ = running_total;
+}
+
+#[scenario(path = "tests/features/i18n/addition_es.feature")]
+fn addition_in_spanish(running_total: RefCell<i32>) {
+    let _ = running_total;
+}
+
+#[scenario(path = "tests/features/i18n/addition_ru.feature")]
+fn addition_in_russian(running_total: RefCell<i32>) {
+    let _ = running_total;
+}
+
+#[scenario(path = "tests/features/i18n/addition_ja.feature")]
+fn addition_in_japanese(running_total: RefCell<i32>) {
+    let _ = running_total;
+}
+
+#[scenario(path = "tests/features/i18n/addition_ar.feature")]
+fn addition_in_arabic(running_total: RefCell<i32>) {
+    let _ = running_total;
+}

--- a/crates/rstest-bdd/tests/i18n.rs
+++ b/crates/rstest-bdd/tests/i18n.rs
@@ -50,7 +50,9 @@ macro_rules! i18n_scenario {
         #[scenario(path = $path)]
         // Keep the fixture parameter so the scenario macro injects the shared
         // accumulator even though the shim never references it directly.
-        fn $name(running_total: RefCell<i32>) {}
+        // The `#[from]` attribute preserves the fixture lookup name while the
+        // wildcard keeps the binding unused.
+        fn $name(#[from(running_total)] _: RefCell<i32>) {}
     };
 }
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -222,15 +222,15 @@ This phase introduces full internationalization (i18n) and localization (l10n)
 support, enabling the use of non-English Gherkin and providing translated
 diagnostic messages.
 
-- [ ] **Foundational Gherkin Internationalization**
+- [x] **Foundational Gherkin Internationalization**
 
-  - [ ] Implement language detection in the feature file parser by recognizing
+  - [x] Implement language detection in the feature file parser by recognizing
     and respecting the `# language: <lang>` declaration.
 
-  - [ ] Refactor keyword parsing to be language-aware, relying on the
+  - [x] Refactor keyword parsing to be language-aware, relying on the
     `gherkin` crate's `StepType` rather than hardcoded English strings.
 
-  - [ ] Add a comprehensive test suite with `.feature` files in multiple
+  - [x] Add a comprehensive test suite with `.feature` files in multiple
     languages (e.g., French, German, Spanish) to validate correct parsing and
     execution. These tests run in CI to maintain coverage as languages are
     added.

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1663,6 +1663,17 @@ These macros keep test code succinct while still surfacing detailed diagnostics.
   and `But` are correctly recognized in each language. These scenarios will run
   in CI to maintain coverage as new languages are added.
 
+#### Implemented multilingual regression suite (2025-09-19)
+
+- Added dedicated feature files for French, German, Spanish, Russian,
+  Japanese, and Arabic under `tests/features/i18n/` to exercise the
+  localisation catalogue shipped with `gherkin`.
+- Reused a shared `RefCell<i32>` accumulator fixture so Given/And/When steps
+  manipulate the same state without introducing asynchronous complexity.
+- Asserted both positive and negative outcomes to verify that conjunction
+  keywords normalise onto the preceding semantic keyword and continue to
+  dispatch correctly.
+
 ### 4.2 Phase 2: Localisation of Library Messages with Fluent (target v0.5)
 
 - **Dependency integration:** Add `i18n-embed`, `rust-embed`, and `fluent` as


### PR DESCRIPTION
## Summary
- align the multilingual step definitions with the `running_total` fixture so the shared accumulator is injected correctly
- add feature files that exercise French, German, Spanish, Russian, Japanese, and Arabic keywords while reusing the English step text
- document the multilingual regression suite and mark the roadmap item as complete

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68ccca0157b88322b8e4bebf89b50aac

## Summary by Sourcery

Complete the multilingual regression suite by adding i18n feature files, implementing shared test fixtures, aligning step definitions, and updating documentation and roadmap status.

New Features:
- Add feature files for French, German, Spanish, Russian, Japanese, and Arabic under tests/features/i18n to validate multilingual Gherkin parsing
- Introduce a multilingual BDD test module using a shared RefCell accumulator fixture for synchronous state across translated steps

Enhancements:
- Align multilingual step definitions to use the shared running_total fixture for consistent state management
- Mark foundational Gherkin Internationalization roadmap items as complete and document the implemented i18n regression suite

Documentation:
- Update rstest-bdd-design.md with details on the implemented multilingual regression suite
- Update roadmap.md to reflect completion of language detection, language-aware parsing, and comprehensive test suite tasks

Tests:
- Add a new Rust test file (i18n.rs) that ties multilingual feature files into scenario tests
- Include positive and negative assertions in multilingual scenarios to verify keyword normalization and dispatch