### PR TITLE
Document DataTableError diagnostics in the user guide

### DIFF
--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -512,7 +512,7 @@ inspection of the row and column that triggered the failure:
 
 ```rust,no_run
 # use rstest_bdd::datatable::{DataTableError, Rows};
-# use rstest_bdd_macros::{DataTable, DataTableRow};
+# use rstest_bdd_macros::DataTableRow;
 #
 # #[derive(Debug, PartialEq, Eq, DataTableRow)]
 # struct UserRow {
@@ -542,7 +542,7 @@ including the human-readable column label:
 
 ```rust,no_run
 # use rstest_bdd::datatable::{DataTableError, Rows};
-# use rstest_bdd_macros::{DataTable, DataTableRow};
+# use rstest_bdd_macros::DataTableRow;
 #
 # #[derive(Debug, PartialEq, Eq, DataTableRow)]
 # struct UserRow {


### PR DESCRIPTION
## Summary
- add a "Debugging data table errors" subsection to the user guide
- illustrate MissingColumn and CellParse failures with concrete snippets to aid troubleshooting

## Testing
- make fmt
- make check-fmt
- make lint
- make test
- make markdownlint

------
https://chatgpt.com/codex/tasks/task_e_68ed638b91048322a93de95ca62eb50d

## Summary by Sourcery

Add a troubleshooting guide for DataTableError variants in the user guide

Documentation:
- Introduce a "Debugging data table errors" subsection in the user guide
- Provide code examples showing how to handle MissingColumn and CellParse errors with row and column context