### PR TITLE
Address feedback on pattern helpers and publish diagnostics

### DIFF
--- a/crates/rstest-bdd-patterns/src/capture.rs
+++ b/crates/rstest-bdd-patterns/src/capture.rs
@@ -30,27 +30,29 @@ pub fn extract_captured_values(re: &Regex, text: &str) -> Option<Vec<String>> {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "tests exercise fallible regex helpers")]
 mod tests {
     use super::*;
 
     #[test]
     fn returns_none_when_pattern_does_not_match() {
-        let regex = Regex::new(r"^(\d+)$").unwrap();
+        let regex = Regex::new(r"^(\d+)$").unwrap_or_else(|err| panic!("valid regex: {err}"));
         assert!(extract_captured_values(&regex, "nope").is_none());
     }
 
     #[test]
     fn collects_captures_in_order() {
-        let regex = Regex::new(r"^(\d+)-(\w+)-(\d+)$").unwrap();
-        let captures = extract_captured_values(&regex, "12-answer-7").unwrap();
+        let regex =
+            Regex::new(r"^(\d+)-(\w+)-(\d+)$").unwrap_or_else(|err| panic!("valid regex: {err}"));
+        let captures = extract_captured_values(&regex, "12-answer-7")
+            .unwrap_or_else(|| panic!("expected a match"));
         assert_eq!(captures, vec!["12", "answer", "7"]);
     }
 
     #[test]
     fn supports_empty_optional_groups() {
-        let regex = Regex::new(r"^(a)?(b)?$").unwrap();
-        let captures = extract_captured_values(&regex, "a").unwrap();
+        let regex = Regex::new(r"^(a)?(b)?$").unwrap_or_else(|err| panic!("valid regex: {err}"));
+        let captures =
+            extract_captured_values(&regex, "a").unwrap_or_else(|| panic!("expected a match"));
         assert_eq!(captures, vec![String::from("a"), String::new()]);
     }
 }

--- a/crates/rstest-bdd-patterns/src/hint.rs
+++ b/crates/rstest-bdd-patterns/src/hint.rs
@@ -47,4 +47,9 @@ mod tests {
     fn defaults_to_lazy_match_for_unknown_types() {
         assert_eq!(get_type_pattern(Some("String")), r".+?");
     }
+
+    #[test]
+    fn defaults_to_lazy_match_when_hint_is_none() {
+        assert_eq!(get_type_pattern(None), r".+?");
+    }
 }

--- a/crates/rstest-bdd-patterns/src/pattern/compiler.rs
+++ b/crates/rstest-bdd-patterns/src/pattern/compiler.rs
@@ -16,7 +16,7 @@ use super::lexer::{Token, lex_pattern};
 /// # use rstest_bdd_patterns::build_regex_from_pattern;
 /// let regex = build_regex_from_pattern("Given {item}")
 ///     .expect("example ensures fallible call succeeds");
-/// assert_eq!(regex, "^Given\ (.+?)$");
+/// assert_eq!(regex, r"^Given (.+?)$");
 /// ```
 pub fn build_regex_from_pattern(pat: &str) -> Result<String, PatternError> {
     let tokens = lex_pattern(pat)?;


### PR DESCRIPTION
## Summary
- replace regex helper tests to panic with helpful messages instead of using lint suppressions
- add coverage for missing type hints and fix the build_regex_from_pattern doctest expectation
- refactor the publish check failure handler to consume a typed command result

## Testing
- make fmt
- make check-fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d1b204e4e083229fa2a3fcd8596f50