### PR TITLE
Suppress unused_variables lint for fixtures in scenarios macro

### DIFF
--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -708,8 +708,33 @@ union of feature, scenario, and example tags described above. Scenarios that do
 not match simply do not generate a test, and outline examples drop unmatched
 rows.
 
-Generated tests cannot currently accept fixtures; use `#[scenario]` when
-fixture injection or custom assertions are required.
+### Fixture injection with `scenarios!`
+
+The `fixtures = [name: Type, ...]` parameter injects fixtures into all
+generated scenario tests. Fixtures are bound via rstest and inserted into the
+step context, making them available to step functions that declare the
+corresponding parameter.
+
+```rust,no_run
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenarios};
+
+struct TestWorld { value: i32 }
+
+#[fixture]
+fn world() -> TestWorld { TestWorld { value: 42 } }
+
+#[given("a precondition")]
+fn step_uses_world(world: &TestWorld) {
+    assert_eq!(world.value, 42);
+}
+
+scenarios!("tests/features/auto", fixtures = [world: TestWorld]);
+```
+
+The macro adds `#[expect(unused_variables)]` to generated test functions when
+fixtures are present, preventing lint warnings since fixture parameters are
+consumed via `StepContext` rather than referenced directly in the test body.
 
 ## Running and maintaining tests
 


### PR DESCRIPTION
## Summary
- Adds fixture injection support to the `scenarios!` macro via a new `fixtures = [...]` argument.
- When fixtures are provided, generated tests suppress the `unused_variables` lint via `#[expect(unused_variables)]` with a descriptive message, since fixture parameters are consumed through StepContext rather than directly in test bodies.
- Introduces `FixtureSpec` to parse fixture syntax and propagates fixtures through code generation.

## Changes

### Macro parsing and code generation
- Extend parsing for the scenarios macro to support `fixtures = [name: Type, ...]`:
  - Add `FixtureSpec { name, ty }` and implement `Parse` for it.
  - Extend `ScenariosArgs` with a `fixtures: Vec<FixtureSpec>` field.
  - Add a `Fixtures(Vec<FixtureSpec>)` variant to `ScenariosArg` and parsing logic.
  - Enforce no duplicate `fixtures` argument.
- Propagate fixtures through the macro:
  - Update `ScenarioTestContext` to include `fixtures: &[FixtureSpec]`.
  - When fixtures are non-empty, generate an `#[expect(unused_variables)]` attribute with a helpful reason.
  - Build and inject fixture parameters into the generated test function signature.
  - Thread fixtures through the feature processing pipeline (`process_feature_file`, `generate_tests_from_features`).
  - Update the `scenarios!` entry point to pass fixtures to downstream logic.

### Tests and fixtures
- Added tests to verify fixture injection and lint suppression:
  - `crates/rstest-bdd/tests/scenarios_fixtures.rs` (new)
  - `crates/rstest-bdd/tests/features/fixtures/fixture_scenario.feature` (new)
- These tests confirm that a fixture provided via `fixtures = [world: TestWorld]` is injected into generated tests and that the unused variables lint is suppressed.

### Documentation
- Updated documentation to reflect fixture injection via `scenarios!`, including:
  - Example usage demonstrating `fixtures = [world: TestWorld]`.
  - Explanation that `#[expect(unused_variables)]` is added when fixtures are present to avoid lint warnings.

## Documentation / User Guide
- docs/users-guide.md: Added a section on Fixture injection with `scenarios!` and a usage example, plus notes on lint suppression.

## Test plan
- Build and run tests for the workspace, including the new scenarios fixtures tests.
- Verify that:
  - Fixtures are correctly injected into generated scenario tests.
  - The `unused_variables` lint is suppressed when fixtures are provided.
  - Existing scenarios without fixtures continue to behave as before.

## Notes
- No public API surface changes for users who do not opt into the new `fixtures` parameter.
- The changes are isolated to macro parsing / codegen and the new tests/docs.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/02dc49f2-f3b9-4f6d-bd3d-7e89b323cb76

## Summary by Sourcery

Add fixture injection support to the `scenarios!` macro and suppress unused variable lints for injected fixtures while updating docs and tests accordingly.

New Features:
- Support injecting fixtures into all generated scenario tests via a new `fixtures = [name: Type, ...]` parameter on the `scenarios!` macro.

Bug Fixes:
- Prevent `unused_variables` lint warnings for fixture parameters in generated scenario tests by adding an `#[expect(unused_variables)]` attribute when fixtures are present.

Enhancements:
- Propagate parsed fixture specifications through the scenarios macro parsing and code generation pipeline to make them available to step functions.

Documentation:
- Document fixture injection for the `scenarios!` macro, including example usage and an explanation of lint suppression for unused fixture parameters.

Tests:
- Add integration tests and feature files to verify fixture injection into generated scenario tests and the suppression of unused variable lints when fixtures are used.