### PR TITLE
Add nested IntoStepResult unit test

### DIFF
--- a/crates/rstest-bdd/tests/features/step_return.feature
+++ b/crates/rstest-bdd/tests/features/step_return.feature
@@ -8,3 +8,14 @@ Feature: Step return values
     Given two competing fixtures
     When a step returns a competing value
     Then the fixtures remain unchanged
+
+  Scenario: Fallible unit step success
+    Given base number is 1
+    When a fallible unit step succeeds
+    Then the base number is unchanged
+
+  Scenario: Fallible result step success
+    Given base number is 1
+    When a fallible increment succeeds
+    Then the fallible result is 2
+

--- a/crates/rstest-bdd/tests/features/step_return.feature
+++ b/crates/rstest-bdd/tests/features/step_return.feature
@@ -3,19 +3,3 @@ Feature: Step return values
     Given base number is 1
     When it is incremented
     Then the result is 2
-
-  Scenario: Ambiguous fixtures ignore override
-    Given two competing fixtures
-    When a step returns a competing value
-    Then the fixtures remain unchanged
-
-  Scenario: Fallible unit step success
-    Given base number is 1
-    When a fallible unit step succeeds
-    Then the base number is unchanged
-
-  Scenario: Fallible result step success
-    Given base number is 1
-    When a fallible increment succeeds
-    Then the fallible result is 2
-

--- a/crates/rstest-bdd/tests/features/step_return_ambiguous.feature
+++ b/crates/rstest-bdd/tests/features/step_return_ambiguous.feature
@@ -1,0 +1,5 @@
+Feature: Step return values with ambiguous fixtures
+  Scenario: Ambiguous fixtures ignore override
+    Given two competing fixtures
+    When a step returns a competing value
+    Then the fixtures remain unchanged

--- a/crates/rstest-bdd/tests/features/step_return_fallible_result.feature
+++ b/crates/rstest-bdd/tests/features/step_return_fallible_result.feature
@@ -1,5 +1,11 @@
+@fallible @value
 Feature: Fallible value step
   Scenario: Fallible value step success
     Given base number is 1
     When a fallible increment succeeds
     Then the fallible result is 2
+
+  Scenario: Fallible value step failure
+    Given base number is 1
+    When a fallible increment fails
+    Then the fallible result fails

--- a/crates/rstest-bdd/tests/features/step_return_fallible_result.feature
+++ b/crates/rstest-bdd/tests/features/step_return_fallible_result.feature
@@ -1,5 +1,5 @@
 Feature: Fallible value step
-  Scenario: Fallible result step success
+  Scenario: Fallible value step success
     Given base number is 1
     When a fallible increment succeeds
     Then the fallible result is 2

--- a/crates/rstest-bdd/tests/features/step_return_fallible_result.feature
+++ b/crates/rstest-bdd/tests/features/step_return_fallible_result.feature
@@ -1,0 +1,5 @@
+Feature: Fallible value step
+  Scenario: Fallible result step success
+    Given base number is 1
+    When a fallible increment succeeds
+    Then the fallible result is 2

--- a/crates/rstest-bdd/tests/features/step_return_fallible_unit.feature
+++ b/crates/rstest-bdd/tests/features/step_return_fallible_unit.feature
@@ -1,0 +1,5 @@
+Feature: Fallible unit step
+  Scenario: Fallible unit step success
+    Given base number is 1
+    When a fallible unit step succeeds
+    Then the base number is unchanged

--- a/crates/rstest-bdd/tests/step_return.rs
+++ b/crates/rstest-bdd/tests/step_return.rs
@@ -143,18 +143,12 @@ fn scenario_fallible_unit(number: Number) {
     let _ = number;
 }
 
-#[scenario(
-    path = "tests/features/step_return_fallible_result.feature",
-    index = 0
-)]
+#[scenario(path = "tests/features/step_return_fallible_result.feature", index = 0)]
 fn scenario_fallible_result_success(number: Number) {
     let _ = number;
 }
 
-#[scenario(
-    path = "tests/features/step_return_fallible_result.feature",
-    index = 1
-)]
+#[scenario(path = "tests/features/step_return_fallible_result.feature", index = 1)]
 #[should_panic(expected = "value failure")]
 fn scenario_fallible_result_failure(number: Number) {
     let _ = number;

--- a/crates/rstest-bdd/tests/step_return.rs
+++ b/crates/rstest-bdd/tests/step_return.rs
@@ -27,8 +27,37 @@ fn increment(number: Number) -> Number {
     Number(number.0 + 1)
 }
 
+#[when("a fallible unit step succeeds")]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step intentionally returns Result to exercise IntoStepResult"
+)]
+fn fallible_unit_step_succeeds(number: Number) -> Result<(), &'static str> {
+    assert_eq!(number.0, 1);
+    Ok(())
+}
+
+#[when("a fallible increment succeeds")]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step intentionally returns Result to exercise IntoStepResult"
+)]
+fn fallible_increment_succeeds(number: Number) -> Result<Number, &'static str> {
+    Ok(Number(number.0 + 1))
+}
+
 #[then("the result is 2")]
 fn check(number: Number) {
+    assert_eq!(number.0, 2);
+}
+
+#[then("the base number is unchanged")]
+fn base_number_unchanged(number: Number) {
+    assert_eq!(number.0, 1);
+}
+
+#[then("the fallible result is 2")]
+fn fallible_result_is_two(number: Number) {
     assert_eq!(number.0, 2);
 }
 
