### PR TITLE
Add GPUI counter demo crate with BDD tests and ExecPlan 9.4.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,6 +736,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpui-counter"
+version = "0.5.0"
+dependencies = [
+ "gpui",
+ "rstest",
+ "rstest-bdd",
+ "rstest-bdd-harness",
+ "rstest-bdd-harness-gpui",
+ "rstest-bdd-macros",
+]
+
+[[package]]
 name = "gpui-macros"
 version = "0.2.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/cargo-bdd",
     "examples/todo-cli",
     "examples/japanese-ledger",
+    "examples/gpui-counter",
 ]
 
 [workspace.package]

--- a/docs/execplans/9-3-7-negative-integration-test-for-async-fn.md
+++ b/docs/execplans/9-3-7-negative-integration-test-for-async-fn.md
@@ -317,7 +317,8 @@ Go/no-go: the trybuild test passes with the new fixture. Proceed.
 
 ### Stage E: update documentation
 
-Goal: keep roadmap, design doc, and user's guide aligned with delivered coverage.
+Goal: keep roadmap, design doc, and user's guide aligned with delivered
+coverage.
 
 **Roadmap** (`docs/roadmap.md`, line 521): change `- [ ]` to `- [x]`:
 
@@ -388,7 +389,8 @@ error message documented in the design doc §2.7.3.
 Quality criteria:
 
 - Tests: `make test` passes (`cargo test --workspace`). The trybuild test
-  `step_macros_compile` exercises all registered fixtures, including the new one.
+  `step_macros_compile` exercises all registered fixtures, including the new
+  one.
 - Lint: `make lint` passes
   (`cargo clippy --workspace --all-targets --all-features -- -D warnings`).
 - Format: `make check-fmt` passes (`cargo fmt --workspace -- --check`).

--- a/docs/execplans/9-4-5-gpui-demonstration-application.md
+++ b/docs/execplans/9-4-5-gpui-demonstration-application.md
@@ -406,84 +406,84 @@ Run all commands from the workspace root: `/home/user/project`.
 
 1. Baseline GPUI-focused checks:
 
-```bash
-set -o pipefail
-cargo test -p rstest-bdd-harness-gpui --features native-gpui-tests \
-  2>&1 | tee /tmp/9-4-5-gpui-plugin-baseline.log
-```
+   ```bash
+   set -o pipefail
+   cargo test -p rstest-bdd-harness-gpui --features native-gpui-tests \
+     2>&1 | tee /tmp/9-4-5-gpui-plugin-baseline.log
+   ```
 
-Expected signal:
+   Expected signal:
 
-```plaintext
-test result: ok
-```
+   ```plaintext
+   test result: ok
+   ```
 
-1. Baseline GPUI integration check:
+2. Baseline GPUI integration check:
 
-```bash
-set -o pipefail
-cargo test -p rstest-bdd --test scenario_harness_gpui \
-  --features gpui-harness-tests \
-  2>&1 | tee /tmp/9-4-5-gpui-integration-baseline.log
-```
+   ```bash
+   set -o pipefail
+   cargo test -p rstest-bdd --test scenario_harness_gpui \
+     --features gpui-harness-tests \
+     2>&1 | tee /tmp/9-4-5-gpui-integration-baseline.log
+   ```
 
-Expected signal:
+   Expected signal:
 
-```plaintext
-test result: ok
-```
+   ```plaintext
+   test result: ok
+   ```
 
-1. During Stage B and Stage C, iterate on the new example crate:
+3. During Stage B and Stage C, iterate on the new example crate:
 
-```bash
-set -o pipefail
-cargo test -p gpui-counter 2>&1 | tee /tmp/9-4-5-gpui-counter.log
-```
+   ```bash
+   set -o pipefail
+   cargo test -p gpui-counter 2>&1 | tee /tmp/9-4-5-gpui-counter.log
+   ```
 
-Expected red/green progression:
+   Expected red/green progression:
 
-```plaintext
-before implementation: one or more unit/BDD assertions fail
-after implementation: test result: ok
-```
+   ```plaintext
+   before implementation: one or more unit/BDD assertions fail
+   after implementation: test result: ok
+   ```
 
-1. Once the example passes locally, run the documentation formatting pass:
+4. Once the example passes locally, run the documentation formatting pass:
 
-```bash
-set -o pipefail
-make fmt 2>&1 | tee /tmp/9-4-5-make-fmt.log
-```
+   ```bash
+   set -o pipefail
+   make fmt 2>&1 | tee /tmp/9-4-5-make-fmt.log
+   ```
 
-1. Run documentation validation:
+5. Run documentation validation:
 
-```bash
-set -o pipefail
-make markdownlint 2>&1 | tee /tmp/9-4-5-markdownlint.log
-```
+   ```bash
+   set -o pipefail
+   make markdownlint 2>&1 | tee /tmp/9-4-5-markdownlint.log
+   ```
 
-```bash
-set -o pipefail
-make nixie 2>&1 | tee /tmp/9-4-5-nixie.log
-```
+   ```bash
+   set -o pipefail
+   make nixie 2>&1 | tee /tmp/9-4-5-nixie.log
+   ```
 
-1. Run the required Rust quality gates:
+6. Run the required Rust quality gates:
 
-```bash
-set -o pipefail
-make check-fmt 2>&1 | tee /tmp/9-4-5-check-fmt.log
-```
+   ```bash
+   set -o pipefail
+   make check-fmt 2>&1 | tee /tmp/9-4-5-check-fmt.log
+   ```
 
-```bash
-set -o pipefail
-make lint 2>&1 | tee /tmp/9-4-5-lint.log
-```
+   ```bash
+   set -o pipefail
+   make lint 2>&1 | tee /tmp/9-4-5-lint.log
+   ```
 
-```bash
-set -o pipefail
-make test 2>&1 | tee /tmp/9-4-5-test.log
-```
+   ```bash
+   set -o pipefail
+   make test 2>&1 | tee /tmp/9-4-5-test.log
+   ```
 
-1. If every command succeeds, update `docs/roadmap.md` to mark 9.4.5 done.
+7. If every command succeeds, update `docs/roadmap.md` to mark 9.4.5 done.
 
 ## Validation and acceptance
 

--- a/docs/execplans/9-4-5-gpui-demonstration-application.md
+++ b/docs/execplans/9-4-5-gpui-demonstration-application.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT (2026-03-12)
+Status: DONE (2026-03-16)
 
 `PLANS.md` is not present in this repository at the time of writing, so this
 ExecPlan is the governing plan for roadmap item 9.4.5.
@@ -128,11 +128,13 @@ the example's BDD scenarios pass, and the full gate set passes: `make fmt`,
 - [x] (2026-03-12 00:00Z) Reviewed current GPUI harness integration tests and
       the workspace GPUI shim.
 - [x] (2026-03-12 00:00Z) Drafted this ExecPlan.
-- [ ] Stage A: confirm the final example topology and baseline command health.
-- [ ] Stage B: scaffold the new example crate and red tests.
-- [ ] Stage C: implement the example domain model and BDD steps.
-- [ ] Stage D: harden docs, native-setup guidance, and roadmap state.
-- [ ] Stage E: run full quality gates and capture logs.
+- [x] (2026-03-16) Stage A: confirm the final example topology and baseline
+      command health.
+- [x] (2026-03-16) Stage B: scaffold the new example crate and red tests.
+- [x] (2026-03-16) Stage C: implement the example domain model and BDD steps.
+- [x] (2026-03-16) Stage D: harden docs, native-setup guidance, and roadmap
+      state.
+- [x] (2026-03-16) Stage E: run full quality gates and capture logs.
 
 ## Surprises & Discoveries
 
