### PR TITLE
Update shared-actions SHA refs in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5
 
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@df81280dcc1d6e66134114dbc924313328b15f05
+        uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
 
       - name: Install bun
         if: ${{ matrix.tools }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Test and Measure Coverage (with features)
         if: ${{ matrix.coverage && matrix.features != '' }}
-        uses: leynos/shared-actions/.github/actions/generate-coverage@df81280dcc1d6e66134114dbc924313328b15f05
+        uses: leynos/shared-actions/.github/actions/generate-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
         continue-on-error: true
         with:
           output-path: lcov.info
@@ -104,7 +104,7 @@ jobs:
 
       - name: Test and Measure Coverage (no features)
         if: ${{ matrix.coverage && matrix.features == '' }}
-        uses: leynos/shared-actions/.github/actions/generate-coverage@df81280dcc1d6e66134114dbc924313328b15f05
+        uses: leynos/shared-actions/.github/actions/generate-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
         continue-on-error: true
         with:
           output-path: lcov.info
@@ -124,7 +124,7 @@ jobs:
 
       - name: Upload coverage data to CodeScene
         if: ${{ matrix.coverage && env.CS_ACCESS_TOKEN && matrix.tools && vars.CODESCENE_CLI_SHA256 }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@df81280dcc1d6e66134114dbc924313328b15f05
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
         with:
           format: lcov
           access-token: ${{ env.CS_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
- Updates the shared-actions SHA references in CI workflow to the latest commit to align with upstream changes.

## Changes
- CI workflow (.github/workflows/ci.yml) updated to use SHA aebb3f5b831102e2a10ef909c83d7d50ea86c332 for the following actions:
  - leynos/shared-actions/.github/actions/setup-rust
  - leynos/shared-actions/.github/actions/generate-coverage (with features)
  - leynos/shared-actions/.github/actions/generate-coverage (no features)
  - leynos/shared-actions/.github/actions/upload-codescene-coverage
- This replaces the previous SHA df81280dcc1d6e66134114dbc924313328b15f05 used in the same steps.

## Rationale
- Keeps CI in sync with the latest changes from the shared-actions repository, ensuring fixes and improvements are picked up automatically.

## Testing
- Validate YAML syntax locally or via CI linting.
- Push branch terragon/update-shared-actions-sha-wnzv1d and open a PR.
- In CI, verify that each updated step resolves to the new SHA (aebb3f5b831102e2a10ef909c83d7d50ea86c332) in the workflow logs and that the jobs run as expected.

## Notes
- No code changes; CI-only update to workflow references.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6107d65e-94ab-42c1-a73e-33c281e3d78b

## Summary by Sourcery

CI:
- Bump leynos/shared-actions SHA reference in the CI workflow for setup-rust, generate-coverage, and upload-codescene-coverage steps.