### PR TITLE
Harden scenario macro name selector

### DIFF
--- a/crates/rstest-bdd/tests/fixtures_macros/duplicate_titles.feature
+++ b/crates/rstest-bdd/tests/fixtures_macros/duplicate_titles.feature
@@ -1,0 +1,11 @@
+Feature: Duplicate titles
+
+  Scenario: Shared title
+    Given a precondition
+    When an action occurs
+    Then a result is produced
+
+  Scenario: Shared title
+    Given a precondition
+    When an action occurs
+    Then a result is produced

--- a/crates/rstest-bdd/tests/fixtures_macros/scenario_duplicate_name.rs
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenario_duplicate_name.rs
@@ -1,0 +1,19 @@
+//! Compile-time fixture verifying that duplicate scenario titles require an
+//! index selector.
+use rstest_bdd_macros::{given, scenario, then, when};
+
+#[given("a precondition")]
+fn precondition() {}
+
+#[when("an action occurs")]
+fn action() {}
+
+#[then("a result is produced")]
+fn result() {}
+
+#[scenario(path = "duplicate_titles.feature", name = "Shared title")]
+fn duplicate_titles() {}
+
+const _: &str = include_str!("duplicate_titles.feature");
+
+fn main() {}

--- a/crates/rstest-bdd/tests/fixtures_macros/scenario_duplicate_name.stderr
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenario_duplicate_name.stderr
@@ -1,0 +1,5 @@
+error: found multiple scenarios named "Shared title"; use the `index` selector to disambiguate (matching indexes: 0, 1; lines: 3, 8)
+  --> tests/fixtures_macros/scenario_duplicate_name.rs:14:54
+   |
+14 | #[scenario(path = "duplicate_titles.feature", name = "Shared title")]
+   |                                                      ^^^^^^^^^^^^^^

--- a/crates/rstest-bdd/tests/fixtures_macros/scenario_missing_name.rs
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenario_missing_name.rs
@@ -1,0 +1,10 @@
+//! Compile-time fixture verifying that selecting a non-existent scenario by
+//! name surfaces a descriptive error.
+use rstest_bdd_macros::scenario;
+
+#[scenario(path = "basic.feature", name = "Does not exist")]
+fn missing_named_scenario() {}
+
+const _: &str = include_str!("basic.feature");
+
+fn main() {}

--- a/crates/rstest-bdd/tests/fixtures_macros/scenario_missing_name.stderr
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenario_missing_name.stderr
@@ -1,0 +1,5 @@
+error: scenario named "Does not exist" not found; available titles: "Example scenario"
+ --> tests/fixtures_macros/scenario_missing_name.rs:5:43
+  |
+5 | #[scenario(path = "basic.feature", name = "Does not exist")]
+  |                                           ^^^^^^^^^^^^^^^^

--- a/crates/rstest-bdd/tests/scenario.rs
+++ b/crates/rstest-bdd/tests/scenario.rs
@@ -88,6 +88,15 @@ fn scenario_with_index(#[case] case_name: &str) {
     clear_events();
 }
 