@@ -155,6 +157,12 @@ the example's BDD scenarios pass, and the full gate set passes: `make fmt`,
   `vendor/gpui/src/lib.rs` and `vendor/gpui-macros/src/lib.rs`. Impact: the
   example should demonstrate harness and context usage, not upstream GPUI view
   APIs that the shim does not provide.
+
+- Observation: the `#[scenario]` macro requires `rstest-bdd-harness` in the
+  crate's `[dev-dependencies]`, even though the example itself never imports
+  from it directly. The macro's Cargo manifest lookup enforces this. Evidence:
+  compile error during Stage B on 2026-03-16. Impact: added
+  `rstest-bdd-harness.workspace = true` to the example's `Cargo.toml`.
 
 ## Decision Log
 
@@ -185,23 +193,30 @@ the example's BDD scenarios pass, and the full gate set passes: `make fmt`,
 
 ## Outcomes & Retrospective
 
-This work has not been implemented yet. Expected delivered outcomes are:
+Implementation completed on 2026-03-16. Delivered outcomes:
 
-- A new example crate under `examples/` that can be run by workspace test
-  commands.
-- Unit coverage for the example's own domain logic.
-- Behavioural coverage through `#[scenario]` bindings that demonstrate GPUI
-  harness context injection.
-- Users-guide and design-doc updates that explain the example and the native
-  setup story.
-- Roadmap item 9.4.5 marked complete after validation.
+- `examples/gpui-counter` crate added as a workspace member with 6 unit tests,
+  2 BDD scenarios, and 1 doctest.
+- BDD suite binds both `harness = GpuiHarness` and
+  `attributes = GpuiAttributePolicy` and demonstrates step access to injected
+  `gpui::TestAppContext` through `#[from(rstest_bdd_harness_context)]`.
+- `docs/users-guide.md` updated with a link to the example, a
+  native-library-setup note, and a reference to the `gpui-counter` crate.
+- `docs/rstest-bdd-design.md` §2.7.4 updated to describe the demonstration
+  crate.
+- `docs/roadmap.md` item 9.4.5 marked done after all gates passed.
 
-Retrospective placeholder:
+Retrospective:
 
-- Revisit whether the chosen example remained the smallest useful expression of
-  GPUI harness integration.
-- Record any friction encountered when moving from the repository's GPUI shim
-  to the user-facing example.
+- The example required `rstest-bdd-harness` as a dev-dependency; the scenario
+  macro's Cargo manifest lookup enforces this. This was discovered quickly and
+  resolved without friction.
+- The workspace GPUI shim required no additional native setup. Linux
+  environments linking against the full upstream GPUI crate need X11 keyboard
+  libraries, but the shim avoids that requirement. This is now explicitly
+  documented in the users' guide.
+- The chosen counter domain was the smallest useful expression of GPUI harness
+  integration, matching the existing example crate style.
 
 ## Context and orientation
 

