### PR TITLE
Refactor cargo command logging test context

### DIFF
--- a/scripts/tests/test_run_publish_check.py
+++ b/scripts/tests/test_run_publish_check.py
@@ -368,24 +368,26 @@ def test_run_cargo_command_uses_env_timeout(
 
 def test_run_cargo_command_logs_failures(
     monkeypatch: pytest.MonkeyPatch,
-    context: CargoTestContext,
+    cargo_test_context: CargoTestContext,
 ) -> None:
-    fake_local = context.patch_local_runner(
+    fake_local = cargo_test_context.patch_local_runner(
         lambda _args, _timeout: (3, "bad stdout", "bad stderr")
     )
 
-    with context.caplog.at_level("ERROR"):
+    with cargo_test_context.caplog.at_level("ERROR"):
         with pytest.raises(SystemExit) as excinfo:
-            context.run_publish_check_module.run_cargo_command(
+            cargo_test_context.run_publish_check_module.run_cargo_command(
                 "demo",
-                context.fake_workspace,
+                cargo_test_context.fake_workspace,
                 ["cargo", "failing"],
                 timeout_secs=5,
             )
     assert "exit code 3" in str(excinfo.value)
-    assert "bad stdout" in context.caplog.text
-    assert "bad stderr" in context.caplog.text
-    assert fake_local.cwd_calls == [context.fake_workspace / "crates" / "demo"]
+    assert "bad stdout" in cargo_test_context.caplog.text
+    assert "bad stderr" in cargo_test_context.caplog.text
+    assert fake_local.cwd_calls == [
+        cargo_test_context.fake_workspace / "crates" / "demo"
+    ]
 
 
 def test_run_cargo_command_passes_command_result(


### PR DESCRIPTION
## Summary
- add a `CargoTestContext` dataclass to package cargo test fixtures
- introduce a `cargo_test_context` fixture for constructing the context
- update `test_run_cargo_command_logs_failures` to use the shared context object

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d2e31cc0388322a1667f0389c859e3

## Summary by Sourcery

Refactor cargo command logging tests to use a shared context fixture backed by a dataclass.

Enhancements:
- Introduce CargoTestContext dataclass and cargo_test_context fixture to consolidate cargo command test fixtures

Tests:
- Refactor test_run_cargo_command_logs_failures to use the new shared context fixture