### PR TITLE
Align trybuild warning stderr expectation

### DIFF
--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_step_warning.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_step_warning.stderr
@@ -1,5 +1,5 @@
 warning: step registry has no definitions for crate ID '$CRATE'. This may indicate a registry issue.
-Warning:  --> tests/fixtures/scenario_missing_step_warning.rs:3:1
+ --> tests/fixtures/scenario_missing_step_warning.rs:3:1
   |
 3 | #[scenario(path = "../../../../crates/rstest-bdd-macros/tests/features/unmatched.feature")]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ Warning:  --> tests/fixtures/scenario_missing_step_warning.rs:3:1
   = note: this warning originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: forced failure
-Error:  --> tests/fixtures/scenario_missing_step_warning.rs:7:1
+ --> tests/fixtures/scenario_missing_step_warning.rs:7:1
   |
 7 | compile_error!("forced failure");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_step_warning.stderr
+++ b/crates/rstest-bdd-macros/tests/fixtures/scenario_missing_step_warning.stderr
@@ -1,13 +1,13 @@
 warning: step registry has no definitions for crate ID '$CRATE'. This may indicate a registry issue.
- --> $DIR/scenario_missing_step_warning.rs:3:1
+Warning:  --> tests/fixtures/scenario_missing_step_warning.rs:3:1
   |
 3 | #[scenario(path = "../../../../crates/rstest-bdd-macros/tests/features/unmatched.feature")]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: this warning originates in the attribute macro `scenario`
+  = note: this warning originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: forced failure
- --> $DIR/scenario_missing_step_warning.rs:7:1
+Error:  --> tests/fixtures/scenario_missing_step_warning.rs:7:1
   |
 7 | compile_error!("forced failure");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary
- update the scenario_missing_step_warning trybuild stderr fixture to match the current compiler warning formatting

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d3390455f48322847b816b7caa016e

## Summary by Sourcery

Tests:
- Update trybuild test fixture for missing-step warning to match current compiler output