--- a/docs/execplans/9-4-5-gpui-demonstration-application.md
+++ b/docs/execplans/9-4-5-gpui-demonstration-application.md
@@ -1,0 +1,592 @@
+# ExecPlan 9.4.5: add a GPUI demonstration application
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT (2026-03-12)
+
+`PLANS.md` is not present in this repository at the time of writing, so this
+ExecPlan is the governing plan for roadmap item 9.4.5.
+
+## Purpose / big picture
+
+Roadmap item 9.4.5 closes the last missing GPUI deliverable from phase 9.4. The
+repository already contains the GPUI plugin crate
+`crates/rstest-bdd-harness-gpui`, behavioural coverage for `GpuiHarness` and
+`GpuiAttributePolicy`, and integration coverage in
+`crates/rstest-bdd/tests/scenario_harness_gpui.rs`. What is still missing is a
+user-facing example under `examples/` that shows how an application crate
+adopts that plugin in the same style as the existing `todo-cli` and
+`japanese-ledger` examples.
+
+After this work:
+
+- A new workspace example crate exists under `examples/` with the same
+  maintenance posture as the existing demonstration crates.
+- The example's BDD suite exercises `harness = GpuiHarness` and
+  `attributes = GpuiAttributePolicy` in generated `#[scenario]` bindings.
+- Step definitions demonstrate direct access to injected
+  `gpui::TestAppContext` through
+  `#[from(rstest_bdd_harness_context)] context: &gpui::TestAppContext` and
+  `&mut gpui::TestAppContext`.
+- The example also contains unit tests for its own domain model so the feature
+  is validated with both unit tests and behavioural tests.
+- `docs/rstest-bdd-design.md` records the design decisions taken while shaping
+  the example.
+- `docs/users-guide.md` points to the example as the canonical GPUI harness
+  walkthrough and clearly states any native-library setup that is or is not
+  required.
+- `docs/roadmap.md` marks 9.4.5 as done only after every gate passes.
+
+Success is observable when `make test` runs the new example crate successfully,
+the example's BDD scenarios pass, and the full gate set passes: `make fmt`,
+`make markdownlint`, `make nixie`, `make check-fmt`, `make lint`, and
+`make test`.
+
+## Constraints
+
+- Implement only roadmap item 9.4.5 from `docs/roadmap.md`.
+- Preserve ADR-005 boundaries: GPUI dependencies remain outside core crates.
+  The example may depend on `gpui` and `rstest-bdd-harness-gpui`, but
+  `rstest-bdd`, `rstest-bdd-macros`, and `rstest-bdd-harness` must not gain new
+  GPUI-specific responsibilities.
+- Preserve ADR-007 usage: step access to harness context must continue to flow
+  through `rstest_bdd_harness_context`.
+- Keep the example aligned with the current workspace GPUI shim in
+  `vendor/gpui`; do not design the example around APIs that the repository does
+  not currently expose.
+- Do not introduce a new third-party dependency unless the repository already
+  carries it in the workspace or the user explicitly approves a new one.
+- Keep files under 400 lines.
+- Every new Rust module must begin with a `//!` module-level comment.
+- Public APIs in the example crate must include Rustdoc, with examples where
+  appropriate.
+- Record final design choices in `docs/rstest-bdd-design.md` §2.7.4.
+- Record user-facing usage and setup in `docs/users-guide.md`.
+- Mark roadmap item 9.4.5 done only after all validation passes.
+- Required gates before completion:
+  `make fmt`, `make markdownlint`, `make nixie`, `make check-fmt`, `make lint`,
+  and `make test`.
+- Run long-lived commands with `set -o pipefail` and `tee`.
+
+## Tolerances (exception triggers)
+
+- Scope: if implementation grows beyond 14 files changed or 750 net lines,
+  stop and escalate.
+- Interfaces: if delivering the example requires changing public signatures in
+  `GpuiHarness`, `GpuiAttributePolicy`, `HarnessAdapter`, or `#[scenario]`,
+  stop and escalate.
+- Dependencies: if the example needs a new external crate that is not already
+  in the workspace, stop and escalate.
+- Native setup: if the example uncovers native-library requirements that are
+  not satisfied by the workspace GPUI shim, stop and document the exact linker
+  or runtime failure before proceeding.
+- Iterations: if `make check-fmt`, `make lint`, or `make test` each fail three
+  consecutive times after attempted fixes, stop and escalate with logs.
+- Ambiguity: if there is more than one reasonable interpretation of
+  "demonstration application" that materially changes the crate shape
+  (library-only example vs. binary app vs. mixed app), stop and resolve that
+  choice before implementation.
+
+## Risks
+
+- Risk: the new example could duplicate the existing GPUI integration test
+  almost verbatim, which would add maintenance cost without improving user
+  guidance. Severity: medium. Likelihood: high. Mitigation: give the example a
+  small but real domain model and README, and keep the integration test focused
+  on framework semantics.
+
+- Risk: proving `TestAppContext` injection via process-global statics would
+  force serial execution and teach poor example hygiene. Severity: medium.
+  Likelihood: medium. Mitigation: keep observation state inside the example's
+  fixture-owned domain model and compare context-derived values there.
+
+- Risk: roadmap wording mentions native-library setup, but this workspace uses
+  a local GPUI test shim rather than the full upstream native stack. Severity:
+  medium. Likelihood: high. Mitigation: explicitly verify the actual runtime
+  requirements during implementation and document the result precisely, even if
+  the answer is "no extra native libraries are required in this repository".
+
+- Risk: adding the example to the workspace may expose latent formatting,
+  Clippy, or doctest issues in example code that are easy to miss if only the
+  focused crate test is run. Severity: medium. Likelihood: medium. Mitigation:
+  run focused example tests first, then the full repository gate set.
+
+- Risk: the minimal GPUI shim may not support a full visual application model.
+  Severity: low. Likelihood: medium. Mitigation: keep the example scoped to
+  harness and context behaviour, not rendering or window-management features
+  outside the shim's surface.
+
+## Progress
+
+- [x] (2026-03-12 00:00Z) Reviewed roadmap item 9.4.5 and prerequisite 9.4.4.
+- [x] (2026-03-12 00:00Z) Reviewed `docs/rstest-bdd-design.md` §2.7.4 and the
+      current GPUI users-guide section.
+- [x] (2026-03-12 00:00Z) Reviewed existing examples under `examples/`.
+- [x] (2026-03-12 00:00Z) Reviewed current GPUI harness integration tests and
+      the workspace GPUI shim.
+- [x] (2026-03-12 00:00Z) Drafted this ExecPlan.
+- [ ] Stage A: confirm the final example topology and baseline command health.
+- [ ] Stage B: scaffold the new example crate and red tests.
+- [ ] Stage C: implement the example domain model and BDD steps.
+- [ ] Stage D: harden docs, native-setup guidance, and roadmap state.
+- [ ] Stage E: run full quality gates and capture logs.
+
+## Surprises & Discoveries
+
+- Observation: the task prompt references `rust-doctest-dry-guide.md` at the
+  repository root, but the actual file in this repository is
+  `docs/rust-doctest-dry-guide.md`. Evidence: repository file lookup on
+  2026-03-12. Impact: this ExecPlan uses the path under `docs/` as the source
+  of truth.
+
+- Observation: the only current example crates are `examples/todo-cli` and
+  `examples/japanese-ledger`; both are intentionally small and keep their BDD
+  assets under `tests/features/`. Evidence: workspace tree inspection on
+  2026-03-12. Impact: the GPUI example should follow that pattern instead of
+  inventing a new structure.
+
+- Observation: the repository uses a workspace-local GPUI shim under
+  `vendor/gpui` and `vendor/gpui-macros`. The shim exposes only the surface
+  needed by `rstest-bdd`: `#[gpui::test]`, `run_test`, `TestDispatcher`,
+  `BackgroundExecutor`, and `TestAppContext`. Evidence:
+  `vendor/gpui/src/lib.rs` and `vendor/gpui-macros/src/lib.rs`. Impact: the
+  example should demonstrate harness and context usage, not upstream GPUI view
+  APIs that the shim does not provide.
+
+## Decision Log
+
+- Decision: the example crate should be a small library-style application under
+  `examples/gpui-counter` rather than a larger binary application. Rationale:
+  the existing demonstration crates are intentionally compact, and a
+  library-style example is sufficient to prove `GpuiHarness`,
+  `GpuiAttributePolicy`, and `TestAppContext` injection end to end.
+  Date/Author: 2026-03-12 / Codex.
+
+- Decision: the primary BDD scenario binding should specify both
+  `harness = rstest_bdd_harness_gpui::GpuiHarness` and
+  `attributes = rstest_bdd_harness_gpui::GpuiAttributePolicy`. Rationale: this
+  gives one canonical code path that exercises both GPUI knobs together,
+  instead of forcing users to assemble the pieces mentally from separate tests.
+  Date/Author: 2026-03-12 / Codex.
+
+- Decision: context observations should be stored in the example fixture-owned
+  model instead of process-global statics. Rationale: examples should model
+  parallel-safe, reusable patterns rather than serial-test-only techniques.
+  Date/Author: 2026-03-12 / Codex.
+
+- Decision: the users' guide should document the exact native setup result from
+  implementation, even if that result is "none required in this workspace".
+  Rationale: roadmap item 9.4.5 explicitly calls for clear native-library
+  guidance, and silence would leave the deliverable incomplete. Date/Author:
+  2026-03-12 / Codex.
+
+## Outcomes & Retrospective
+
+This work has not been implemented yet. Expected delivered outcomes are:
+
+- A new example crate under `examples/` that can be run by workspace test
+  commands.
+- Unit coverage for the example's own domain logic.
+- Behavioural coverage through `#[scenario]` bindings that demonstrate GPUI
+  harness context injection.
+- Users-guide and design-doc updates that explain the example and the native
+  setup story.
+- Roadmap item 9.4.5 marked complete after validation.
+
+Retrospective placeholder:
+
+- Revisit whether the chosen example remained the smallest useful expression of
+  GPUI harness integration.
+- Record any friction encountered when moving from the repository's GPUI shim
+  to the user-facing example.
+
+## Context and orientation
+
+The repository is a Cargo workspace. Relevant current files are:
+
+- `Cargo.toml`: workspace members currently include `examples/todo-cli` and
+  `examples/japanese-ledger`, but no GPUI example yet.
+- `examples/todo-cli/` and `examples/japanese-ledger/`: existing reference
+  examples for scope, file layout, and README expectations.
+- `crates/rstest-bdd-harness-gpui/src/gpui_harness.rs`: the delivered GPUI
+  harness adapter.
+- `crates/rstest-bdd-harness-gpui/src/policy.rs`: the delivered GPUI attribute
+  policy plugin.
+- `crates/rstest-bdd/tests/scenario_harness_gpui.rs` and
+  `crates/rstest-bdd/tests/features/gpui_harness.feature`: the current GPUI
+  integration tests that validate framework semantics but are not a user-facing
+  example.
+- `docs/rstest-bdd-design.md` §2.7.4: design document section describing
+  first-party plugin targets.
+- `docs/users-guide.md`: current GPUI harness documentation, which explains the
+  API but does not yet point to a canonical example crate.
+- `docs/roadmap.md`: roadmap section 9.4.5, currently unchecked.
+- `vendor/gpui/src/lib.rs`: workspace-local GPUI shim that defines
+  `TestAppContext`, `run_test`, and related test support.
+
+Terms used in this plan:
+
+- **Harness adapter**: a type implementing `HarnessAdapter` that decides how a
+  scenario request executes. Here that is `GpuiHarness`.
+- **Attribute policy**: a type implementing `AttributePolicy` that decides
+  which test attributes get emitted on generated scenario tests. Here that is
+  `GpuiAttributePolicy`.
+- **Harness context**: the framework-specific object a harness injects into
+  step execution. For GPUI, that object is `gpui::TestAppContext`.
+- **BDD suite**: the combination of `.feature` files plus Rust step bindings in
+  `tests/`.
+
+Reference documents reviewed while drafting this plan:
+
+- `docs/roadmap.md`
+- `docs/rstest-bdd-design.md`
+- `docs/rstest-bdd-language-server-design.md`
+- `docs/rust-testing-with-rstest-fixtures.md`
+- `docs/rust-doctest-dry-guide.md`
+- `docs/complexity-antipatterns-and-refactoring-strategies.md`
+- `docs/gherkin-syntax.md`
+- `docs/adr-005-harness-adapter-crates-for-framework-specific-test-integration.md`
+- `docs/adr-007-harness-context-injection.md`
+
+## Plan of work
+
+### Stage A: confirm topology and baseline
+
+Goal: lock down the crate shape and confirm there is no hidden infrastructure
+constraint before writing code.
+
+Implementation details:
+
+- Re-read the existing example crates and confirm the new GPUI example should
+  be a library-style example with `src/lib.rs`, `tests/*.rs`, and
+  `tests/features/*.feature`.
+- Verify whether the current workspace GPUI shim requires any native-library
+  setup to run tests. If no extra setup is required, document that result
+  explicitly for later propagation to `docs/users-guide.md`.
+- Record baseline command health for the focused GPUI suites:
+  `cargo test -p rstest-bdd-harness-gpui --features native-gpui-tests` and
+  `cargo test -p rstest-bdd --test scenario_harness_gpui --features gpui-harness-tests`.
+
+Go/no-go validation:
+
+- The final crate name and layout are chosen.
+- The native-setup story is known well enough to document accurately.
+- Baseline GPUI-focused suites pass before the example is added.
+
+### Stage B: scaffold the example crate and write red tests
+
+Goal: add a new workspace member and encode desired behaviour before filling in
+all implementation details.
+
+Implementation details:
+
+- Add `examples/gpui-counter` to the workspace members in `Cargo.toml`.
+- Create:
+  - `examples/gpui-counter/Cargo.toml`
+  - `examples/gpui-counter/README.md`
+  - `examples/gpui-counter/src/lib.rs`
+  - `examples/gpui-counter/tests/counter.rs`
+  - `examples/gpui-counter/tests/features/counter.feature`
+- Mirror the dependency posture of the other examples, plus GPUI-specific
+  dev-dependencies: `gpui`, `rstest-bdd-harness-gpui`, `rstest`, `rstest-bdd`,
+  `rstest-bdd-macros`.
+- Define the intended behaviour first in tests:
+  - Unit tests for the example's domain model in `src/lib.rs`.
+  - BDD scenarios in `tests/counter.rs` that bind to the feature file and
+    assert the desired counter behaviour plus `TestAppContext` access.
+- Choose step text that reads like a tiny application, not a framework test.
+  Example theme: a counter application records user increments while also
+  capturing GPUI harness context details.
+
+Go/no-go validation:
+
+- `cargo test -p gpui-counter` fails only for the expected red-phase reasons
+  before the implementation is completed.
+- The example compiles as a workspace member.
+
+### Stage C: implement the example domain model and step bindings
+
+Goal: make the red tests pass with the smallest clear implementation.
+
+Implementation details:
+
+- In `examples/gpui-counter/src/lib.rs`, implement a small domain model such as
+  `CounterApp` plus an observation record for GPUI context facts. Keep the
+  public surface tiny and documented.
+- Keep example logic self-contained and deterministic. The model should be easy
+  to exercise from both unit tests and BDD steps.
+- In `examples/gpui-counter/tests/counter.rs`:
+  - add a fixture returning the example model;
+  - add `#[given]`, `#[when]`, and `#[then]` step definitions;
+  - demonstrate immutable and mutable step access to
+    `gpui::TestAppContext` via `#[from(rstest_bdd_harness_context)]`;
+  - bind at least one scenario with both
+    `harness = rstest_bdd_harness_gpui::GpuiHarness` and
+    `attributes = rstest_bdd_harness_gpui::GpuiAttributePolicy`.
+- The step assertions should show a real user benefit and a real harness fact.
+  A good target is:
+  - the counter value changes as requested;
+  - the same injected `TestAppContext` is visible across steps;
+  - a GPUI-specific method such as `on_quit`, `dispatcher().seed()`, or
+    `test_function_name()` is observed and recorded in the model.
+- If a second scenario improves clarity, add one. Keep the feature file small
+  enough to remain a teaching example.
+
+Go/no-go validation:
+
+- `cargo test -p gpui-counter` passes.
+- The BDD suite clearly demonstrates harness-context injection.
+- No globals or serial-only scaffolding are required.
+
+### Stage D: documentation and roadmap hardening
+
+Goal: make the new example discoverable and keep docs consistent.
+
+Implementation details:
+
+- Update `docs/rstest-bdd-design.md` §2.7.4 to record the design decisions
+  taken for the example, including the chosen scope and any native-setup
+  conclusion.
+- Update `docs/users-guide.md` in the GPUI harness section to:
+  - link to `examples/gpui-counter`;
+  - show the canonical `#[scenario(...)]` binding using both
+    `GpuiHarness` and `GpuiAttributePolicy`;
+  - explain how steps request `TestAppContext`;
+  - state exactly what native-library setup is required in this repository.
+- Update `examples/gpui-counter/README.md` with focused instructions for
+  running just the example crate.
+- Mark 9.4.5 done in `docs/roadmap.md` only after all stage validations and
+  full gates pass.
+
+Go/no-go validation:
+
+- The design doc, users' guide, README, and roadmap all describe the same
+  delivered example.
+- The users' guide contains an explicit statement about native setup.
+
+### Stage E: full validation and cleanup
+
+Goal: prove the repository still passes all required quality gates.
+
+Implementation details:
+
+- Run focused crate checks first for faster feedback.
+- Run the documentation gates because this task changes Markdown.
+- Run the required Rust gates from the workspace root.
+- If any command fails, fix the underlying issue and rerun until clean or until
+  a tolerance threshold is hit.
+
+Go/no-go validation:
+
+- All commands in `Validation and acceptance` pass.
+- The example crate is included in workspace-wide testing.
+
+## Concrete steps
+
+Run all commands from the workspace root: `/home/user/project`.
+
+1. Baseline GPUI-focused checks:
+
+```bash
+set -o pipefail
+cargo test -p rstest-bdd-harness-gpui --features native-gpui-tests \
+  2>&1 | tee /tmp/9-4-5-gpui-plugin-baseline.log
+```
+
+Expected signal:
+
+```plaintext
+test result: ok
+```
+
+1. Baseline GPUI integration check:
+
+```bash
+set -o pipefail
+cargo test -p rstest-bdd --test scenario_harness_gpui \
+  --features gpui-harness-tests \
+  2>&1 | tee /tmp/9-4-5-gpui-integration-baseline.log
+```
+
+Expected signal:
+
+```plaintext
+test result: ok
+```
+
+1. During Stage B and Stage C, iterate on the new example crate:
+
+```bash
+set -o pipefail
+cargo test -p gpui-counter 2>&1 | tee /tmp/9-4-5-gpui-counter.log
+```
+
+Expected red/green progression:
+
+```plaintext
+before implementation: one or more unit/BDD assertions fail
+after implementation: test result: ok
+```
+
+1. Once the example passes locally, run the documentation formatting pass:
+
+```bash
+set -o pipefail
+make fmt 2>&1 | tee /tmp/9-4-5-make-fmt.log
+```
+
+1. Run documentation validation:
+
+```bash
+set -o pipefail
+PATH=/root/.bun/bin:$PATH make markdownlint \
+  2>&1 | tee /tmp/9-4-5-markdownlint.log
+```
+
+```bash
+set -o pipefail
+make nixie 2>&1 | tee /tmp/9-4-5-nixie.log
+```
+
+1. Run the required Rust quality gates:
+
+```bash
+set -o pipefail
+make check-fmt 2>&1 | tee /tmp/9-4-5-check-fmt.log
+```
+
+```bash
+set -o pipefail
+make lint 2>&1 | tee /tmp/9-4-5-lint.log
+```
+
+```bash
+set -o pipefail
+make test 2>&1 | tee /tmp/9-4-5-test.log
+```
+
+1. If every command succeeds, update `docs/roadmap.md` to mark 9.4.5 done.
+
+## Validation and acceptance
+
+Acceptance is behavioural, not structural.
+
+Tests:
+
+- `cargo test -p gpui-counter` passes and includes both unit coverage for the
+  example model and the BDD scenario suite.
+- The BDD suite demonstrates step access to injected `gpui::TestAppContext`.
+- Existing GPUI-focused suites still pass:
+  - `cargo test -p rstest-bdd-harness-gpui --features native-gpui-tests`
+  - `cargo test -p rstest-bdd --test scenario_harness_gpui --features gpui-harness-tests`
+
+Lint and formatting:
+
+- `make fmt` completes cleanly.
+- `make markdownlint` passes.
+- `make nixie` passes.
+- `make check-fmt` passes.
+- `make lint` passes.
+
+Workspace regression gate:
+
+- `make test` passes from the repository root and runs the new example crate as
+  part of the workspace.
+
+Documentation:
+
+- `docs/users-guide.md` links to the new example and explicitly states the
+  native setup story.
+- `docs/rstest-bdd-design.md` records the design choices taken for the example.
+- `docs/roadmap.md` marks 9.4.5 done only after the gates above succeed.
+
+## Idempotence and recovery
+
+This plan is intentionally additive. Re-running the steps is safe.
+
+- The example crate creation is idempotent once files exist; reruns should only
+  update content.
+- If Stage B chooses the wrong example name or layout, fix that before Stage C
+  rather than carrying both structures forward.
+- If the example proves too ambitious for the shim's surface, simplify the
+  domain model instead of broadening the shim unless the user approves that
+  wider scope.
+- If a late-stage gate fails, keep the roadmap checkbox unchecked and rerun the
+  failing command after fixes.
+
+## Artifacts and notes
+
+Expected final artefacts:
+
+- `examples/gpui-counter/Cargo.toml`
+- `examples/gpui-counter/README.md`
+- `examples/gpui-counter/src/lib.rs`
+- `examples/gpui-counter/tests/counter.rs`
+- `examples/gpui-counter/tests/features/counter.feature`
+- `docs/rstest-bdd-design.md` updates
+- `docs/users-guide.md` updates
+- `docs/roadmap.md` update
+
+Expected evidence to keep in logs:
+
+- `/tmp/9-4-5-gpui-plugin-baseline.log`
+- `/tmp/9-4-5-gpui-integration-baseline.log`
+- `/tmp/9-4-5-gpui-counter.log`
+- `/tmp/9-4-5-make-fmt.log`
+- `/tmp/9-4-5-markdownlint.log`
+- `/tmp/9-4-5-nixie.log`
+- `/tmp/9-4-5-check-fmt.log`
+- `/tmp/9-4-5-lint.log`
+- `/tmp/9-4-5-test.log`
+
+## Interfaces and dependencies
+
+The example crate should depend on the already-delivered GPUI integration
+surface, not invent a new one.
+
+Required crate dependencies:
+
+- `gpui` as a dev-dependency, matching the workspace dependency.
+- `rstest-bdd-harness-gpui` as a dev-dependency.
+- `rstest`, `rstest-bdd`, and `rstest-bdd-macros` as dev-dependencies.
+
+Expected Rust-facing interfaces:
+
+```rust
+pub struct CounterApp {
+    /* application state plus GPUI context observations */
+}
+```
+
+```rust
+#[scenario(
+    path = "tests/features/counter.feature",
+    name = "...",
+    harness = rstest_bdd_harness_gpui::GpuiHarness,
+    attributes = rstest_bdd_harness_gpui::GpuiAttributePolicy,
+)]
+fn counter_scenario(/* example fixture(s) */) {}
+```
+
+```rust
+#[when("...")]
+fn step_name(
+    app: &mut CounterApp,
+    #[from(rstest_bdd_harness_context)] context: &mut gpui::TestAppContext,
+) {
+    /* record both application and harness effects */
+}
+```
+
+The example should not require any new extension points in
+`rstest-bdd-harness-gpui`; the entire point of 9.4.5 is to prove that the
+existing plugin interfaces are sufficient for a real application example.
+
+## Revision note
+
+Initial draft created on 2026-03-12 for roadmap item 9.4.5 after reviewing the
+existing GPUI plugin crate, GPUI integration tests, example crates, and the
+workspace GPUI shim.

