### PR TITLE
docs: update milestone wording in user guide to outcomes

### DIFF
--- a/docs/execplans/9-6-1-update-the-harness-adapter-chapter-in-the-users-guide.md
+++ b/docs/execplans/9-6-1-update-the-harness-adapter-chapter-in-the-users-guide.md
@@ -261,7 +261,7 @@ Implementation details:
 - Re-read the harness sections in `docs/users-guide.md` and
   `docs/rstest-bdd-design.md` side by side.
 - Build a checklist from the roadmap wording:
-  - delivered 9.3 work,
+  - delivered 9.3 outcomes,
   - attribute-policy wiring from 9.3.4,
   - context injection from 9.5.
 - Cross-check each claim against the current code and behavioural tests so the


### PR DESCRIPTION
## Summary
- Update milestone wording in the Harness Adapter chapter of the user guide to use "outcomes" instead of "work" for the 9.3 milestone.

## Changes
- Documentation: In docs/execplans/9-6-1-update-the-harness-adapter-chapter-in-the-users-guide.md, replace the line:
  - delivered 9.3 work,
  with:
  - delivered 9.3 outcomes,

## Rationale
- Align terminology across the user guide to reduce ambiguity and maintain consistency with other milestones and outcomes language used elsewhere in the documentation.

## Validation
- [x] Confirmed the specific wording change in the target file.
- [x] Performed a quick manual review to ensure no other instances of the old wording remain in this document.

## Impact
- No code changes. This is purely a documentation wording update.

## Additional notes
- If further terminology harmonization is planned, consider a broader pass to standardize milestone wording across the docs.

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/9ec3e7bd-f693-4017-a4e8-16144403cea4

## Summary by Sourcery

Documentation:
- Adjust Harness Adapter execution plan checklist wording to say "delivered 9.3 outcomes" instead of "delivered 9.3 work" for milestone 9.3.