### PR TITLE
Augment workspace diagnostics and handle toml arrays

### DIFF
--- a/scripts/publish_patch.py
+++ b/scripts/publish_patch.py
@@ -309,17 +309,18 @@ def main() -> None:
     parser.add_argument("crate", choices=sorted(REPLACEMENTS))
     parser.add_argument("manifest", type=Path)
     parser.add_argument("--version", required=True)
-    parser.add_argument(
+    parser.set_defaults(include_local_path=True)
+    local_path = parser.add_mutually_exclusive_group(required=False)
+    local_path.add_argument(
         "--include-local-path",
         dest="include_local_path",
         action="store_true",
-        default=True,
         help=(
             "Retain relative path dependencies for publish-checks. This is the "
             "default behaviour."
         ),
     )
-    parser.add_argument(
+    local_path.add_argument(
         "--omit-local-path",
         dest="include_local_path",
         action="store_false",

--- a/scripts/publish_workspace.py
+++ b/scripts/publish_workspace.py
@@ -16,7 +16,11 @@ from pathlib import Path
 import tomllib
 from plumbum import local
 from publish_patch import REPLACEMENTS, apply_replacements
-from tomlkit import dumps, parse
+from tomlkit import array, dumps, parse
+from tomlkit.items import Array
+
+if typ.TYPE_CHECKING:
+    from tomlkit.toml_document import TOMLDocument
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
@@ -107,17 +111,43 @@ def prune_workspace_members(manifest: Path) -> None:
         The manifest is rewritten with only crate directories listed.
     """
     document = parse(manifest.read_text(encoding="utf-8"))
-    workspace = document.get("workspace")
-    if workspace is None:
-        return
-
-    members = workspace.get("members")
+    members = _get_valid_workspace_members(document)
     if members is None:
         return
 
-    if not isinstance(members, list):
-        return
+    changed = _filter_workspace_members(members)
+    _write_manifest_if_changed(
+        document=document,
+        manifest=manifest,
+        changed=changed,
+        members=members,
+    )
 
+
+def _get_valid_workspace_members(document: TOMLDocument) -> Array | None:
+    """Return the workspace members array when it exists and is valid."""
+    workspace = document.get("workspace")
+    if workspace is None:
+        return None
+
+    members = workspace.get("members")
+    if members is None:
+        return None
+
+    if isinstance(members, Array):
+        return members
+
+    if isinstance(members, list):
+        rebuilt_members = array()
+        rebuilt_members.extend(members)
+        workspace["members"] = rebuilt_members
+        return typ.cast("Array", rebuilt_members)
+
+    return None
+
+
+def _filter_workspace_members(members: Array) -> bool:
+    """Remove ineligible workspace members, returning ``True`` if mutated."""
     changed = False
     for index in range(len(members) - 1, -1, -1):
         entry = members[index]
@@ -125,8 +155,26 @@ def prune_workspace_members(manifest: Path) -> None:
             del members[index]
             changed = True
 
+    return changed
+
+
+def _write_manifest_if_changed(
+    *, document: TOMLDocument, manifest: Path, changed: bool, members: Array
+) -> None:
+    """Persist ``document`` to ``manifest`` only when ``changed`` is ``True``."""
     if not changed:
         return
+
+    workspace = document.get("workspace")
+    if workspace is None:
+        return
+
+    rebuilt_members = array()
+    rebuilt_members.extend(list(members))
+    members_text = members.as_string()
+    if "\n" in members_text:
+        rebuilt_members.multiline(multiline=True)
+    workspace["members"] = rebuilt_members
 
     rendered = dumps(document)
     if not rendered.endswith("\n"):
@@ -192,7 +240,8 @@ def workspace_version(manifest: Path) -> str:
     SystemExit
         Raised when the workspace manifest lacks the version entry.
     """
-    data = tomllib.loads(manifest.read_text(encoding="utf-8"))
+    manifest_text = manifest.read_text(encoding="utf-8")
+    data = tomllib.loads(manifest_text)
     try:
         return data["workspace"]["package"]["version"]
     except KeyError as err:
@@ -201,7 +250,33 @@ def workspace_version(manifest: Path) -> str:
             "[workspace.package] must define a version for publish automation to run. "
             "Check the manifest defines the key."
         )
+        snippet = _workspace_section_excerpt(manifest_text)
+        if snippet:
+            indented_snippet = "\n".join(f"    {line}" for line in snippet)
+            message = (
+                f"{message}\n\n"
+                "Workspace manifest excerpt:\n"
+                f"{indented_snippet}"
+            )
         raise SystemExit(message) from err
+
+
+def _workspace_section_excerpt(manifest_text: str) -> list[str] | None:
+    """Return the lines around the ``[workspace]`` section for diagnostics."""
+    lines = manifest_text.splitlines()
+    for index, line in enumerate(lines):
+        if line.strip().startswith("[workspace"):
+            start = max(index - 1, 0)
+            end = index + 1
+            while end < len(lines):
+                stripped = lines[end].strip()
+                if stripped.startswith("[") and not stripped.startswith("[workspace"):
+                    break
+                if end - start >= 8:
+                    break
+                end += 1
+            return lines[start:end]
+    return None
 
 
 def remove_patch_entry(manifest: Path, crate: str) -> None:

--- a/scripts/publish_workspace.py
+++ b/scripts/publish_workspace.py
@@ -246,8 +246,7 @@ def workspace_version(manifest: Path) -> str:
             "[workspace.package] must define a version for publish automation to run. "
             "Check the manifest defines the key."
         )
-        snippet = _workspace_section_excerpt(manifest_text)
-        if snippet:
+        if snippet := _workspace_section_excerpt(manifest_text):
             indented_snippet = "\n".join(f"    {line}" for line in snippet)
             message = f"{message}\n\nWorkspace manifest excerpt:\n{indented_snippet}"
         raise SystemExit(message) from err

--- a/scripts/publish_workspace.py
+++ b/scripts/publish_workspace.py
@@ -165,16 +165,12 @@ def _write_manifest_if_changed(
     if not changed:
         return
 
-    workspace = document.get("workspace")
-    if workspace is None:
+    if document.get("workspace") is None:
         return
 
-    rebuilt_members = array()
-    rebuilt_members.extend(list(members))
     members_text = members.as_string()
     if "\n" in members_text:
-        rebuilt_members.multiline(multiline=True)
-    workspace["members"] = rebuilt_members
+        members.multiline(multiline=True)
 
     rendered = dumps(document)
     if not rendered.endswith("\n"):

--- a/scripts/tests/test_publish_workspace_helpers.py
+++ b/scripts/tests/test_publish_workspace_helpers.py
@@ -1,0 +1,249 @@
+"""Unit tests for publish_workspace helper functions."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import typing as typ
+from pathlib import Path
+
+import pytest
+from tomlkit import array, dumps, parse
+from tomlkit.items import Array
+
+if typ.TYPE_CHECKING:
+    from types import ModuleType
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _load_publish_workspace_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "publish_workspace", SCRIPTS_DIR / "publish_workspace.py"
+    )
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive guard
+        message = "publish_workspace module could not be loaded"
+        raise RuntimeError(message)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def publish_workspace_module() -> ModuleType:
+    """Provide the publish_workspace module for helper unit tests."""
+    return _load_publish_workspace_module()
+
+
+def test_get_valid_workspace_members_returns_array(
+    publish_workspace_module: ModuleType,
+) -> None:
+    """Return the array intact when the manifest already uses tomlkit arrays."""
+    document = parse(
+        "\n".join(
+            (
+                "[workspace]",
+                'members = ["crates/rstest-bdd", "examples/todo-cli"]',
+            )
+        )
+    )
+
+    result = publish_workspace_module._get_valid_workspace_members(document)
+
+    assert isinstance(result, Array)
+    assert [*result] == ["crates/rstest-bdd", "examples/todo-cli"]
+
+
+def test_get_valid_workspace_members_rebuilds_list(
+    publish_workspace_module: ModuleType,
+) -> None:
+    """Convert list-based members back into a tomlkit array."""
+    document = parse('[workspace]\nresolver = "2"\n')
+    document["workspace"]["members"] = [
+        "crates/rstest-bdd",
+        "examples/todo-cli",
+    ]
+
+    result = publish_workspace_module._get_valid_workspace_members(document)
+
+    assert isinstance(result, Array)
+    assert document["workspace"]["members"] is result
+    assert [*result] == ["crates/rstest-bdd", "examples/todo-cli"]
+
+
+def test_get_valid_workspace_members_handles_missing_members(
+    publish_workspace_module: ModuleType,
+) -> None:
+    """Return ``None`` when the members array is absent."""
+    document = parse('[workspace]\nresolver = "2"\n')
+
+    result = publish_workspace_module._get_valid_workspace_members(document)
+
+    assert result is None
+
+
+def test_get_valid_workspace_members_handles_missing_workspace(
+    publish_workspace_module: ModuleType,
+) -> None:
+    """Return ``None`` when the manifest lacks a workspace table."""
+    document = parse('[package]\nname = "demo"\n')
+
+    result = publish_workspace_module._get_valid_workspace_members(document)
+
+    assert result is None
+
+
+def test_filter_workspace_members_removes_ineligible_entries(
+    publish_workspace_module: ModuleType,
+) -> None:
+    """Strip members that do not correspond to publishable crates."""
+    members = array()
+    members.extend(["crates/rstest-bdd", "examples/todo-cli", 42])
+
+    changed = publish_workspace_module._filter_workspace_members(members)
+
+    assert changed is True
+    assert [*members] == ["crates/rstest-bdd"]
+
+
+def test_filter_workspace_members_retains_publishable_entries(
+    publish_workspace_module: ModuleType,
+) -> None:
+    """Leave publishable crate entries untouched."""
+    members = array()
+    members.extend(["crates/rstest-bdd", "crates/rstest-bdd-macros"])
+
+    changed = publish_workspace_module._filter_workspace_members(members)
+
+    assert changed is False
+    assert [*members] == [
+        "crates/rstest-bdd",
+        "crates/rstest-bdd-macros",
+    ]
+
+
+def test_write_manifest_if_changed_skips_write(
+    publish_workspace_module: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """Do not rewrite manifests when members remain unchanged."""
+    document = parse('[workspace]\nmembers = ["crates/rstest-bdd"]\n')
+    members = publish_workspace_module._get_valid_workspace_members(document)
+    manifest = tmp_path / "Cargo.toml"
+    manifest.write_text("original", encoding="utf-8")
+
+    publish_workspace_module._write_manifest_if_changed(
+        document=document,
+        manifest=manifest,
+        changed=False,
+        members=members,
+    )
+
+    assert manifest.read_text(encoding="utf-8") == "original"
+
+
+def test_write_manifest_if_changed_persists_updates(
+    publish_workspace_module: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """Persist the manifest when pruning mutates the members array."""
+    document = parse(
+        "\n".join(
+            (
+                "[workspace]",
+                "members = [",
+                '  "crates/rstest-bdd",',
+                '  "examples/todo-cli"',
+                "]",
+            )
+        )
+    )
+    members = publish_workspace_module._get_valid_workspace_members(document)
+    publish_workspace_module._filter_workspace_members(members)
+    manifest = tmp_path / "Cargo.toml"
+    manifest.write_text("stale", encoding="utf-8")
+
+    publish_workspace_module._write_manifest_if_changed(
+        document=document,
+        manifest=manifest,
+        changed=True,
+        members=members,
+    )
+
+    expected = dumps(document)
+    if not expected.endswith("\n"):
+        expected = f"{expected}\n"
+    assert manifest.read_text(encoding="utf-8") == expected
+
+
+def test_workspace_section_excerpt_returns_none(
+    publish_workspace_module: ModuleType,
+) -> None:
+    """Return ``None`` when the manifest lacks a workspace section."""
+    manifest_text = '[package]\nname = "demo"\n'
+
+    assert publish_workspace_module._workspace_section_excerpt(manifest_text) is None
+
+
+def test_workspace_section_excerpt_stops_at_next_section(
+    publish_workspace_module: ModuleType,
+) -> None:
+    """Stop the excerpt when the next table header appears."""
+    manifest_text = "\n".join(
+        (
+            "[package]",
+            'name = "demo"',
+            "",
+            "[workspace]",
+            'members = ["crates/rstest-bdd"]',
+            "",
+            "[dependencies]",
+            'demo = "1"',
+        )
+    )
+
+    excerpt = publish_workspace_module._workspace_section_excerpt(manifest_text)
+
+    assert excerpt == [
+        "[package]",
+        "",
+        "[workspace]",
+        'members = ["crates/rstest-bdd"]',
+    ]
+
+
+def test_workspace_section_excerpt_limits_line_count(
+    publish_workspace_module: ModuleType,
+) -> None:
+    """Limit the excerpt to eight lines following the section header."""
+    manifest_text = "\n".join(
+        [
+            "[workspace]",
+            "members = [",
+            '  "a"',
+            '  "b"',
+            "]",
+            "",
+            "# comment",
+            'key = "value"',
+            'another = "value"',
+            'final = "value"',
+            "[dependencies]",
+        ]
+    )
+
+    excerpt = publish_workspace_module._workspace_section_excerpt(manifest_text)
+
+    assert excerpt == [
+        "[workspace]",
+        "members = [",
+        '  "a"',
+        '  "b"',
+        "]",
+        "",
+        "# comment",
+        'key = "value"',
+    ]


### PR DESCRIPTION
## Summary
- surface a trimmed workspace manifest excerpt when the version key is missing
- reuse the manifest contents so diagnostics can be generated without re-reading the file
- allow workspace pruning to operate on tomlkit arrays and rebuild the members entry without losing formatting
- ensure the publish-patch CLI enforces mutual exclusivity between local path flags so ambiguous invocations are rejected

## Testing
- make lint
- uv run --with pytest --with cyclopts --with plumbum --with tomlkit python -m pytest scripts/tests/publish_check/test_workspace_operations.py

------
https://chatgpt.com/codex/tasks/task_e_68d807c5b31083229cf3acf8ba1197e8

## Summary by Sourcery

Augment workspace manifest handling and diagnostics, and enforce exclusive local path flags in the publish-patch CLI.

New Features:
- Add mutually exclusive --include-local-path and --omit-local-path options to the publish-patch CLI to prevent ambiguous invocations.

Enhancements:
- Support tomlkit Array instances in workspace member pruning and rewrite the members entry only when changed while preserving formatting.
- Cache and reuse the manifest text in workspace_version and surface a trimmed workspace section excerpt in missing-version errors.