--- a/docs/execplans/9-4-5-gpui-demonstration-application.md
+++ b/docs/execplans/9-4-5-gpui-demonstration-application.md
@@ -1,4 +1,4 @@
-# ExecPlan 9.4.5: add a GPUI demonstration application
+# ExecPlan 9.4.5: add a GPUI (Graphical Processing User Interface) demonstration application
 
 This ExecPlan (execution plan) is a living document. The sections
 `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
@@ -25,8 +25,9 @@ After this work:
 
 - A new workspace example crate exists under `examples/` with the same
   maintenance posture as the existing demonstration crates.
-- The example's BDD suite exercises `harness = GpuiHarness` and
-  `attributes = GpuiAttributePolicy` in generated `#[scenario]` bindings.
+- The example's behaviour-driven development (BDD) suite exercises
+  `harness = GpuiHarness` and `attributes = GpuiAttributePolicy` in generated
+  `#[scenario]` bindings.
 - Step definitions demonstrate direct access to injected
   `gpui::TestAppContext` through
   `#[from(rstest_bdd_harness_context)] context: &gpui::TestAppContext` and
@@ -48,10 +49,10 @@ the example's BDD scenarios pass, and the full gate set passes: `make fmt`,
 ## Constraints
 
 - Implement only roadmap item 9.4.5 from `docs/roadmap.md`.
