### PR TITLE
ADR-008: Harness-led integration defaults

### DIFF
--- a/docs/adr-008-harness-led-attribute-policy-defaults.md
+++ b/docs/adr-008-harness-led-attribute-policy-defaults.md
@@ -196,12 +196,12 @@ class GpuiAttributePolicy {
 }
 
 class PolicyResolver {
-  +resolve(harness_path, attribute_policy_path) Result
+  +resolve(harness_path, attribute_policy_path) ResolvedAttributePolicy
 }
 
 class ScenarioMacro {
   +expand(harness_path, attribute_policy_path) TokenStream
-  +generate_test_attrs(harness_path, attribute_policy_path) Result
+  +generate_test_attrs(harness_path, attribute_policy_path) TokenStream2
 }
 
 HarnessAdapter <|.. StdHarness

--- a/docs/adr-008-harness-led-attribute-policy-defaults.md
+++ b/docs/adr-008-harness-led-attribute-policy-defaults.md
@@ -1,0 +1,256 @@
+# Architectural decision record (ADR) 008: harness-led integration defaults
+
+## Status
+
+Proposed.
+
+## Date
+
+2026-03-26.
+
+## Context and problem statement
+
+`#[scenario]` and `scenarios!` currently expose two separate integration
+parameters:
+
+- `harness = path::ToHarness`
+- `attributes = path::ToPolicy`
+
+This split is architecturally coherent because the parameters control distinct
+concerns. `harness` selects the runtime delegation boundary and any
+harness-provided context injection. `attributes` selects the test attributes
+emitted on the generated test function.
+
+In practice, first-party integrations are usually configured in matched pairs:
+
+- `TokioHarness` with `TokioAttributePolicy`
+- `GpuiHarness` with `GpuiAttributePolicy`
+
+Requiring both parameters at each call site is repetitive and invites drift
+between the runtime behaviour and the emitted test attributes. At the same
+time, the concepts are not fully interchangeable:
+
+- `harness` without `attributes` is a valid and tested configuration,
+- `attributes` without `harness` is also valid and tested, and
+- procedural macros cannot evaluate arbitrary user-defined
+  `AttributePolicy::test_attributes()` implementations at expansion time.
+
+The decision is whether to keep the current fully explicit model, to make one
+parameter subordinate to the other, or to replace both with a crate-level or
+profile-level selector.
+
+## Decision drivers
+
+- Reduce repetition in the common first-party harness configuration path.
+- Keep runtime behaviour and generated test attributes aligned by default.
+- Preserve the architectural separation introduced by ADR-005.
+- Retain support for valid `attributes`-only and `harness`-only use cases.
+- Avoid relying on compile-time reflection that Rust procedural macros do not
+  provide.
+- Keep the extension model understandable for third-party harness authors.
+
+## Options considered
+
+### Option A: keep both parameters fully explicit
+
+Retain the current surface as the canonical model and require users to spell
+both parameters whenever they want both behaviours.
+
+Pros:
+
+- Maximum explicitness at call sites.
+- No new inference rules or precedence questions.
+- Keeps the current proc-macro implementation model unchanged.
+
+Cons:
+
+- Repetitive for first-party harnesses.
+- Easy to specify a mismatched pair accidentally.
+- Makes the common case feel heavier than it needs to be.
+
+### Option B: make `harness` the lead parameter (proposed)
+
+Keep the concepts separate internally, but when `harness = ...` is present and
+`attributes = ...` is omitted, resolve a default attribute policy from the
+selected harness. An explicit `attributes = ...` continues to override the
+default.
+
+Pros:
+
+- Reduces boilerplate in the common case.
+- Treats runtime selection as the primary user decision.
+- Preserves independent `attributes`-only configuration where it is useful.
+- Avoids crate-level ambiguity by continuing to reference concrete Rust types.
+
+Cons:
+
+- Introduces inference and precedence rules that must be documented clearly.
+- Default inference can only be principled for known first-party harnesses
+  unless a stronger compile-time metadata mechanism is added later.
+- Users may assume all third-party harnesses automatically imply attributes,
+  which is not true under current proc-macro constraints.
+
+### Option C: replace both parameters with one integration selector
+
+Replace `harness = ...` and `attributes = ...` with a single selector such as
+`integration = rstest_bdd_harness_tokio` or a marker type exported by that
+crate.
+
+Pros:
+
+- Potentially the shortest user-facing syntax.
+- Presents integrations as cohesive packages.
+
+Cons:
+
+- A crate name is too coarse and becomes ambiguous once a crate exports more
+  than one harness or policy.
+- Rust macros cannot discover “the default harness” or “the default policy”
+  from an arbitrary crate without an additional explicit contract.
+- Obscures the fact that harness delegation and emitted test attributes are
+  still separate architectural concerns.
+
+| Topic                           | Option A | Option B | Option C |
+| ------------------------------- | -------- | -------- | -------- |
+| Common-case ergonomics          | Low      | High     | Medium   |
+| Explicitness                    | High     | High     | Medium   |
+| Supports `attributes`-only use  | High     | High     | Low      |
+| Supports third-party extensions | High     | Medium   | Low      |
+| Proc-macro feasibility today    | High     | High     | Low      |
+| Risk of user confusion          | Medium   | Medium   | High     |
+| Alignment of runtime and attrs  | Medium   | High     | Medium   |
+| Long-term API clarity           | High     | High     | Medium   |
+
+_Table 1: Trade-offs between configuration models for harness integrations._
+
+## Decision outcome / proposed direction
+
+Adopt Option B.
+
+The architectural model remains two concepts:
+
+- `HarnessAdapter` governs runtime delegation and harness-provided context.
+- `AttributePolicy` governs emitted test attributes.
+
+The user-facing configuration model changes to make `harness` the lead
+parameter:
+
+1. If neither parameter is specified, preserve existing default behaviour.
+2. If `harness = ...` is specified and `attributes = ...` is omitted, infer the
+   default attribute policy for that harness when one is known.
+3. If `attributes = ...` is specified explicitly, it overrides any harness-led
+   default.
+4. If `attributes = ...` is specified without `harness = ...`, preserve that
+   configuration as a supported escape hatch.
+
+For first-party harnesses, the intended defaults are:
+
+- `StdHarness` -> `DefaultAttributePolicy`
+- `TokioHarness` -> `TokioAttributePolicy`
+- `GpuiHarness` -> `GpuiAttributePolicy`
+
+This means the common Tokio and GPUI configuration can become:
+
+```rust,no_run
+use rstest_bdd_macros::scenario;
+
+#[scenario(
+    path = "tests/features/my_async.feature",
+    harness = rstest_bdd_harness_tokio::TokioHarness,
+)]
+fn my_tokio_scenario() {}
+```
+
+while still allowing an explicit override:
+
+```rust,no_run
+use rstest_bdd_macros::scenario;
+
+#[scenario(
+    path = "tests/features/my_async.feature",
+    harness = rstest_bdd_harness_tokio::TokioHarness,
+    attributes = rstest_bdd_harness::DefaultAttributePolicy,
+)]
+fn my_customized_tokio_scenario() {}
+```
+
+This ADR does not recommend crate-name-only autodiscovery. If the project wants
+a future single-knob abstraction, it should use an explicit marker type or
+profile type rather than a bare crate name.
+
+## Goals and non-goals
+
+### Goals
+
+- Make the common first-party harness path less repetitive.
+- Treat runtime selection as the primary integration choice.
+- Preserve explicit override capability for advanced cases.
+- Keep the public model understandable to third-party harness authors.
+
+### Non-goals
+
+- Introduce dynamic plug-in discovery from dependency metadata.
+- Infer arbitrary third-party attribute policies from trait methods at macro
+  expansion time.
+- Remove support for `attributes`-only configuration.
+- Collapse `HarnessAdapter` and `AttributePolicy` into one trait.
+
+## Migration plan
+
+1. Extend policy-resolution support with harness-to-policy hints.
+   Goal: provide one canonical place for first-party harness defaults.
+   Deliverables:
+   - Add harness-path hint resolution alongside existing policy-path hint
+     resolution.
+   - Document precedence between explicit `attributes`, inferred harness
+     defaults, and legacy runtime compatibility behaviour.
+
+2. Update macro code generation.
+   Goal: let `generate_test_attrs` resolve policy hints from the selected
+   harness when `attributes` is omitted. Deliverables:
+   - Resolve a first-party default policy hint from known harness paths.
+   - Keep explicit `attributes = ...` authoritative.
+   - Preserve current deduplication rules for emitted test attributes.
+
+3. Update user-facing documentation and behavioural coverage.
+   Goal: make the preferred configuration obvious and verify it end to end.
+   Deliverables:
+   - Update the user guide and design document examples to lead with
+     harness-only configuration for first-party integrations.
+   - Add tests covering harness-led default attribute resolution and explicit
+     override behaviour.
+
+## Known risks and limitations
+
+- Default inference is only robust for known first-party harness paths under
+  the current proc-macro trust model.
+- Third-party harness authors may expect inference to work automatically; the
+  documentation must state clearly when explicit `attributes = ...` is still
+  required.
+- If a harness crate later exposes multiple harness types with different
+  policies, the mapping must remain type-specific rather than crate-wide.
+- The legacy `runtime = "tokio-current-thread"` compatibility path must retain
+  a clear precedence relationship with harness-led defaults.
+
+## Outstanding decisions
+
+- Whether harness-to-policy mapping should live in `rstest-bdd-policy` beside
+  policy-path hints, or in a dedicated helper module.
+- Whether future third-party integrations should opt into inference through a
+  marker type path, a registration macro, or remain explicit-only.
+- Whether a later “integration profile” syntax is worth adding once the
+  harness-led default model has settled.
+
+## Architectural rationale
+
+This direction keeps the clean boundary introduced by ADR-005: runtime
+delegation and emitted test attributes remain separate responsibilities. It
+improves ergonomics by defaulting the secondary concern from the primary one,
+which is usually what users mean when they choose a harness.
+
+Using `harness` as the lead parameter is also the better fit for Rust’s
+proc-macro constraints. The macro can validate trait bounds for arbitrary
+types, but it cannot evaluate arbitrary trait methods at expansion time. Known
+first-party harness mappings are therefore a pragmatic middle ground: they
+reduce repetition without pretending that macros can auto-discover semantic
+defaults from arbitrary crates.

