### PR TITLE
Update shared-actions SHA references in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5
 
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@ebbaaa0d7a776ec3187f3940667e5c7c9379cdf5
+        uses: leynos/shared-actions/.github/actions/setup-rust@df81280dcc1d6e66134114dbc924313328b15f05
 
       - name: Install bun
         if: ${{ matrix.tools }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Test and Measure Coverage (with features)
         if: ${{ matrix.coverage && matrix.features != '' }}
-        uses: leynos/shared-actions/.github/actions/generate-coverage@ebbaaa0d7a776ec3187f3940667e5c7c9379cdf5
+        uses: leynos/shared-actions/.github/actions/generate-coverage@df81280dcc1d6e66134114dbc924313328b15f05
         continue-on-error: true
         with:
           output-path: lcov.info
@@ -104,7 +104,7 @@ jobs:
 
       - name: Test and Measure Coverage (no features)
         if: ${{ matrix.coverage && matrix.features == '' }}
-        uses: leynos/shared-actions/.github/actions/generate-coverage@ebbaaa0d7a776ec3187f3940667e5c7c9379cdf5
+        uses: leynos/shared-actions/.github/actions/generate-coverage@df81280dcc1d6e66134114dbc924313328b15f05
         continue-on-error: true
         with:
           output-path: lcov.info
@@ -124,7 +124,7 @@ jobs:
 
       - name: Upload coverage data to CodeScene
         if: ${{ matrix.coverage && env.CS_ACCESS_TOKEN && matrix.tools && vars.CODESCENE_CLI_SHA256 }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@ebbaaa0d7a776ec3187f3940667e5c7c9379cdf5
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@df81280dcc1d6e66134114dbc924313328b15f05
         with:
           format: lcov
           access-token: ${{ env.CS_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
- Pins shared-actions steps to a new commit SHA in CI workflow
- Replaces previous SHAs for setup-rust, generate-coverage, and upload-codescene-coverage to ensure consistent builds

## Changes
### CI Workflow Updates
- Update SHAs in .github/workflows/ci.yml to df81280dcc1d6e66134114dbc924313328b15f05 for:
  - setup-rust action
  - generate-coverage (with features)
  - generate-coverage (no features)
  - upload-codescene-coverage

## Testing
- Trigger CI to verify that Rust setup, coverage generation, and Codescene upload actions execute correctly with the new SHAs
- Confirm no functional changes beyond pinning to the new commit


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/1151c4db-b7af-4430-a6ff-47af1ed91dd6

## Summary by Sourcery

CI:
- Bump shared leynos/setup-rust, generate-coverage, and upload-codescene-coverage actions in ci.yml to a newer pinned commit SHA for consistent CI runs.