### PR TITLE
Document scenario title binding plans

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -216,10 +216,10 @@ improves the developer experience.
     discover all `.feature` files in a directory and generate a test module
     containing a test function for every `Scenario` found.
 
-  - [ ] Allow the `#[scenario]` macro to bind to scenarios by title via a new
-    `name` argument, falling back to the index only when duplicates exist. Emit
-    a compile-time error when the requested title is absent to keep tests
-    resilient to reordering in feature files.
+  - [ ] Harden the `#[scenario]` macro's existing `name` selector with
+    compile-time diagnostics: emit an error when the requested title is absent
+    so bindings stay robust to feature reordering, and fall back to the index
+    only when duplicate titles exist.
 
 ## Phase 4: Internationalization and Localization
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -216,6 +216,11 @@ improves the developer experience.
     discover all `.feature` files in a directory and generate a test module
     containing a test function for every `Scenario` found.
 
+  - [ ] Allow the `#[scenario]` macro to bind to scenarios by title via a new
+    `name` argument, falling back to the index only when duplicates exist. Emit
+    a compile-time error when the requested title is absent to keep tests
+    resilient to reordering in feature files.
+
 ## Phase 4: Internationalization and Localization
 
 This phase introduces full internationalization (i18n) and localization (l10n)

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1414,6 +1414,43 @@ step definitions by exact string comparison. Argument parsing and fixture
 handling remain unimplemented to minimize complexity while proving the
 orchestration works.
 
+#### 3.7.1 Scenario selection by title
+
+Binding scenarios by zero-based index is brittle in active feature files,
+because inserting a new scenario silently retargets existing tests. To reduce
+that coupling the macro will accept an alternative `name` argument so call
+sites can reference a scenario by its title. The string literal is matched
+case-sensitively against every `Scenario` and `Scenario Outline` heading in the
+parsed feature.
+
+- `name` and `index` are mutually exclusive. Supplying both emits a
+  `compile_error!` explaining the conflict and suggesting that the caller pick
+  a single selector.
+- When a unique title matches, the macro reuses the existing code path by
+  computing the corresponding index internally. This keeps downstream code
+  generation unchanged.
+- If no title matches, the macro emits a `compile_error!` listing the available
+  scenario titles in the feature file so the caller can correct the binding.
+- When multiple scenarios share the same title, the macro reports the
+  ambiguity, enumerates the matching line numbers, and suggests switching back
+  to the explicit `index` selector. This allows teams to keep duplicate titles
+  while retaining deterministic bindings.
+
+Implementation sketch:
+
+1. Extend the argument parser so `ScenarioArgs` stores `index: Option<usize>`
+   and `name: Option<String>`, enforcing mutual exclusion during parsing.
+2. After parsing the feature, walk the scenario list once, pushing each title
+   into a `HashMap<&str, Vec<usize>>` that records indexes for every title.
+3. When `name` is set, look up the vector of matching indexes:
+   - Empty vectors trigger the missing-title diagnostic.
+   - Single-entry vectors reuse the existing index-based selection.
+   - Multi-entry vectors trigger the ambiguity diagnostic. Include the
+     formatted title and 1-based line numbers to help the user disambiguate.
+4. Tests cover the happy path, missing title, and ambiguous cases to lock in
+   the diagnostics. Trybuild fixtures exercise each compiler error so the
+   messages remain stable as the macro evolves.
+
 ### 3.8 Fixture Integration Implementation
 
 The second phase extends the macro system to support fixtures. Step definition


### PR DESCRIPTION
## Summary
- add a Phase 3 roadmap task to let the `#[scenario]` macro bind by title instead of relying on scenario order
- sketch the design for a `name` argument in the `#[scenario]` macro, including diagnostics for missing and duplicate titles

## Testing
- make fmt
- make lint *(fails: ruff flags a pre-existing generator comprehension in scripts/publish_workspace_dependencies.py)*
- make test


------
https://chatgpt.com/codex/tasks/task_e_68dcf07be404832288ccd9184a808d31

## Summary by Sourcery

Document the plan to support scenario selection by title in the rstest BDD macro and update the Phase 3 roadmap accordingly.

Documentation:
- Add a new section detailing the design sketch for a `name` argument to bind scenarios by title, including error diagnostics for missing or duplicate titles.
- Update the roadmap to include a Phase 3 task for enabling scenario binding by title with compile‐time checks.