--- a/docs/adr-008-harness-led-attribute-policy-defaults.md
+++ b/docs/adr-008-harness-led-attribute-policy-defaults.md
@@ -149,6 +149,68 @@ For first-party harnesses, the intended defaults are:
 - `TokioHarness` -> `TokioAttributePolicy`
 - `GpuiHarness` -> `GpuiAttributePolicy`
 
+For screen readers: The following class diagram shows the separation between
+the `HarnessAdapter` and `AttributePolicy` traits, the first-party harness and
+policy implementations, and the way `ScenarioMacro` delegates default-policy
+selection to `PolicyResolver`.
+
+```mermaid
+classDiagram
+
+class HarnessAdapter {
+  <<trait>>
+  +Context Context
+}
+
+class AttributePolicy {
+  <<trait>>
+  +test_attributes() Result
+}
+
+class StdHarness {
+}
+class TokioHarness {
+}
+class GpuiHarness {
+}
+
+class DefaultAttributePolicy {
+}
+class TokioAttributePolicy {
+}
+class GpuiAttributePolicy {
+}
+
+class PolicyResolver {
+  +resolve(harness_path, attribute_policy_path) Result
+}
+
+class ScenarioMacro {
+  +expand(harness_path, attribute_policy_path) TokenStream
+  +generate_test_attrs(harness_path, attribute_policy_path) Result
+}
+
+HarnessAdapter <|.. StdHarness
+HarnessAdapter <|.. TokioHarness
+HarnessAdapter <|.. GpuiHarness
+
+AttributePolicy <|.. DefaultAttributePolicy
+AttributePolicy <|.. TokioAttributePolicy
+AttributePolicy <|.. GpuiAttributePolicy
+
+ScenarioMacro --> PolicyResolver : uses
+
+PolicyResolver --> AttributePolicy : selects_default
+PolicyResolver --> HarnessAdapter : reads_harness_type
+
+StdHarness --> DefaultAttributePolicy : default_policy
+TokioHarness --> TokioAttributePolicy : default_policy
+GpuiHarness --> GpuiAttributePolicy : default_policy
+```
+
+_Figure 1: Harness-led default policy resolution between the macro layer,
+resolver, harness types, and attribute-policy types._
+
 This means the common Tokio and GPUI configuration can become:
 
 ```rust,no_run

--- a/docs/adr-008-harness-led-attribute-policy-defaults.md
+++ b/docs/adr-008-harness-led-attribute-policy-defaults.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-Proposed.
+Proposed
 
 ## Date
 
-2026-03-26.
+2026-03-26
 
 ## Context and problem statement
 

--- a/docs/adr-008-harness-led-attribute-policy-defaults.md
+++ b/docs/adr-008-harness-led-attribute-policy-defaults.md
@@ -178,7 +178,7 @@ class HarnessAdapter {
 
 class AttributePolicy {
   <<trait>>
-  +test_attributes() Result
+  +test_attributes() &'static [TestAttribute]
 }
 
 class StdHarness {

--- a/docs/adr-008-harness-led-attribute-policy-defaults.md
+++ b/docs/adr-008-harness-led-attribute-policy-defaults.md
@@ -143,6 +143,20 @@ parameter:
 4. If `attributes = ...` is specified without `harness = ...`, preserve that
    configuration as a supported escape hatch.
 
+The exact precedence rules are:
+
+1. An explicit `attributes = ...` selection always wins.
+2. Otherwise, if an explicit `harness = ...` selection resolves to a known
+   first-party harness mapping, use that harness-led default policy.
+3. Otherwise, if the deprecated `runtime = "tokio-current-thread"`
+   compatibility alias is active, use its Tokio current-thread hint.
+4. Otherwise, fall back to the existing runtime-mode or synchronous default
+   behaviour.
+
+If both an explicit harness and the deprecated runtime alias are present, the
+explicit harness remains authoritative; the runtime alias contributes only its
+deprecation signal and does not change attribute selection.
+
 For first-party harnesses, the intended defaults are:
 
 - `StdHarness` -> `DefaultAttributePolicy`

--- a/docs/execplans/9-6-1-update-the-harness-adapter-chapter-in-the-users-guide.md
+++ b/docs/execplans/9-6-1-update-the-harness-adapter-chapter-in-the-users-guide.md
@@ -11,14 +11,13 @@ ExecPlan is the governing plan for roadmap item 9.6.1.
 
 ## Purpose / big picture
 
-Roadmap item 9.6.1 closes the documentation gap left after phases 9.3, 9.4,
-and 9.5 delivered the harness adapter core, Tokio and Graphical Processing
-User Interface (GPUI) opt-in crates, path-based attribute-policy wiring, and
-`HarnessAdapter::Context` injection.
-The current harness chapter in the user guide and the corresponding design-doc
-sections already mention parts of that work, but the narrative is split across
-multiple passages and does not yet present the delivered model as one coherent
-story.
+Roadmap item 9.6.1 closes the documentation gap left after phases 9.3, 9.4, and
+9.5 delivered the harness adapter core, Tokio and Graphical Processing User
+Interface (GPUI) opt-in crates, path-based attribute-policy wiring, and
+`HarnessAdapter::Context` injection. The current harness chapter in the user
+guide and the corresponding design-doc sections already mention parts of that
+work, but the narrative is split across multiple passages and does not yet
+present the delivered model as one coherent story.
 
 After this work:
 
@@ -27,17 +26,17 @@ After this work:
   compatibility-alias behaviour, and `Context`-based fixture injection.
 - `docs/rstest-bdd-design.md` records the delivered architecture and any
   design decisions taken while tightening the documentation around
-  Architectural Decision Record (ADR) 005, ADR-007, and the 9.3.4 codegen
-  trust model.
+  Architectural Decision Record (ADR) 005, ADR-007, and the 9.3.4 codegen trust
+  model.
 - Unit tests and behavioural tests validate any examples, emitted attributes,
   and end-to-end documentation claims introduced while updating the docs.
 - `docs/roadmap.md` marks 9.6.1 done only after the documentation, tests, and
   required quality gates all pass.
 
-Success is observable when a reader can follow one authoritative chapter in
-the user guide from `harness = ...` and `attributes = ...` configuration
-through to context injection and framework-specific examples, and when the
-quality gates pass: `make check-fmt`, `make lint`, and `make test`.
+Success is observable when a reader can follow one authoritative chapter in the
+user guide from `harness = ...` and `attributes = ...` configuration through to
+context injection and framework-specific examples, and when the quality gates
+pass: `make check-fmt`, `make lint`, and `make test`.
 
 ## Constraints
 
@@ -46,8 +45,8 @@ quality gates pass: `make check-fmt`, `make lint`, and `make test`.
 - Treat 9.5.3 as delivered and document the current `HarnessAdapter::Context`
   contract, not speculative alternatives.
 - Keep ADR-005 boundaries intact: framework-specific details belong in opt-in
-  crates and documentation must not imply that Tokio or GPUI are built into
-  the core runtime.
+  crates and documentation must not imply that Tokio or GPUI are built into the
+  core runtime.
 - Preserve the documented 9.3.4 trust model: attribute-policy resolution is
   path-based during macro expansion, not arbitrary trait-method execution on
   user types.
@@ -74,8 +73,7 @@ quality gates pass: `make check-fmt`, `make lint`, and `make test`.
   public Rust API changes, stop and split that into a separate implementation
   task.
 - Validation: if `make check-fmt`, `make lint`, or `make test` fails for
-  unrelated reasons, capture logs and stop before marking the roadmap item
-  done.
+  unrelated reasons, capture logs and stop before marking the roadmap item done.
 - Iterations: if the same gate fails three consecutive fix attempts, stop and
   escalate with the recorded log path.
 - Ambiguity: if the user guide, design doc, ADRs, and implementation disagree
@@ -171,10 +169,10 @@ quality gates pass: `make check-fmt`, `make lint`, and `make test`.
 Delivered outcomes for 9.6.1:
 
 - Reworked the harness-adapter guidance in `docs/users-guide.md` so it now
-  presents explicit `harness = ...` and `attributes = ...` configuration as
-  the canonical path, documents the Tokio compatibility alias as deprecated
-  legacy syntax, and calls out the current first-party policy-resolution trust
-  model for Tokio and GPUI.
+  presents explicit `harness = ...` and `attributes = ...` configuration as the
+  canonical path, documents the Tokio compatibility alias as deprecated legacy
+  syntax, and calls out the current first-party policy-resolution trust model
+  for Tokio and GPUI.
 - Updated `docs/users-guide.md` custom-harness material to explain
   `HarnessAdapter::Context`, `rstest_bdd_harness_context`, and the current
   limitation for third-party attribute-policy paths during macro expansion.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -618,26 +618,30 @@ opt-in crates rather than the core runtime or macros.
 
 ### 9.7. Harness-led attribute-policy defaults
 
+These items are gated on ADR-008 being accepted. While
+`docs/adr-008-harness-led-attribute-policy-defaults.md` remains in `Proposed`
+status, treat the tasks below as contingent planning items rather than active
+implementation commitments.
+
 - [ ] 9.7.1. Extend first-party policy hint resolution so known harness paths
   can imply default test-attribute hints when `attributes = ...` is omitted.
   Add canonical mappings for `StdHarness`, `TokioHarness`, and `GpuiHarness`,
-  and document precedence against explicit `attributes = ...` and the
-  deprecated `runtime = "tokio-current-thread"` compatibility alias. Finish
-  line: shared helpers resolve the same hint from either the first-party
-  harness path or the first-party attribute-policy path, with unit tests for
-  unknown third-party paths and precedence edge cases. Prerequisite: ADR-008
-  accepted; 9.3.4 and 9.4.4 delivered. Design Doc:
+  and implement the precedence rules defined in ADR-008. Finish line: shared
+  helpers resolve the same hint from either the first-party harness path or the
+  first-party attribute-policy path, with unit tests for unknown third-party
+  paths and precedence edge cases. Prerequisite: ADR-008 accepted; 9.3.4 and
+  9.4.4 delivered. Design Doc:
   `docs/adr-008-harness-led-attribute-policy-defaults.md`,
   `docs/rstest-bdd-design.md` §2.7.3. (Pandalump)
 - [ ] 9.7.2. Update `#[scenario]` and `scenarios!` code generation so
   first-party harnesses imply their default attribute policies when
   `attributes = ...` is omitted, while explicit `attributes = ...` remains
   authoritative. Preserve `attributes`-only configuration, harness-only
