### PR TITLE
Refactor: introduce ClassificationContext for arg classification

### DIFF
--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/extract.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/extract.rs
@@ -10,7 +10,7 @@ use std::collections::HashSet;
 use super::{
     classify::{
         classify_datatable, classify_docstring, classify_fixture_or_step, classify_step_struct,
-        extract_step_struct_attribute,
+        extract_step_struct_attribute, ClassificationContext,
     },
     ExtractedArgs,
 };
@@ -57,7 +57,8 @@ fn classifier_pipeline() -> Vec<Classifier> {
         },
         |st, arg, pat, ty, placeholders| {
             if placeholders.contains(&pat.to_string()) {
-                classify_fixture_or_step(st, arg, pat.clone(), ty.clone(), placeholders)?;
+                let mut ctx = ClassificationContext::new(st, placeholders);
+                classify_fixture_or_step(&mut ctx, arg, pat.clone(), ty.clone())?;
                 Ok(true)
             } else {
                 Ok(false)
@@ -66,7 +67,8 @@ fn classifier_pipeline() -> Vec<Classifier> {
         |st, arg, pat, ty, _| classify_datatable(st, arg, pat, ty),
         |st, arg, pat, ty, _| classify_docstring(st, arg, pat, ty),
         |st, arg, pat, ty, placeholders| {
-            classify_fixture_or_step(st, arg, pat.clone(), ty.clone(), placeholders)?;
+            let mut ctx = ClassificationContext::new(st, placeholders);
+            classify_fixture_or_step(&mut ctx, arg, pat.clone(), ty.clone())?;
             Ok(true)
         },
     ]


### PR DESCRIPTION
## Summary
- Introduces a new ClassificationContext to modularize argument classification and separate concerns between extraction and placeholder tracking.
- Refactors classify_fixture_or_step to operate against the new context, simplifying logic and improving testability.
- Reworks step_args expansion to be more modular by decomposing field collection and parsing logic.

## Changes
### Core Refactor
- Add ClassificationContext<'a> with fields:
  - extracted: &'a mut ExtractedArgs
  - placeholders: &'a mut HashSet<String>
- Update classify_fixture_or_step to accept &mut ClassificationContext instead of direct extracted/placeholders handling.
  - Use ctx.extracted and ctx.placeholders for state management.
  - Preserve existing error behavior when a named step argument is incompatible with step_args.

### Macro codegen: wrapper args classify/extract
- classify.rs
  - Replace direct placeholders usage with ClassificationContext.
  - Adjust calls to push Arg variants through the context’s extracted field.
- extract.rs
  - classifier_pipeline now creates a ClassificationContext and passes it to classify_fixture_or_step when handling step-arg placeholders.
  - Maintains existing classification fallbacks for other rules (datatable/docstring).

### StepArgs expansion refactor
- step_args.rs
  - Rename and restructure helpers:
    - collect_field_info(fields) -> (field_idents, field_types, field_name_literals)
    - add_fromstr_bounds(generics, field_types) to add FromStr bounds for all field types
    - generate_field_parsing(field_idents, field_types, runtime) to produce per-field parsing code
  - Rework expand_named_struct to:
    - Use collect_field_info to gather field data
    - Enforce at least one field with a clear error message
    - Apply add_fromstr_bounds and split generics for impl blocks
    - Use generate_field_parsing to build field initializers
  - Keep runtime path compatibility via the existing runtime token path, wired into parsing logic

## Why
- Increases modularity and readability by separating concerns: argument classification state is isolated in ClassificationContext, and field parsing logic is decomposed into small, focused helpers.
- Simplifies unit testing and future maintenance by reducing monolithic functions and clarifying data flow.

## Impact
- Internal refactor only; no public API changes.
- Requires recompilation of the crates that depend on these internal modules (rstest-bdd-macros).

## Tests / Validation
- Build should succeed with updated module wiring.
- If there are existing tests for macro expansion, re-run to ensure no regressions.
- Quick validation: derive macro expansion paths that include step_args placeholders should still classify as before, now via ClassificationContext.

## Notes
- Ensure all imports referencing ClassificationContext are adjusted accordingly where used in classify/extract modules.
- If any downstream code relies on the old function signatures, update them to pass a ClassificationContext instead of separate extracted/placeholders references.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a40f9091-fc13-40ac-a11b-2f5c0417d15c

## Summary by Sourcery

Introduce ClassificationContext to encapsulate argument classification state and refactor related code, and modularize step_args expansion by extracting helper functions for field info collection, generics handling, and parsing logic.

Enhancements:
- Encapsulate extracted arguments and placeholders in a new ClassificationContext and update classification routines to use it
- Decompose step_args expansion by splitting expand_named_struct into distinct helpers for collecting field info, adding FromStr bounds, and generating parsing code