### PR TITLE
Prevent publish-check CLI from exiting under tests

### DIFF
--- a/scripts/run_publish_check.py
+++ b/scripts/run_publish_check.py
@@ -108,7 +108,10 @@ ALREADY_PUBLISHED_MARKERS_FOLDED: typ.Final[tuple[str, ...]] = tuple(
 
 DEFAULT_PUBLISH_TIMEOUT_SECS = 900
 
-app = App(config=cyclopts.config.Env("PUBLISH_CHECK_", command=False))
+app = App(
+    config=cyclopts.config.Env("PUBLISH_CHECK_", command=False),
+    result_action="return_value",
+)
 
 
 def _resolve_timeout(timeout_secs: int | None) -> int:


### PR DESCRIPTION
## Summary
- configure the publish-check cyclopts app to return values instead of invoking SystemExit during test execution

## Testing
- uv run --with pytest --with cyclopts --with plumbum --with tomlkit python -m pytest scripts/tests/publish_check

------
https://chatgpt.com/codex/tasks/task_e_68f8ca1109bc8322b8e3b4854e62c656

## Summary by Sourcery

Enhancements:
- Add result_action="return_value" to the cyclopts App instantiation in run_publish_check.py to prevent exits under tests