-  configuration, current attribute de-duplication rules, and the deprecated
-  Tokio runtime-alias semantics. Finish line: generated test attributes for
-  `StdHarness`, `TokioHarness`, and `GpuiHarness` match their first-party
-  defaults without requiring paired `attributes = ...`, and explicit override
-  scenarios still expand correctly. Prerequisite: 9.7.1. Design Doc:
+  configuration, current attribute de-duplication rules, and the ADR-008
+  precedence order. Finish line: generated test attributes for `StdHarness`,
+  `TokioHarness`, and `GpuiHarness` match their first-party defaults without
+  requiring paired `attributes = ...`, and explicit override scenarios still
+  expand correctly. Prerequisite: 9.7.1. Design Doc:
   `docs/adr-008-harness-led-attribute-policy-defaults.md`,
   `docs/rstest-bdd-design.md` §2.7.3. (Pandalump, Doggylump)
 - [ ] 9.7.3. Add unit, trybuild, and behavioural coverage for harness-led

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -615,3 +615,45 @@ opt-in crates rather than the core runtime or macros.
   custom `HarnessAdapter` (for example, `rstest-bdd-harness-bevy`), including
   the `Context` type, attribute policy, and `Cargo.toml` configuration. Finish
   line: cookbook section in the user guide with a working example. (Dinolump)
