### PR TITLE
Enable fallible scenario bodies with Result<(), E> and skip handling

### DIFF
--- a/docs/execplans/5-1-6-fallible-scenario-bodies.md
+++ b/docs/execplans/5-1-6-fallible-scenario-bodies.md
@@ -21,11 +21,11 @@ leave a passed record in the reporting collector.
 
 ## Constraints
 
-- Follow ADR-006 exactly: allow only `Result<(), E>` or `StepResult<(), E>`
-  for fallible scenario bodies, return `Ok(())` on skips, and ensure `Err` does
-  not record a pass.
-- Reuse the existing return-type classifier in
-  `crates/rstest-bdd-macros/src/return_classifier.rs`.
+- Follow Architecture Decision Record (ADR-006) exactly: allow only
+  `Result<(), E>` or `StepResult<(), E>` for fallible scenario bodies, return
+  `Ok(())` on skips, and ensure `Err` does not record a pass.
+- Reuse the existing return-type classifier in the `rstest-bdd-macros` crate
+  (currently `crates/rstest-bdd-macros/src/return_classifier.rs`).
 - Do not introduce new external dependencies.
 - Keep module-level `//!` doc comments for any new module.
 - No file may exceed 400 lines; split helpers if needed.
@@ -39,7 +39,7 @@ leave a passed record in the reporting collector.
 - Scope: if the change requires more than 10 files or 600 net lines,
   stop and escalate.
 - Interface: if a public API signature must change in `rstest-bdd`, stop
-  and escalate (new internal helpers are ok).
+  and escalate (new internal helpers are OK).
 - Dependencies: if a new external crate is required, stop and escalate.
 - Tests: if tests fail after 3 debugging attempts on the same issue,
   stop and escalate.
@@ -112,24 +112,30 @@ leave a passed record in the reporting collector.
 
 ## Context and orientation
 
-`#[scenario]` lives in `crates/rstest-bdd-macros/src/macros/scenario/mod.rs`
-and generates tests via `crates/rstest-bdd-macros/src/codegen/scenario.rs`. The
-runtime scaffolding (scenario guard, skip handler, step executor loop) comes
-from `crates/rstest-bdd-macros/src/codegen/scenario/runtime/`.
+`#[scenario]` lives in the `rstest-bdd-macros` crate module `macros::scenario`
+(currently `crates/rstest-bdd-macros/src/macros/scenario/mod.rs`) and generates
+tests via the `codegen::scenario` module (currently
+`crates/rstest-bdd-macros/src/codegen/scenario.rs`). The runtime scaffolding
+(scenario guard, skip handler, step executor loop) comes from
+`codegen::scenario::runtime` (currently
+`crates/rstest-bdd-macros/src/codegen/scenario/runtime/`).
 `__RstestBddScenarioReportGuard` records `Passed` on drop if not already
 recorded; this is the key mechanism that must be updated to avoid marking `Err`
-returns as passed. The shared return-type classifier lives in
-`crates/rstest-bdd-macros/src/return_classifier.rs` and already recognises
+returns as passed. The shared return-type classifier lives in the
+`rstest-bdd-macros` crate (currently
+`crates/rstest-bdd-macros/src/return_classifier.rs`) and already recognizes
 `Result` and `StepResult` paths.
 
-Tests and fixtures to reference:
+Tests and fixtures to reference (by crate/module name, paths may move):
 
-- `crates/rstest-bdd/tests/scenario.rs` for behavioural scenario coverage.
-- `crates/rstest-bdd/tests/skip.rs` for skip handling and reporting.
-- `crates/rstest-bdd/tests/trybuild_macros.rs` plus
-  `crates/rstest-bdd/tests/ui_macros/` for compile-fail macro tests.
-- `crates/rstest-bdd-macros/src/codegen/scenario/runtime/tests.rs` for
-  generator unit tests.
+- `rstest-bdd` integration test `scenario.rs` for behavioural scenario
+  coverage.
+- `rstest-bdd` integration test `skip.rs` for skip handling and reporting.
+- `rstest-bdd` trybuild harness `trybuild_macros.rs` and the `ui_macros`
+  fixtures for compile-fail macro tests.
+- `rstest-bdd-macros` module `codegen::scenario::runtime` tests for generator
+  unit coverage (currently
+  `crates/rstest-bdd-macros/src/codegen/scenario/runtime/tests.rs`).
 
 Docs to update:
 
