### PR TITLE
Add ADR 001: Async fixtures and tests (Tokio)

### DIFF
--- a/docs/adr-001-async-fixtures-and-test.md
+++ b/docs/adr-001-async-fixtures-and-test.md
@@ -1,4 +1,4 @@
-# Architectural decision record (ADR) 001: Async fixtures and tests (Tokio)
+# Architectural decision record (ADR) 001: async fixtures and tests (Tokio)
 
 ## Status
 
@@ -114,7 +114,7 @@ whilst allowing async projects to adopt Tokio step execution incrementally.
   `Future`-aware unwind capture to preserve `skip!` interception) and the
   required trait bounds (`Send` depends on current-thread versus multi-thread
   mode).
-- Wrapper generation must normalise sync and async step definitions into a
+- Wrapper generation must normalize sync and async step definitions into a
   single callable interface.
 - The implementation must preserve unwind handling, so panics continue to be
   surfaced with context, and `skip!` continues to be intercepted.
@@ -219,7 +219,7 @@ Alternative designs include:
 ## Current-thread limitations and failure modes
 
 When Tokio current-thread is the initial runtime, expected limitations and
-failure modes should be documented so users can select an appropriate mode.
+failure modes should be documented, so users can select an appropriate mode.
 
 - Blocking operations (for example, `std::thread::sleep`, blocking I/O, or CPU
   heavy work) will block the entire runtime thread and can stall the scenario.


### PR DESCRIPTION
## Summary
- Adds ADR 001: Async fixtures and tests (Tokio) to rstest-bdd
- Documents rationale and proposed approach to enable async step and fixture support with Tokio
- Proposes starting with Tokio current-thread mode for minimal disruption

## Changes
- New: docs/adr-001-async-fixtures-and-test.md

## Rationale
- The current synchronous step execution blocks awaiting futures from async step definitions
- Users expect end-to-end asynchronous execution with rstest fixtures
- The design must balance mutable fixture storage, `Send`/non-`Send` constraints, and runtime configuration

## Design overview
- Step definitions must support both `fn` and `async fn` forms
- Scenario execution should await each step sequentially (no concurrent step scheduling)
- rstest asynchronous fixtures should remain usable in scenario tests
- The `scenarios!` macro should be able to generate Tokio-compatible tests (auto-wrapped in the appropriate runtime)
- Unwind handling and `skip!` behavior must be preserved with context for failures
- Documentation should clearly specify Tokio runtime constraints (e.g., whether `Send` is required)

## Proposed direction
- Implement Tokio current-thread mode first to enable correct async step and fixture behavior with minimal disruption
- Evaluate multi-thread (Send) mode as a follow-up ADR
- Normalize sync and async step definitions into a single callable interface while preserving unwind safety
- Define runtime constraints and guidance for mixed sync/async steps

## Impact
- Documentation-only for this PR; no code changes yet
- Lays groundwork for future changes to StepContext, fixture binding, and test wrappers

## Migration plan
- No user-facing changes yet; future PRs will introduce config and macro changes to opt into Tokio async behavior

## Testing plan
- Review ADR for completeness and correctness
- Add tests for async step usage and async fixtures once the runtime path is implemented

## Notes
- ADR status: Proposed
- ADR date: 2025-12-13

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/655a9422-5622-4eb4-8d42-4eb7bdb572b8

## Summary by Sourcery

Documentation:
- Add ADR 001 describing requirements, design options, and proposed direction for supporting Tokio async fixtures and tests, starting with current-thread mode.