+
+### 9.7. Harness-led attribute-policy defaults
+
+- [ ] 9.7.1. Extend first-party policy hint resolution so known harness paths
+  can imply default test-attribute hints when `attributes = ...` is omitted.
+  Add canonical mappings for `StdHarness`, `TokioHarness`, and `GpuiHarness`,
+  and document precedence against explicit `attributes = ...` and the
+  deprecated `runtime = "tokio-current-thread"` compatibility alias. Finish
+  line: shared helpers resolve the same hint from either the first-party
+  harness path or the first-party attribute-policy path, with unit tests for
+  unknown third-party paths and precedence edge cases. Prerequisite: ADR-008
+  accepted; 9.3.4 and 9.4.4 delivered. Design Doc:
+  `docs/adr-008-harness-led-attribute-policy-defaults.md`,
+  `docs/rstest-bdd-design.md` §2.7.3. (Pandalump)
+- [ ] 9.7.2. Update `#[scenario]` and `scenarios!` code generation so
+  first-party harnesses imply their default attribute policies when
+  `attributes = ...` is omitted, while explicit `attributes = ...` remains
+  authoritative. Preserve `attributes`-only configuration, harness-only
+  configuration, current attribute de-duplication rules, and the deprecated
+  Tokio runtime-alias semantics. Finish line: generated test attributes for
+  `StdHarness`, `TokioHarness`, and `GpuiHarness` match their first-party
+  defaults without requiring paired `attributes = ...`, and explicit override
+  scenarios still expand correctly. Prerequisite: 9.7.1. Design Doc:
+  `docs/adr-008-harness-led-attribute-policy-defaults.md`,
+  `docs/rstest-bdd-design.md` §2.7.3. (Pandalump, Doggylump)
+- [ ] 9.7.3. Add unit, trybuild, and behavioural coverage for harness-led
+  defaults and explicit overrides across the first-party harnesses. Cover
+  harness-only scenarios, explicit override scenarios, attributes-only
+  scenarios, and unknown third-party harness paths where relevant. Finish line:
+  tests prove that harness-only Tokio and GPUI scenarios receive their
+  first-party test attributes when the generated signature permits it, explicit
+  overrides win, and `attributes`-only behaviour remains unchanged.
+  Prerequisite: 9.7.2. Design Doc:
+  `docs/adr-008-harness-led-attribute-policy-defaults.md`. (Buzzy Bee)
+- [ ] 9.7.4. Update the user guide, design document, and first-party example
+  prose to lead with harness-only configuration once the default-inference
+  behaviour lands. Retain `attributes = ...` as an override pattern and keep
+  the current third-party caveats explicit. Finish line: `docs/users-guide.md`
+  and `docs/rstest-bdd-design.md` recommend harness-led defaults for the
+  first-party integrations, examples no longer require both parameters by
+  default, and `make markdownlint` passes. Prerequisite: 9.7.3. Design Doc:
+  `docs/adr-008-harness-led-attribute-policy-defaults.md`. (Dinolump)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -600,15 +600,15 @@ opt-in crates rather than the core runtime or macros.
 ### 9.6. Documentation and validation
 
 - [x] 9.6.1. Update the harness adapter chapter in the user guide and design