-- Preserve ADR-005 boundaries: GPUI dependencies remain outside core crates.
-  The example may depend on `gpui` and `rstest-bdd-harness-gpui`, but
-  `rstest-bdd`, `rstest-bdd-macros`, and `rstest-bdd-harness` must not gain new
-  GPUI-specific responsibilities.
+- Preserve Architecture Decision Record (ADR) 005 boundaries: GPUI
+  dependencies remain outside core crates. The example may depend on `gpui` and
+  `rstest-bdd-harness-gpui`, but `rstest-bdd`, `rstest-bdd-macros`, and
+  `rstest-bdd-harness` must not gain new GPUI-specific responsibilities.
 - Preserve ADR-007 usage: step access to harness context must continue to flow
   through `rstest_bdd_harness_context`.
 - Keep the example aligned with the current workspace GPUI shim in
@@ -457,8 +458,7 @@ make fmt 2>&1 | tee /tmp/9-4-5-make-fmt.log
 
 ```bash
 set -o pipefail
-PATH=/root/.bun/bin:$PATH make markdownlint \
-  2>&1 | tee /tmp/9-4-5-markdownlint.log
+make markdownlint 2>&1 | tee /tmp/9-4-5-markdownlint.log
 ```
 
 ```bash

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -549,14 +549,14 @@ opt-in crates rather than the core runtime or macros.
 - [x] 9.4.3. Execute scenarios inside the GPUI test harness and inject fixtures
   such as `TestAppContext`.
 - [x] 9.4.4. Provide the matching GPUI test attribute policy plugin.
-- [ ] 9.4.5. Add a simple GPUI demonstration application and BDD test suite
+- [x] 9.4.5. Add a simple GPUI demonstration application and BDD test suite
   under `examples/`, similar in scope to the existing demonstration
   applications. The example should exercise `GpuiHarness` and
   `GpuiAttributePolicy` end-to-end and demonstrate step access to injected
   `TestAppContext`. Finish line: a new example crate and its BDD suite run
   successfully via `make test`, with any required native-library setup clearly
   documented in the user guide. Prerequisite: 9.4.4 delivered. Design Doc:
-  §2.7.4. (Dinolump)
+  §2.7.4. Delivered via `examples/gpui-counter`. (Dinolump)
 
 ### 9.5. Context injection mechanism
 

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1710,7 +1710,12 @@ The first official adapters and policies are:
   artifact for `rstest-bdd-harness-gpui` and compiles a generated validator
   crate against upstream `gpui`; GPUI behavioural and integration tests remain
   feature-gated (`native-gpui-tests` and `gpui-harness-tests`) as explicit
-  opt-in suites.
+  opt-in suites. A user-facing demonstration crate under
+  `examples/gpui-counter` models a simple counter application whose BDD suite
+  exercises both `GpuiHarness` and `GpuiAttributePolicy` end-to-end, with step
+  definitions that access injected `TestAppContext` through
+  `rstest_bdd_harness_context`. The example requires no native-library setup
+  beyond the workspace GPUI shim.
 
 Future adapters (for example, Bevy) are planned to follow the same pattern
 without requiring new dependencies in `rstest-bdd` or `rstest-bdd-macros`.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -897,6 +897,20 @@ fn my_gpui_scenario() {
 `gpui::TestAppContext`, and passes it through `HarnessAdapter::Context`.
 `GpuiAttributePolicy` emits `#[rstest::rstest]` and `#[gpui::test]`.
 
