### PR TITLE
Fix PR test generation to match rebased commit and add debug

### DIFF
--- a/crates/rstest-bdd-macros/src/macros/scenarios/macro_args.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/macro_args.rs
@@ -13,7 +13,7 @@ use syn::punctuated::Punctuated;
 use syn::token::Comma;
 
 /// A single fixture specification: `name: Type`.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(super) struct FixtureSpec {
     pub(super) name: syn::Ident,
     pub(super) ty: syn::Type,

--- a/crates/rstest-bdd-macros/src/macros/scenarios/test_generation.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/test_generation.rs
@@ -139,8 +139,9 @@ pub(super) fn generate_scenario_test(
     let example_params = build_example_params(examples.as_ref());
     let mut sig = build_test_signature(&fn_ident, &fixture_params, &example_params);
 
-    let Ok((_args, fixture_setup)) = extract_function_fixtures(&mut sig) else {
-        unreachable!("failed to bind fixtures for generated signature");
+    let (_args, fixture_setup) = match extract_function_fixtures(&mut sig) {
+        Ok(result) => result,
+        Err(err) => return err.to_compile_error(),
     };
 
     let feature_path = ctx.manifest_dir.join(ctx.rel_path).display().to_string();


### PR DESCRIPTION
## Summary
- Aligns PR test generation with the rebased commit by improving fixture extraction error handling during code generation
- Adds Debug trait derivation to FixtureSpec for easier debugging of test generation and macro errors

## Changes
### Core Changes
- crates/rstest-bdd-macros/src/macros/scenarios/macro_args.rs
  - Derive(Debug) for FixtureSpec to aid debugging
- crates/rstest-bdd-macros/src/macros/scenarios/test_generation.rs
  - Replace unwrap-style Ok(...) pattern with explicit match to handle Ok/Err from extract_function_fixtures
  - Propagate compilation errors via to_compile_error() when fixture extraction fails

## Why
- The rebased commit modified error handling for fixture extraction. This PR updates the macro test generation to surface compile-time errors gracefully instead of panicking, and adds debug support for easier troubleshooting.

## Impact
- Generated PR tests will produce compile-time errors with informative messages when fixture extraction fails, rather than triggering unreachable branches.
- Debugging fixture specs is now easier due to the added Debug trait on FixtureSpec.

## Test plan
- Build the workspace and run the macro-related tests (e.g., cargo test -p rstest-bdd-macros)
- Verify that fixture extraction errors are emitted as compile_error! results during code generation
- Ensure deriving Debug on FixtureSpec does not alter runtime behavior and aids during debugging


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/2f857999-78ab-478c-ac22-505c00e8dfe9

## Summary by Sourcery

Improve scenario test generation error handling for fixture extraction failures and make fixture specs easier to debug.

Bug Fixes:
- Handle failures from extract_function_fixtures in scenario test generation by returning a compile-time error instead of panicking on unreachable branches.

Enhancements:
- Derive Debug for FixtureSpec to simplify debugging of fixture specifications and macro-generated tests.