-  docs to reflect delivered 9.3 outcomes, the attribute policy wiring
-  (9.3.4), and the context injection mechanism (9.5). Finish line:
-  `docs/users-guide.md` now leads with explicit harness and attribute-policy
-  configuration, documents the Tokio compatibility alias as deprecated legacy
-  syntax, records `rstest_bdd_harness_context`-based context injection, and
-  clarifies the current first-party policy-resolution trust model for Tokio
-  and GPUI. `docs/rstest-bdd-design.md` records the delivered architecture
-  and validation surface, and `make check-fmt`, `make lint`, and `make test`
-  pass. Prerequisite: 9.5.3. Delivered 2026-03-22. (Pandalump)
+  docs to reflect delivered 9.3 outcomes, the attribute policy wiring (9.3.4),
+  and the context injection mechanism (9.5). Finish line: `docs/users-guide.md`
+  now leads with explicit harness and attribute-policy configuration, documents
+  the Tokio compatibility alias as deprecated legacy syntax, records
+  `rstest_bdd_harness_context`-based context injection, and clarifies the
+  current first-party policy-resolution trust model for Tokio and GPUI.
+  `docs/rstest-bdd-design.md` records the delivered architecture and validation
+  surface, and `make check-fmt`, `make lint`, and `make test` pass.
+  Prerequisite: 9.5.3. Delivered 2026-03-22. (Pandalump)
 - [ ] 9.6.2. Add integration tests covering attribute policy resolution for
   GPUI once 9.4 is delivered. Prerequisite: 9.4.3. (Pandalump)
 - [ ] 9.6.3. Add a third-party harness cookbook documenting how to write a


