### PR TITLE
Document publish patch helpers and stabilise scenario fixture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ CARGO ?= cargo
 BUILD_JOBS ?=
 CLIPPY_FLAGS ?= --workspace --all-targets --all-features -- -D warnings
 MDLINT ?= markdownlint
+UV ?= uv
 
 build: target/debug/$(APP) ## Build debug binary
 release: target/release/$(APP) ## Build release binary
@@ -40,7 +41,7 @@ nixie:
 	nixie --no-sandbox
 
 publish-check: ## Package crates in release order to validate publish readiness
-	uv run scripts/run_publish_check.py
+	$(UV) run scripts/run_publish_check.py
 
 
 help: ## Show available targets

--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_step_warning.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_step_warning.stderr
@@ -1,13 +1,13 @@
 warning: step registry has no definitions for crate ID '$CRATE'. This may indicate a registry issue.
- --> tests/fixtures/scenario_missing_step_warning.rs:3:1
+ --> $DIR/scenario_missing_step_warning.rs:3:1
   |
 3 | #[scenario(path = "../../../../crates/rstest-bdd-macros/tests/features/unmatched.feature")]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: this warning originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this warning originates in the attribute macro `scenario`
 
 error: forced failure
- --> tests/fixtures/scenario_missing_step_warning.rs:7:1
+ --> $DIR/scenario_missing_step_warning.rs:7:1
   |
 7 | compile_error!("forced failure");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/scripts/publish_patch.py
+++ b/scripts/publish_patch.py
@@ -151,7 +151,7 @@ def extract_existing_items(value: object) -> Iterable[tuple[str, object]]:
 
     Returns
     -------
-    Iterable[tuple[str, object]]
+    tuple[tuple[str, object], ...]
         Key-value pairs that should be retained when rebuilding the entry.
 
     Examples

