### PR TITLE
Remove trailing whitespace from beta.feature files

### DIFF
--- a/crates/rstest-bdd/tests/features/auto/beta.feature
+++ b/crates/rstest-bdd/tests/features/auto/beta.feature
@@ -10,6 +10,6 @@ Feature: Beta
     Then events are recorded
 
   Scenario: one
-    Given a precondition  
+    Given a precondition
     When an action occurs
     Then events are recorded

--- a/crates/rstest-bdd/tests/features/macros/auto/beta.feature
+++ b/crates/rstest-bdd/tests/features/macros/auto/beta.feature
@@ -10,6 +10,6 @@ Feature: Beta
     Then events are recorded
 
   Scenario: one
-    Given a precondition  
+    Given a precondition
     When an action occurs
     Then events are recorded


### PR DESCRIPTION
## Summary
- Remove trailing whitespace from beta.feature files in tests to maintain clean diffs and whitespace consistency.
- No functional changes.

## Changes
### Test Fixtures
- Updated two files:
  - crates/rstest-bdd/tests/features/auto/beta.feature
  - crates/rstest-bdd/tests/features/macros/auto/beta.feature
- Removed trailing spaces after the 'Given a precondition' line in scenario one.

### Rationale
- Ensures consistent formatting across repository and prevents whitespace-related diffs.

## Test plan
- [x] Build and run tests locally: `cargo test --workspace`
- [x] Run formatting checks: `cargo fmt --all -- --check`
- [x] Verify modified files contain no trailing whitespace
- [x] CI should pass with whitespace normalization

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9d6c5450-cfa0-40bc-a139-3bf4bb1ebce8

## Summary by Sourcery

Enhancements:
- Clean up trailing whitespace in beta.feature test fixture files without changing test behavior.