### PR TITLE
Configure Ruff and align publish-check tests with lint policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ target/%/$(APP): ## Build binary in debug or release mode
 
 lint: ## Run Clippy with warnings denied
 	$(CARGO) clippy $(CLIPPY_FLAGS)
+	find scripts -type f -name "*.py" -print0 | xargs -r -0 uvx ruff check
 
 fmt: ## Format Rust and Markdown sources
 	$(CARGO) fmt --all
@@ -34,6 +35,7 @@ fmt: ## Format Rust and Markdown sources
 
 check-fmt: ## Verify formatting
 	$(CARGO) fmt --all -- --check
+	find scripts -type f -name "*.py" -print0 | xargs -r -0 uvx ruff format --check
 
 markdownlint: ## Lint Markdown files
 	find . -type f -name '*.md' -not -path '*/target/*' -not -path '*/node_modules/*' -print0 | xargs -0 $(MDLINT)

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,65 @@
+line-length = 88
+
+[lint]
+select = [
+    "F",
+    "W",
+    "E",
+    "I",
+    "UP",
+    "C4",
+    "FA",
+    "ISC",
+    "ICN",
+    "RET",
+    "SIM",
+    "TID",
+    "TC",
+    "PTH",
+    "TD",
+    "A",
+    "BLE",
+    "S",
+    "DTZ",
+    "FBT",
+    "N",
+    "FURB",
+    "B",
+    "RUF",
+    "LOG",
+    "Q",
+    "PT",
+    "RSE",
+    "PERF",
+    "TRY",
+    "EM",
+    "D",
+    "ANN",
+]
+per-file-ignores = {"**/test_*.py" = ["S101"]}
+ignore = ["D205"]
+
+[lint.flake8-import-conventions]
+# Declare the banned `from` imports.
+banned-from = [
+    "typing",
+    "datetime",
+    "collections.abc",
+    "dataclasses",
+    "enum",
+    "unittest.mock",
+    "msgspec",
+    "msgspec.json",
+]
+
+[lint.flake8-import-conventions.aliases]
+"collections.abc" = "cabc"
+datetime = "dt"
+"unittest.mock" = "mock"
+msgspec = "ms"
+"msgspec.json" = "msjson"
+typing = "typ"
+
+[lint.pydocstyle]
+# Enforce NumPy docstring 
+convention = "numpy"

--- a/scripts/publish_patch.py
+++ b/scripts/publish_patch.py
@@ -6,18 +6,24 @@
 # ]
 # ///
 """Utility helpers for adjusting manifests during publish checks."""
+
 from __future__ import annotations
 
 import argparse
-from dataclasses import dataclass
+import dataclasses as dc
+import typing as typ
 from pathlib import Path
-from typing import Iterable
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+else:  # pragma: no cover - runtime placeholder for type checking imports
+    cabc: typ.Any = None
 
 from tomlkit import TOMLDocument, dumps, inline_table, parse
 from tomlkit.items import InlineTable, Table
 
 
-@dataclass(frozen=True)
+@dc.dataclass(frozen=True)
 class DependencyPatch:
     """Describe how a dependency should be rewritten for publish checks."""
 
@@ -26,18 +32,30 @@ class DependencyPatch:
     path: str
 
 
+@dc.dataclass(frozen=True)
+class DependencyConfig:
+    """Configuration values required to rewrite a dependency entry."""
+
+    version: str
+    include_local_path: bool = True
+
+
 REPLACEMENTS: dict[str, tuple[DependencyPatch, ...]] = {
     "rstest-bdd-macros": (
-        DependencyPatch("dependencies", "rstest-bdd-patterns", "../rstest-bdd-patterns"),
+        DependencyPatch(
+            "dependencies", "rstest-bdd-patterns", "../rstest-bdd-patterns"
+        ),
         DependencyPatch("dev-dependencies", "rstest-bdd", "../rstest-bdd"),
     ),
     "rstest-bdd": (
-        DependencyPatch("dependencies", "rstest-bdd-patterns", "../rstest-bdd-patterns"),
-        DependencyPatch("dev-dependencies", "rstest-bdd-macros", "../rstest-bdd-macros"),
+        DependencyPatch(
+            "dependencies", "rstest-bdd-patterns", "../rstest-bdd-patterns"
+        ),
+        DependencyPatch(
+            "dev-dependencies", "rstest-bdd-macros", "../rstest-bdd-macros"
+        ),
     ),
-    "cargo-bdd": (
-        DependencyPatch("dependencies", "rstest-bdd", "../rstest-bdd"),
-    ),
+    "cargo-bdd": (DependencyPatch("dependencies", "rstest-bdd", "../rstest-bdd"),),
 }
 
 
@@ -48,7 +66,7 @@ def apply_replacements(
     *,
     include_local_path: bool = True,
 ) -> None:
-    """Rewrite workspace dependencies to point at packaged versions.
+    r"""Rewrite workspace dependencies to point at packaged versions.
 
     Parameters
     ----------