### PR DESCRIPTION
## Summary
- Introduces Architectural Decision Record (ADR) 008: harness-led integration defaults.
- Establishes a two-concept model where HarnessAdapter governs runtime behavior and AttributePolicy governs emitted test attributes, with harness acting as the lead configuration parameter.
- Defines default attribute policies for first-party harnesses and a precedence for overriding with explicit attributes.
- Updates documentation to reflect the new ergonomic pattern and guidance for first-party vs. third-party usage.
- Extends the roadmap with 9.7 harness-led defaults planning and related tasks.

## Changes
- Added: docs/adr-008-harness-led-attribute-policy-defaults.md
  - Documents the rationale, decision drivers, options considered, and the chosen path (Option B).
  - Details the new lead-parameter model and the default policy inferences for known first-party harnesses.
  - Provides examples for common configurations and explicit overrides.
- Updated: docs/execplans/9-6-1-update-the-harness-adapter-chapter-in-the-users-guide.md
  - Refines the narrative to present the canonical harness-based configuration flow and clarifies the relationship between HarnessAdapter and Context injection.
  - Clarifies the scope of first-party policy-resolution and usage with harness-led defaults.
- Updated: docs/roadmap.md
  - Reflects the updated 9.6.1 deliverables: harness-adapter guidance, explicit harness+attribute-policy configuration as canonical path, deprecation notes for legacy Tokio alias, and the first-party policy-resolution trust model for Tokio and GPUI.
  - Sets expectations for future validation gates (fmt, lint, test) and the prerequisite 9.5.3 delivery.
