### PR TITLE
Reduce cyclomatic complexity of truthy_bool

### DIFF
--- a/crates/rstest-bdd/src/datatable/parsers.rs
+++ b/crates/rstest-bdd/src/datatable/parsers.rs
@@ -4,6 +4,22 @@ use std::error::Error as StdError;
 
 use thiserror::Error;
 
+/// Checks whether the input matches any candidate string while ignoring ASCII
+/// case.
+///
+/// # Parameters
+/// - `s`: The input string to compare.
+/// - `candidates`: Slice of candidate strings to match against.
+///
+/// # Returns
+/// `true` when `s` matches any candidate, otherwise `false`.
+///
+/// # Examples
+/// ```
+/// # use rstest_bdd::datatable::parsers::matches_any_case_insensitive;
+/// assert!(matches_any_case_insensitive("YES", &["yes", "y"]));
+/// assert!(!matches_any_case_insensitive("maybe", &["yes", "no"]));
+/// ```
 fn matches_any_case_insensitive(s: &str, candidates: &[&str]) -> bool {
     candidates
         .iter()


### PR DESCRIPTION
## Summary
- extract a case-insensitive matcher helper for parsing datatable booleans
- reuse the helper with constant candidate lists to simplify `truthy_bool`

## Testing
- make check-fmt
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e6f89f310c8322b9bc295b39d67326

## Summary by Sourcery

Reduce cyclomatic complexity of truthy_bool by extracting a case-insensitive matcher helper and using constant candidate lists for truthy and falsy values

Enhancements:
- Extract matches_any_case_insensitive helper for case-insensitive matching
- Simplify truthy_bool by replacing repetitive comparisons with constant TRUTHY_VALUES and FALSY_VALUES slices