@@ -196,10 +202,10 @@ Behavioural tests:
 
 Trybuild tests:
 
-- Add a new UI fixture under `crates/rstest-bdd/tests/ui_macros/` that
-  defines a `#[scenario]` returning `Result<u8, E>` and asserts the compile
-  error matches ADR-006. Register the fixture in
-  `crates/rstest-bdd/tests/trybuild_macros.rs`.
+- Add a new user interface (UI) fixture under
+  `crates/rstest-bdd/tests/ui_macros/` that defines a `#[scenario]` returning
+  `Result<u8, E>` and asserts the compile error matches ADR-006. Register the
+  fixture in `crates/rstest-bdd/tests/trybuild_macros.rs`.
 
 Stage E: documentation and roadmap updates.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -39,8 +39,8 @@ discovered and executed by a procedural macro at runtime.
 - [x] 1.4.3. The macro must generate a new test function annotated with
   `#[rstest]`.
 - [x] 1.4.4. The body of the generated function must, at runtime, iterate
-  through the scenario's Gherkin steps and find matching `Step` definitions from
-  the `inventory::iter`.
+  through the scenario's Gherkin steps and find matching `Step` definitions
+  from the `inventory::iter`.
 - [x] 1.4.5. For this phase, only support exact, case-sensitive string matching
   with no argument parsing.
 
@@ -91,8 +91,8 @@ Development (BDD) frameworks and improves the developer experience.
 - [x] 3.1.1. Implement support for `Background` sections, so their steps run
   before each `Scenario` in a feature file.
 - [x] 3.1.2. Implement support for `Data Tables`, initially making the data
-  available to the step function as a `Vec<Vec<String>>` (legacy baseline; typed
-  support is planned below).
+  available to the step function as a `Vec<Vec<String>>` (legacy baseline;
+  typed support is planned below).
 - [x] 3.1.3. Implement support for `Docstring`, making the content available as
   a `String` argument named `docstring`.
 
@@ -109,9 +109,9 @@ Development (BDD) frameworks and improves the developer experience.
 - [x] 3.3.1. Add a `datatable` runtime module exposing `DataTableError`,
   `HeaderSpec`, `RowSpec`, `Rows<T>`, and convenience parsers such as
   `truthy_bool` and `trimmed<T: FromStr>`.
-- [x] 3.3.2. Implement `TryFrom<Vec<Vec<String>>> for Rows<T>` (with `T:
-  DataTableRow`) to split optional headers, build index maps, and surface row
-  and column context on errors.
+- [x] 3.3.2. Implement `TryFrom<Vec<Vec<String>>> for Rows<T>` (with
+  `T: DataTableRow`) to split optional headers, build index maps, and surface
+  row and column context on errors.
 - [x] 3.3.3. Provide `#[derive(DataTableRow)]` and `#[derive(DataTable)]` macros
   with field- and struct-level attributes for column mapping, optional or
   default cells, trimming, tolerant booleans, custom parsers, and row
@@ -131,7 +131,8 @@ Development (BDD) frameworks and improves the developer experience.
 - [x] 3.4.2. Extend the `scenarios!` macro to filter scenarios using the same
   tag syntax at macro-expansion time. See [design §1.3.4].
 - [x] 3.4.3. Document tag-expression grammar and precedence (§1.3.4).
