### PR TITLE
Simplify publish check command detail helper

### DIFF
--- a/scripts/run_publish_check.py
+++ b/scripts/run_publish_check.py
@@ -243,15 +243,12 @@ def _has_incomplete_legacy_parameters(
 
 
 def _extract_command_details(
-    crate: str,
     result_or_command: CommandResult | Sequence[str],
     return_code: int | None = None,
     stdout: str | None = None,
     stderr: str | None = None,
 ) -> tuple[list[str], int, str, str]:
     """Normalise command failure arguments for legacy and dataclass inputs."""
-
-    del crate  # Signature matches _handle_command_failure; crate is unused.
 
     if isinstance(result_or_command, CommandResult):
         return (
@@ -285,7 +282,6 @@ def _handle_command_failure(
     """
 
     command, exit_code, stdout_text, stderr_text = _extract_command_details(
-        crate,
         result_or_command,
         return_code=return_code,
         stdout=stdout,


### PR DESCRIPTION
## Summary
- remove the unused crate parameter from `_extract_command_details`
- update the failure handler to call the helper with the revised signature

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d239c6d4c883228d6535107df1c9c0

## Summary by Sourcery

Enhancements:
- Remove unused crate parameter from _extract_command_details and update its invocation in _handle_command_failure