+#[scenario(path = "tests/features/multi.feature", name = "Second")]
+#[serial]
+fn scenario_with_name_selector() {
+    with_locked_events(|events| {
+        assert_eq!(events.as_slice(), ["precondition", "action", "result"]);
+    });
+    clear_events();
+}
+
 #[scenario(path = "tests/features/web_search.feature", index = 0)]
 #[serial]
 fn explicit_syntax() {

--- a/crates/rstest-bdd/tests/trybuild_macros.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros.rs
@@ -180,6 +180,8 @@ fn run_passing_macro_tests(t: &trybuild::TestCases) {
 fn run_failing_macro_tests(t: &trybuild::TestCases) {
     for case in [
         MacroFixtureCase::from("scenario_missing_file.rs"),
+        MacroFixtureCase::from("scenario_missing_name.rs"),
+        MacroFixtureCase::from("scenario_duplicate_name.rs"),
         MacroFixtureCase::from("step_macros_invalid_identifier.rs"),
         MacroFixtureCase::from("step_tuple_pattern.rs"),
         MacroFixtureCase::from("step_struct_pattern.rs"),

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -210,13 +210,13 @@ improves the developer experience.
 
 [design §1.3.4]: ./rstest-bdd-design.md#134-filtering-scenarios-with-tags
 
-- [ ] **Boilerplate Reduction**
+- [x] **Boilerplate Reduction**
 
   - [x] Implement the `scenarios!("path/to/features/")` macro to automatically
     discover all `.feature` files in a directory and generate a test module
     containing a test function for every `Scenario` found.
 
-  - [ ] Harden the `#[scenario]` macro's existing `name` selector with
+  - [x] Harden the `#[scenario]` macro's existing `name` selector with
     compile-time diagnostics: emit an error when the requested title is absent
     so bindings stay robust to feature reordering, and fall back to the index
     only when duplicate titles exist.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -204,18 +204,22 @@ registers an empty pattern instead of inferring one.
 ## Binding tests to scenarios
 
 The `#[scenario]` macro is the entry point that ties a Rust test function to a
-scenario defined in a `.feature` file. It accepts two arguments:
+scenario defined in a `.feature` file. It accepts three arguments:
 
-| Argument       | Purpose                                                                                                      | Status                                                                                                         |
-| -------------- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
-| `path: &str`   | Relative path to the feature file from the crate root. This is mandatory.                                    | **Implemented**: the macro resolves the path at compile time and parses the feature using the `gherkin` crate. |
-| `index: usize` | Optional zero‑based index selecting a scenario when the file contains multiple scenarios. Defaults to `0`.   | **Implemented**: the macro uses the index to pick the scenario.                                                |
+| Argument       | Purpose                                                   | Status                                                               |
+| -------------- | --------------------------------------------------------- | -------------------------------------------------------------------- |
+| `path: &str`   | Relative path to the feature file (required).             | **Implemented**: resolved and parsed at compile time.                |
+| `index: usize` | Optional zero-based scenario index (defaults to `0`).     | **Implemented**: selects the scenario by position.                  |
+| `name: &str`   | Optional scenario title; resolves to an index when unique. | **Implemented**: errors when missing and directs duplicates to `index`. |
 
 If the feature file cannot be found or contains invalid Gherkin, the macro
 emits a compile-time error with the offending path.
 
-The design document proposes a `name` argument to select scenarios by name, but
-only `path` and `index` are currently accepted.
+When `name` is provided, the macro matches the title case-sensitively. A
+missing title triggers a diagnostic listing the available headings in the
+feature. Duplicate titles yield a diagnostic that highlights the conflict and
+lists the matching indexes and line numbers so you can switch back to the
+`index` argument when needed.
 
 During macro expansion, the feature file is read and parsed. The macro
 generates a new test function annotated with `#[rstest::rstest]` that performs
@@ -384,10 +388,6 @@ delimited by triple double-quotes or triple backticks.
 
 The `rstest‑bdd` project is evolving. Several features described in the design
 document and README remain unimplemented in the current codebase:
-
-- **Selecting scenarios by name.** The README hints at a `name` argument for
-  the `#[scenario]` macro, but the macro only accepts `path` and optional
-  `index`.
 
 - **Wildcard keywords and** `*` **steps.** The asterisk (`*`) can replace any
   step keyword in Gherkin to improve readability, but step lookup is based


### PR DESCRIPTION
## Summary
- emit compile-time errors when `#[scenario]` names are missing or ambiguous before falling back to index selection
- add behavioural and trybuild fixtures that cover name-based selection and duplicate-title diagnostics
- document the name selector in the user guide and design notes, and mark the roadmap item as complete

## Testing
- make check-fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68debbca376883228dc49abdc38facdd