### PR TITLE
Add Dependabot automerge workflow integration

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,22 @@
+name: dependabot-automerge
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+  statuses: read
+
+jobs:
+  automerge:
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@235d2d07b9a321364a742310873f6732d7228e72
+    with:
+      pull-request-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- Adds a dedicated automerge workflow for Dependabot pull requests
- Leverages a shared automerge action to perform automatic merges

## Changes
### Workflow
- New file: .github/workflows/dependabot-automerge.yml
- Triggers on pull_request events: opened, reopened, synchronize, labeled
- Runs only for Dependabot PRs: if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
- Uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@235d2d07b9a321364a742310873f6732d7228e72
- Passes: pull-request-number: ${{ github.event.pull_request.number }}

### Permissions
- contents: write
- pull-requests: write
- checks: read
- statuses: read

## Test plan
- [x] Open or simulate a Dependabot PR and verify automerge is triggered after required checks pass
- [x] Ensure non-Dependabot PRs are ignored
- [x] Verify the reusable workflow runs with the correct PR number


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ebac12ce-2185-4962-ad37-c2ad6396f8cc

## Summary by Sourcery

CI:
- Introduce a dependabot-automerge workflow that triggers on Dependabot pull_request events and delegates merging to a shared reusable workflow with appropriate permissions.