-- [x] 3.4.4. Filter at macro-expansion time and emit `compile_error!` diagnostics
+- [x] 3.4.4. Filter at macro-expansion time and emit `compile_error!`
+      diagnostics
   for invalid tag expressions (explicit empty string `""`, empty parentheses
   `()`, dangling operators). Omitting the `tags` argument applies no filter
   (`error: missing tag (allowed)`). Diagnostics include the byte offset and a
@@ -169,10 +170,10 @@ Development (BDD) frameworks and improves the developer experience.
 - [x] 3.5.2. Provide a `skip!` macro that records a `Skipped` outcome and
   short-circuits remaining steps.
 - [x] 3.5.3. Expose skipped status through `cargo-bdd` and the JSON and JUnit
-  writers. Emit a `<skipped>` child on each `<testcase>` element in JUnit output
-  with an optional `message` attribute, and use lowercase `skipped` status
-  strings in JSON and the CLI while preserving long messages and consistent
-  casing.
+  writers. Emit a `<skipped>` child on each `<testcase>` element in JUnit
+  output with an optional `message` attribute, and use lowercase `skipped`
+  status strings in JSON and the CLI while preserving long messages and
+  consistent casing.
 - [x] 3.5.4. Document the `skip!` macro, the `@allow_skipped` tag and migration
   guidance for adopting Rust 1.85 / edition 2024.
 
@@ -184,8 +185,8 @@ Development (BDD) frameworks and improves the developer experience.
 ### 3.6. Boilerplate reduction
 
 - [x] 3.6.1. Implement the `scenarios!("path/to/features/")` macro to
-  automatically discover all `.feature` files in a directory and generate a test
-  module containing a test function for every `Scenario` found.
+  automatically discover all `.feature` files in a directory and generate a
+  test module containing a test function for every `Scenario` found.
 - [x] 3.6.2. Harden the `#[scenario]` macro's existing `name` selector with
   compile-time diagnostics: emit an error when the requested title is absent so
   bindings stay robust to feature reordering, and fall back to the index only
@@ -257,8 +258,8 @@ experience by introducing more powerful and intuitive APIs.
   `Result`-returning steps.
 - [x] 5.1.4. Refined `skip!` macro: Polish the macro's syntax and surface clear
   diagnostics when misused. Coverage: disallow usage outside a step or hook
-  (panic with a descriptive message), reject calls from non-test threads, verify
-  short-circuit behaviour, and preserve the message in writer outputs.
+  (panic with a descriptive message), reject calls from non-test threads,
+  verify short-circuit behaviour, and preserve the message in writer outputs.
 - [x] 5.1.5. Skipped-step assertions: Provide helper macros for verifying that
   steps or scenarios were skipped as expected.
 - [x] 5.1.6. Fallible scenario bodies: Allow `#[scenario]` functions to return
@@ -268,8 +269,8 @@ experience by introducing more powerful and intuitive APIs.
 ### 5.2. State management and data flow
 
 - [x] 5.2.1. Step return values: Allow `#[when]` steps to return values, which
-  can then be automatically injected into subsequent `#[then]` steps, enabling a
-  more functional style of testing. Returned values override fixtures of the
+  can then be automatically injected into subsequent `#[then]` steps, enabling
+  a more functional style of testing. Returned values override fixtures of the
   same type.
 - [x] 5.2.2. Scenario state management: Introduce a `#[derive(ScenarioState)]`
   macro and a `Slot<T>` type to simplify the management of shared state across
@@ -278,13 +279,13 @@ experience by introducing more powerful and intuitive APIs.
 ### 5.3. Advanced ergonomics
 
 - [x] 5.3.1. Struct-based step arguments: Introduce a `#[step_args]` derive
-  macro to allow multiple placeholders from a step pattern to be parsed directly
-  into the fields of a struct, simplifying step function signatures.
+  macro to allow multiple placeholders from a step pattern to be parsed
+  directly into the fields of a struct, simplifying step function signatures.
 
 ## 6. Extensions and tooling
 