--- a/scripts/publish_patch.py
+++ b/scripts/publish_patch.py
@@ -42,6 +42,36 @@ REPLACEMENTS: dict[str, tuple[DependencyPatch, ...]] = {
 
 
 def apply_replacements(crate: str, manifest: Path, version: str) -> None:
+    """Rewrite workspace dependencies to point at packaged versions.
+
+    Parameters
+    ----------
+    crate : str
+        Name of the crate whose manifest should be altered.
+    manifest : Path
+        Path to the `Cargo.toml` file that will be rewritten in place.
+    version : str
+        Version string applied to patched dependency entries.
+
+    Raises
+    ------
+    SystemExit
+        Raised when *crate* does not have a configured replacement set.
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> tmp = Path('Cargo.toml')
+    >>> _ = tmp.write_text(
+    ...     '[dependencies]\n'
+    ...     'rstest-bdd-patterns = { path = "../rstest-bdd-patterns" }\n'
+    ...     '[dev-dependencies]\n'
+    ...     'rstest-bdd-macros = { path = "../rstest-bdd-macros" }'
+    ... )
+    >>> apply_replacements('rstest-bdd', tmp, '1.2.3')
+    >>> 'version = "1.2.3"' in tmp.read_text()
+    True
+    """
     document = parse(manifest.read_text(encoding="utf-8"))
     patches = REPLACEMENTS.get(crate)
     if patches is None:
@@ -57,6 +87,34 @@ def update_dependency(
     version: str,
     manifest: Path,
 ) -> None:
+    """Replace a workspace dependency with an inline publish-friendly entry.
+
+    Parameters
+    ----------
+    document : TOMLDocument
+        Parsed manifest document that will be mutated in place.
+    patch : DependencyPatch
+        Replacement metadata describing the dependency to update.
+    version : str
+        Version string used for the inline dependency.
+    manifest : Path
+        Path to the manifest used for error reporting.
+
+    Raises
+    ------
+    SystemExit
+        Raised when the manifest is missing the targeted section or dependency.
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> from tomlkit import parse
+    >>> doc = parse('[dependencies]\nfoo = { path = "../foo" }')
+    >>> patch = DependencyPatch('dependencies', 'foo', '../foo')
+    >>> update_dependency(doc, patch, '1.0.0', Path('Cargo.toml'))
+    >>> dict(doc['dependencies']['foo'])['version']
+    '1.0.0'
+    """
     try:
         section = document[patch.section]
     except KeyError as error:
@@ -74,6 +132,26 @@ def update_dependency(
 
 
 def extract_existing_items(value: object) -> Iterable[tuple[str, object]]:
+    """Return preserved dependency metadata from an existing entry.
+
+    Parameters
+    ----------
+    value : object
+        Existing dependency definition, potentially a table or inline table.
+
+    Returns
+    -------
+    Iterable[tuple[str, object]]
+        Key-value pairs that should be retained when rebuilding the entry.
+
+    Examples
+    --------
+    >>> from tomlkit import parse
+    >>> table = parse('[dependencies]\nfoo = { default-features = false }')
+    >>> items = extract_existing_items(table['dependencies']['foo'])
+    >>> dict(items)
+    {'default-features': False}
+    """
     if isinstance(value, (Table, InlineTable)):
         return tuple(
             (key, item)
@@ -88,6 +166,28 @@ def build_inline_dependency(
     path: str,
     version: str,
 ) -> InlineTable:
+    """Construct a normalised inline dependency table.
+
+    Parameters
+    ----------
+    extra_items : Iterable[tuple[str, object]]
+        Additional metadata retained from the previous dependency definition.
+    path : str
+        Relative path to the dependency crate.
+    version : str
+        Version string for the dependency.
+
+    Returns
+    -------
+    InlineTable
+        Inline table ready to be inserted into the manifest document.
+
+    Examples
+    --------
+    >>> inline = build_inline_dependency((), '../foo', '1.0.0')
+    >>> dict(inline)
+    {'path': '../foo', 'version': '1.0.0'}
+    """
     dependency = inline_table()
     dependency["path"] = path
     dependency["version"] = version
@@ -98,6 +198,39 @@ def build_inline_dependency(
 
 
 def main() -> None:
+    """Parse CLI arguments and rewrite the requested manifest.
+
+    Raises
+    ------
+    SystemExit
+        Propagated when argument parsing fails or an unknown crate is given.
+
+    Examples
+    --------
+    >>> import sys
+    >>> from pathlib import Path
+    >>> tmp = Path('Cargo.toml')
+    >>> _ = tmp.write_text(
+    ...     '[dependencies]\n'
+    ...     'rstest-bdd-patterns = { path = "../rstest-bdd-patterns" }\n'
+    ...     '[dev-dependencies]\n'
+    ...     'rstest-bdd-macros = { path = "../rstest-bdd-macros" }'
+    ... )
+    >>> argv = sys.argv
+    >>> sys.argv = [
+    ...     'publish_patch.py',
+    ...     'rstest-bdd',
+    ...     str(tmp),
+    ...     '--version',
+    ...     '1.2.3',
+    ... ]
+    >>> try:
+    ...     main()
+    ... finally:
+    ...     sys.argv = argv
+    >>> 'version = "1.2.3"' in tmp.read_text()
+    True
+    """
     parser = argparse.ArgumentParser(
         description="Adjust workspace manifests for publish-check packaging."
     )

--- a/scripts/publish_patch.py
+++ b/scripts/publish_patch.py
@@ -53,6 +53,11 @@ def apply_replacements(crate: str, manifest: Path, version: str) -> None:
     version : str
         Version string applied to patched dependency entries.
 
+    Returns
+    -------
+    None
+        The manifest file is rewritten in place with patched dependencies.
+
     Raises
     ------
     SystemExit
@@ -99,6 +104,11 @@ def update_dependency(
         Version string used for the inline dependency.
     manifest : Path
         Path to the manifest used for error reporting.
+
+    Returns
+    -------
+    None
+        The targeted dependency entry is updated in ``document``.
 
     Raises
     ------
@@ -199,6 +209,11 @@ def build_inline_dependency(
 
 def main() -> None:
     """Parse CLI arguments and rewrite the requested manifest.
+
+    Returns
+    -------
+    None
+        Exits with status ``0`` after the manifest has been patched successfully.
 
     Raises
     ------


### PR DESCRIPTION
## Summary
- allow overriding the uv executable in the publish-check target
- document the publish_patch helpers with comprehensive NumPy-style docstrings
- normalise the scenario_missing_step_warning stderr fixture to remove paths and nightly-only text

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d2fd3df4d0832284fc60050e78c906

## Summary by Sourcery

Allow overriding the UV executable in publish-check, add comprehensive docstrings to publish_patch helpers, and stabilize the scenario_missing_step_warning test fixture

Enhancements:
- Add NumPy-style docstrings to publish_patch helper functions
- Normalize scenario_missing_step_warning stderr fixture by removing paths and nightly-only text

Build:
- Introduce UV variable in Makefile and use it in the publish-check target to allow overriding the uv executable

Tests:
- Update stderr fixture for missing scenario steps to remove file paths and nightly-specific text