### PR TITLE
Update trybuild expected output for registry warning

### DIFF
--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_step_warning.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_step_warning.stderr
@@ -1,3 +1,11 @@
+warning: step registry has no definitions for crate ID '$CRATE'. This may indicate a registry issue.
+ --> tests/fixtures/scenario_missing_step_warning.rs:3:1
+  |
+3 | #[scenario(path = "../../../../crates/rstest-bdd-macros/tests/features/unmatched.feature")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this warning originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: forced failure
  --> tests/fixtures/scenario_missing_step_warning.rs:7:1
   |


### PR DESCRIPTION
## Summary
- update the trybuild fixture for `scenario_missing_step_warning` to include the registry warning emitted by the macro

## Testing
- cargo test trybuild

------
https://chatgpt.com/codex/tasks/task_e_68cfdee9e8108322a56229ee5c5d55f7

## Summary by Sourcery

Tests:
- Include registry warning in scenario_missing_step_warning stderr fixture to match updated macro output