### PR TITLE
Mark scenarios! macro doctest as ignored

### DIFF
--- a/crates/rstest-bdd-macros/src/lib.rs
+++ b/crates/rstest-bdd-macros/src/lib.rs
@@ -162,7 +162,7 @@ pub fn derive_step_args(input: TokenStream) -> TokenStream {
 ///   `#[given]`, `#[when]`, and `#[then]` functions.
 ///
 /// Example:
-/// ```ignore
+/// ```rust,ignore
 /// use rstest_bdd_macros::{given, when, then, scenarios};
 ///
 /// # #[given("a precondition")] fn precondition() {}


### PR DESCRIPTION
## Summary
- Mark scenarios! macro doctest as ignored
- Update doctest code fence to `rust,ignore` for proper doctest handling and syntax highlighting

## Changes

### Documentation
- In `crates/rstest-bdd-macros/src/lib.rs`, update the doctest block from ```ignore to ```rust,ignore so the example is ignored by doctest while enabling Rust syntax highlighting.

## Rationale
- Ensures the doctest runner does not attempt to compile the scenarios! macro example while preserving syntax highlighting for the documentation.

## Test plan
- [x] Run `cargo test` to ensure build and tests pass
- [x] Verify doctests are ignored for the `scenarios!` macro example
- [x] Quick sanity check of updated code fence formatting in docs

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6264bbe3-ff79-4a03-8749-9fc1a65d9b1a

## Summary by Sourcery

Documentation:
- Change the scenarios! macro doctest code fence to use `rust,ignore` so the example is skipped by doctests but rendered with Rust syntax highlighting.