### PR TITLE
Refactor publish workspace conditionals

### DIFF
--- a/scripts/publish_workspace.py
+++ b/scripts/publish_workspace.py
@@ -1,153 +1,34 @@
-"""Workspace preparation helpers shared by publish automation scripts.
+"""Facade module for publish workspace utilities.
 
-The routines in this module manipulate an exported copy of the repository so
-release workflows can operate on a clean tree. They are intentionally
-side-effect free apart from file-system writes inside the provided workspace
-root, which keeps the publish scripts deterministic and safe to run locally.
+This module preserves the historical import surface while delegating the
+implementation to focused helper modules. Callers should prefer the re-exported
+functions documented in the respective modules for clarity.
 """
 
 from __future__ import annotations
 
-import tarfile
-import tempfile
 import typing as typ
-from pathlib import Path
 
-import tomllib
-from plumbum import local
-from publish_patch import REPLACEMENTS, apply_replacements
-from tomlkit import array, dumps, parse
-from tomlkit.items import Array
+import publish_workspace_archive as _archive
+import publish_workspace_dependencies as _dependencies
+import publish_workspace_members as _members
+import publish_workspace_patch as _patch
+import publish_workspace_serialise as _serialise
+import publish_workspace_versioning as _versioning
+from plumbum import local as _default_local
+from tomlkit import parse as _default_parse
 
 if typ.TYPE_CHECKING:
-    from tomlkit.toml_document import TOMLDocument
+    from pathlib import Path
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-
-PUBLISHABLE_CRATES: typ.Final[tuple[str, ...]] = (
-    "rstest-bdd-patterns",
-    "rstest-bdd-macros",
-    "rstest-bdd",
-    "cargo-bdd",
-)
+local = _default_local
+parse = _default_parse
 
 
 def export_workspace(destination: Path) -> None:
-    """Extract the repository HEAD into ``destination`` via ``git archive``.
-
-    Parameters
-    ----------
-    destination : Path
-        Directory that will receive the exported workspace contents.
-
-    Returns
-    -------
-    None
-        The repository snapshot is written directly to ``destination``.
-    """
-    with tempfile.TemporaryDirectory() as archive_dir:
-        archive_path = Path(archive_dir) / "workspace.tar"
-        git_archive = local["git"][
-            "archive", "--format=tar", "HEAD", f"--output={archive_path}"
-        ]
-        with local.cwd(PROJECT_ROOT):
-            return_code, stdout, stderr = git_archive.run(
-                timeout=60,
-                retcode=None,
-            )
-        if return_code != 0:
-            diagnostics = (stderr or stdout or "").strip()
-            detail = f": {diagnostics}" if diagnostics else ""
-            message = f"git archive failed with exit code {return_code}{detail}"
-            raise SystemExit(message)
-        with tarfile.open(archive_path) as tar:
-            tar.extractall(destination, filter="data")
-
-
-def strip_patch_section(manifest: Path) -> None:
-    """Strip the ``[patch.crates-io]`` section from ``manifest``.
-
-    Parameters
-    ----------
-    manifest : Path
-        Manifest whose patch entries should be removed in place.
-
-    Returns
-    -------
-    None
-        The manifest on disk is rewritten without the patch section.
-    """
-    document = parse(manifest.read_text(encoding="utf-8"))
-    patch_tables = _get_patch_crates_io_tables(document)
-    if patch_tables is None:
-        return
-
-    patch_table, _ = patch_tables
-    _remove_patch_section(document, patch_table)
-    _write_manifest_with_newline(document, manifest)
-
-
-def prune_workspace_members(manifest: Path) -> None:
-    """Remove non-crate entries from the workspace members list.
-
-    Parameters
-    ----------
-    manifest : Path
-        Workspace manifest whose members array should only contain crates.
-
-    Returns
-    -------
-    None
-        The manifest is rewritten with only crate directories listed.
-    """
-    document = parse(manifest.read_text(encoding="utf-8"))
-    members = _get_valid_workspace_members(document)
-    if members is None:
-        return
-
-    changed = _filter_workspace_members(members)
-    _write_manifest_if_changed(
-        document=document,
-        manifest=manifest,
-        changed=changed,
-        members=members,
-    )
-
-
-def _get_valid_workspace_members(document: TOMLDocument) -> Array | None:
-    """Return the workspace members array when it exists and is valid."""
-    workspace = document.get("workspace")
-    if workspace is None:
-        return None
-
-    members = workspace.get("members")
-    if members is None:
-        return None
-
-    return _ensure_members_array(workspace, members)
-
-
-def _filter_workspace_members(members: Array) -> bool:
-    """Remove ineligible workspace members, returning ``True`` if mutated."""
-    changed = False
-    for index in range(len(members) - 1, -1, -1):
-        entry = members[index]
-        if not isinstance(entry, str) or Path(entry).name not in PUBLISHABLE_CRATES:
-            del members[index]
-            changed = True
-
-    return changed
-
-
-def _write_manifest_if_changed(
-    *, document: TOMLDocument, manifest: Path, changed: bool, members: Array
-) -> None:
-    """Persist ``document`` to ``manifest`` only when ``changed`` is ``True``."""
-    if not _should_write_manifest(changed=changed, document=document):
-        return
-
-    _format_multiline_members_if_needed(members)
-    _write_manifest_with_newline(document, manifest)
+    """Dispatch to the archive helper while respecting runtime monkeypatches."""
+    _archive.local = local
+    _archive.export_workspace(destination)
 
 
 def apply_workspace_replacements(
@@ -157,229 +38,80 @@ def apply_workspace_replacements(
     include_local_path: bool,
     crates: tuple[str, ...] | None = None,
 ) -> None:
-    """Rewrite workspace dependency declarations for publish workflows.
-
-    Parameters
-    ----------
-    workspace_root : Path
-        Root of the exported workspace containing crate directories.
-    version : str
-        Version string written to dependency entries.
-    include_local_path : bool
-        When ``True`` the relative ``path`` entries are retained so dry-run
-        checks use the local workspace.
-    crates : tuple[str, ...] | None, optional
-        Specific crates to update. Defaults to all known crates when ``None``.
-
-    Returns
-    -------
-    None
-        Each targeted manifest is rewritten in place.
-    """
-    targets = REPLACEMENTS if crates is None else crates
-    for crate in targets:
-        if crate not in REPLACEMENTS:
-            continue
-        manifest = workspace_root / "crates" / crate / "Cargo.toml"
-        apply_replacements(
-            crate,
-            manifest,
-            version,
-            include_local_path=include_local_path,
-        )
+    """Proxy dependency rewriting through the dedicated module."""
+    _dependencies.apply_workspace_replacements(
+        workspace_root,
+        version,
+        include_local_path=include_local_path,
+        crates=crates,
+    )
 
 
-def workspace_version(manifest: Path) -> str:
-    """Return the workspace package version from the root manifest.
-
-    Parameters
-    ----------
-    manifest : Path
-        Path to the workspace ``Cargo.toml`` file.
-
-    Returns
-    -------
-    str
-        The semantic version configured under ``[workspace.package]``.
-
-    Raises
-    ------
-    SystemExit
-        Raised when the workspace manifest lacks the version entry.
-    """
-    manifest_text = manifest.read_text(encoding="utf-8")
-    data = tomllib.loads(manifest_text)
-    try:
-        return data["workspace"]["package"]["version"]
-    except KeyError as err:
-        message = (
-            f"expected [workspace.package].version in {manifest}; "
-            "[workspace.package] must define a version for publish automation to run. "
-            "Check the manifest defines the key."
-        )
-        if snippet := _workspace_section_excerpt(manifest_text):
-            indented_snippet = "\n".join(f"    {line}" for line in snippet)
-            message = f"{message}\n\nWorkspace manifest excerpt:\n{indented_snippet}"
-        raise SystemExit(message) from err
+def prune_workspace_members(manifest: Path) -> None:
+    """Filter workspace members using the current ``parse`` implementation."""
+    _members.parse = parse
+    _members.prune_workspace_members(manifest)
 
 
-def _workspace_section_excerpt(manifest_text: str) -> list[str] | None:
-    """Return the lines around the ``[workspace]`` section for diagnostics."""
-    lines = manifest_text.splitlines()
-    workspace_index = _find_workspace_section_index(lines)
-
-    if workspace_index is None:
-        return None
-
-    return _extract_section_lines(lines, workspace_index)
-
-
-def _find_workspace_section_index(lines: list[str]) -> int | None:
-    """Find the index of the [workspace] section."""
-    for index, line in enumerate(lines):
-        if line.strip().startswith("[workspace"):
-            return index
-    return None
-
-
-def _extract_section_lines(lines: list[str], workspace_index: int) -> list[str]:
-    """Extract lines around the workspace section for diagnostics."""
-    start = max(workspace_index - 1, 0)
-    end = workspace_index + 1
-
-    while _should_include_more_lines(lines, end, start):
-        end += 1
-
-    return lines[start:end]
+def strip_patch_section(manifest: Path) -> None:
+    """Remove the patch section using the current ``parse`` implementation."""
+    _patch.parse = parse
+    _patch.strip_patch_section(manifest)
 
 
 def remove_patch_entry(manifest: Path, crate: str) -> None:
-    """Remove the ``crate`` entry from the root ``[patch.crates-io]`` table.
-
-    Parameters
-    ----------
-    manifest : Path
-        Root workspace manifest that may contain patch overrides.
-    crate : str
-        Name of the crate whose patch entry should be removed.
-
-    Returns
-    -------
-    None
-        The manifest is rewritten only when the patch entry was present.
-    """
-    document = parse(manifest.read_text(encoding="utf-8"))
-    patch_tables = _get_patch_crates_io_tables(document)
-    if patch_tables is None:
-        return
-
-    patch_table, crates_io = patch_tables
-    if crate not in crates_io:
-        return
-
-    _remove_crate_and_cleanup_empty_sections(
-        document=document,
-        patch_table=patch_table,
-        crates_io=crates_io,
-        crate=crate,
-    )
-    _write_manifest_with_newline(document, manifest)
+    """Remove a single patch entry using the current ``parse`` implementation."""
+    _patch.parse = parse
+    _patch.remove_patch_entry(manifest, crate)
 
 
-def _get_patch_crates_io_tables(
-    document: TOMLDocument,
-) -> tuple[dict[str, typ.Any], dict[str, typ.Any]] | None:
-    """Return the patch and crates-io tables when both are present."""
-    patch_table = document.get("patch")
-    if patch_table is None:
-        return None
-
-    crates_io = patch_table.get("crates-io")
-    if crates_io is None:
-        return None
-
-    return (
-        typ.cast("dict[str, typ.Any]", patch_table),
-        typ.cast("dict[str, typ.Any]", crates_io),
-    )
+def workspace_version(manifest: Path) -> str:
+    """Expose the workspace version helper."""
+    return _versioning.workspace_version(manifest)
 
 
-def _remove_patch_section(
-    document: TOMLDocument, patch_table: dict[str, typ.Any]
-) -> None:
-    """Remove the entire ``[patch.crates-io]`` table from ``document``."""
-    patch_table.pop("crates-io", None)
-    if not patch_table:
-        del document["patch"]
+PUBLISHABLE_CRATES: typ.Final[tuple[str, ...]] = _members.PUBLISHABLE_CRATES
+_get_valid_workspace_members = _members._get_valid_workspace_members
+_ensure_members_array = _members._ensure_members_array
+_convert_list_to_array = _members._convert_list_to_array
+_filter_workspace_members = _members._filter_workspace_members
+_should_write_manifest = _members._should_write_manifest
+_format_multiline_members_if_needed = _members._format_multiline_members_if_needed
+_write_manifest_if_changed = _members._write_manifest_if_changed
+_get_patch_crates_io_tables = _patch._get_patch_crates_io_tables
+_remove_patch_section = _patch._remove_patch_section
+_remove_crate_and_cleanup_empty_sections = (
+    _patch._remove_crate_and_cleanup_empty_sections
+)
+_write_manifest_with_newline = _serialise._write_manifest_with_newline
+_workspace_section_excerpt = _versioning._workspace_section_excerpt
+_find_workspace_section_index = _versioning._find_workspace_section_index
+_extract_section_lines = _versioning._extract_section_lines
+_should_include_more_lines = _versioning._should_include_more_lines
 
-
-def _remove_crate_and_cleanup_empty_sections(
-    *,
-    document: TOMLDocument,
-    patch_table: dict[str, typ.Any],
-    crates_io: dict[str, typ.Any],
-    crate: str,
-) -> None:
-    """Remove ``crate`` from the patch section and drop empty tables."""
-    del crates_io[crate]
-    if not crates_io:
-        del patch_table["crates-io"]
-    if not patch_table:
-        del document["patch"]
-
-
-def _should_include_more_lines(lines: list[str], end: int, start: int) -> bool:
-    """Return ``True`` when diagnostic extraction should continue."""
-    if end >= len(lines):
-        return False
-
-    if end - start >= 8:
-        return False
-
-    stripped = lines[end].strip()
-    is_non_workspace_section = stripped.startswith("[") and not stripped.startswith(
-        "[workspace"
-    )
-    return not is_non_workspace_section
-
-
-def _ensure_members_array(workspace: dict, members: object) -> Array | None:
-    """Normalise ``workspace['members']`` to a TOML array when possible."""
-    if isinstance(members, Array):
-        return members
-
-    if isinstance(members, list):
-        return _convert_list_to_array(workspace, members)
-
-    return None
-
-
-def _convert_list_to_array(workspace: dict, members: list) -> Array:
-    """Convert ``members`` list to a TOML array attached to ``workspace``."""
-    rebuilt_members = array()
-    rebuilt_members.extend(members)
-    workspace["members"] = rebuilt_members
-    return typ.cast("Array", rebuilt_members)
-
-
-def _should_write_manifest(*, changed: bool, document: TOMLDocument) -> bool:
-    """Return ``True`` when the manifest should be persisted."""
-    if not changed:
-        return False
-
-    return document.get("workspace") is not None
-
-
-def _format_multiline_members_if_needed(members: Array) -> None:
-    """Ensure ``members`` is rendered as multiline when it spans lines."""
-    if "\n" in members.as_string():
-        members.multiline(multiline=True)
-
-
-def _write_manifest_with_newline(document: TOMLDocument, manifest: Path) -> None:
-    """Serialise ``document`` to ``manifest`` and ensure a trailing newline."""
-    rendered = dumps(document)
-    if not rendered.endswith("\n"):
-        rendered = f"{rendered}\n"
-
-    manifest.write_text(rendered, encoding="utf-8")
+__all__ = [
+    "PUBLISHABLE_CRATES",
+    "_convert_list_to_array",
+    "_ensure_members_array",
+    "_extract_section_lines",
+    "_filter_workspace_members",
+    "_find_workspace_section_index",
+    "_format_multiline_members_if_needed",
+    "_get_patch_crates_io_tables",
+    "_get_valid_workspace_members",
+    "_remove_crate_and_cleanup_empty_sections",
+    "_remove_patch_section",
+    "_should_include_more_lines",
+    "_should_write_manifest",
+    "_workspace_section_excerpt",
+    "_write_manifest_if_changed",
+    "_write_manifest_with_newline",
+    "apply_workspace_replacements",
+    "export_workspace",
+    "local",
+    "parse",
+    "prune_workspace_members",
+    "remove_patch_entry",
+    "strip_patch_section",
+    "workspace_version",
+]

--- a/scripts/publish_workspace.py
+++ b/scripts/publish_workspace.py
@@ -79,6 +79,7 @@ _should_write_manifest = _members._should_write_manifest
 _format_multiline_members_if_needed = _members._format_multiline_members_if_needed
 _write_manifest_if_changed = _members._write_manifest_if_changed
 _get_patch_crates_io_tables = _patch._get_patch_crates_io_tables
+_should_remove_patch_section = _patch._should_remove_patch_section
 _remove_patch_section = _patch._remove_patch_section
 _remove_crate_and_cleanup_empty_sections = (
     _patch._remove_crate_and_cleanup_empty_sections
@@ -102,6 +103,7 @@ __all__ = [
     "_remove_crate_and_cleanup_empty_sections",
     "_remove_patch_section",
     "_should_include_more_lines",
+    "_should_remove_patch_section",
     "_should_write_manifest",
     "_workspace_section_excerpt",
     "_write_manifest_if_changed",

--- a/scripts/publish_workspace_archive.py
+++ b/scripts/publish_workspace_archive.py
@@ -1,0 +1,52 @@
+"""Archive helpers for exporting publishable workspace snapshots.
+
+The functions defined here encapsulate the tarball export logic used by the
+publish automation. They deliberately keep filesystem side effects scoped to the
+provided destination so callers can stage archives without mutating the working
+copy.
+"""
+
+from __future__ import annotations
+
+import tarfile
+import tempfile
+from pathlib import Path
+
+from plumbum import local
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+__all__ = ["export_workspace"]
+
+
+def export_workspace(destination: Path) -> None:
+    """Extract the repository HEAD into ``destination`` via ``git archive``.
+
+    Parameters
+    ----------
+    destination : Path
+        Directory that will receive the exported workspace contents.
+
+    Returns
+    -------
+    None
+        The repository snapshot is written directly to ``destination``.
+    """
+    with tempfile.TemporaryDirectory() as archive_dir:
+        archive_path = Path(archive_dir) / "workspace.tar"
+        git_archive = local["git"][
+            "archive", "--format=tar", "HEAD", f"--output={archive_path}"
+        ]
+        with local.cwd(PROJECT_ROOT):
+            return_code, stdout, stderr = git_archive.run(
+                timeout=60,
+                retcode=None,
+            )
+        if return_code != 0:
+            diagnostics = (stderr or stdout or "").strip()
+            detail = f": {diagnostics}" if diagnostics else ""
+            message = f"git archive failed with exit code {return_code}{detail}"
+            raise SystemExit(message)
+        with tarfile.open(archive_path) as tar:
+            tar.extractall(destination, filter="data")

--- a/scripts/publish_workspace_archive.py
+++ b/scripts/publish_workspace_archive.py
@@ -104,6 +104,8 @@ def export_workspace(destination: Path) -> None:
         The repository snapshot is written directly to ``destination`` and the
         export honours ``GIT_ARCHIVE_TIMEOUT_S`` to bound ``git`` execution.
     """
