### PR TITLE
Clarify braces restriction and lexer rules for placeholders (docs)

### DIFF
--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -628,10 +628,13 @@ Best practices for writing effective scenarios include:
   is treated literally, so `\d` matches the two-character sequence `\d`. Braces
   are not allowed inside type hints. Placeholders use `{name}` or
   `{name:type}`; the type hint must not contain braces (for example,
-  `{n:{u32}}` and `{n:Vec<{u32}>}` are rejected). The lexer closes the
-  placeholder at the first `}` after the optional type hint, so extra text
-  inside `{name ...}` has no semantics beyond the type hint. `name` must start
-  with a letter or underscore and may contain letters, digits, or underscores
+  `{n:{u32}}` and `{n:Vec<{u32}>}` are rejected). To describe braces in the
+  surrounding step text (for example, referring to `{u32}`), escape them as
+  `{{` and `}}` rather than placing them inside `{name:type}`. The lexer closes
+  the placeholder at the first `}` after the optional type hint; any characters
+  between the `:type` and that first `}` are ignored (for example,
+  `{n:u32 extra}` parses as `name = n`, `type = u32`). `name` must start with a
+  letter or underscore and may contain letters, digits, or underscores
   (`[A-Za-z_][A-Za-z0-9_]*`). Whitespace within the type hint is ignored (for
   example, `{count: u32}` and `{count:u32}` are both accepted), but whitespace
   is not allowed between the name and the colon. Prefer the compact form


### PR DESCRIPTION
## Summary
- Clarifies placeholder syntax and lexer behavior for braces in placeholders.
- Braces are not allowed inside type hints; placeholders use `{name}` or `{name:type}`.
- The type hint must not contain braces (for example, `{n:{u32}}` and `{n:Vec<{u32}>}` are rejected).
- To describe braces in surrounding step text, escape them as `{{` and `}}` rather than placing them inside `{name:type}`.
- The lexer closes the placeholder at the first `}` after the optional type hint; any extra text inside `{name ...}` up to that `}` is ignored beyond the type hint.
- The accepted rules for placeholder names: `name` must start with a letter or underscore and may contain letters, digits, or underscores (`[A-Za-z_][A-Za-z0-9_]*`).
- Whitespace within the type hint is ignored (e.g., `{count: u32}` and `{count:u32}` are both accepted), but whitespace is not allowed between the name and the colon.
- Prefer the compact form `{count:u32}` in new code.
- When a pattern contains no placeholders, the step text must match exactly.
- Unknown type hints are treated as generic placeholders and capture any non-newline text greedily.

## Changes

### Documentation
- **docs/users-guide.md**: Updated the placeholder section in Best practices
  - Replaced nested-brace note with explicit restriction: braces are not allowed inside type hints.
  - Enforced the `{name}` or `{name:type}` form; type hints must not contain braces.
  - The lexer closes the placeholder at the first `}` after the optional type hint; extra text inside `{name ...}` has no semantics beyond the type hint.
  - Escaping braces in surrounding text using `{{` and `}}` is recommended.
  - The name pattern and whitespace rules remain as before; whitespace within the type hint is ignored; whitespace is not allowed between the name and the colon.
  - Prefer the compact form `{count:u32}` in new code.
  - When a pattern contains no placeholders, the step text must match exactly.
  - Unknown type hints are treated as generic placeholders and capture any non-newline text greedily.

## Rationale
- Aligns docs with the actual lexer rules and reduces confusion around nested braces.

## How to test
- [ ] Read the updated section to verify clarity and accuracy.
- [ ] Check examples illustrate accepted vs. rejected forms.
- [ ] Ensure no other sections rely on deprecated nested-brace guidance.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/7f459182-5a38-43d8-bf43-3df3757bd864