-These tasks can be addressed after the core framework is stable and are aimed at
-improving maintainability and IDE integration.
+These tasks can be addressed after the core framework is stable and are aimed
+at improving maintainability and IDE integration.
 
 ### 6.1. Diagnostic tooling
 
@@ -334,10 +335,10 @@ improving maintainability and IDE integration.
 
 ## 7. Language server foundations
 
-This phase delivers the first `rstest-bdd-server` release, focused on navigation
-between Rust step definitions and Gherkin features plus on-save consistency
-diagnostics. Real-time analysis and autocomplete remain out of scope until the
-core workflow is stable.
+This phase delivers the first `rstest-bdd-server` release, focused on
+navigation between Rust step definitions and Gherkin features plus on-save
+consistency diagnostics. Real-time analysis and autocomplete remain out of
+scope until the core workflow is stable.
 
 ### 7.1. Server scaffolding
 
@@ -345,9 +346,8 @@ core workflow is stable.
   depends on `async-lsp`, `gherkin`, and the shared pattern parser to align
   semantics with the macros.
 - [x] 7.1.2. Implement Language Server Protocol (LSP) initialize/shutdown
-  handlers, crate-root discovery
-  via `cargo metadata`, and structured logging configurable through environment
-  variables.
+  handlers, crate-root discovery via `cargo metadata`, and structured logging
+  configurable through environment variables.
 
 ### 7.2. Indexing pipeline
 
