### PR TITLE
Make pattern matching on references explicit in step_struct

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,6 +5,13 @@ slow-timeout = { period = "60s", terminate-after = 1, grace-period = "5s" }
 # Put a hard ceiling on the whole run.
 global-timeout = "5m"
 
+[[profile.default.overrides]]
+# `cargo-bdd` CLI integration tests compile a small fixture crate on the fly on
+# their first run, which can legitimately exceed the default 60s slow-timeout
+# on cold caches.
+filter = "binary_id(cargo-bdd::cli)"
+slow-timeout = { period = "180s", terminate-after = 1, grace-period = "5s" }
+
 [profile.long]
 slow-timeout = { period = "180s", terminate-after = 1, grace-period = "5s" }
 global-timeout = "15m"

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/step_struct.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/step_struct.rs
@@ -58,7 +58,7 @@ fn validate_no_from_attr(arg: &syn::PatType) -> syn::Result<()> {
 
 fn validate_owned_type(ty: &syn::Type) -> syn::Result<()> {
     validate_condition(
-        matches!(ty, syn::Type::Reference(_)),
+        matches!(ty, &syn::Type::Reference(_)),
         ty,
         "#[step_args] parameters must own their struct type",
     )


### PR DESCRIPTION
## Summary
- Make pattern matching on references explicit in step argument validation
- Extend Nextest slow-timeout for cargo-bdd CLI tests to account for cold cache fixtures

## Changes
### Rust code
- In crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/step_struct.rs, update ownership/reference validation:
  - from `matches!(ty, syn::Type::Reference(_))` to `matches!(ty, &syn::Type::Reference(_))`
  - this makes pattern matching on references explicit when `ty` is a reference itself

### Test configuration
- In .config/nextest.toml, add default profile overrides for cargo-bdd CLI tests:
  - filter = "binary_id(cargo-bdd::cli)"
  - slow-timeout = { period = "180s", terminate-after = 1, grace-period = "5s" }
- Rationale: on cold caches, cargo-bdd’s small fixture crate can exceed the default slow-timeout

## Rationale
- The previous code attempted to pattern-match a reference without explicitly matching the referenced type, which is error-prone when dealing with borrowed values. Explicitly matching on `&syn::Type::Reference` ensures correct behavior and clearer intent.
- Extending the slow-timeout for cargo-bdd tests avoids flaky failures due to initial fixture compilation on cold caches.

## Testing
- Build and run the test suite: `cargo test` for the workspace
- Run cargo-bdd CLI integration tests to ensure the new timeout is effective and there are no compilation errors from the type pattern change
- Verify that owned types continue to validate correctly and that reference types are now handled explicitly

## Notes
- No public API changes; this is an internal fix to the macro codegen validation and test configuration. The change improves reliability and clarity of pattern matching on reference types.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/36db4c1a-cc72-4fe6-9a2c-06e1f5dcb70a

## Summary by Sourcery

Fix step argument ownership validation and relax CLI test slow-timeouts for cargo-bdd.

Bug Fixes:
- Correct owned-type validation in step argument handling by explicitly matching reference types when the type is borrowed.

Tests:
- Extend Nextest default profile with a slower timeout override for cargo-bdd CLI integration tests to account for cold-cache fixture compilation.