### PR TITLE
Improve compile-time Examples table validation with detailed row errors

### DIFF
--- a/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
@@ -13,7 +13,7 @@ use crate::parsing::tags::{self, TagExpression};
 use crate::utils::errors::error_to_tokens;
 cfg_if::cfg_if! {
     if #[cfg(feature = "compile-time-validation")] {
-        use crate::validation::examples::validate_examples_in_feature_text;
+        use crate::validation::examples::{validate_examples_in_feature_text, FeatureText};
     }
 }
 
@@ -172,7 +172,9 @@ pub(crate) fn parse_and_load_feature(path: &Path) -> Result<Feature, proc_macro2
         #[cfg(feature = "compile-time-validation")]
         {
             if let Ok(text) = std::fs::read_to_string(&feature_path) {
-                if let Err(validation_err) = validate_examples_in_feature_text(&text) {
+                if let Err(validation_err) =
+                    validate_examples_in_feature_text(FeatureText::new(&text))
+                {
                     return validation_err;
                 }
             }


### PR DESCRIPTION
## Summary
- Introduce FeatureText and TableRow wrappers for compile-time validation of feature text and each Examples row.
- Improve error reporting for Examples table column mismatches to include row number and actual vs. expected counts.
- Add compile-time validation tests to verify the new message for both extra and missing columns.

## Changes
### Validation
- validate_examples_in_feature_text now accepts a FeatureText wrapper; header and rows are processed via a TableRow wrapper.
- Iterate data rows with enumerate to capture the row index; compute row_number as i + 2 so the message reflects the actual feature file line (header is row 1).
- On mismatch, generate a detailed error message:
  - "Malformed Examples table: row {row_number} has {actual_columns} columns, expected {expected_columns}"
- Replace the previous generic error with the new, actionable message.
- Add wrappers:
  - FeatureText wraps the full feature text content.
  - TableRow wraps a single row from an Examples table.
- Update counting semantics: count_columns now takes a TableRow; header_row is counted as TableRow::new(header_row).
- Parsing path updated to pass FeatureText::new(text) into validate_examples_in_feature_text when compile-time validation is enabled.

### Tests
- Added tests under #[cfg(all(test, feature = "compile-time-validation"))] mod tests:
  - accepts_matching_columns: ensures valid tables pass validation.
  - reports_row_with_extra_columns: checks that a row with extra columns reports
    the exact message: "Malformed Examples table: row 3 has 4 columns, expected 3".
  - reports_row_with_missing_columns: checks that a row with missing columns reports
    the exact message: "Malformed Examples table: row 3 has 3 columns, expected 4".
- Tests use a helper error_message(text) to extract the error string from validate_examples_in_feature_text.

### Parsing
- In feature parsing, when the compile-time-validation feature is enabled, pass FeatureText::new(&text) into validate_examples_in_feature_text.

## Why
- Provides clearer and more actionable feedback for users diagnosing Issues in Examples tables, especially when column counts don’t match the header.
- Ensures the new message format remains stable via tests.

## Test plan
- Run tests with the compile-time-validation feature enabled:
  - cargo test --features compile-time-validation -p rstest-bdd-macros
- Verify:
  - Valid Examples tables pass validation.
  - Invalid tables produce the exact expected substrings in the error message for both extra and missing columns.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---
ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/39ee3017-2441-46a0-a0e6-d93495d50060