### PR TITLE
Refine publish check tooling

### DIFF
--- a/crates/rstest-bdd-patterns/tests/patterns.rs
+++ b/crates/rstest-bdd-patterns/tests/patterns.rs
@@ -34,3 +34,19 @@ fn maps_unknown_type_hint_to_lazy_match() {
     assert_eq!(get_type_pattern(Some("Custom")), r".+?");
     assert_eq!(get_type_pattern(None), r".+?");
 }
+
+#[test]
+fn rejects_placeholder_hint_with_whitespace() {
+    let Err(err) = build_regex_from_pattern("{value:bad hint}") else {
+        panic!("expected placeholder error");
+    };
+    assert!(err.to_string().contains("invalid placeholder"));
+}
+
+#[test]
+fn rejects_placeholder_hint_with_braces() {
+    let Err(err) = build_regex_from_pattern("{value:Vec<{u32}>}") else {
+        panic!("expected placeholder error");
+    };
+    assert!(err.to_string().contains("invalid placeholder"));
+}

--- a/crates/rstest-bdd-patterns/tests/patterns.rs
+++ b/crates/rstest-bdd-patterns/tests/patterns.rs
@@ -1,18 +1,16 @@
+#![expect(clippy::expect_used, reason = "test asserts conversion path")]
+
 use regex::Regex;
 
 use rstest_bdd_patterns::{build_regex_from_pattern, extract_captured_values, get_type_pattern};
 
 #[test]
 fn builds_regex_and_extracts_values() {
-    let Ok(regex_src) = build_regex_from_pattern("I have {count:u32} cukes") else {
-        panic!("unexpected pattern error");
-    };
-    let Ok(regex) = Regex::new(&regex_src) else {
-        panic!("failed to compile regex");
-    };
-    let Some(captures) = extract_captured_values(&regex, "I have 12 cukes") else {
-        panic!("expected captures for test step");
-    };
+    let regex_src =
+        build_regex_from_pattern("I have {count:u32} cukes").expect("pattern should compile");
+    let regex = Regex::new(&regex_src).expect("regex should compile");
+    let captures = extract_captured_values(&regex, "I have 12 cukes")
+        .expect("expected captures for test step");
     assert_eq!(captures, vec!["12".to_string()]);
 }
 

--- a/scripts/tests/test_run_publish_check.py
+++ b/scripts/tests/test_run_publish_check.py
@@ -1,0 +1,109 @@
+"""Tests for :mod:`scripts.run_publish_check`."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import os
+import subprocess
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+_publish_patch_stub = types.ModuleType("publish_patch")
+_publish_patch_stub.REPLACEMENTS = {}
+
+
+def _noop_apply_replacements(*_args: object, **_kwargs: object) -> None:
+    return None
+
+
+_publish_patch_stub.apply_replacements = _noop_apply_replacements
+sys.modules.setdefault("publish_patch", _publish_patch_stub)
+
+_MODULE_PATH = _SCRIPTS_DIR / "run_publish_check.py"
+_SPEC = importlib.util.spec_from_file_location("run_publish_check", _MODULE_PATH)
+_run_publish_check = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader  # narrow mypy and silence None analysis
+_SPEC.loader.exec_module(_run_publish_check)
+
+run_cargo_command = _run_publish_check.run_cargo_command
+
+
+class RunCargoCommandUnitTests(unittest.TestCase):
+    """Unit tests that exercise validation paths in :func:`run_cargo_command`."""
+
+    def setUp(self) -> None:  # noqa: D401 - unittest API contract
+        self._workspace = tempfile.TemporaryDirectory()
+        self.addCleanup(self._workspace.cleanup)
+        self.workspace = Path(self._workspace.name)
+        (self.workspace / "crates" / "demo").mkdir(parents=True)
+
+    def test_rejects_non_cargo_command(self) -> None:
+        """``run_cargo_command`` requires the command to start with ``cargo``."""
+
+        with self.assertRaises(ValueError):
+            run_cargo_command("demo", self.workspace, ["not-cargo"])
+
+    def test_invalid_timeout_logs_and_exits(self) -> None:
+        """An invalid timeout emits an error log before exiting."""
+
+        with mock.patch.dict(os.environ, {"PUBLISH_CHECK_TIMEOUT_SECS": "oops"}):
+            with self.assertLogs(level="ERROR") as captured:
+                with self.assertRaises(SystemExit):
+                    run_cargo_command("demo", self.workspace, ["cargo", "--version"])
+        self.assertTrue(
+            any("PUBLISH_CHECK_TIMEOUT_SECS" in entry for entry in captured.output)
+        )
+
+    def test_logs_output_when_command_fails(self) -> None:
+        """Failures surface the captured stdout and stderr in the log."""
+
+        failure = subprocess.CompletedProcess(
+            args=["cargo", "check"],
+            returncode=1,
+            stdout="compile error",
+            stderr="missing dependency",
+        )
+        with mock.patch.dict(os.environ, {}, clear=True), mock.patch(
+            "run_publish_check.subprocess.run", return_value=failure
+        ) as run_mock, self.assertLogs(level="ERROR") as captured:
+            with self.assertRaises(subprocess.CalledProcessError):
+                run_cargo_command("demo", self.workspace, ["cargo", "check"])
+        run_mock.assert_called_once()
+        joined_logs = "\n".join(captured.output)
+        self.assertIn("cargo stdout", joined_logs)
+        self.assertIn("cargo stderr", joined_logs)
+
+
+class RunCargoCommandBehaviouralTests(unittest.TestCase):
+    """Behavioural tests that execute ``cargo`` in a throwaway workspace."""
+
+    def test_runs_cargo_command_successfully(self) -> None:
+        """The helper executes a cargo command and streams its output."""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            crate_dir = workspace / "crates" / "demo"
+            crate_dir.mkdir(parents=True)
+            stdout_buffer = io.StringIO()
+            stderr_buffer = io.StringIO()
+            with mock.patch.dict(os.environ, {}, clear=True), contextlib.redirect_stdout(
+                stdout_buffer
+            ), contextlib.redirect_stderr(stderr_buffer):
+                run_cargo_command("demo", workspace, ["cargo", "--version"])
+            output = stdout_buffer.getvalue()
+            self.assertIn("cargo", output.lower())
+            self.assertEqual("", stderr_buffer.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extract `run_cargo_command` to deduplicate cargo invocation, harden manifest munging, and add timeout support in `run_publish_check.py`
- split `parse_optional_hint` by extracting hint slicing and UTF-8 parsing helpers to keep the cyclomatic complexity within limits
- update the integration test to use `expect` helpers and document the lint expectation

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68cff3b262ec83229040567839a4b7e2

## Summary by Sourcery

Refactor publish check script to centralize cargo invocation with timeout and enhance manifest manipulation, split placeholder hint parsing into dedicated helpers with validation, and update integration tests to use expect helpers.

Enhancements:
- Extract run_cargo_command in run_publish_check to deduplicate cargo invocations and support a configurable timeout
- Harden manifest munging with regex-based strip_patch_section and improved prune_workspace_members behavior
- Add error handling for missing workspace.package.version in run_publish_check

Tests:
- Update integration test to use expect helpers and add clippy expect_used annotation