+  - Adds a new 9.7 milestone: Harness-led attribute-policy defaults, with detailed planning items.

## Rationale and design decisions
- Opted for Option B: make harness the lead parameter and infer a default AttributePolicy from the selected harness when attributes are omitted.
- Benefits:
  - Reduces boilerplate in common first-party harness configurations.
  - Keeps runtime behaviour and emitted test attributes aligned by default.
  - Preserves explicit control via explicit attributes when needed.
  - Maintains a clear separation between HarnessAdapter (runtime) and AttributePolicy (test attributes).
- Default mappings for known first-party harnesses:
  - StdHarness -> DefaultAttributePolicy
  - TokioHarness -> TokioAttributePolicy
  - GpuiHarness -> GpuiAttributePolicy

## How to use (examples)
- Tokio example with harness-led default and explicit override
  ```rust,no_run
  use rstest_bdd_macros::scenario;

  #[scenario(
      path = "tests/features/my_async.feature",
      harness = rstest_bdd_harness_tokio::TokioHarness,
  )]
  fn my_tokio_scenario() {}
  ```
+
- Tokio example with explicit attribute policy override
  ```rust,no_run
  use rstest_bdd_macros::scenario;

  #[scenario(
      path = "tests/features/my_async.feature",
      harness = rstest_bdd_harness_tokio::TokioHarness,
      attributes = rstest_bdd_harness::DefaultAttributePolicy,
  )]
  fn my_customized_tokio_scenario() {}
  ```
