### PR TITLE
Simplify publish-check CLI dependencies

### DIFF
--- a/scripts/publish_workspace.py
+++ b/scripts/publish_workspace.py
@@ -15,8 +15,22 @@ import publish_workspace_members as _members
 import publish_workspace_patch as _patch
 import publish_workspace_serialise as _serialise
 import publish_workspace_versioning as _versioning
-from plumbum import local as _default_local
 from tomlkit import parse as _default_parse
+
+try:
+    from plumbum import local as _default_local
+except ModuleNotFoundError:  # pragma: no cover - exercised via CLI tests
+    class _PlumbumLocalPlaceholder:
+        """Fail with guidance when plumbum is unavailable at runtime."""
+
+        def __getattr__(self, name: str) -> typ.NoReturn:
+            message = (
+                "plumbum is required for workspace export; install plumbum or "
+                "invoke the automation via `make publish-check`"
+            )
+            raise SystemExit(message)
+
+    _default_local = _PlumbumLocalPlaceholder()
 
 if typ.TYPE_CHECKING:
     from pathlib import Path

--- a/scripts/publish_workspace_archive.py
+++ b/scripts/publish_workspace_archive.py
@@ -16,10 +16,27 @@ from __future__ import annotations
 import sys
 import tarfile
 import tempfile
+import typing
 from pathlib import Path
 
-from plumbum import local
-from plumbum.commands import CommandNotFound
+try:
+    from plumbum import local
+    from plumbum.commands import CommandNotFound
+except ModuleNotFoundError:  # pragma: no cover - exercised via CLI tests
+    class _PlumbumLocalPlaceholder:
+        """Fail with guidance when plumbum is unavailable at runtime."""
+
+        def __getattr__(self, name: str) -> typing.NoReturn:
+            message = (
+                "plumbum is required to export the workspace; install plumbum or "
+                "invoke the automation via `make publish-check`"
+            )
+            raise SystemExit(message)
+
+    local = _PlumbumLocalPlaceholder()
+
+    class CommandNotFound(RuntimeError):
+        """Sentinel exception used when plumbum is unavailable."""
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 


### PR DESCRIPTION
## Summary
- replace the publish-check CLI wiring with an argparse implementation so defaults come from the environment without requiring cyclopts
- add defensive fallbacks for missing plumbum so the CLI module can be imported before installing optional tooling

## Testing
- uv run --with pytest --with cyclopts --with plumbum --with tomlkit python -m pytest scripts/tests/publish_check -q

------
https://chatgpt.com/codex/tasks/task_e_68f8c52fda5883229db1420e00f66be5