+For a complete working example, see the `examples/gpui-counter` crate, which
+models a simple counter application whose BDD suite exercises both
+`GpuiHarness` and `GpuiAttributePolicy` end-to-end. Step definitions in that
+example demonstrate accessing injected `TestAppContext` through the
+`#[from(rstest_bdd_harness_context)]` fixture key and recording
+harness-provided values (such as the dispatcher seed) in the domain model.
+
+> **Native-library setup:** this workspace uses a local GPUI test shim under
+> `vendor/gpui` that requires no additional native-library installation beyond
+> standard Rust toolchain components. Linux environments that link against the
+> full upstream GPUI crate may need X11 keyboard libraries (`libxcb1-dev`,
+> `libxkbcommon-dev`, `libxkbcommon-x11-dev` on Debian/Ubuntu), but the
+> workspace shim avoids that requirement.
+>
 > **Workspace note:** this repository patches `gpui` test support locally to
 > keep the dependency graph free of `async-trait`. The patched surface keeps
 > the `run_test`, `TestAppContext`, and `#[gpui::test]` APIs used by

--- a/examples/gpui-counter/Cargo.toml
+++ b/examples/gpui-counter/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "gpui-counter"
+version = "0.5.0"
+edition.workspace = true
+publish = false
+rust-version.workspace = true
+
+[dependencies]
+
+[dev-dependencies]
+gpui.workspace = true
+rstest = { workspace = true }
+rstest-bdd.workspace = true
+rstest-bdd-harness.workspace = true
+rstest-bdd-harness-gpui.workspace = true
+rstest-bdd-macros.workspace = true

--- a/examples/gpui-counter/README.md
+++ b/examples/gpui-counter/README.md
@@ -1,9 +1,10 @@
 # GPUI counter example
 
-This example crate demonstrates writing behaviour-driven tests that exercise
-the GPUI harness adapter and attribute policy from `rstest-bdd-harness-gpui`.
-The scenarios model a simple counter application while also observing
-GPUI-injected `TestAppContext` details from within step definitions.
+This example crate demonstrates writing behaviour-driven development (BDD)
+tests that exercise the GPUI harness adapter and attribute policy from
+`rstest-bdd-harness-gpui`. The scenarios model a simple counter application
+while also observing GPUI-injected `TestAppContext` details from within step
+definitions.
 
 ## Running the tests
 

--- a/examples/gpui-counter/README.md
+++ b/examples/gpui-counter/README.md
@@ -1,0 +1,26 @@
+# GPUI counter example
+
+This example crate demonstrates writing behaviour-driven tests that exercise
+the GPUI harness adapter and attribute policy from `rstest-bdd-harness-gpui`.
+The scenarios model a simple counter application while also observing
+GPUI-injected `TestAppContext` details from within step definitions.
+
+## Running the tests
+
+Execute the test suite with:
+
+```bash
+cargo test -p gpui-counter
+```
+
+The BDD scenarios live in `tests/features/counter.feature`. Step definitions in
+`tests/counter.rs` demonstrate:
+
+- Binding scenarios with both `harness = GpuiHarness` and
+  `attributes = GpuiAttributePolicy`.
+- Accessing the injected `gpui::TestAppContext` through the
+  `#[from(rstest_bdd_harness_context)]` fixture key.
+- Recording harness context observations (e.g. dispatcher seed) in the
+  example's own domain model.
+
+Unit tests for the `CounterApp` domain model live in `src/lib.rs`.

--- a/examples/gpui-counter/src/lib.rs
+++ b/examples/gpui-counter/src/lib.rs
@@ -10,8 +10,11 @@ use std::cell::Cell;
 /// A simple counter that also records observations from the GPUI test
 /// harness context.
 ///
-/// The counter uses interior mutability so that step definitions can borrow
-/// it immutably while still modifying the count.
+/// All fields use [`Cell`] for interior mutability so that BDD step
+/// definitions can share a single `&CounterApp` across Given/When/Then
+/// steps without requiring `&mut` access.  This is safe because scenario
+/// execution is single-threaded; `CounterApp` intentionally does *not*
+/// implement `Sync`.
 ///
 /// # Examples
 ///
@@ -22,6 +25,11 @@ use std::cell::Cell;
 /// app.increment(5);
 /// app.decrement(2);
 /// assert_eq!(app.value(), 3);