+    destination = Path(destination)
+    destination.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory() as archive_dir:
         archive_root = Path(archive_dir)
         archive_path = _create_archive(archive_root)

--- a/scripts/publish_workspace_archive.py
+++ b/scripts/publish_workspace_archive.py
@@ -28,28 +28,44 @@ def _validated_members(
     members: list[tarfile.TarInfo] = []
     for member in tar.getmembers():
         candidate_path = (safe_root / member.name).resolve()
-        try:
-            candidate_path.relative_to(safe_root)
-        except ValueError as error:  # pragma: no cover - defensive branch
-            message = f"refusing to extract member outside destination: {member.name!r}"
-            raise SystemExit(message) from error
+        _ensure_member_within_destination(candidate_path, safe_root, member)
         if member.islnk() or member.issym():
-            link_target = Path(member.linkname)
-            if link_target.is_absolute():
-                target_path = Path(link_target).resolve()
-            else:
-                target_path = (candidate_path.parent / link_target).resolve()
-            try:
-                target_path.relative_to(safe_root)
-            except ValueError as error:  # pragma: no cover - defensive branch
-                detail = repr(member.name)
-                message = (
-                    "refusing to extract link entry outside destination: "
-                    + detail
-                )
-                raise SystemExit(message) from error
+            _ensure_link_within_destination(candidate_path, safe_root, member)
         members.append(member)
     return members
+
+
+def _ensure_member_within_destination(
+    candidate_path: Path, safe_root: Path, member: tarfile.TarInfo
+) -> None:
+    """Abort when ``member`` would escape ``safe_root`` during extraction."""
+    message = f"refusing to extract member outside destination: {member.name!r}"
+    _assert_within_destination(candidate_path, safe_root, message)
+
+
+def _ensure_link_within_destination(
+    candidate_path: Path, safe_root: Path, member: tarfile.TarInfo
+) -> None:
+    """Abort when link targets escape ``safe_root`` during extraction."""
+    target_path = _resolve_link_target(candidate_path, member.linkname)
+    detail = repr(member.name)
+    message = "refusing to extract link entry outside destination: " + detail
+    _assert_within_destination(target_path, safe_root, message)
+
+
+def _resolve_link_target(candidate_path: Path, linkname: str) -> Path:
+    """Return the absolute path a link would resolve to when extracted."""
+    link_target = Path(linkname)
+    if link_target.is_absolute():
+        return link_target.resolve()
+    return (candidate_path.parent / link_target).resolve()
+
+
+def _assert_within_destination(path: Path, safe_root: Path, message: str) -> None:
+    try:
+        path.relative_to(safe_root)
+    except ValueError as error:  # pragma: no cover - defensive branch
+        raise SystemExit(message) from error
 
 
 def export_workspace(destination: Path) -> None:
@@ -66,25 +82,43 @@ def export_workspace(destination: Path) -> None:
         The repository snapshot is written directly to ``destination``.
     """
     with tempfile.TemporaryDirectory() as archive_dir:
-        archive_path = Path(archive_dir) / "workspace.tar"
-        git_archive = local["git"][
-            "archive", "--format=tar", "HEAD", f"--output={archive_path}"
-        ]
-        with local.cwd(PROJECT_ROOT):
-            return_code, stdout, stderr = git_archive.run(
-                timeout=60,
-                retcode=None,
-            )
-        if return_code != 0:
-            diagnostics = (stderr or stdout or "").strip()
-            detail = f": {diagnostics}" if diagnostics else ""
-            message = f"git archive failed with exit code {return_code}{detail}"
-            raise SystemExit(message)
-        with tarfile.open(archive_path) as tar:
-            safe_members = _validated_members(tar, destination)
-            if sys.version_info >= (3, 12):
-                for member in safe_members:
-                    tar.extract(member, destination, filter="data")
-            else:
-                for member in safe_members:
-                    tar.extract(member, destination)
+        archive_root = Path(archive_dir)
+        archive_path = _create_archive(archive_root)
+        _extract_archive(archive_path, destination)
+
+
+def _create_archive(archive_root: Path) -> Path:
+    """Run ``git archive`` and return the resulting tarball path."""
+    archive_path = archive_root / "workspace.tar"
+    git_archive = local["git"][
+        "archive", "--format=tar", "HEAD", f"--output={archive_path}"
+    ]
+    with local.cwd(PROJECT_ROOT):
+        return_code, stdout, stderr = git_archive.run(
+            timeout=60,
+            retcode=None,
+        )
+    if return_code != 0:
+        diagnostics = (stderr or stdout or "").strip()
+        detail = f": {diagnostics}" if diagnostics else ""
+        message = f"git archive failed with exit code {return_code}{detail}"
+        raise SystemExit(message)
+    return archive_path
+
+
+def _extract_archive(archive_path: Path, destination: Path) -> None:
+    """Extract ``archive_path`` into ``destination`` after validation."""
+    with tarfile.open(archive_path) as tar:
+        safe_members = _validated_members(tar, destination)
+        _extract_members(tar, destination, safe_members)
+
+
+def _extract_members(
+    tar: tarfile.TarFile, destination: Path, safe_members: list[tarfile.TarInfo]
+) -> None:
+    """Extract ``safe_members`` into ``destination`` with version-aware safety."""
+    extract_kwargs = {}
+    if sys.version_info >= (3, 12):
+        extract_kwargs["filter"] = "data"
+    for member in safe_members:
+        tar.extract(member, destination, **extract_kwargs)

--- a/scripts/publish_workspace_archive.py
+++ b/scripts/publish_workspace_archive.py
@@ -70,7 +70,7 @@ def _ensure_link_within_destination(
 ) -> None:
     """Abort when link targets escape ``safe_root`` during extraction."""
     if member.islnk():
-        target_path = (safe_root / member.linkname).resolve()
+        target_path = safe_root.joinpath(member.linkname).resolve(strict=False)
     else:
         target_path = _resolve_link_target(candidate_path, member.linkname)
     detail = repr(member.name)
@@ -118,15 +118,11 @@ def export_workspace(destination: Path) -> None:
 def _create_archive(archive_root: Path) -> Path:
     """Run ``git archive`` and return the resulting tarball path."""
     archive_path = archive_root / "workspace.tar"
-    try:
-        git_archive = local["git"][
-            "archive", "--format=tar", "HEAD", f"--output={archive_path}"
-        ]
-    except CommandNotFound as error:
-        message = "git not found on PATH; unable to export workspace"
-        raise SystemExit(message) from error
     with local.cwd(PROJECT_ROOT):
         try:
+            git_archive = local["git"][
+                "archive", "--format=tar", "HEAD", f"--output={archive_path}"
+            ]
             return_code, stdout, stderr = git_archive.run(
                 timeout=GIT_ARCHIVE_TIMEOUT_S,
                 retcode=None,

--- a/scripts/publish_workspace_dependencies.py
+++ b/scripts/publish_workspace_dependencies.py
@@ -41,15 +41,15 @@ def apply_workspace_replacements(
     None
         All matching manifests are rewritten in place.
 
-    Examples
-    --------
-    >>> from pathlib import Path
-    >>> apply_workspace_replacements(Path("."), "1.2.3", include_local_path=False)
-
     Raises
     ------
     SystemExit
         Raised when any supplied crate lacks a replacement configuration.
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> apply_workspace_replacements(Path("."), "1.2.3", include_local_path=False)
     """
     workspace_root = Path(workspace_root)
     if crates is None:

--- a/scripts/publish_workspace_dependencies.py
+++ b/scripts/publish_workspace_dependencies.py
@@ -44,7 +44,8 @@ def apply_workspace_replacements(
     Raises
     ------
     SystemExit
-        Raised when any supplied crate lacks a replacement configuration.
+        Raised when any supplied crate lacks a replacement configuration or a
+        manifest cannot be rewritten due to a missing replacement entry.
 
     Examples
     --------

--- a/scripts/publish_workspace_dependencies.py
+++ b/scripts/publish_workspace_dependencies.py
@@ -45,6 +45,11 @@ def apply_workspace_replacements(
     --------
     >>> from pathlib import Path
     >>> apply_workspace_replacements(Path("."), "1.2.3", include_local_path=False)
+
+    Raises
+    ------
+    SystemExit
+        Raised when any supplied crate lacks a replacement configuration.
     """
     workspace_root = Path(workspace_root)
     if crates is None:

--- a/scripts/publish_workspace_dependencies.py
+++ b/scripts/publish_workspace_dependencies.py
@@ -1,0 +1,37 @@
+"""Dependency rewriting utilities for publish-time manifest adjustments.
+
+These helpers centralise the logic that updates inter-crate dependency entries
+so release automation can substitute version numbers and optional local path
+references in a single place.
+"""
+
+from __future__ import annotations
+
+import typing as typ
+from pathlib import Path
+
+from publish_patch import REPLACEMENTS, apply_replacements
+
+__all__ = ["apply_workspace_replacements"]
+
+
+def apply_workspace_replacements(
+    workspace_root: Path,
+    version: str,
+    *,
+    include_local_path: bool,
+    crates: tuple[str, ...] | None = None,
+) -> None:
+    """Rewrite workspace dependency declarations for publish workflows."""
+    workspace_root = Path(workspace_root)
+    targets: typ.Final[tuple[str, ...]] = REPLACEMENTS if crates is None else crates
+    for crate in targets:
+        if crate not in REPLACEMENTS:
+            continue
+        manifest = workspace_root / "crates" / crate / "Cargo.toml"
+        apply_replacements(
+            crate,
+            manifest,
+            version,
+            include_local_path=include_local_path,
+        )

--- a/scripts/publish_workspace_dependencies.py
+++ b/scripts/publish_workspace_dependencies.py
@@ -22,7 +22,30 @@ def apply_workspace_replacements(
     include_local_path: bool,
     crates: tuple[str, ...] | None = None,
 ) -> None:
-    """Rewrite workspace dependency declarations for publish workflows."""
+    """Rewrite workspace dependency declarations for publish workflows.
+
+    Parameters
+    ----------
+    workspace_root : Path
+        Root directory of the rstest-bdd workspace whose manifests are rewritten.
+    version : str
+        Version string applied to patched dependency entries.
+    include_local_path : bool
+        Toggle whether rewritten dependencies retain their relative path entries.
+    crates : tuple[str, ...] | None, optional
+        Subset of crates to update; default rewrites every crate with
+        replacements.
+
+    Returns
+    -------
+    None
+        All matching manifests are rewritten in place.
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> apply_workspace_replacements(Path("."), "1.2.3", include_local_path=False)
+    """
     workspace_root = Path(workspace_root)
     if crates is None:
         targets: typ.Final[tuple[str, ...]] = tuple(REPLACEMENTS)

--- a/scripts/publish_workspace_dependencies.py
+++ b/scripts/publish_workspace_dependencies.py
@@ -24,10 +24,16 @@ def apply_workspace_replacements(
 ) -> None:
     """Rewrite workspace dependency declarations for publish workflows."""
     workspace_root = Path(workspace_root)
-    targets: typ.Final[tuple[str, ...]] = REPLACEMENTS if crates is None else crates
+    if crates is None:
+        targets: typ.Final[tuple[str, ...]] = tuple(REPLACEMENTS)
+    else:
+        unknown = tuple(crate for crate in crates if crate not in REPLACEMENTS)
+        if unknown:
+            formatted = ", ".join(repr(crate) for crate in unknown)
+            message = "unknown crates: " + formatted
+            raise SystemExit(message)
+        targets = crates
     for crate in targets:
-        if crate not in REPLACEMENTS:
-            continue
         manifest = workspace_root / "crates" / crate / "Cargo.toml"
         apply_replacements(
             crate,

--- a/scripts/publish_workspace_members.py
+++ b/scripts/publish_workspace_members.py
@@ -111,10 +111,7 @@ def _write_manifest_if_changed(
 
 def _should_write_manifest(*, changed: bool, document: TOMLDocument) -> bool:
     """Return ``True`` when the manifest should be persisted."""
-    if not changed:
-        return False
-
-    return document.get("workspace") is not None
+    return changed and document.get("workspace") is not None
 
 
 def _format_multiline_members_if_needed(members: Array) -> None:

--- a/scripts/publish_workspace_members.py
+++ b/scripts/publish_workspace_members.py
@@ -1,0 +1,123 @@
+"""Workspace member maintenance for publish preparation workflows.
+
+This module concentrates all helpers that validate, filter, and persist the
+workspace member listings so that the main automation can depend on consistent
+manifest structure.
+"""
+
+from __future__ import annotations
+
+import typing as typ
+from pathlib import Path
+
+from publish_workspace_serialise import _write_manifest_with_newline
+from tomlkit import array, parse
+from tomlkit.items import Array
+
+if typ.TYPE_CHECKING:
+    from tomlkit.toml_document import TOMLDocument
+
+PUBLISHABLE_CRATES: typ.Final[tuple[str, ...]] = (
+    "rstest-bdd-patterns",
+    "rstest-bdd-macros",
+    "rstest-bdd",
+    "cargo-bdd",
+)
+
+__all__ = [
+    "PUBLISHABLE_CRATES",
+    "_convert_list_to_array",
+    "_ensure_members_array",
+    "_filter_workspace_members",
+    "_format_multiline_members_if_needed",
+    "_get_valid_workspace_members",
+    "_should_write_manifest",
+    "_write_manifest_if_changed",
+    "prune_workspace_members",
+]
+
+
+def prune_workspace_members(manifest: Path) -> None:
+    """Remove non-crate entries from the workspace members list."""
+    manifest = Path(manifest)
+    document = parse(manifest.read_text(encoding="utf-8"))
+    members = _get_valid_workspace_members(document)
+    if members is None:
+        return
+
+    changed = _filter_workspace_members(members)
+    _write_manifest_if_changed(
+        document=document,
+        manifest=manifest,
+        changed=changed,
+        members=members,
+    )
+
+
+def _get_valid_workspace_members(document: TOMLDocument) -> Array | None:
+    """Return the workspace members array when it exists and is valid."""
+    workspace = document.get("workspace")
+    if workspace is None:
+        return None
+
+    members = workspace.get("members")
+    if members is None:
+        return None
+
+    return _ensure_members_array(workspace, members)
+
+
+def _ensure_members_array(workspace: dict, members: object) -> Array | None:
+    """Normalise ``workspace['members']`` to a TOML array when possible."""
+    if isinstance(members, Array):
+        return members
+
+    if isinstance(members, list):
+        return _convert_list_to_array(workspace, members)
+
+    return None
+
+
+def _convert_list_to_array(workspace: dict, members: list) -> Array:
+    """Convert ``members`` list to a TOML array attached to ``workspace``."""
+    rebuilt_members = array()
+    rebuilt_members.extend(members)
+    workspace["members"] = rebuilt_members
+    return typ.cast("Array", rebuilt_members)
+
+
+def _filter_workspace_members(members: Array) -> bool:
+    """Remove ineligible workspace members, returning ``True`` if mutated."""
+    changed = False
+    for index in range(len(members) - 1, -1, -1):
+        entry = members[index]
+        if not isinstance(entry, str) or Path(entry).name not in PUBLISHABLE_CRATES:
+            del members[index]
+            changed = True
+
+    return changed
+
+
+def _write_manifest_if_changed(
+    *, document: TOMLDocument, manifest: Path, changed: bool, members: Array
+) -> None:
+    """Persist ``document`` to ``manifest`` only when ``changed`` is ``True``."""
+    if not _should_write_manifest(changed=changed, document=document):
+        return
+
+    _format_multiline_members_if_needed(members)
+    _write_manifest_with_newline(document, manifest)
+
+
+def _should_write_manifest(*, changed: bool, document: TOMLDocument) -> bool:
+    """Return ``True`` when the manifest should be persisted."""
+    if not changed:
+        return False
+
+    return document.get("workspace") is not None
+
+
+def _format_multiline_members_if_needed(members: Array) -> None:
+    """Ensure ``members`` is rendered as multiline when it spans lines."""
+    if "\n" in members.as_string():
+        members.multiline(multiline=True)

--- a/scripts/publish_workspace_patch.py
+++ b/scripts/publish_workspace_patch.py
@@ -1,0 +1,100 @@
+"""Patch table management for workspace manifests prepared for publishing.
+
+The helpers in this module encapsulate logic for stripping ``[patch.crates-io]``
+entries so release pipelines can clean manifests before packaging crates.
+"""
+
+from __future__ import annotations
+
+import typing as typ
+from pathlib import Path
+
+from publish_workspace_serialise import _write_manifest_with_newline
+from tomlkit import parse
+
+if typ.TYPE_CHECKING:
+    from tomlkit.toml_document import TOMLDocument
+
+__all__ = [
+    "_get_patch_crates_io_tables",
+    "_remove_crate_and_cleanup_empty_sections",
+    "_remove_patch_section",
+    "remove_patch_entry",
+    "strip_patch_section",
+]
+
+
+def strip_patch_section(manifest: Path) -> None:
+    """Strip the ``[patch.crates-io]`` section from ``manifest``."""
+    manifest = Path(manifest)
+    document = parse(manifest.read_text(encoding="utf-8"))
+    patch_tables = _get_patch_crates_io_tables(document)
+    if patch_tables is None:
+        return
+
+    patch_table, _ = patch_tables
+    _remove_patch_section(document, patch_table)
+    _write_manifest_with_newline(document, manifest)
+
+
+def remove_patch_entry(manifest: Path, crate: str) -> None:
+    """Remove the ``crate`` entry from the root ``[patch.crates-io]`` table."""
+    manifest = Path(manifest)
+    document = parse(manifest.read_text(encoding="utf-8"))
+    patch_tables = _get_patch_crates_io_tables(document)
+    if patch_tables is None:
+        return
+
+    patch_table, crates_io = patch_tables
+    if crate not in crates_io:
+        return
+
+    _remove_crate_and_cleanup_empty_sections(
+        document=document,
+        patch_table=patch_table,
+        crates_io=crates_io,
+        crate=crate,
+    )
+    _write_manifest_with_newline(document, manifest)
+
+
+def _get_patch_crates_io_tables(
+    document: TOMLDocument,
+) -> tuple[dict[str, typ.Any], dict[str, typ.Any]] | None:
+    """Return the patch and crates-io tables when both are present."""
+    patch_table = document.get("patch")
+    if patch_table is None:
+        return None
+
+    crates_io = patch_table.get("crates-io")
+    if crates_io is None:
+        return None
+
+    return (
+        typ.cast("dict[str, typ.Any]", patch_table),
+        typ.cast("dict[str, typ.Any]", crates_io),
+    )
+
+
+def _remove_patch_section(
+    document: TOMLDocument, patch_table: dict[str, typ.Any]
+) -> None:
+    """Remove the entire ``[patch.crates-io]`` table from ``document``."""
+    patch_table.pop("crates-io", None)
+    if not patch_table:
+        del document["patch"]
+
+
+def _remove_crate_and_cleanup_empty_sections(
+    *,
+    document: TOMLDocument,
+    patch_table: dict[str, typ.Any],
+    crates_io: dict[str, typ.Any],
+    crate: str,
+) -> None:
+    """Remove ``crate`` from the patch section and drop empty tables."""
+    del crates_io[crate]
+    if not crates_io:
+        del patch_table["crates-io"]
+    if not patch_table:
+        del document["patch"]

--- a/scripts/publish_workspace_serialise.py
+++ b/scripts/publish_workspace_serialise.py
@@ -1,0 +1,28 @@
+"""Manifest serialisation helpers shared across publish workspace utilities.
+
+These utilities encapsulate TOML rendering behaviour so that individual
+workflows can focus on their domain logic while relying on consistent output
+formatting.
+"""
+
+from __future__ import annotations
+
+import typing as typ
+from pathlib import Path
+
+from tomlkit import dumps
+
+if typ.TYPE_CHECKING:
+    from tomlkit.toml_document import TOMLDocument
+
+__all__ = ["_write_manifest_with_newline"]
+
+
+def _write_manifest_with_newline(document: TOMLDocument, manifest: Path) -> None:
+    """Serialise ``document`` to ``manifest`` and ensure a trailing newline."""
+    manifest = Path(manifest)
+    rendered = dumps(document)
+    if not rendered.endswith("\n"):
+        rendered = f"{rendered}\n"
+
+    manifest.write_text(rendered, encoding="utf-8")

--- a/scripts/publish_workspace_versioning.py
+++ b/scripts/publish_workspace_versioning.py
@@ -1,0 +1,83 @@
+"""Workspace version diagnostics for publish automation.
+
+These helpers provide access to the workspace package version and produce
+contextual diagnostics when required keys are missing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import tomllib
+
+__all__ = [
+    "_extract_section_lines",
+    "_find_workspace_section_index",
+    "_should_include_more_lines",
+    "_workspace_section_excerpt",
+    "workspace_version",
+]
+
+
+def workspace_version(manifest: Path) -> str:
+    """Return the workspace package version from the root manifest."""
+    manifest = Path(manifest)
+    manifest_text = manifest.read_text(encoding="utf-8")
+    data = tomllib.loads(manifest_text)
+    try:
+        return data["workspace"]["package"]["version"]
+    except KeyError as err:
+        message = (
+            f"expected [workspace.package].version in {manifest}; "
+            "[workspace.package] must define a version for publish automation to run. "
+            "Check the manifest defines the key."
+        )
+        if snippet := _workspace_section_excerpt(manifest_text):
+            indented_snippet = "\n".join(f"    {line}" for line in snippet)
+            message = f"{message}\n\nWorkspace manifest excerpt:\n{indented_snippet}"
+        raise SystemExit(message) from err
+
+
+def _workspace_section_excerpt(manifest_text: str) -> list[str] | None:
+    """Return the lines around the ``[workspace]`` section for diagnostics."""
+    lines = manifest_text.splitlines()
+    workspace_index = _find_workspace_section_index(lines)
+
+    if workspace_index is None:
+        return None
+
+    return _extract_section_lines(lines, workspace_index)
+
+
+def _find_workspace_section_index(lines: list[str]) -> int | None:
+    """Find the index of the [workspace] section."""
+    for index, line in enumerate(lines):
+        if line.strip().startswith("[workspace"):
+            return index
+    return None
+
+
+def _extract_section_lines(lines: list[str], workspace_index: int) -> list[str]:
+    """Extract lines around the workspace section for diagnostics."""
+    start = max(workspace_index - 1, 0)
+    end = workspace_index + 1
+
+    while _should_include_more_lines(lines, end, start):
+        end += 1
+
+    return lines[start:end]
+
+
+def _should_include_more_lines(lines: list[str], end: int, start: int) -> bool:
+    """Return ``True`` when diagnostic extraction should continue."""
+    if end >= len(lines):
+        return False
+
+    if end - start >= 8:
+        return False
+
+    stripped = lines[end].strip()
+    is_non_workspace_section = stripped.startswith("[") and not stripped.startswith(
+        "[workspace"
+    )
+    return not is_non_workspace_section

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -1,0 +1,36 @@
+"""Shared fixtures for publish workspace tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import typing as typ
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+if typ.TYPE_CHECKING:
+    from types import ModuleType
+
+
+def _load_publish_workspace_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "publish_workspace", SCRIPTS_DIR / "publish_workspace.py"
+    )
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive guard
+        message = "publish_workspace module could not be loaded"
+        raise RuntimeError(message)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def publish_workspace_module() -> ModuleType:
+    """Provide the publish_workspace module for helper unit tests."""
+    return _load_publish_workspace_module()

--- a/scripts/tests/test_publish_workspace_patch_helpers.py
+++ b/scripts/tests/test_publish_workspace_patch_helpers.py
@@ -1,0 +1,109 @@
+"""Unit tests for publish_workspace patch helper functions."""
+
+from __future__ import annotations
+
+import typing as typ
+
+from tomlkit import parse
+
+if typ.TYPE_CHECKING:
+    from types import ModuleType
+
+
+def test_should_remove_patch_section_detects_entries(
+    publish_workspace_module: ModuleType,
+) -> None:
+    """Identify manifests that define ``[patch.crates-io]`` entries."""
+    document = parse(
+        "\n".join(
+            (
+                "[patch.crates-io]",
+                'serde = { path = "../serde" }',
+            )
+        )
+    )
+
+    assert publish_workspace_module._should_remove_patch_section(document) is True
+
+
+def test_should_remove_patch_section_ignores_invalid_tables(
+    publish_workspace_module: ModuleType,
+) -> None:
+    """Return ``False`` when the patch section is malformed."""
+    document = parse('[patch]\ncomment = "broken"\n')
+    document["patch"] = "not-a-table"
+
+    assert publish_workspace_module._should_remove_patch_section(document) is False
+
+
+def test_remove_patch_section_deletes_patch_table(
+    publish_workspace_module: ModuleType,
+) -> None:
+    """Drop the patch table when ``crates-io`` entries are removed."""
+    document = parse(
+        "\n".join(
+            (
+                "[patch.crates-io]",
+                'serde = { path = "../serde" }',
+            )
+        )
+    )
+    patch_table, _ = publish_workspace_module._get_patch_crates_io_tables(document)
+
+    publish_workspace_module._remove_patch_section(document, patch_table)
+
+    assert "patch" not in document
+
+
+def test_remove_crate_and_cleanup_preserves_remaining_entries(
+    publish_workspace_module: ModuleType,
+) -> None:
+    """Retain the patch table when other crates remain."""
+    document = parse(
+        "\n".join(
+            (
+                "[patch.crates-io]",
+                'serde = { path = "../serde" }',
+                'toml = { path = "../toml" }',
+            )
+        )
+    )
+    patch_table, crates_io = publish_workspace_module._get_patch_crates_io_tables(
+        document
+    )
+
+    publish_workspace_module._remove_crate_and_cleanup_empty_sections(
+        document=document,
+        patch_table=patch_table,
+        crates_io=crates_io,
+        crate="serde",
+    )
+
+    assert "serde" not in crates_io
+    assert "patch" in document
+
+
+def test_remove_crate_and_cleanup_removes_empty_patch(
+    publish_workspace_module: ModuleType,
+) -> None:
+    """Delete the patch table when the final crate is removed."""
+    document = parse(
+        "\n".join(
+            (
+                "[patch.crates-io]",
+                'serde = { path = "../serde" }',
+            )
+        )
+    )
+    patch_table, crates_io = publish_workspace_module._get_patch_crates_io_tables(
+        document
+    )
+
+    publish_workspace_module._remove_crate_and_cleanup_empty_sections(
+        document=document,
+        patch_table=patch_table,
+        crates_io=crates_io,
+        crate="serde",
+    )
+
+    assert "patch" not in document


### PR DESCRIPTION
## Summary
- extract helpers to simplify patch section stripping and crate-specific removal
- normalise workspace member validation and manifest persistence logic with focused helpers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d84a8d4b488322ab98a62f2c1a394f

## Summary by Sourcery

Refactor publish_workspace.py by extracting and centralizing conditional logic into helper functions

Enhancements:
- Extract patch section detection and removal into dedicated helper functions
- Consolidate crate-specific patch entry removal and cleanup logic
- Normalize workspace member validation and conversion to TOML array via helper functions
- Centralize manifest persistence and formatting (multiline members, trailing newline) into shared helpers
- Extract diagnostic section line extraction logic into a standalone helper