+
- If you only specify attributes (escape hatch), you may omit harness:
  ```rust,no_run
  use rstest_bdd_macros::scenario;

  #[scenario(
      path = "tests/features/my_async.feature",
      attributes = rstest_bdd_harness::DefaultAttributePolicy,
  )]
  fn my_scenario_with_only_attributes() {}
  ```

## Migration plan
1) Extend policy-resolution with harness-to-policy hints; provide a canonical place for first-party defaults.
2) Update macro code generation to let generate_test_attrs resolve policy hints from the selected harness when attributes are omitted; keep explicit attributes authoritative.
3) Update user-facing docs and tests:
   - Lead with harness-only configuration for first-party integrations.
   - Add tests for harness-led default attribute resolution and explicit overrides.
   - Ensure compatibility notes are clear for existing users.

## Backwards compatibility and gotchas
- If neither parameter is specified, existing default behaviour remains.
- If attributes are specified without a harness, that configuration remains supported as an escape hatch.
- Third-party harness authors should not assume automatic inference for their crates; explicit attributes may still be required.

## Validation plan
- Update unit and behavioural tests to cover:
  - Harness-led default attribute resolution for known first-party harnesses.
  - Explicit override precedence when both harness and attributes are provided.
  - Attributes-only usage still permitted as an escape hatch.
- Documentation checks to ensure consistency with ADR-008 guidance and examples.

## Related context
- ADR-005: Separation of runtime (HarnessAdapter) and emitted attributes (AttributePolicy).
- ADR-007: Existing path-based policy-resolution model and macro expansion behaviour.

## References
- ADR-008: harness-led integration defaults (new)
- Roadmap 9.6: harness adapter improvements and documentation alignment

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

📎 **Task**: https://www.devboxer.com/task/6f5f9d46-6371-4990-a626-ae384126355b