@@ -431,8 +431,7 @@ redesigned. For the full architectural decision record, see
 ### 8.4. Documentation and migration
 
 - [x] 8.4.1. Document async scenario execution in the user guide (see
-  [users-guide.md §Async scenario
-  execution](users-guide.md#async-scenario-execution)).
+  [users-guide.md §Async scenario execution](users-guide.md#async-scenario-execution)).
 - [x] 8.4.2. Document Tokio current-thread limitations (blocking operations,
   nested runtimes, `spawn_local` patterns) in the design document §2.5.
 - [x] 8.4.3. Update design document §2.5 with implementation status.
@@ -440,8 +439,8 @@ redesigned. For the full architectural decision record, see
 ## 9. Harness adapters and attribute plugins
 
 This phase implements ADR-005 by introducing a harness adapter layer and an
-attribute policy plugin interface, so Tokio and GPUI integrations live in opt-in
-crates rather than the core runtime or macros.
+attribute policy plugin interface, so Tokio and GPUI integrations live in
+opt-in crates rather than the core runtime or macros.
 
 ### 9.1. Harness adapter core
 


### PR DESCRIPTION
## Summary
- Adds support for fallible scenario bodies that return Result<(), E> or StepResult<(), E> in #[scenario] tests.
- Introduces a return-kind classification and wiring to wrap fallible bodies so that ? and return Err(...) can propagate correctly without marking tests as Passed.
- Updates skip handling to return appropriate short-circuit values based on scenario return kind.
- Adds unit and behavioural tests, along with trybuild fixtures to ensure compile-time constraints are enforced.
- Updates documentation and roadmaps to reflect the new design and usage.

## Changes
- Codegen and runtime
  - Introduced ScenarioReturnKind enum with Unit and ResultUnit variants to classify scenario bodies.
  - Propagated return_kind through ScenarioConfig and related metadata so runtime generation can adapt.
  - Added new module crates/rstest-bdd-macros/src/codegen/scenario/runtime/body.rs (build_scenario_body) to assemble the scenario body depending on the return kind and async mode.
  - Updated code generation for scenarios and outlines to pass return_kind into all relevant token assemblies.
  - Updated runtime generators to accept return_kind and to emit a skip handler that returns either unit or Ok(()) depending on the kind.
  - Updated skip handling tests to verify that skip paths return the correct value for both Unit and ResultUnit scenarios.
- Macros and type system
  - Added ScenarioReturnKind to crates/rstest-bdd-macros/src/codegen/scenario.rs and related type plumbing so the runtime can adapt behavior per-scenario.
  - Updated ScenarioMetadata and ScenarioTestConfig implementations to expose and utilize return_kind.
  - Updated return classifier integration so non-unit fallible returns are rejected with the ADR-006 message where applicable.
- Tests and fixtures
  - Added new tests in crates/rstest-bdd-macros/src/codegen/scenario/runtime/tests.rs to assert skip handler behavior for Unit vs. ResultUnit.
  - Added behavioural test fixture crates/rstest-bdd/tests/fallible_scenario.rs and feature crates/rstest-bdd/tests/features/fallible_scenario.feature to exercise fallible bodies (success, skip, error).
  - Added a trybuild fixture crates/rstest-bdd/tests/fixtures_macros/scenario_result_requires_unit.rs and corresponding stderr to ensure compilation errors for non-unit fallible returns.
  - Updated trybuild harness to include scenario_result_requires_unit in MacroFixtureCase list.
- Documentation and docs infrastructure
  - docs/ergonomics-and-developer-experience.md: added section 2.4 Fallible scenario bodies describing the design and usage.
  - docs/users-guide.md: added a subsection showing fallible scenario bodies with examples and notes about skip semantics.
  - docs/execplans/5-1-6-fallible-scenario-bodies.md: added a comprehensive ExecPlan outlining the approach and evaluation criteria for fallible scenario bodies.
  - docs/roadmap.md: updated item 5.1.6 status to reflect completion and updated related phrasing.
- Test plan and validation artifacts
  - Added tests to ensure generate_skip_handler emits appropriate tokens for both Unit and fallible scenarios.
  - Included a compile-time validation path for incorrect fallible returns to enforce ADR-006 constraints.

## Why this change
- Enables ergonomic and expressive tests by allowing scenario bodies to use ? and propagate errors without wrapping in extra Result<()> scaffolding.
- Maintains strict correctness by ensuring incorrect fallible return types are rejected at compile time.
- Keeps skip behavior consistent with the type of the scenario body, ensuring short-circuit paths are type-safe.

## Compatibility and migration
- Internal API changes: ScenarioReturnKind and related plumbing are private to the macros crate (with pub(crate) exposure for internal access). Public user-facing API remains unchanged.
- Existing unit-scenario behavior remains intact; fallible behavior is opt-in via returning Result<(), E> or StepResult<(), E> from #[scenario] bodies.
- If upgrading an existing codebase, users can begin writing fallible scenario bodies by changing the signature to return Result<(), E> (or StepResult<(), E>) and using ? within the body where appropriate.

## Testing plan
- Run: cargo test -p rstest-bdd-macros
- Run: cargo test -p rstest-bdd
- Run: cargo test -p rstest-bdd --tests
- Run trybuild tests to ensure compile-time diagnostics for invalid fallible returns are emitted as ADR-006 messages

## Validation steps for reviewers
- Verify that skip scenarios return Ok(()) for fallible bodies and return; for unit bodies via the skip handler.
- Verify that a scenario body returning Err propagates the error and does not mark the scenario as Passed.
- Confirm trybuild fixtures enforce the compile-time error for non-unit fallible return types.
- Confirm documentation sections reflect the new capability and usage patterns.

## Notes for future work
- Further ergonomic refinements and extended tests for diverse async runtimes.
- Potential expansion to cover more nuanced data-flow between steps with fallible bodies.
- Final polishing of formatting and linting to satisfy all quality gates.

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/39752fbb-a845-4917-810a-3e05629f3741

## Summary by Sourcery

Update documentation for fallible scenario bodies and refine roadmap wording without changing public APIs.

Enhancements:
- Standardize documentation references to crate and module names to remain accurate if file paths change.

Documentation:
- Clarify ADR-006 references, module locations, and path stability in the fallible scenario bodies execution plan.
- Improve guidance on required trybuild UI fixtures and behavioural tests for fallible scenario bodies.
- Tighten roadmap and documentation wording and wrapping for readability while keeping content unchanged.