### PR TITLE
Document IntoStepResult specialisations

### DIFF
--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -110,12 +110,12 @@ impl FromStr for StepKeyword {
     }
 }
 
+#[deprecated(
+    since = "0.1.0",
+    note = "Use StepKeyword::try_from(...) or StepKeyword::from_str(...) instead"
+)]
+#[expect(useless_deprecated, reason = "trait impl deprecation has no effect")]
 impl From<&str> for StepKeyword {
-    #[deprecated(
-        since = "0.1.0",
-        note = "Use StepKeyword::try_from(...) or StepKeyword::from_str(...) instead"
-    )]
-    #[expect(useless_deprecated, reason = "trait impl deprecation has no effect")]
     #[expect(
         clippy::expect_used,
         reason = "deprecated shim for backward compatibility"


### PR DESCRIPTION
## Summary
- expand the `IntoStepResult` docs to describe the specialised implementations and the fallback behaviour

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68cbeb81fd2c8322a09793e755463611

## Summary by Sourcery

Document and implement specializations for the IntoStepResult trait, reorganize its implementations using private auto traits, update crate documentation to describe nightly requirement and conversion behavior, and add tests to validate the new specializations.

Enhancements:
- Introduce private auto traits NotResult and NotUnit to control blanket implementations of IntoStepResult
- Reorganize IntoStepResult impls to provide specialized handling for unit values, Result<(), E>, Result<T, E>, and a default fallback

Documentation:
- Add crate-level doc warning about nightly Rust requirement
- Expand IntoStepResult documentation to detail each specialization and fallback behavior

Tests:
- Add internal tests for default boxing, unit conversion, Result<(), E> mapping, and Result<T, E> boxing cases

Chores:
- Reposition deprecation attribute on From<&str> for StepKeyword for backward compatibility