### PR TITLE
Fix publish-check macros dependency expectations

### DIFF
--- a/scripts/publish_patch.py
+++ b/scripts/publish_patch.py
@@ -45,7 +45,6 @@ REPLACEMENTS: dict[str, tuple[DependencyPatch, ...]] = {
         DependencyPatch(
             "dependencies", "rstest-bdd-patterns", "../rstest-bdd-patterns"
         ),
-        DependencyPatch("dev-dependencies", "rstest-bdd", "../rstest-bdd"),
     ),
     "rstest-bdd": (
         DependencyPatch(


### PR DESCRIPTION
## Summary
- stop the publish patch helper from expecting a dev-dependency on `rstest-bdd` in the macros crate, reflecting the new manifest layout

## Testing
- make publish-check

------
https://chatgpt.com/codex/tasks/task_e_68d97a682d388322b1c70b3c70b14154

## Summary by Sourcery

Bug Fixes:
- Remove dev-dependency expectation on rstest-bdd in the macros crate within the publish-check script