### PR TITLE
Update trybuild expectation for missing step warning

### DIFF
--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_step_warning.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_step_warning.stderr
@@ -1,13 +1,13 @@
 warning: step registry has no definitions for crate ID '$CRATE'. This may indicate a registry issue.
- --> $DIR/scenario_missing_step_warning.rs:3:1
+ --> tests/fixtures/scenario_missing_step_warning.rs:3:1
   |
 3 | #[scenario(path = "../../../../crates/rstest-bdd-macros/tests/features/unmatched.feature")]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: this warning originates in the attribute macro `scenario`
+  = note: this warning originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: forced failure
- --> $DIR/scenario_missing_step_warning.rs:7:1
+ --> tests/fixtures/scenario_missing_step_warning.rs:7:1
   |
 7 | compile_error!("forced failure");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary
- align the trybuild expectation for the missing-step warning with the current compiler output
- capture the nightly macro backtrace hint in the recorded warning text

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d2350261448322afa4c3dd6a879fc8

## Summary by Sourcery

Align the trybuild test fixture for missing-step warnings with the latest compiler output, including the nightly macro backtrace hint.

Enhancements:
- Update the scenario_missing_step_warning.stderr fixture to reflect the current compiler warning format

Tests:
- Capture the nightly macro backtrace hint in the recorded warning text for missing-step scenarios