@@ -91,14 +109,18 @@ def apply_replacements(
     document = parse(manifest.read_text(encoding="utf-8"))
     patches = REPLACEMENTS.get(crate)
     if patches is None:
-        raise SystemExit(f"unknown crate {crate!r}")
+        message = f"unknown crate {crate!r}"
+        raise SystemExit(message)
+    config = DependencyConfig(
+        version=version,
+        include_local_path=include_local_path,
+    )
     for patch in patches:
         update_dependency(
             document,
             patch,
-            version,
+            config,
             manifest,
-            include_local_path=include_local_path,
         )
     manifest.write_text(dumps(document), encoding="utf-8")
 
@@ -106,12 +128,10 @@ def apply_replacements(
 def update_dependency(
     document: TOMLDocument,
     patch: DependencyPatch,
-    version: str,
+    config: DependencyConfig,
     manifest: Path,
-    *,
-    include_local_path: bool,
 ) -> None:
-    """Replace a workspace dependency with an inline publish-friendly entry.
+    r"""Replace a workspace dependency with an inline publish-friendly entry.
 
     Parameters
     ----------
@@ -119,13 +139,11 @@ def update_dependency(
         Parsed manifest document that will be mutated in place.
     patch : DependencyPatch
         Replacement metadata describing the dependency to update.
-    version : str
-        Version string used for the inline dependency.
+    config : DependencyConfig
+        Configuration describing the replacement version and whether the
+        dependency should retain a ``path`` entry.
     manifest : Path
         Path to the manifest used for error reporting.
-    include_local_path : bool
-        Forwarded to :func:`build_inline_dependency` to control whether the
-        ``path`` attribute is retained.
 
     Returns
     -------
@@ -146,9 +164,8 @@ def update_dependency(
     >>> update_dependency(
     ...     doc,
     ...     patch,
-    ...     '1.0.0',
+    ...     DependencyConfig('1.0.0'),
     ...     Path('Cargo.toml'),
-    ...     include_local_path=True,
     ... )
     >>> dict(doc['dependencies']['foo'])['version']
     '1.0.0'
@@ -156,26 +173,24 @@ def update_dependency(
     try:
         section = document[patch.section]
     except KeyError as error:
-        raise SystemExit(
-            f"expected section [{patch.section}] in {manifest}"
-        ) from error
+        message = f"expected section [{patch.section}] in {manifest}"
+        raise SystemExit(message) from error
     try:
         existing = section[patch.name]
     except KeyError as error:
-        raise SystemExit(
-            f"expected dependency {patch.name!r} in {manifest}"
-        ) from error
+        message = f"expected dependency {patch.name!r} in {manifest}"
+        raise SystemExit(message) from error
     extra_items = extract_existing_items(existing)
     section[patch.name] = build_inline_dependency(
         extra_items,
         patch.path,
-        version,
-        include_local_path=include_local_path,
+        config.version,
+        include_local_path=config.include_local_path,
     )
 
 
-def extract_existing_items(value: object) -> Iterable[tuple[str, object]]:
-    """Return preserved dependency metadata from an existing entry.
+def extract_existing_items(value: object) -> cabc.Iterable[tuple[str, object]]:
+    r"""Return preserved dependency metadata from an existing entry.
 
     Parameters
     ----------
@@ -205,7 +220,7 @@ def extract_existing_items(value: object) -> Iterable[tuple[str, object]]:
 
 
 def build_inline_dependency(
-    extra_items: Iterable[tuple[str, object]],
+    extra_items: cabc.Iterable[tuple[str, object]],
     path: str,
     version: str,
     *,
@@ -215,7 +230,7 @@ def build_inline_dependency(
 
     Parameters
     ----------
-    extra_items : Iterable[tuple[str, object]]
+    extra_items : cabc.Iterable[tuple[str, object]]
         Additional metadata retained from the previous dependency definition.
     path : str
         Relative path to the dependency crate.
@@ -250,7 +265,7 @@ def build_inline_dependency(
 
 
 def main() -> None:
-    """Parse CLI arguments and rewrite the requested manifest.
+    r"""Parse CLI arguments and rewrite the requested manifest.
 
     Returns
     -------
@@ -309,8 +324,7 @@ def main() -> None:
         dest="include_local_path",
         action="store_false",
         help=(
-            "Drop relative path dependencies so manifests resolve crates on "
-            "crates.io."
+            "Drop relative path dependencies so manifests resolve crates on crates.io."
         ),
     )
     args = parser.parse_args()

--- a/scripts/publish_patch.py
+++ b/scripts/publish_patch.py
@@ -189,7 +189,7 @@ def update_dependency(
     )
 
 
-def extract_existing_items(value: object) -> cabc.Iterable[tuple[str, object]]:
+def extract_existing_items(value: object) -> tuple[tuple[str, object], ...]:
     r"""Return preserved dependency metadata from an existing entry.
 
     Parameters

--- a/scripts/publish_workspace.py
+++ b/scripts/publish_workspace.py
@@ -14,7 +14,6 @@ from pathlib import Path
 
 import tomllib
 from plumbum import local
-
 from publish_patch import REPLACEMENTS, apply_replacements
 from tomlkit import dumps, parse
 
@@ -22,11 +21,23 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 def export_workspace(destination: Path) -> None:
-    """Extract the repository HEAD into ``destination`` via ``git archive``."""
+    """Extract the repository HEAD into ``destination`` via ``git archive``.
 
+    Parameters
+    ----------
+    destination : Path
+        Directory that will receive the exported workspace contents.
+
+    Returns
+    -------
+    None
+        The repository snapshot is written directly to ``destination``.
+    """
     with tempfile.TemporaryDirectory() as archive_dir:
         archive_path = Path(archive_dir) / "workspace.tar"
-        git_archive = local["git"]["archive", "--format=tar", "HEAD", f"--output={archive_path}"]
+        git_archive = local["git"][
+            "archive", "--format=tar", "HEAD", f"--output={archive_path}"
+        ]
         with local.cwd(PROJECT_ROOT):
             git_archive()
         with tarfile.open(archive_path) as tar:
@@ -35,17 +46,17 @@ def export_workspace(destination: Path) -> None:
 
 def _is_patch_section_start(line: str) -> bool:
     """Return True when the line marks the ``[patch.crates-io]`` section."""
-
     return line.strip() == "[patch.crates-io]"
 
 
 def _is_any_section_start(line: str) -> bool:
     """Return True when the line starts a new manifest section."""
-
     return line.startswith("[")
 
 
-def _process_patch_section_line(line: str, skipping_patch: bool) -> tuple[bool, bool]:
+def _process_patch_section_line(
+    line: str, *, skipping_patch: bool
+) -> tuple[bool, bool]:
     """Process a line for patch section handling.
 
     Parameters
@@ -60,7 +71,6 @@ def _process_patch_section_line(line: str, skipping_patch: bool) -> tuple[bool, 
     tuple[bool, bool]
         A tuple of (should_include_line, new_skipping_patch_state).
     """
-
     if not skipping_patch and _is_patch_section_start(line):
         return False, True
 
@@ -72,20 +82,31 @@ def _process_patch_section_line(line: str, skipping_patch: bool) -> tuple[bool, 
 
 def _ensure_proper_file_ending(lines: list[str]) -> None:
     """Ensure the file ends with a newline by adding an empty string if needed."""
-
     if not lines or lines[-1] != "":
         lines.append("")
 
 
 def strip_patch_section(manifest: Path) -> None:
-    """Strip the [patch.crates-io] section from a Cargo manifest file."""
+    """Strip the ``[patch.crates-io]`` section from ``manifest``.
 
+    Parameters
+    ----------
+    manifest : Path
+        Manifest whose patch entries should be removed in place.
+
+    Returns
+    -------
+    None
+        The manifest on disk is rewritten without the patch section.
+    """
     lines = manifest.read_text(encoding="utf-8").splitlines()
     cleaned: list[str] = []
     skipping_patch = False
 
     for line in lines:
-        should_include, skipping_patch = _process_patch_section_line(line, skipping_patch)
+        should_include, skipping_patch = _process_patch_section_line(
+            line, skipping_patch=skipping_patch
+        )
         if should_include:
             cleaned.append(line)
 
@@ -95,26 +116,22 @@ def strip_patch_section(manifest: Path) -> None:
 
 def _is_members_section_start(line: str) -> bool:
     """Return True if the line starts a workspace members section."""
-
     stripped = line.strip()
     return stripped.startswith("members") and stripped.endswith("[")
 
 
 def _is_members_section_end(line: str) -> bool:
     """Return True if the line ends a workspace members section."""
-
     return line.strip() == "]"
 
 
 def _should_include_member_line(line: str) -> bool:
     """Return True if the member entry references a crate directory."""
-
     return '"crates/' in line.strip()
 
 
-def _process_member_line(line: str, inside_members: bool, result: list[str]) -> bool:
+def _process_member_line(line: str, *, inside_members: bool, result: list[str]) -> bool:
     """Update workspace member parsing state for a manifest line."""
-
     if _is_members_section_start(line):
         result.append(line)
         return True
@@ -131,13 +148,27 @@ def _process_member_line(line: str, inside_members: bool, result: list[str]) -> 
 
 
 def prune_workspace_members(manifest: Path) -> None:
-    """Remove non-crate entries from the workspace members list."""
+    """Remove non-crate entries from the workspace members list.
 
+    Parameters
+    ----------
+    manifest : Path
+        Workspace manifest whose members array should only contain crates.
+
+    Returns
+    -------
+    None
+        The manifest is rewritten with only crate directories listed.
+    """
     lines = manifest.read_text(encoding="utf-8").splitlines()
     result: list[str] = []
     inside_members = False
     for line in lines:
-        inside_members = _process_member_line(line, inside_members, result)
+        inside_members = _process_member_line(
+            line,
+            inside_members=inside_members,
+            result=result,
+        )
     if result and result[-1] != "":
         result.append("")
     manifest.write_text("\n".join(result), encoding="utf-8")
@@ -150,8 +181,25 @@ def apply_workspace_replacements(
     include_local_path: bool,
     crates: tuple[str, ...] | None = None,
 ) -> None:
-    """Rewrite workspace dependency declarations for publish workflows."""
+    """Rewrite workspace dependency declarations for publish workflows.
 
+    Parameters
+    ----------
+    workspace_root : Path
+        Root of the exported workspace containing crate directories.
+    version : str
+        Version string written to dependency entries.
+    include_local_path : bool
+        When ``True`` the relative ``path`` entries are retained so dry-run
+        checks use the local workspace.
+    crates : tuple[str, ...] | None, optional
+        Specific crates to update. Defaults to all known crates when ``None``.
+
+    Returns
+    -------
+    None
+        Each targeted manifest is rewritten in place.
+    """
     targets = REPLACEMENTS if crates is None else crates
     for crate in targets:
         if crate not in REPLACEMENTS:
@@ -166,18 +214,46 @@ def apply_workspace_replacements(
 
 
 def workspace_version(manifest: Path) -> str:
-    """Return the workspace package version from the root manifest."""
+    """Return the workspace package version from the root manifest.
 
+    Parameters
+    ----------
+    manifest : Path
+        Path to the workspace ``Cargo.toml`` file.
+
+    Returns
+    -------
+    str
+        The semantic version configured under ``[workspace.package]``.
+
+    Raises
+    ------
+    SystemExit
+        Raised when the workspace manifest lacks the version entry.
+    """
     data = tomllib.loads(manifest.read_text(encoding="utf-8"))
     try:
         return data["workspace"]["package"]["version"]
     except KeyError as err:
-        raise SystemExit(f"expected [workspace.package].version in {manifest}") from err
+        message = f"expected [workspace.package].version in {manifest}"
+        raise SystemExit(message) from err
 
 
 def remove_patch_entry(manifest: Path, crate: str) -> None:
-    """Remove the ``crate`` entry from the root ``[patch.crates-io]`` table."""
+    """Remove the ``crate`` entry from the root ``[patch.crates-io]`` table.
 
+    Parameters
+    ----------
+    manifest : Path
+        Root workspace manifest that may contain patch overrides.
+    crate : str
+        Name of the crate whose patch entry should be removed.
+
+    Returns
+    -------
+    None
+        The manifest is rewritten only when the patch entry was present.
+    """
     document = parse(manifest.read_text(encoding="utf-8"))
     patch_table = document.get("patch")
     if patch_table is None:

--- a/scripts/run_publish_check.py
+++ b/scripts/run_publish_check.py
@@ -245,14 +245,32 @@ def run_cargo_command(
         _handle_command_output(result.stdout, result.stderr)
 
 
+def _run_cargo_subcommand(
+    crate: str,
+    workspace_root: Path,
+    subcommand: str,
+    args: cabc.Sequence[str],
+    *,
+    timeout_secs: int | None = None,
+) -> None:
+    command = ["cargo", subcommand, *list(args)]
+    run_cargo_command(
+        crate,
+        workspace_root,
+        command,
+        timeout_secs=timeout_secs,
+    )
+
+
 def package_crate(
     crate: str, workspace_root: Path, *, timeout_secs: int | None = None
 ) -> None:
     """Invoke ``cargo package`` for ``crate`` within the exported workspace."""
-    run_cargo_command(
+    _run_cargo_subcommand(
         crate,
         workspace_root,
-        ["cargo", "package", "--allow-dirty", "--no-verify"],
+        "package",
+        ["--allow-dirty", "--no-verify"],
         timeout_secs=timeout_secs,
     )
 
@@ -261,10 +279,11 @@ def check_crate(
     crate: str, workspace_root: Path, *, timeout_secs: int | None = None
 ) -> None:
     """Run ``cargo check`` for ``crate`` using the exported workspace."""
-    run_cargo_command(
+    _run_cargo_subcommand(
         crate,
         workspace_root,
-        ["cargo", "check", "--all-features"],
+        "check",
+        ["--all-features"],
         timeout_secs=timeout_secs,
     )
 

--- a/scripts/run_publish_check.py
+++ b/scripts/run_publish_check.py
@@ -262,30 +262,43 @@ def _run_cargo_subcommand(
     )
 
 
-def package_crate(
-    crate: str, workspace_root: Path, *, timeout_secs: int | None = None
-) -> None:
-    """Invoke ``cargo package`` for ``crate`` within the exported workspace."""
-    _run_cargo_subcommand(
-        crate,
-        workspace_root,
-        "package",
-        ["--allow-dirty", "--no-verify"],
-        timeout_secs=timeout_secs,
-    )
+def _create_cargo_action(
+    subcommand: str,
+    args: cabc.Sequence[str],
+    docstring: str,
+) -> CrateAction:
+    command_args = tuple(args)
+
+    def action(
+        crate: str,
+        workspace_root: Path,
+        *,
+        timeout_secs: int | None = None,
+    ) -> None:
+        _run_cargo_subcommand(
+            crate,
+            workspace_root,
+            subcommand,
+            command_args,
+            timeout_secs=timeout_secs,
+        )
+
+    action.__doc__ = docstring
+    return typ.cast("CrateAction", action)
 
 
-def check_crate(
-    crate: str, workspace_root: Path, *, timeout_secs: int | None = None
-) -> None:
-    """Run ``cargo check`` for ``crate`` using the exported workspace."""
-    _run_cargo_subcommand(
-        crate,
-        workspace_root,
-        "check",
-        ["--all-features"],
-        timeout_secs=timeout_secs,
-    )
+package_crate = _create_cargo_action(
+    "package",
+    ["--allow-dirty", "--no-verify"],
+    "Invoke ``cargo package`` for ``crate`` within the exported workspace.",
+)
+
+
+check_crate = _create_cargo_action(
+    "check",
+    ["--all-features"],
+    "Run ``cargo check`` for ``crate`` using the exported workspace.",
+)
 
 
 def publish_crate_commands(

--- a/scripts/run_publish_check.py
+++ b/scripts/run_publish_check.py
@@ -245,20 +245,26 @@ def run_cargo_command(
         _handle_command_output(result.stdout, result.stderr)
 
 
+@dc.dataclass(frozen=True)
+class CargoExecutionContext:
+    """Context for executing cargo commands in a workspace."""
+
+    crate: str
+    workspace_root: Path
+    timeout_secs: int | None = None
+
+
 def _run_cargo_subcommand(
-    crate: str,
-    workspace_root: Path,
+    context: CargoExecutionContext,
     subcommand: str,
     args: cabc.Sequence[str],
-    *,
-    timeout_secs: int | None = None,
 ) -> None:
     command = ["cargo", subcommand, *list(args)]
     run_cargo_command(
-        crate,
-        workspace_root,
+        context.crate,
+        context.workspace_root,
         command,
-        timeout_secs=timeout_secs,
+        timeout_secs=context.timeout_secs,
     )
 
 
@@ -275,12 +281,15 @@ def _create_cargo_action(
         *,
         timeout_secs: int | None = None,
     ) -> None:
-        _run_cargo_subcommand(
+        context = CargoExecutionContext(
             crate,
             workspace_root,
+            timeout_secs,
+        )
+        _run_cargo_subcommand(
+            context,
             subcommand,
             command_args,
-            timeout_secs=timeout_secs,
         )
 
     action.__doc__ = docstring

--- a/scripts/tests/publish_check/conftest.py
+++ b/scripts/tests/publish_check/conftest.py
@@ -3,24 +3,28 @@
 from __future__ import annotations
 
 import contextlib
+import dataclasses as dc
 import importlib.util
 import sys
-from dataclasses import dataclass
+import typing as typ
 from pathlib import Path
-from types import ModuleType
-from typing import Callable
 
 import pytest
+
+if typ.TYPE_CHECKING:
+    from types import ModuleType
 
 SCRIPTS_DIR = Path(__file__).resolve().parents[2]
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
-RunCallable = Callable[[list[str], int | None], tuple[int, str, str]]
+RunCallable = typ.Callable[[list[str], int | None], tuple[int, str, str]]
 
 
-@dataclass(frozen=True)
+@dc.dataclass(frozen=True)
 class CommandFailureTestCase:
+    """Describe an expected crate failure and associated log fragments."""
+
     crate: str
     result_kwargs: dict[str, object]
     expected_exit_fragment: str | None
@@ -28,11 +32,11 @@ class CommandFailureTestCase:
     unexpected_logs: tuple[str, ...]
 
 
-@dataclass(frozen=True)
+@dc.dataclass(frozen=True)
 class CargoTestContext:
     """Test context container for cargo command scenarios."""
 
-    patch_local_runner: Callable[[RunCallable], "FakeLocal"]
+    patch_local_runner: typ.Callable[[RunCallable], FakeLocal]
     fake_workspace: Path
     caplog: pytest.LogCaptureFixture
     run_publish_check_module: ModuleType
@@ -40,27 +44,39 @@ class CargoTestContext:
 
 @pytest.fixture(scope="module")
 def run_publish_check_module() -> ModuleType:
+    """Load ``run_publish_check`` as a real module for integration tests."""
     spec = importlib.util.spec_from_file_location(
         "run_publish_check", SCRIPTS_DIR / "run_publish_check.py"
     )
+    if spec is None or spec.loader is None:
+        msg = "Failed to locate run_publish_check module spec"
+        raise RuntimeError(msg)
+
     module = importlib.util.module_from_spec(spec)
-    assert spec and spec.loader
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
 
 
 @pytest.fixture(scope="module")
-def publish_workspace_module(run_publish_check_module: ModuleType) -> ModuleType:
-    module = sys.modules.get("publish_workspace")
-    assert module is not None
+def publish_workspace_module() -> ModuleType:
+    """Load ``publish_workspace`` as a module for integration tests."""
+    spec = importlib.util.spec_from_file_location(
+        "publish_workspace", SCRIPTS_DIR / "publish_workspace.py"
+    )
+    if spec is None or spec.loader is None:
+        msg = "Failed to locate publish_workspace module spec"
+        raise RuntimeError(msg)
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
     return module
 
 
 @pytest.fixture
 def fake_workspace(tmp_path: Path) -> Path:
     """Provision a fake workspace tree used by cargo command tests."""
-
     workspace = tmp_path / "workspace"
     (workspace / "crates" / "demo").mkdir(parents=True)
     return workspace
@@ -71,7 +87,6 @@ def mock_cargo_runner(
     monkeypatch: pytest.MonkeyPatch, run_publish_check_module: ModuleType
 ) -> list[tuple[str, Path, list[str], int]]:
     """Capture invocations made to ``run_cargo_command``."""
-
     calls: list[tuple[str, Path, list[str], int]] = []
 
     def fake_run_cargo(
@@ -90,10 +105,10 @@ def mock_cargo_runner(
 @pytest.fixture
 def patch_local_runner(
     monkeypatch: pytest.MonkeyPatch, run_publish_check_module: ModuleType
-) -> Callable[[RunCallable], "FakeLocal"]:
+) -> typ.Callable[[RunCallable], FakeLocal]:
     """Install a ``FakeLocal`` around the provided callable."""
 
-    def _install(run_callable: RunCallable) -> "FakeLocal":
+    def _install(run_callable: RunCallable) -> FakeLocal:
         fake_local = FakeLocal(run_callable)
         monkeypatch.setattr(run_publish_check_module, "local", fake_local)
         return fake_local
@@ -103,11 +118,12 @@ def patch_local_runner(
 
 @pytest.fixture
 def cargo_test_context(
-    patch_local_runner: Callable[[RunCallable], "FakeLocal"],
+    patch_local_runner: typ.Callable[[RunCallable], FakeLocal],
     fake_workspace: Path,
     caplog: pytest.LogCaptureFixture,
     run_publish_check_module: ModuleType,
 ) -> CargoTestContext:
+    """Bundle fixtures required for cargo command assertions."""
     return CargoTestContext(
         patch_local_runner=patch_local_runner,
         fake_workspace=fake_workspace,
@@ -117,42 +133,59 @@ def cargo_test_context(
 
 
 class FakeCargoInvocation:
-    def __init__(self, local: "FakeLocal", args: list[str]):
+    """Record a cargo invocation and proxy execution to the fake runner."""
+
+    def __init__(self, local: FakeLocal, args: list[str]) -> None:
+        """Store the invocation context for later assertions."""
         self._local = local
         self._args = ["cargo", *args]
 
-    def run(self, *, retcode: object | None, timeout: int | None) -> tuple[int, str, str]:
+    def run(
+        self, *, retcode: object | None, timeout: int | None
+    ) -> tuple[int, str, str]:
+        """Record an invocation and delegate to the configured callable."""
         self._local.invocations.append((self._args, timeout))
         return self._local.run_callable(self._args, timeout)
 
 
 class FakeCargo:
-    def __init__(self, local: "FakeLocal") -> None:
+    """Proxy indexing calls into ``FakeCargoInvocation`` instances."""
+
+    def __init__(self, local: FakeLocal) -> None:
+        """Initialise the cargo proxy for a fake local environment."""
         self._local = local
 
     def __getitem__(self, args: object) -> FakeCargoInvocation:
-        if isinstance(args, (list, tuple)):
-            extras = list(args)
-        else:
-            extras = [str(args)]
+        """Return an invocation wrapper for the provided command arguments."""
+        extras = list(args) if isinstance(args, (list, tuple)) else [str(args)]
         return FakeCargoInvocation(self._local, extras)
 
 
 class FakeLocal:
-    def __init__(self, run_callable: RunCallable):
+    """Mimic a fabric ``local`` helper for cargo orchestration tests."""
+
+    def __init__(self, run_callable: RunCallable) -> None:
+        """Store the callable that will service fake local invocations."""
         self.run_callable = run_callable
         self.cwd_calls: list[Path] = []
         self.env_calls: list[dict[str, str]] = []
         self.invocations: list[tuple[list[str], int | None]] = []
 
     def __getitem__(self, command: str) -> FakeCargo:
-        assert command == "cargo"
+        """Return a ``FakeCargo`` proxy for the ``cargo`` command."""
+        if command != "cargo":
+            msg = (
+                f"FakeLocal only understands the 'cargo' command, received {command!r}"
+            )
+            raise RuntimeError(msg)
         return FakeCargo(self)
 
-    def cwd(self, path: Path):
+    def cwd(self, path: Path) -> contextlib.AbstractContextManager[None]:
+        """Record the working directory change for later assertions."""
         self.cwd_calls.append(path)
         return contextlib.nullcontext()
 
-    def env(self, **kwargs: str):
+    def env(self, **kwargs: str) -> contextlib.AbstractContextManager[None]:
+        """Record environment mutations for later assertions."""
         self.env_calls.append(kwargs)
         return contextlib.nullcontext()

--- a/scripts/tests/publish_check/test_cli.py
+++ b/scripts/tests/publish_check/test_cli.py
@@ -1,16 +1,20 @@
-"""CLI argument parsing behaviour for publish check entrypoint."""
+"""CLI wiring tests for the publish-check entry point."""
 
 from __future__ import annotations
 
-from types import ModuleType
+import typing as typ
 
-import pytest
+if typ.TYPE_CHECKING:
+    from types import ModuleType
+
+    import pytest
 
 
 def test_main_uses_defaults(
     monkeypatch: pytest.MonkeyPatch,
     run_publish_check_module: ModuleType,
 ) -> None:
+    """Confirm the CLI invokes the workflow with default arguments."""
     captured: dict[str, object] = {}
 
     def fake_run_publish_check(
@@ -23,7 +27,9 @@ def test_main_uses_defaults(
         captured["timeout_secs"] = timeout_secs
         captured["live"] = live
 
-    monkeypatch.setattr(run_publish_check_module, "run_publish_check", fake_run_publish_check)
+    monkeypatch.setattr(
+        run_publish_check_module, "run_publish_check", fake_run_publish_check
+    )
 
     run_publish_check_module.app([])
 
@@ -38,6 +44,7 @@ def test_main_honours_environment(
     monkeypatch: pytest.MonkeyPatch,
     run_publish_check_module: ModuleType,
 ) -> None:
+    """Ensure environment variables influence the invoked workflow."""
     observed: list[tuple[bool, int, bool]] = []
 
     def fake_run_publish_check(
@@ -48,7 +55,9 @@ def test_main_honours_environment(
     ) -> None:
         observed.append((keep_tmp, timeout_secs, live))
 
-    monkeypatch.setattr(run_publish_check_module, "run_publish_check", fake_run_publish_check)
+    monkeypatch.setattr(
+        run_publish_check_module, "run_publish_check", fake_run_publish_check
+    )
     monkeypatch.setenv("PUBLISH_CHECK_KEEP_TMP", "true")
     monkeypatch.setenv("PUBLISH_CHECK_TIMEOUT_SECS", "60")
 
@@ -61,6 +70,7 @@ def test_main_cli_overrides_env(
     monkeypatch: pytest.MonkeyPatch,
     run_publish_check_module: ModuleType,
 ) -> None:
+    """Ensure CLI arguments override environment configuration."""
     observed: list[tuple[bool, int, bool]] = []
 
     def fake_run_publish_check(
@@ -71,7 +81,9 @@ def test_main_cli_overrides_env(
     ) -> None:
         observed.append((keep_tmp, timeout_secs, live))
 
-    monkeypatch.setattr(run_publish_check_module, "run_publish_check", fake_run_publish_check)
+    monkeypatch.setattr(
+        run_publish_check_module, "run_publish_check", fake_run_publish_check
+    )
     monkeypatch.setenv("PUBLISH_CHECK_KEEP_TMP", "false")
     monkeypatch.setenv("PUBLISH_CHECK_TIMEOUT_SECS", "900")
 
@@ -84,6 +96,7 @@ def test_main_live_flag(
     monkeypatch: pytest.MonkeyPatch,
     run_publish_check_module: ModuleType,
 ) -> None:
+    """Verify the live flag toggles the publish workflow accordingly."""
     observed: list[tuple[bool, int, bool]] = []
 
     def fake_run_publish_check(
@@ -94,7 +107,9 @@ def test_main_live_flag(
     ) -> None:
         observed.append((keep_tmp, timeout_secs, live))
 
-    monkeypatch.setattr(run_publish_check_module, "run_publish_check", fake_run_publish_check)
+    monkeypatch.setattr(
+        run_publish_check_module, "run_publish_check", fake_run_publish_check
+    )
 
     run_publish_check_module.app(["--live"])
 

--- a/scripts/tests/publish_check/test_integration.py
+++ b/scripts/tests/publish_check/test_integration.py
@@ -401,12 +401,13 @@ class TestRunPublishCheckLiveMode:
         )
         monkeypatch.setattr(
             run_publish_check_module,
-            "_live_publish_commands",
-            lambda crate: (
-                (("cargo", "publish", "--dry-run"), ("cargo", "publish"))
-                if crate == "demo-crate"
-                else (_ for _ in ()).throw(KeyError(crate))
-            ),
+            "LIVE_PUBLISH_COMMANDS",
+            {
+                "demo-crate": (
+                    ("cargo", "publish", "--dry-run"),
+                    ("cargo", "publish"),
+                )
+            },
         )
 
     def _verify_live_publish_execution(

--- a/scripts/tests/publish_check/test_integration.py
+++ b/scripts/tests/publish_check/test_integration.py
@@ -298,12 +298,12 @@ class TestRunPublishCheckLiveMode:
         steps, record = self._setup_recording_infrastructure()
         fake_apply, fake_remove = self._create_fake_functions(steps)
         commands, fake_run_cargo = self._setup_cargo_recording()
-        mocks = WorkspaceMocks(
+        self._workspace_mocks = WorkspaceMocks(
             record=record,
             fake_apply=fake_apply,
             fake_remove=fake_remove,
         )
-        self._setup_workspace_mocks(monkeypatch, run_publish_check_module, mocks)
+        self._setup_workspace_mocks(monkeypatch, run_publish_check_module)
         self._setup_cargo_and_config_mocks(
             monkeypatch,
             run_publish_check_module,
@@ -369,17 +369,22 @@ class TestRunPublishCheckLiveMode:
         self,
         monkeypatch: pytest.MonkeyPatch,
         run_publish_check_module: ModuleType,
-        mocks: WorkspaceMocks,
     ) -> None:
         """Replace workspace helpers with recording doubles."""
         monkeypatch.setattr(
-            run_publish_check_module, "export_workspace", mocks.record("export")
+            run_publish_check_module,
+            "export_workspace",
+            self._workspace_mocks.record("export"),
         )
         monkeypatch.setattr(
-            run_publish_check_module, "prune_workspace_members", mocks.record("prune")
+            run_publish_check_module,
+            "prune_workspace_members",
+            self._workspace_mocks.record("prune"),
         )
         monkeypatch.setattr(
-            run_publish_check_module, "strip_patch_section", mocks.record("strip")
+            run_publish_check_module,
+            "strip_patch_section",
+            self._workspace_mocks.record("strip"),
         )
         monkeypatch.setattr(
             run_publish_check_module, "workspace_version", lambda _manifest: "1.2.3"
@@ -387,10 +392,12 @@ class TestRunPublishCheckLiveMode:
         monkeypatch.setattr(
             run_publish_check_module,
             "apply_workspace_replacements",
-            mocks.fake_apply,
+            self._workspace_mocks.fake_apply,
         )
         monkeypatch.setattr(
-            run_publish_check_module, "remove_patch_entry", mocks.fake_remove
+            run_publish_check_module,
+            "remove_patch_entry",
+            self._workspace_mocks.fake_remove,
         )
 
     def _setup_cargo_and_config_mocks(

--- a/scripts/tests/publish_check/test_workspace_operations.py
+++ b/scripts/tests/publish_check/test_workspace_operations.py
@@ -1,17 +1,21 @@
-"""Workspace export and pruning behaviour for publish checks."""
+"""Workspace export workflow tests."""
 
 from __future__ import annotations
 
 import contextlib
-from pathlib import Path
-from types import ModuleType
+import typing as typ
 
 import pytest
+
+if typ.TYPE_CHECKING:
+    from pathlib import Path
+    from types import ModuleType
 
 
 def test_export_workspace_creates_manifest_copy(
     run_publish_check_module: ModuleType, tmp_path: Path
 ) -> None:
+    """Verify exporting the workspace copies the manifest into place."""
     destination = tmp_path / "workspace"
     destination.mkdir()
 
@@ -25,21 +29,25 @@ def test_export_workspace_propagates_git_failure(
     publish_workspace_module: ModuleType,
     tmp_path: Path,
 ) -> None:
+    """Ensure failures raised by git archive are surfaced to the caller."""
+
     class FakeCommand:
-        def __getitem__(self, _args: object) -> "FakeCommand":
+        def __getitem__(self, _args: object) -> FakeCommand:
             return self
 
         def __call__(self, *_args: object, **_kwargs: object) -> None:
-            raise RuntimeError("archive failed")
+            error_message = "archive failed"
+            raise RuntimeError(error_message)
 
     class FakeLocal:
         def __getitem__(self, name: str) -> FakeCommand:
-            assert name == "git"
+            if name != "git":
+                msg = f"FakeLocal expected 'git' command but received {name!r}"
+                raise RuntimeError(msg)
             return FakeCommand()
 
-        @contextlib.contextmanager
-        def cwd(self, _path: Path):
-            yield
+        def cwd(self, _path: Path) -> contextlib.AbstractContextManager[None]:
+            return contextlib.nullcontext()
 
     monkeypatch.setattr(publish_workspace_module, "local", FakeLocal())
 

--- a/scripts/tests/test_publish_patch.py
+++ b/scripts/tests/test_publish_patch.py
@@ -1,0 +1,89 @@
+"""Unit tests for dependency patch helpers."""
+
+from __future__ import annotations
+
+import pytest
+from publish_patch import build_inline_dependency, extract_existing_items
+from tomlkit import inline_table, parse
+
+
+class TestExtractExistingItems:
+    """Tests for :func:`publish_patch.extract_existing_items`."""
+
+    def test_filters_workspace_metadata(self) -> None:
+        """Existing tables should discard workspace-specific keys."""
+        document = parse(
+            "[dependencies]\n"
+            "foo = { workspace = true, path = '../foo', version = '0.1.0', "
+            "default-features = false, features = ['serde'] }"
+        )
+        table = document["dependencies"]["foo"]
+
+        assert extract_existing_items(table) == (
+            ("default-features", False),
+            ("features", ["serde"]),
+        )
+
+    def test_returns_empty_for_non_tables(self) -> None:
+        """Non-table dependency declarations should produce no metadata."""
+        assert extract_existing_items("version") == ()
+
+
+class TestBuildInlineDependency:
+    """Tests for :func:`publish_patch.build_inline_dependency`."""
+
+    @pytest.mark.parametrize("include_local_path", [True, False])
+    def test_builds_dependency_with_optional_path(
+        self, *, include_local_path: bool
+    ) -> None:
+        """Inline dependencies should include the path only when requested."""
+        extra_items = (("default-features", False),)
+
+        inline = build_inline_dependency(
+            extra_items,
+            "../foo",
+            "1.2.3",
+            include_local_path=include_local_path,
+        )
+
+        expected = {"version": "1.2.3", "default-features": False}
+        if include_local_path:
+            expected["path"] = "../foo"
+
+        assert dict(inline) == expected
+
+    def test_appends_additional_metadata(self) -> None:
+        """Existing metadata should be appended after the required fields."""
+        extra_items = (
+            ("default-features", False),
+            ("features", ["serde"]),
+        )
+
+        inline = build_inline_dependency(
+            extra_items,
+            "../foo",
+            "1.2.3",
+            include_local_path=True,
+        )
+
+        assert list(inline.items()) == [
+            ("path", "../foo"),
+            ("version", "1.2.3"),
+            ("default-features", False),
+            ("features", ["serde"]),
+        ]
+
+    def test_accepts_inline_table_metadata(self) -> None:
+        """The helper should accept iterables derived from inline tables."""
+        existing = inline_table()
+        existing["default-features"] = False
+        extra_items = tuple(existing.items())
+
+        inline = build_inline_dependency(
+            extra_items,
+            "../foo",
+            "1.2.3",
+            include_local_path=True,
+        )
+
+        assert dict(inline)["default-features"] is False


### PR DESCRIPTION
## Summary
- add the project Ruff configuration with the requested lint selections and per-file ignore policy
- refresh publish-check test fixtures to satisfy the stricter Ruff rules by adding docstrings, splitting asserts, and replacing TYPE_CHECKING-only imports
- modernise the publish-check integration helpers with explicit runtime checks, richer fake implementations, and typing updates that keep the live workflow tests readable

## Testing
- make check-fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d5adf331a48322a33df34e61efe088

## Summary by Sourcery

Configure Ruff for Python linting and update publish-check scripts and tests to comply with the new lint policy.

Enhancements:
- Add a Ruff configuration file with selected lint rules and per-file ignores for test files.
- Refactor run_publish_check, publish_workspace, and publish_patch modules to use explicit type aliases, Protocols under TYPE_CHECKING, consistent LOGGER usage, and improved live-publish command resolution.
- Modernise publish-check integration helpers and workflow logic with richer fake implementations, unified recording helpers, and updated type hints to keep tests lint-clean and readable.

Build:
- Update Makefile to run Ruff checks and format verification across Python scripts.

Documentation:
- Add or expand NumPy-style docstrings for user-facing functions in publish_workspace and related scripts.

Tests:
- Revise publish-check tests to satisfy stricter Ruff rules by moving imports into TYPE_CHECKING, adding docstrings, splitting asserts, consolidating mock fixtures, and aligning type annotations.