### PR TITLE
Align lexer test names with release guidance

### DIFF
--- a/crates/rstest-bdd-patterns/Cargo.toml
+++ b/crates/rstest-bdd-patterns/Cargo.toml
@@ -8,6 +8,7 @@ description = "Shared step-pattern compilation utilities for rstest-bdd."
 homepage.workspace = true
 repository.workspace = true
 readme = "README.md"
+include = ["src/**", "README.md", "LICENSE*", "CHANGELOG*", "Cargo.toml"]
 keywords.workspace = true
 categories.workspace = true
 rust-version.workspace = true

--- a/crates/rstest-bdd-patterns/src/pattern/lexer.rs
+++ b/crates/rstest-bdd-patterns/src/pattern/lexer.rs
@@ -180,7 +180,7 @@ mod tests {
     }
 
     lex_test!(
-        tokenises_literals_and_placeholders,
+        tokenizes_literals_and_placeholders,
         "Given {value:u32}",
         [
             Token::Literal("Given ".into()),
@@ -193,7 +193,7 @@ mod tests {
     );
 
     lex_test!(
-        recognises_doubled_braces_as_literals,
+        recognizes_doubled_braces_as_literals,
         "{{outer}} {inner}",
         [
             Token::Literal("{outer} ".into()),
@@ -230,7 +230,7 @@ mod tests {
     );
 
     lex_test!(
-        treats_placeholders_with_invalid_start_as_literals,
+        tokenizes_invalid_placeholder_start_as_braces_and_literal,
         "{  value}",
         [
             Token::OpenBrace { index: 0 },

--- a/docs/releasing-crates.md
+++ b/docs/releasing-crates.md
@@ -1,6 +1,6 @@
 # Releasing rstest-bdd crates
 
-This guide summarises the steps for publishing the `rstest-bdd` workspace
+This guide summarizes the steps for publishing the `rstest-bdd` workspace
 crates to [crates.io](https://crates.io/). Each release assumes the workspace
 version in `Cargo.toml` has already been bumped and the changelog entries are
 prepared. The workspace contains three libraries and the `cargo-bdd` support
@@ -11,22 +11,28 @@ tool, so follow the sequence below to keep the dependency graph satisfied.
    failures before proceeding.
 2. **Publish `rstest-bdd-patterns`.**
    - `cd crates/rstest-bdd-patterns`
+   - `cargo publish --dry-run`
    - `cargo publish`
 3. **Publish `rstest-bdd-macros`.**
    - `cd crates/rstest-bdd-macros`
+   - `cargo publish --dry-run`
    - `cargo publish`
 4. **Publish `rstest-bdd`.**
    - `cd crates/rstest-bdd`
+   - `cargo publish --dry-run`
    - `cargo publish`
 5. **Publish `cargo-bdd`.** This binary depends on the `rstest-bdd`
    diagnostics feature, so wait until crates.io finishes indexing the library
    release before packaging it.
    - `cd crates/cargo-bdd`
-   - `cargo publish`
-   - Optionally run `cargo install --path . --locked` from the same directory
-     to validate that the crate installs correctly before publishing.
+   - Optionally run `cargo install --path . --locked` from the same directory to
+     validate that the crate installs correctly before publishing.
+   - `cargo publish --dry-run --locked`
+   - `cargo publish --locked`
 6. **Tag the release.** Create a git tag matching the published version and
    push it to the repository.
+   - `git tag -a vX.Y.Z -m "rstest-bdd vX.Y.Z"`
+   - `git push origin vX.Y.Z`
 
 Cargo enforces that published dependencies already exist on crates.io. This is
 why the crates must be released in the order shown above.


### PR DESCRIPTION
## Summary
- rename the lexer `lex_test!` cases to use -ize spelling and clarify the invalid placeholder behaviour
- restrict the `rstest-bdd-patterns` crate publication to the source, docs, and manifest files via an include list
- expand the release checklist with dry-run commands, Oxford -ize spelling, and explicit tagging guidance

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d2f33fc0348322ad43f6302a1c8f1a

## Summary by Sourcery

Align lexer test names with American -ize spelling and clarify placeholder tests, restrict crate publishing files, and refine the release documentation with dry-run and tagging guidance

Enhancements:
- Restrict rstest-bdd-patterns crate publication to source, docs, and manifest files via an include list

Documentation:
- Update release guide with cargo publish dry-run commands, American -ize spelling, and explicit git tagging steps

Tests:
- Rename lexer test cases to use American spelling and clarify invalid placeholder behavior