### PR TITLE
Return error when accessing uncompiled step regex

### DIFF
--- a/crates/rstest-bdd/src/pattern.rs
+++ b/crates/rstest-bdd/src/pattern.rs
@@ -5,6 +5,7 @@
 use crate::types::{PlaceholderSyntaxError, StepPatternError};
 use regex::Regex;
 use rstest_bdd_patterns::{PatternError, compile_regex_from_pattern};
+use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
 use std::sync::OnceLock;
 
@@ -81,13 +82,26 @@ impl StepPattern {
 
     /// Return the cached regular expression.
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rstest_bdd::StepPattern;
+    ///
+    /// let pattern = StepPattern::from("literal text");
+    /// assert!(pattern.regex().is_err());
+    /// pattern.compile().expect("literal patterns compile");
+    /// let regex = pattern.regex().expect("regex available after compilation");
+    /// assert!(regex.is_match("literal text"));
+    /// ```
+    ///
     /// # Errors
     /// Returns [`StepPatternError::NotCompiled`] if [`compile`](Self::compile)
     /// was not invoked beforehand.
+    #[must_use = "handle the Result to ensure the pattern was compiled"]
     pub fn regex(&self) -> Result<&Regex, StepPatternError> {
-        self.regex
-            .get()
-            .ok_or(StepPatternError::NotCompiled { pattern: self.text })
+        self.regex.get().ok_or(StepPatternError::NotCompiled {
+            pattern: Cow::Borrowed(self.text),
+        })
     }
 }
 

--- a/crates/rstest-bdd/src/pattern.rs
+++ b/crates/rstest-bdd/src/pattern.rs
@@ -79,18 +79,15 @@ impl StepPattern {
         Ok(())
     }
 
-    /// Return the cached regular expression or panic if not compiled.
+    /// Return the cached regular expression.
     ///
-    /// # Panics
-    /// Panics if `compile()` was not called before this accessor.
-    #[must_use]
-    pub fn regex(&self) -> &Regex {
-        self.regex.get().unwrap_or_else(|| {
-            panic!(
-                "step pattern regex must be precompiled; call compile() first on pattern '{}'",
-                self.text
-            )
-        })
+    /// # Errors
+    /// Returns [`StepPatternError::NotCompiled`] if [`compile`](Self::compile)
+    /// was not invoked beforehand.
+    pub fn regex(&self) -> Result<&Regex, StepPatternError> {
+        self.regex
+            .get()
+            .ok_or(StepPatternError::NotCompiled { pattern: self.text })
     }
 }
 

--- a/crates/rstest-bdd/src/pattern.rs
+++ b/crates/rstest-bdd/src/pattern.rs
@@ -97,7 +97,7 @@ impl StepPattern {
     /// # Errors
     /// Returns [`StepPatternError::NotCompiled`] if [`compile`](Self::compile)
     /// was not invoked beforehand.
-    #[must_use = "handle the Result to ensure the pattern was compiled"]
+    #[must_use = "check whether compilation succeeded"]
     pub fn regex(&self) -> Result<&Regex, StepPatternError> {
         self.regex.get().ok_or(StepPatternError::NotCompiled {
             pattern: Cow::Borrowed(self.text),

--- a/crates/rstest-bdd/src/placeholder.rs
+++ b/crates/rstest-bdd/src/placeholder.rs
@@ -19,6 +19,8 @@ use rstest_bdd_patterns::extract_captured_values;
 ///   placeholders.
 /// - [`PlaceholderError::InvalidPattern`]: generated regular expression failed
 ///   to compile.
+/// - [`PlaceholderError::NotCompiled`]: the compiled regex was requested before
+///   the pattern was compiled.
 pub fn extract_placeholders(
     pattern: &StepPattern,
     text: StepText<'_>,

--- a/crates/rstest-bdd/src/placeholder.rs
+++ b/crates/rstest-bdd/src/placeholder.rs
@@ -24,6 +24,6 @@ pub fn extract_placeholders(
     text: StepText<'_>,
 ) -> Result<Vec<String>, PlaceholderError> {
     pattern.compile()?;
-    let re = pattern.regex();
+    let re = pattern.regex()?;
     extract_captured_values(re, text.as_str()).ok_or(PlaceholderError::PatternMismatch)
 }

--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -222,6 +222,14 @@ pub enum StepPatternError {
     /// The generated regular expression failed to compile.
     #[error("{0}")]
     InvalidPattern(#[from] regex::Error),
+    /// Attempted to access the compiled regex before calling [`StepPattern::compile`](crate::pattern::StepPattern::compile).
+    #[error(
+        "step pattern regex has not been compiled; call compile() first on pattern '{pattern}'"
+    )]
+    NotCompiled {
+        /// Pattern text that has not yet been compiled.
+        pattern: &'static str,
+    },
 }
 
 /// Error conditions that may arise when extracting placeholders.
@@ -245,7 +253,7 @@ impl From<StepPatternError> for PlaceholderError {
             StepPatternError::PlaceholderSyntax(err) => {
                 Self::InvalidPlaceholder(err.user_message())
             }
-            StepPatternError::InvalidPattern(re) => Self::InvalidPattern(re.to_string()),
+            other => Self::InvalidPattern(other.to_string()),
         }
     }
 }

--- a/crates/rstest-bdd/tests/placeholder_parsing.rs
+++ b/crates/rstest-bdd/tests/placeholder_parsing.rs
@@ -25,6 +25,24 @@ fn expect_placeholder_syntax(pat: StepPattern) -> PlaceholderSyntaxError {
 }
 
 #[test]
+fn regex_requires_prior_compilation() {
+    let pattern = StepPattern::from("literal text");
+    assert!(
+        matches!(pattern.regex(), Err(StepPatternError::NotCompiled { .. })),
+        "accessing the regex without compiling should return an error",
+    );
+
+    if let Err(err) = pattern.compile() {
+        panic!("compiling literal pattern should succeed: {err:?}");
+    }
+    let re = match pattern.regex() {
+        Ok(regex) => regex,
+        Err(err) => panic!("regex should be available after compilation: {err:?}"),
+    };
+    assert!(re.is_match("literal text"));
+}
+
+#[test]
 fn type_hint_uses_specialised_fragment() {
     // u32: positive integer
     let pat = compiled("value {n:u32}");


### PR DESCRIPTION
## Summary
- closes #32
- return `Result` from `StepPattern::regex` and surface a new `StepPatternError::NotCompiled` variant
- propagate the new error through placeholder extraction and cover it with a regression test
- tidy the workspace dependency helper to keep ruff happy during linting

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68dcfc83e24c8322bd3212849cf40500

## Summary by Sourcery

Change StepPattern::regex to return a Result with a NotCompiled error instead of panicking, propagate the new error through placeholder extraction, and add a regression test to cover accessing the regex without prior compilation. Also tidy the workspace dependency helper script.

Bug Fixes:
- Make StepPattern::regex return a Result with StepPatternError::NotCompiled instead of panicking when uncompiled
- Propagate regex access error through placeholder extraction

Tests:
- Add regression test verifying regex accessor returns an error before compilation and succeeds after

Chores:
- Refactor publish_workspace_dependencies.py to use a set comprehension for unknown crates