### PR TITLE
Add edge-case tests for sanitize_ident with param cases

### DIFF
--- a/crates/rstest-bdd-macros/src/utils/ident.rs
+++ b/crates/rstest-bdd-macros/src/utils/ident.rs
@@ -77,6 +77,7 @@ const RUST_KEYWORDS: &[&str] = &[
 #[cfg(test)]
 mod tests {
     use super::sanitize_ident;
+    use rstest::rstest;
 
     #[test]
     fn sanitizes_invalid_identifiers() {
@@ -110,20 +111,21 @@ mod tests {
         assert_eq!(sanitize_ident("a--b__c"), "a_b_c");
     }
 
-    #[test]
-    fn sanitizes_all_non_alnum() {
-        assert_eq!(sanitize_ident("!!!"), "_");
-        assert_eq!(sanitize_ident("🙈🙉🙊"), "_");
+    #[rstest]
+    #[case("!!!")]
+    #[case("🙈🙉🙊")]
+    fn sanitizes_inputs_made_entirely_of_non_alphanumeric_chars(#[case] input: &str) {
+        assert_eq!(sanitize_ident(input), "_");
     }
 
-    #[test]
-    fn sanitizes_trailing_punctuation() {
-        assert_eq!(sanitize_ident("abc!!!"), "abc");
-    }
-
-    #[test]
-    fn trims_trailing_underscores() {
-        assert_eq!(sanitize_ident("hello!"), "hello");
-        assert_eq!(sanitize_ident("end__"), "end");
+    #[rstest]
+    #[case("abc!!!", "abc")]
+    #[case("hello!", "hello")]
+    #[case("end__", "end")]
+    fn trims_trailing_punctuation_and_redundant_underscores(
+        #[case] input: &str,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(sanitize_ident(input), expected);
     }
 }


### PR DESCRIPTION
## Summary
- Adds edge-case tests for sanitize_ident using parameterized test cases to cover non-alphanumeric inputs and trailing punctuation/remnant underscores.

## Changes
### Tests
- Rewrote existing sanitize_ident tests to use rstest for parameterization.
- Added new parameterized tests:
  - sanitizes_inputs_made_entirely_of_non_alphanumeric_chars for inputs like "!!!" and "🙈🙉🙊" (expecting "_").
  - sanitizes_trailing_punctuation_and_redundant_underscores with cases like ("abc!!!", "abc"), ("hello!", "hello"), and ("end__", "end").
- Imported rstest in the test module.
- Note: The existing sanitizes_invalid_identifiers test remains to preserve baseline behavior.

## Test plan
- [x] Run cargo test to ensure all tests pass.
- [x] Validate edge-case expectations for non-alphanumeric inputs and trailing punctuation.
- [x] Confirm integration of rstest in test compilation.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/239d8e82-1d92-4858-b9ae-b6ecf8c9b4c7

## Summary by Sourcery

Refactor sanitize_ident tests to use rstest parameterization and add edge-case coverage for non-alphanumeric-only inputs and trimming of trailing punctuation and underscores.

Enhancements:
- Adopt rstest for parameterized test functions in sanitize_ident test module

Tests:
- Add parameterized tests for inputs composed entirely of non-alphanumeric characters
- Add parameterized tests for trimming trailing punctuation and redundant underscores