@@ -92,4 +121,14 @@ fn scenario_step_return_ambiguous(
     secondary_value: SecondaryValue,
 ) {
     let _ = (primary_value, competing_primary_value, secondary_value);
+}
+
+#[scenario(path = "tests/features/step_return.feature", index = 2)]
+fn scenario_fallible_unit(number: Number) {
+    let _ = number;
+}
+
+#[scenario(path = "tests/features/step_return.feature", index = 3)]
+fn scenario_fallible_result(number: Number) {
+    let _ = number;
 }

--- a/crates/rstest-bdd/tests/step_return.rs
+++ b/crates/rstest-bdd/tests/step_return.rs
@@ -46,6 +46,12 @@ fn fallible_increment_succeeds(number: Number) -> Result<Number, &'static str> {
     Ok(Number(number.0 + 1))
 }
 
+#[when("a fallible increment fails")]
+fn fallible_increment_fails(number: Number) -> Result<Number, &'static str> {
+    assert_eq!(number.0, 1);
+    Err("value failure")
+}
+
 #[then("the result is 2")]
 fn check(number: Number) {
     assert_eq!(number.0, 2);
@@ -59,6 +65,15 @@ fn base_number_unchanged(number: Number) {
 #[then("the fallible result is 2")]
 fn fallible_result_is_two(number: Number) {
     assert_eq!(number.0, 2);
+}
+
+#[then("the fallible result fails")]
+#[expect(
+    clippy::panic,
+    reason = "failure scenario should stop before reaching this step"
+)]
+fn fallible_result_fails() {
+    panic!("fallible failure scenario should stop before assertions");
 }
 
 #[scenario(path = "tests/features/step_return.feature")]
@@ -128,7 +143,19 @@ fn scenario_fallible_unit(number: Number) {
     let _ = number;
 }
 
-#[scenario(path = "tests/features/step_return_fallible_result.feature")]
-fn scenario_fallible_result(number: Number) {
+#[scenario(
+    path = "tests/features/step_return_fallible_result.feature",
+    index = 0
+)]
+fn scenario_fallible_result_success(number: Number) {
+    let _ = number;
+}
+
+#[scenario(
+    path = "tests/features/step_return_fallible_result.feature",
+    index = 1
+)]
+#[should_panic(expected = "value failure")]
+fn scenario_fallible_result_failure(number: Number) {
     let _ = number;
 }

--- a/crates/rstest-bdd/tests/step_return.rs
+++ b/crates/rstest-bdd/tests/step_return.rs
@@ -114,7 +114,7 @@ fn fixtures_remain(
     assert_eq!(secondary_value.0, 20);
 }
 
-#[scenario(path = "tests/features/step_return.feature", index = 1)]
+#[scenario(path = "tests/features/step_return_ambiguous.feature")]
 fn scenario_step_return_ambiguous(
     primary_value: PrimaryValue,
     competing_primary_value: PrimaryValue,
@@ -123,12 +123,12 @@ fn scenario_step_return_ambiguous(
     let _ = (primary_value, competing_primary_value, secondary_value);
 }
 
-#[scenario(path = "tests/features/step_return.feature", index = 2)]
+#[scenario(path = "tests/features/step_return_fallible_unit.feature")]
 fn scenario_fallible_unit(number: Number) {
     let _ = number;
 }
 
-#[scenario(path = "tests/features/step_return.feature", index = 3)]
+#[scenario(path = "tests/features/step_return_fallible_result.feature")]
 fn scenario_fallible_result(number: Number) {
     let _ = number;
 }


### PR DESCRIPTION
## Summary
- add a unit test exercising IntoStepResult with a nested Result payload to confirm outer and inner error handling

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68cdb97516508322b081728e8b95e601

## Summary by Sourcery

Add comprehensive tests and step definitions to validate IntoStepResult behavior for nested and various Result payloads

New Features:
- Introduce fallible BDD steps returning Result<(), FancyError> and Result<FancyValue, FancyError> with execution tests
- Add nested and edge-case unit tests in internal_tests.rs to verify IntoStepResult handles unit, alias, zero-sized, display, and nested Result values
- Extend BDD step_return.rs and feature file with fallible unit and value scenarios

Enhancements:
- Ensure IntoStepResult mapping covers nested Result payloads and correctly unwraps values or propagates inner and outer errors

Tests:
- Add new cases in step_error_behaviour.rs and internal_tests.rs for error mapping and value round-trips
- Add BDD tests in step_return.rs and corresponding feature scenarios for fallible steps