### PR TITLE
Add pattern-handling sequence diagrams to design doc

### DIFF
--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -748,7 +748,7 @@ time, `StepPattern::compile` returns a `Result<(), regex::Error>`, and
 `PlaceholderError::InvalidPattern` at runtime.
 
 Runtime placeholder extraction reuses the same parser. The sequence below
-summarises the call path when placeholders are resolved at runtime.
+summarizes the call path when placeholders are resolved at runtime.
 
 ```mermaid
 sequenceDiagram


### PR DESCRIPTION
## Summary
- document how `rstest-bdd-macros::MacroPattern` compiles and caches regexes by delegating to the shared patterns crate
- add a runtime sequence diagram showing how `extract_placeholders` resolves captured values through the patterns helper

## Testing
- make fmt
- make lint
- make test
- make markdownlint
- make nixie

------
https://chatgpt.com/codex/tasks/task_e_68d2e378d1388322a9a3f22c659228d0

## Summary by Sourcery

Update the rstest-bdd design documentation to describe how macros delegate regex parsing and caching to the rstest-bdd-patterns crate and to include sequence diagrams for both compile-time and runtime pattern-handling flows.

Documentation:
- Enhance the design document with details on MacroPattern’s regex compilation and caching via the shared rstest-bdd-patterns crate
- Add a Mermaid sequence diagram illustrating compile-time pattern compilation and caching in procedural macros
- Add a Mermaid sequence diagram illustrating runtime placeholder extraction through the shared patterns helper