+///
+/// // Amounts are unsigned (`u32`), so the direction is always unambiguous.
+/// app.set_value(-1);
+/// app.increment(3);
+/// assert_eq!(app.value(), 2);
 /// ```
 #[derive(Debug, Default)]
 pub struct CounterApp {
@@ -30,7 +38,7 @@ pub struct CounterApp {
 }
 
 impl CounterApp {
-    /// Creates a counter initialised to the given starting value.
+    /// Creates a counter initialized to the given starting value.
     #[must_use]
     pub fn new(start: i32) -> Self {
         Self {
@@ -45,14 +53,25 @@ impl CounterApp {
         self.value.get()
     }
 
+    /// Replaces the stored counter value with the provided amount.
+    pub fn set_value(&self, amount: i32) {
+        self.value.set(amount);
+    }
+
     /// Increases the counter by `amount`, saturating at `i32::MAX`.
-    pub fn increment(&self, amount: i32) {
-        self.value.set(self.value.get().saturating_add(amount));
+    ///
+    /// The amount is unsigned so the direction is always unambiguous.
+    pub fn increment(&self, amount: u32) {
+        let delta = i64::from(self.value.get()) + i64::from(amount);
+        self.value.set(saturate_to_i32(delta));
     }
 
     /// Decreases the counter by `amount`, saturating at `i32::MIN`.
-    pub fn decrement(&self, amount: i32) {
-        self.value.set(self.value.get().saturating_sub(amount));
+    ///
+    /// The amount is unsigned so the direction is always unambiguous.
+    pub fn decrement(&self, amount: u32) {
+        let delta = i64::from(self.value.get()) - i64::from(amount);
+        self.value.set(saturate_to_i32(delta));
     }
 
     /// Records an observed GPUI dispatcher seed.
@@ -64,6 +83,17 @@ impl CounterApp {
     #[must_use]
     pub fn dispatcher_seed(&self) -> Option<u64> {
         self.dispatcher_seed.get()
+    }
+}
+
+/// Clamps an `i64` value to the `i32` range.
+fn saturate_to_i32(value: i64) -> i32 {
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "value is clamped to i32 range before truncation"
+    )]
+    {
+        value.clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32
     }
 }
 
@@ -97,15 +127,15 @@ mod tests {
 
     #[rstest]
     fn saturates_on_overflow(counter: CounterApp) {
-        counter.increment(i32::MAX);
+        counter.increment(u32::MAX);
         counter.increment(1);
         assert_eq!(counter.value(), i32::MAX);
     }
 
     #[rstest]
     fn saturates_on_underflow(counter: CounterApp) {
-        counter.decrement(i32::MAX);
-        counter.decrement(i32::MAX);
+        counter.decrement(u32::MAX);
+        counter.decrement(u32::MAX);
         assert_eq!(counter.value(), i32::MIN);
     }
 

--- a/examples/gpui-counter/src/lib.rs
+++ b/examples/gpui-counter/src/lib.rs
@@ -99,7 +99,7 @@ fn saturate_to_i32(value: i64) -> i32 {
 
 #[cfg(test)]
 mod tests {
-    //! Tests for `CounterApp` behavior.
+    //! Tests for `CounterApp` behaviour.
 
     use super::CounterApp;
     use rstest::{fixture, rstest};

--- a/examples/gpui-counter/src/lib.rs
+++ b/examples/gpui-counter/src/lib.rs
@@ -1,0 +1,118 @@
+//! Example counter application for demonstrating GPUI harness integration
+//! with rstest-bdd.
+//!
+//! The library models a simple counter with an observation record for GPUI
+//! context details. Fixtures share the counter across steps via interior
+//! mutability, following the same pattern as the `japanese-ledger` example.
+
+use std::cell::Cell;
+
+/// A simple counter that also records observations from the GPUI test
+/// harness context.
+///
+/// The counter uses interior mutability so that step definitions can borrow
+/// it immutably while still modifying the count.
+///
+/// # Examples
+///
+/// ```
+/// use gpui_counter::CounterApp;
+///
+/// let app = CounterApp::new(0);
+/// app.increment(5);
+/// app.decrement(2);
+/// assert_eq!(app.value(), 3);
+/// ```
+#[derive(Debug, Default)]
+pub struct CounterApp {
+    value: Cell<i32>,
+    dispatcher_seed: Cell<Option<u64>>,
+}
+
+impl CounterApp {
+    /// Creates a counter initialised to the given starting value.
+    #[must_use]
+    pub fn new(start: i32) -> Self {
+        Self {
+            value: Cell::new(start),
+            dispatcher_seed: Cell::new(None),
+        }
+    }
+
+    /// Returns the current counter value.
+    #[must_use]
+    pub fn value(&self) -> i32 {
+        self.value.get()
+    }
+
+    /// Increases the counter by `amount`, saturating at `i32::MAX`.
+    pub fn increment(&self, amount: i32) {
+        self.value.set(self.value.get().saturating_add(amount));
+    }
+
+    /// Decreases the counter by `amount`, saturating at `i32::MIN`.
+    pub fn decrement(&self, amount: i32) {
+        self.value.set(self.value.get().saturating_sub(amount));
+    }
+
+    /// Records an observed GPUI dispatcher seed.
+    pub fn record_dispatcher_seed(&self, seed: u64) {
+        self.dispatcher_seed.set(Some(seed));
+    }
+
+    /// Returns the last recorded dispatcher seed, if any.
+    #[must_use]
+    pub fn dispatcher_seed(&self) -> Option<u64> {
+        self.dispatcher_seed.get()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CounterApp;
+    use rstest::{fixture, rstest};
+
+    #[fixture]
+    fn counter() -> CounterApp {
+        CounterApp::new(0)
+    }
+
+    #[rstest]
+    fn starts_at_zero(counter: CounterApp) {
+        assert_eq!(counter.value(), 0);
+    }
+
+    #[rstest]
+    fn increments_value(counter: CounterApp) {
+        counter.increment(5);
+        assert_eq!(counter.value(), 5);
+    }
+
+    #[rstest]
+    fn decrements_value(counter: CounterApp) {
+        counter.increment(10);
+        counter.decrement(3);
+        assert_eq!(counter.value(), 7);
+    }
+
+    #[rstest]
+    fn saturates_on_overflow(counter: CounterApp) {
+        counter.increment(i32::MAX);
+        counter.increment(1);
+        assert_eq!(counter.value(), i32::MAX);
+    }
+
+    #[rstest]
+    fn saturates_on_underflow(counter: CounterApp) {
+        counter.decrement(i32::MAX);
+        counter.decrement(i32::MAX);
+        assert_eq!(counter.value(), i32::MIN);
+    }
+
+    #[rstest]
+    fn records_dispatcher_seed(counter: CounterApp) {
+        assert!(counter.dispatcher_seed().is_none());
+        counter.record_dispatcher_seed(42);
+        assert_eq!(counter.dispatcher_seed(), Some(42));
+    }
+}

--- a/examples/gpui-counter/src/lib.rs
+++ b/examples/gpui-counter/src/lib.rs
@@ -99,6 +99,8 @@ fn saturate_to_i32(value: i64) -> i32 {
 
 #[cfg(test)]
 mod tests {
+    //! Tests for `CounterApp` behavior.
+
     use super::CounterApp;
     use rstest::{fixture, rstest};
 

--- a/examples/gpui-counter/tests/counter.rs
+++ b/examples/gpui-counter/tests/counter.rs
@@ -1,0 +1,64 @@
+//! BDD acceptance tests for the GPUI counter example.
+//!
+//! These tests demonstrate `GpuiHarness` and `GpuiAttributePolicy` in a
+//! user-facing example crate, with step access to injected
+//! `gpui::TestAppContext` via the `rstest_bdd_harness_context` fixture key.
+
+use gpui_counter::CounterApp;
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenario, then, when};
+
+#[fixture]
+fn app() -> CounterApp {
+    CounterApp::new(0)
+}
+
+#[given("a counter starting at {start:i32}")]
+fn a_counter_starting_at(app: &CounterApp, start: i32) {
+    // Re-initialise the counter to the requested starting value.
+    app.increment(start.saturating_sub(app.value()));
+}
+
+#[when("I increment the counter by {amount:i32}")]
+fn increment_counter(app: &CounterApp, amount: i32) {
+    app.increment(amount);
+}
+
+#[when("I decrement the counter by {amount:i32}")]
+fn decrement_counter(app: &CounterApp, amount: i32) {
+    app.decrement(amount);
+}
+
+#[when("I record the GPUI dispatcher seed")]
+fn record_dispatcher_seed(
+    app: &CounterApp,
+    #[from(rstest_bdd_harness_context)] context: &gpui::TestAppContext,
+) {
+    app.record_dispatcher_seed(context.dispatcher().seed());
+}
+
+#[then("the counter value is {expected:i32}")]
+fn counter_value_is(app: &CounterApp, expected: i32) {
+    assert_eq!(app.value(), expected);
+}
+
+#[then("the recorded dispatcher seed is {expected:u64}")]
+fn recorded_dispatcher_seed_is(app: &CounterApp, expected: u64) {
+    assert_eq!(app.dispatcher_seed(), Some(expected));
+}
+
+#[scenario(
+    path = "tests/features/counter.feature",
+    name = "Increment a counter and observe GPUI context",
+    harness = rstest_bdd_harness_gpui::GpuiHarness,
+    attributes = rstest_bdd_harness_gpui::GpuiAttributePolicy,
+)]
+fn increment_and_observe_gpui_context(#[from(app)] _: CounterApp) {}
+
+#[scenario(
+    path = "tests/features/counter.feature",
+    name = "Multiple increments and decrements",
+    harness = rstest_bdd_harness_gpui::GpuiHarness,
+    attributes = rstest_bdd_harness_gpui::GpuiAttributePolicy,
+)]
+fn multiple_increments_and_decrements(#[from(app)] _: CounterApp) {}

--- a/examples/gpui-counter/tests/counter.rs
+++ b/examples/gpui-counter/tests/counter.rs
@@ -15,17 +15,16 @@ fn app() -> CounterApp {
 
 #[given("a counter starting at {start:i32}")]
 fn a_counter_starting_at(app: &CounterApp, start: i32) {
-    // Re-initialise the counter to the requested starting value.
-    app.increment(start.saturating_sub(app.value()));
+    app.set_value(start);
 }
 
-#[when("I increment the counter by {amount:i32}")]
-fn increment_counter(app: &CounterApp, amount: i32) {
+#[when("I increment the counter by {amount:u32}")]
+fn increment_counter(app: &CounterApp, amount: u32) {
     app.increment(amount);
 }
 
-#[when("I decrement the counter by {amount:i32}")]
-fn decrement_counter(app: &CounterApp, amount: i32) {
+#[when("I decrement the counter by {amount:u32}")]
+fn decrement_counter(app: &CounterApp, amount: u32) {
     app.decrement(amount);
 }
 
@@ -42,9 +41,15 @@ fn counter_value_is(app: &CounterApp, expected: i32) {
     assert_eq!(app.value(), expected);
 }
 
-#[then("the recorded dispatcher seed is {expected:u64}")]
-fn recorded_dispatcher_seed_is(app: &CounterApp, expected: u64) {
-    assert_eq!(app.dispatcher_seed(), Some(expected));
+#[then("a dispatcher seed was recorded")]
+fn a_dispatcher_seed_was_recorded(app: &CounterApp) {
+    // Assert that a seed exists rather than checking a specific value.
+    // The concrete seed depends on the SEED environment variable and harness
+    // configuration, so asserting existence keeps the scenario stable.
+    assert!(
+        app.dispatcher_seed().is_some(),
+        "expected the GPUI dispatcher seed to have been recorded"
+    );
 }
 
 #[scenario(

--- a/examples/gpui-counter/tests/features/counter.feature
+++ b/examples/gpui-counter/tests/features/counter.feature
@@ -1,0 +1,14 @@
+Feature: Counter application with GPUI harness
+
+  Scenario: Increment a counter and observe GPUI context
+    Given a counter starting at 0
+    When I increment the counter by 3
+    And I record the GPUI dispatcher seed
+    Then the counter value is 3
+    And the recorded dispatcher seed is 0
+
+  Scenario: Multiple increments and decrements
+    Given a counter starting at 10
+    When I decrement the counter by 4
+    And I increment the counter by 7
+    Then the counter value is 13

--- a/examples/gpui-counter/tests/features/counter.feature
+++ b/examples/gpui-counter/tests/features/counter.feature
@@ -5,7 +5,7 @@ Feature: Counter application with GPUI harness
     When I increment the counter by 3
     And I record the GPUI dispatcher seed
     Then the counter value is 3
-    And the recorded dispatcher seed is 0
+    And a dispatcher seed was recorded
 
   Scenario: Multiple increments and decrements
     Given a counter starting at 10


### PR DESCRIPTION
## Summary
- Adds a GPUI demonstration crate under `examples/gpui-counter` with unit tests and BDD tests to exercise `GpuiHarness` and `GpuiAttributePolicy` end-to-end.
- Introduces ExecPlan documentation for 9.4.5 at `docs/execplans/9-4-5-gpui-demonstration-application.md` and marks Roadmap 9.4.5 as done.
- Updates the workspace to include the new example crate and its tests, and updates related docs to reference the new example.

## Changes
### Added:
- `docs/execplans/9-4-5-gpui-demonstration-application.md` (new) detailing the ExecPlan for 9.4.5.
- `examples/gpui-counter/` with:
  - `Cargo.toml` (workspace-style setup)
  - `README.md`
  - `src/lib.rs` implementing a small CounterApp domain model with GPUI context tracking
  - `tests/counter.rs` (BDD-style tests binding to GPUI harness and context)
  - `tests/features/counter.feature` describing two scenarios
- `Cargo.lock` updated to include the new `gpui-counter` package (as part of the workspace changes).

### Updated:
- `Cargo.toml` workspace to include `examples/gpui-counter` as a member.
- `docs/roadmap.md` to reflect 9.4.5 as done (Delivered via the new GPUI demo crate).
- Documentation sections referencing the new example (in `docs/rstest-bdd-design.md` and `docs/users-guide.md`).

## Rationale
- Provides a concrete, user-facing GPUI demonstration example that exercises `GpuiHarness` and `GpuiAttributePolicy` end-to-end, mirroring existing examples (`examples/todo-cli`, `examples/japanese-ledger`).
- Formalizes the plan for a GPUI demonstration app with BDD tests and aligns Documentation with ADRs and the roadmap.

## Plan of work (Stage overview)
### Stage A: Confirm topology and baseline
- Lock down crate shape and confirm there is no hidden infrastructure constraint before writing code.
- Record baseline command health for the GPUI-focused suites.

### Stage B: Scaffold the example crate and write red tests
- Add `examples/gpui-counter` to the workspace.
- Create the crate structure and red tests that describe the intended behaviour.

### Stage C: Implement the example domain model and step bindings
- Implement `CounterApp` in `src/lib.rs` and step bindings in `tests/counter.rs`.
- Demonstrate access to `gpui::TestAppContext` via `#[from(rstest_bdd_harness_context)]`.

### Stage D: Documentation and roadmap hardening
- Update design/docs references to describe the new example, and document native setup guidance in the user guide.
- Mark 9.4.5 done in the roadmap after gates pass.

### Stage E: Full validation and cleanup
- Run focused crate checks, documentation gates, and repository-wide gates.
- Ensure the workspace passes all required quality gates.

## Interfaces and dependencies
The example crate depends on the existing GPUI integration surface and workspace GPUI shim.

Required crate dependencies:
- `gpui` as a dev-dependency (workspace)
- `rstest-bdd-harness-gpui` as a dev-dependency
- `rstest`, `rstest-bdd`, and `rstest-bdd-macros` as dev-dependencies

Expected Rust-facing interfaces:
- `CounterApp` domain model exposing minimal public API and a way to record GPUI context observations.
- A `#[scenario(...)]` binding that uses both `GpuiHarness` and `GpuiAttributePolicy`.
- Step definitions that access `gpui::TestAppContext` via `#[from(rstest_bdd_harness_context)]`.

The example should not require new extension points in `rstest-bdd-harness-gpui`; it should work with the existing interfaces.

## Revision note
- Initial draft created in the context of roadmap item 9.4.5, aligning with the GPUI plugin crates, workspace GPUI shim, and existing examples.

## Artifacts & expectations
- Final artefacts now include the `gpui-counter` crate as a workspace member with unit tests and BDD feature files.
- Documentation updates in `docs/rstest-bdd-design.md`, `docs/users-guide.md`, and `docs/roadmap.md` reflect the new example and native-setup guidance.
- Logs and gate outputs will be produced as part of CI, per the ExecPlan.

## Validation & acceptance
- The new example crate demonstrates end-to-end GPUI harness and context injection in a user-facing crate.
- The BDD suite binds both `harness = GpuiHarness` and `attributes = GpuiAttributePolicy` and shows access to `gpui::TestAppContext` in steps.
- The workspace continues to pass the standard gates (fmt, lint, docs, nixie, tests).

## Idempotence and recovery
- The changes are additive: re-running the update is safe and idempotent.
- If any gate fails, fix and re-run the gates until green.

## Artifacts and notes
- `examples/gpui-counter/` crate added as a workspace member with BDD tests and a minimal domain model.
- `docs/execplans/9-4-5-gpui-demonstration-application.md` added to describe the ExecPlan for 9.4.5.
- `docs/roadmap.md` updated to mark 9.4.5 as done.
- `docs/users-guide.md` and `docs/rstest-bdd-design.md` updated to reference the new example and native-setup guidance.
- `Cargo.lock` updated to reflect the new workspace member and its dependencies.



📎 **Task**: https://www.devboxer.com/task/a91fc017-05b1-45e2-96dc-0bd90e2e0ace