### PR TITLE
GPUI attribute-policy tests: canonical/absolute paths (9.6.2)

### DIFF
--- a/crates/rstest-bdd/tests/features/gpui_harness_policy_scenarios/harness_context.feature
+++ b/crates/rstest-bdd/tests/features/gpui_harness_policy_scenarios/harness_context.feature
@@ -1,5 +1,6 @@
 Feature: GPUI harness with attribute policy via scenarios macro
 
   Scenario: GPUI harness provides context through scenarios macro
-    Given a GPUI test context can be accessed
+    Given a GPUI test is running
+    When I access the GPUI test context
     Then the GPUI test context is valid

--- a/crates/rstest-bdd/tests/features/gpui_harness_policy_scenarios/harness_context.feature
+++ b/crates/rstest-bdd/tests/features/gpui_harness_policy_scenarios/harness_context.feature
@@ -1,0 +1,5 @@
+Feature: GPUI harness with attribute policy via scenarios macro
+
+  Scenario: GPUI harness provides context through scenarios macro
+    Given a GPUI test context can be accessed
+    Then the GPUI test context is valid

--- a/crates/rstest-bdd/tests/features/gpui_policy_scenarios/policy.feature
+++ b/crates/rstest-bdd/tests/features/gpui_policy_scenarios/policy.feature
@@ -2,4 +2,4 @@ Feature: GPUI policy scenarios macro integration
 
   Scenario: GPUI scenarios macro attribute policy runs
     Given a GPUI scenarios macro policy run starts
-    Then the GPUI scenarios macro policy run completed
+    Then the GPUI scenarios macro policy run completes

--- a/crates/rstest-bdd/tests/features/gpui_policy_scenarios/policy.feature
+++ b/crates/rstest-bdd/tests/features/gpui_policy_scenarios/policy.feature
@@ -1,0 +1,5 @@
+Feature: GPUI policy scenarios macro integration
+
+  Scenario: GPUI scenarios macro attribute policy runs
+    Given a GPUI scenarios macro policy run starts
+    Then the GPUI scenarios macro policy run completed

--- a/crates/rstest-bdd/tests/fixtures_macros/scenario_attributes_gpui.rs
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenario_attributes_gpui.rs
@@ -1,0 +1,23 @@
+//! Compile-pass fixture validating that `#[scenario]` resolves the canonical
+//! GPUI attribute-policy path.
+use rstest_bdd_macros::{given, scenario, then, when};
+
+#[given("a precondition")]
+fn precondition() {}
+
+#[when("an action occurs")]
+fn action() {}
+
+#[then("a result is produced")]
+fn result() {}
+
+#[scenario(
+    path = "basic.feature",
+    attributes = rstest_bdd_harness_gpui::GpuiAttributePolicy,
+)]
+async fn with_gpui_attributes_policy() {}
+
+// Compile-time guard: fail fast if the feature path changes.
+const _: &str = include_str!("basic.feature");
+
+fn main() {}

--- a/crates/rstest-bdd/tests/fixtures_macros/scenario_attributes_gpui_absolute.rs
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenario_attributes_gpui_absolute.rs
@@ -1,0 +1,23 @@
+//! Compile-pass fixture validating that `#[scenario]` resolves the absolute
+//! first-party GPUI attribute-policy path.
+use rstest_bdd_macros::{given, scenario, then, when};
+
+#[given("a precondition")]
+fn precondition() {}
+
+#[when("an action occurs")]
+fn action() {}
+
+#[then("a result is produced")]
+fn result() {}
+
+#[scenario(
+    path = "basic.feature",
+    attributes = ::rstest_bdd_harness_gpui::GpuiAttributePolicy,
+)]
+async fn with_absolute_gpui_attributes_policy() {}
+
+// Compile-time guard: fail fast if the feature path changes.
+const _: &str = include_str!("basic.feature");
+
+fn main() {}

--- a/crates/rstest-bdd/tests/fixtures_macros/scenarios_attributes_gpui.rs
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenarios_attributes_gpui.rs
@@ -1,0 +1,19 @@
+//! Compile-pass fixture validating that `scenarios!` accepts the canonical
+//! GPUI attribute-policy path.
+use rstest_bdd_macros::{given, scenarios, then, when};
+
+#[given("a precondition")]
+fn precondition() {}
+
+#[when("an action occurs")]
+fn action() {}
+
+#[then("a result is produced")]
+fn result() {}
+
+scenarios!(
+    "tests/features/auto",
+    attributes = rstest_bdd_harness_gpui::GpuiAttributePolicy,
+);
+
+fn main() {}

--- a/crates/rstest-bdd/tests/scenario_harness_gpui.rs
+++ b/crates/rstest-bdd/tests/scenario_harness_gpui.rs
@@ -2,13 +2,14 @@
 //! adapter and attribute policy from `rstest-bdd-harness-gpui`.
 #![cfg(feature = "gpui-harness-tests")]
 
-use rstest_bdd_macros::{given, scenario, then, when};
+use rstest_bdd_macros::{given, scenario, scenarios, then, when};
 use serial_test::serial;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 static CONTEXT_POINTER: AtomicUsize = AtomicUsize::new(0);
 static CONTEXT_MUTATED: AtomicBool = AtomicBool::new(false);
 static GPUI_POLICY_RAN: AtomicBool = AtomicBool::new(false);
+static GPUI_SCENARIOS_MACRO_RAN: AtomicBool = AtomicBool::new(false);
 
 #[expect(
     clippy::unnecessary_wraps,
@@ -72,6 +73,20 @@ fn plain_gpui_policy_scenario_completed() {
     GPUI_POLICY_RAN.store(false, Ordering::SeqCst);
 }
 
+#[given("a GPUI scenarios macro policy run starts")]
+fn gpui_scenarios_macro_policy_run_starts() {
+    GPUI_SCENARIOS_MACRO_RAN.store(true, Ordering::SeqCst);
+}
+
+#[then("the GPUI scenarios macro policy run completed")]
+fn gpui_scenarios_macro_policy_run_completed() {
+    assert!(
+        GPUI_SCENARIOS_MACRO_RAN.load(Ordering::SeqCst),
+        "scenarios! should execute under the GPUI attribute policy"
+    );
+    GPUI_SCENARIOS_MACRO_RAN.store(false, Ordering::SeqCst);
+}
+
 #[scenario(
     path = "tests/features/gpui_harness.feature",
     name = "GPUI harness injects TestAppContext",
@@ -96,3 +111,17 @@ fn scenario_gpui_harness_with_attribute_policy() {}
 )]
 #[serial]
 fn scenario_gpui_attribute_policy_without_harness() {}
+
+#[scenario(
+    path = "tests/features/gpui_harness.feature",
+    name = "GPUI attribute policy runs without harness",
+    attributes = rstest_bdd_harness_gpui::GpuiAttributePolicy,
+)]
+#[gpui::test]
+#[serial]
+fn scenario_gpui_attribute_policy_dedup() {}
+
+scenarios!(
+    "tests/features/gpui_policy_scenarios",
+    attributes = rstest_bdd_harness_gpui::GpuiAttributePolicy,
+);

--- a/crates/rstest-bdd/tests/scenario_harness_gpui.rs
+++ b/crates/rstest-bdd/tests/scenario_harness_gpui.rs
@@ -80,11 +80,44 @@ fn gpui_scenarios_macro_policy_run_starts() {
 
 #[then("the GPUI scenarios macro policy run completed")]
 fn gpui_scenarios_macro_policy_run_completed() {
+    // NOTE: This is a minimal runtime smoke test verifying that scenarios! with
+    // GPUI attribute policy can execute steps. The attribute-policy application itself
+    // is verified by the corresponding trybuild compile-pass fixture at
+    // crates/rstest-bdd/tests/fixtures_macros/scenarios_attributes_gpui.rs, which
+    // ensures the generated code compiles with #[gpui::test] attributes.
+    // A stronger runtime assertion would require accessing GPUI-specific state
+    // (e.g., TestAppContext), which is only available when using GpuiHarness,
+    // not when using GpuiAttributePolicy alone.
     assert!(
         GPUI_SCENARIOS_MACRO_RAN.load(Ordering::SeqCst),
         "scenarios! should execute under the GPUI attribute policy"
     );
     GPUI_SCENARIOS_MACRO_RAN.store(false, Ordering::SeqCst);
+}
+
+#[given("a GPUI test context can be accessed")]
+fn gpui_test_context_can_be_accessed(
+    #[from(rstest_bdd_harness_context)] context: &gpui::TestAppContext,
+) {
+    // This step verifies GPUI-specific behaviour: the harness must inject a TestAppContext,
+    // and the attribute policy must emit #[gpui::test] to provide the GPUI test infrastructure.
+    // If either were missing, this parameter injection would fail.
+    assert!(
+        context.dispatcher().seed() == 0,
+        "GPUI TestAppContext should be injected with default seed"
+    );
+}
+
+#[then("the GPUI test context is valid")]
+fn gpui_test_context_is_valid(#[from(rstest_bdd_harness_context)] context: &gpui::TestAppContext) {
+    // Verify we can access GPUI-specific functionality. This assertion would fail
+    // if GpuiAttributePolicy were not correctly applied, because without #[gpui::test]
+    // the GPUI test infrastructure wouldn't be available to create the TestAppContext.
+    assert_eq!(
+        context.dispatcher().seed(),
+        0,
+        "GPUI TestAppContext dispatcher should have expected seed value"
+    );
 }
 
 #[scenario(
@@ -123,5 +156,11 @@ fn scenario_gpui_attribute_policy_dedup() {}
 
 scenarios!(
     "tests/features/gpui_policy_scenarios",
+    attributes = rstest_bdd_harness_gpui::GpuiAttributePolicy,
+);
+
+scenarios!(
+    "tests/features/gpui_harness_policy_scenarios",
+    harness = rstest_bdd_harness_gpui::GpuiHarness,
     attributes = rstest_bdd_harness_gpui::GpuiAttributePolicy,
 );

--- a/crates/rstest-bdd/tests/scenario_harness_gpui.rs
+++ b/crates/rstest-bdd/tests/scenario_harness_gpui.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 static CONTEXT_POINTER: AtomicUsize = AtomicUsize::new(0);
 static CONTEXT_MUTATED: AtomicBool = AtomicBool::new(false);
 static GPUI_POLICY_RAN: AtomicBool = AtomicBool::new(false);
-static GPUI_SCENARIOS_MACRO_RAN: AtomicBool = AtomicBool::new(false);
+static GPUI_SCENARIOS_MACRO_RUN_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 #[expect(
     clippy::unnecessary_wraps,
@@ -75,11 +75,11 @@ fn plain_gpui_policy_scenario_completed() {
 
 #[given("a GPUI scenarios macro policy run starts")]
 fn gpui_scenarios_macro_policy_run_starts() {
-    GPUI_SCENARIOS_MACRO_RAN.store(true, Ordering::SeqCst);
+    GPUI_SCENARIOS_MACRO_RUN_COUNT.fetch_add(1, Ordering::SeqCst);
 }
 
-#[then("the GPUI scenarios macro policy run completed")]
-fn gpui_scenarios_macro_policy_run_completed() {
+#[then("the GPUI scenarios macro policy run completes")]
+fn gpui_scenarios_macro_policy_run_completes() {
     // NOTE: This is a minimal runtime smoke test verifying that scenarios! with
     // GPUI attribute policy can execute steps. The attribute-policy application itself
     // is verified by the corresponding trybuild compile-pass fixture at
@@ -89,10 +89,18 @@ fn gpui_scenarios_macro_policy_run_completed() {
     // (e.g., TestAppContext), which is only available when using GpuiHarness,
     // not when using GpuiAttributePolicy alone.
     assert!(
-        GPUI_SCENARIOS_MACRO_RAN.load(Ordering::SeqCst),
+        GPUI_SCENARIOS_MACRO_RUN_COUNT.load(Ordering::SeqCst) > 0,
         "scenarios! should execute under the GPUI attribute policy"
     );
-    GPUI_SCENARIOS_MACRO_RAN.store(false, Ordering::SeqCst);
+}
+
+/// Asserts that a GPUI `TestAppContext` has the expected default seed value.
+fn assert_gpui_context_seed_default(context: &gpui::TestAppContext) {
+    assert_eq!(
+        context.dispatcher().seed(),
+        0,
+        "GPUI TestAppContext should have default seed value"
+    );
 }
 
 #[given("a GPUI test is running")]
@@ -110,13 +118,8 @@ fn i_access_the_gpui_test_context(
     // proves that GpuiHarness is active. We verify GPUI-specific properties to ensure
     // the infrastructure is working correctly.
 
-    // Access GPUI-specific API: dispatcher() is unique to GPUI's TestAppContext
-    let dispatcher = context.dispatcher();
-    assert_eq!(
-        dispatcher.seed(),
-        0,
-        "GPUI dispatcher should provide seed value"
-    );
+    // Verify GPUI-specific invariant: default seed value
+    assert_gpui_context_seed_default(context);
 
     // Access another GPUI-specific API: executor() returns BackgroundExecutor
     let _executor = context.executor();
@@ -130,11 +133,7 @@ fn gpui_test_context_is_valid(#[from(rstest_bdd_harness_context)] context: &gpui
     // (which emits #[gpui::test] to provide GPUI infrastructure) are correctly applied.
 
     // Verify the context has GPUI-specific properties
-    assert_eq!(
-        context.dispatcher().seed(),
-        0,
-        "GPUI TestAppContext should have default seed value"
-    );
+    assert_gpui_context_seed_default(context);
 
     // Verify we can access GPUI-specific methods
     assert!(

--- a/crates/rstest-bdd/tests/scenario_harness_gpui.rs
+++ b/crates/rstest-bdd/tests/scenario_harness_gpui.rs
@@ -95,28 +95,51 @@ fn gpui_scenarios_macro_policy_run_completed() {
     GPUI_SCENARIOS_MACRO_RAN.store(false, Ordering::SeqCst);
 }
 
-#[given("a GPUI test context can be accessed")]
-fn gpui_test_context_can_be_accessed(
+#[given("a GPUI test is running")]
+fn gpui_test_is_running() {
+    // This step simply establishes the precondition that we're in a GPUI test context.
+    // The actual verification happens in the When and Then steps.
+}
+
+#[when("I access the GPUI test context")]
+fn i_access_the_gpui_test_context(
     #[from(rstest_bdd_harness_context)] context: &gpui::TestAppContext,
 ) {
-    // This step verifies GPUI-specific behaviour: the harness must inject a TestAppContext,
-    // and the attribute policy must emit #[gpui::test] to provide the GPUI test infrastructure.
-    // If either were missing, this parameter injection would fail.
-    assert!(
-        context.dispatcher().seed() == 0,
-        "GPUI TestAppContext should be injected with default seed"
+    // This step performs the action of accessing the GPUI test context.
+    // The fact that this context parameter can be injected via #[from(rstest_bdd_harness_context)]
+    // proves that GpuiHarness is active. We verify GPUI-specific properties to ensure
+    // the infrastructure is working correctly.
+
+    // Access GPUI-specific API: dispatcher() is unique to GPUI's TestAppContext
+    let dispatcher = context.dispatcher();
+    assert_eq!(
+        dispatcher.seed(),
+        0,
+        "GPUI dispatcher should provide seed value"
     );
+
+    // Access another GPUI-specific API: executor() returns BackgroundExecutor
+    let _executor = context.executor();
 }
 
 #[then("the GPUI test context is valid")]
 fn gpui_test_context_is_valid(#[from(rstest_bdd_harness_context)] context: &gpui::TestAppContext) {
-    // Verify we can access GPUI-specific functionality. This assertion would fail
-    // if GpuiAttributePolicy were not correctly applied, because without #[gpui::test]
-    // the GPUI test infrastructure wouldn't be available to create the TestAppContext.
+    // Verify GPUI-specific behaviour by accessing APIs unique to gpui::TestAppContext.
+    // These assertions would fail at compile time if the context weren't a GPUI TestAppContext,
+    // proving that both the harness (which injects the context) and the attribute policy
+    // (which emits #[gpui::test] to provide GPUI infrastructure) are correctly applied.
+
+    // Verify the context has GPUI-specific properties
     assert_eq!(
         context.dispatcher().seed(),
         0,
-        "GPUI TestAppContext dispatcher should have expected seed value"
+        "GPUI TestAppContext should have default seed value"
+    );
+
+    // Verify we can access GPUI-specific methods
+    assert!(
+        !context.did_prompt_for_new_path(),
+        "GPUI-specific did_prompt_for_new_path() method should be accessible"
     );
 }
 

--- a/crates/rstest-bdd/tests/trybuild_macros.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros.rs
@@ -67,7 +67,10 @@ fn run_passing_macro_tests(t: &trybuild::TestCases) {
         MacroFixtureCase::from("scenario_attributes_tokio.rs"),
         MacroFixtureCase::from("scenario_attributes_tokio_sync.rs"),
         MacroFixtureCase::from("scenario_attributes_tokio_dedup.rs"),
+        MacroFixtureCase::from("scenario_attributes_gpui.rs"),
+        MacroFixtureCase::from("scenario_attributes_gpui_absolute.rs"),
         MacroFixtureCase::from("scenarios_harness_params.rs"),
+        MacroFixtureCase::from("scenarios_attributes_gpui.rs"),
     ] {
         t.pass(macros_fixture(case).as_std_path());
     }

--- a/docs/execplans/9-6-2-integration-tests-covering-gpui-attribute-policy-resolution.md
+++ b/docs/execplans/9-6-2-integration-tests-covering-gpui-attribute-policy-resolution.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: DONE
 
 `PLANS.md` is not present in this repository at the time of writing, so this
 ExecPlan is the governing plan for roadmap item 9.6.2.
@@ -127,16 +127,22 @@ validation.
 - [x] (2026-03-26) Reviewed current GPUI unit, trybuild, and integration
       coverage to identify the remaining validation gap.
 - [x] (2026-03-26) Drafted this ExecPlan.
-- [ ] Stage A: confirm the missing GPUI policy-resolution matrix and capture a
-      red test.
-- [ ] Stage B: add GPUI compile-time integration fixtures to the `trybuild`
-      suite.
-- [ ] Stage C: add or extend GPUI runtime integration coverage in `rstest-bdd`
-      so generated GPUI tests execute through public macros.
-- [ ] Stage D: update design and user documentation for the delivered
-      validation surface.
-- [ ] Stage E: run focused GPUI validation plus repository-wide gates.
-- [ ] Stage F: mark roadmap item 9.6.2 done and record outcomes.
+- [x] (2026-03-28) Stage A: confirmed the missing GPUI policy-resolution
+      matrix. The missing integration cases were GPUI compile-pass fixtures for
+      `#[scenario]` canonical and absolute policy paths, GPUI compile-pass
+      coverage for `scenarios!`, and runtime `scenarios!` coverage.
+- [x] (2026-03-28) Stage B: added GPUI compile-time integration fixtures to
+      the `trybuild` suite.
+- [x] (2026-03-28) Stage C: extended GPUI runtime integration coverage in
+      `rstest-bdd` so generated GPUI tests execute through public macros,
+      including `scenarios!` and `#[scenario]` deduplication with an explicit
+      `#[gpui::test]`.
+- [x] (2026-03-28) Stage D: updated design and user documentation for the
+      delivered validation surface.
+- [x] (2026-03-28) Stage E: ran focused GPUI validation plus repository-wide
+      gates.
+- [x] (2026-03-28) Stage F: marked roadmap item 9.6.2 done and recorded
+      outcomes.
 
 ## Surprises & Discoveries
 
@@ -156,6 +162,11 @@ validation.
   attribute-policy cases but no GPUI counterparts in
   `crates/rstest-bdd/tests/fixtures_macros/`. Impact: 9.6.2 should almost
   certainly add GPUI fixtures there.
+
+- Observation: `scenario_harness_gpui.rs` can host both explicit `#[scenario]`
+  tests and generated `scenarios!` GPUI tests behind the existing
+  `gpui-harness-tests` feature gate. Impact: Stage C could stay within the
+  existing integration binary instead of adding a second GPUI test target.
 
 - Observation: `make test` is insufficient on its own for this milestone
   because `tests/trybuild_macros.rs` returns early when `NEXTEST_RUN_ID` is
@@ -192,15 +203,49 @@ validation.
   supported usage notes and validation references needed to keep the docs
   current with the stronger GPUI test surface. Date/Author: 2026-03-26 / Codex.
 
+- Decision: cover GPUI `#[scenario]` deduplication at runtime instead of
+  adding another compile-pass fixture that would duplicate the existing
+  unit-level dedup assertion. Rationale: the integration crate already depends
+  on `gpui`, so an explicit `#[gpui::test]` on a
+  `#[scenario(..., attributes = ...)]` function proves the public macro surface
+  does not emit a conflicting second GPUI test attribute. Date/Author:
+  2026-03-28 / Codex.
+
 ## Outcomes & Retrospective
 
-Pending implementation. This section must be updated after 9.6.2 lands with:
+- Added GPUI compile-pass fixtures in
+  `crates/rstest-bdd/tests/fixtures_macros/` for:
+  - canonical `rstest_bdd_harness_gpui::GpuiAttributePolicy` on `#[scenario]`;
+  - absolute `::rstest_bdd_harness_gpui::GpuiAttributePolicy` on `#[scenario]`;
+  - canonical `rstest_bdd_harness_gpui::GpuiAttributePolicy` on `scenarios!`.
+- Extended `crates/rstest-bdd/tests/scenario_harness_gpui.rs` with:
+  - a generated `scenarios!` GPUI policy runtime case; and
+  - an explicit `#[gpui::test]` plus `#[scenario(..., attributes = ...)]`
+    deduplication case.
+- Updated `docs/users-guide.md` and `docs/rstest-bdd-design.md` to record the
+  supported GPUI path forms and the strengthened validation layer.
+- Updated `docs/roadmap.md` only after the following commands passed:
 
-- the exact GPUI policy-resolution cases added,
-- the final validation commands and their outcomes,
-- any code changes required beyond tests,
-- the documentation updates made, and
-- confirmation that `docs/roadmap.md` was updated only after all gates passed.
+```bash
+set -o pipefail; cargo test -p rstest-bdd-policy 2>&1 | tee /tmp/9-6-2-policy.log
+set -o pipefail; cargo test -p rstest-bdd-macros --lib gpui_policy 2>&1 | \
+  tee /tmp/9-6-2-macros-gpui.log
+set -o pipefail; RUSTFLAGS="-D warnings" cargo test -p rstest-bdd \
+  --test trybuild_macros step_macros_compile -- --exact 2>&1 | \
+  tee /tmp/9-6-2-trybuild.log
+set -o pipefail; RUSTFLAGS="-D warnings" cargo test -p rstest-bdd \
+  --test scenario_harness_gpui --features gpui-harness-tests 2>&1 | \
+  tee /tmp/9-6-2-gpui-integration.log
+set -o pipefail; make fmt 2>&1 | tee /tmp/9-6-2-make-fmt.log
+set -o pipefail; make markdownlint 2>&1 | tee /tmp/9-6-2-make-markdownlint.log
+set -o pipefail; make nixie 2>&1 | tee /tmp/9-6-2-make-nixie.log
+set -o pipefail; make check-fmt 2>&1 | tee /tmp/9-6-2-make-check-fmt.log
+set -o pipefail; make lint 2>&1 | tee /tmp/9-6-2-make-lint.log
+set -o pipefail; make test 2>&1 | tee /tmp/9-6-2-make-test.log
+```
+
+- No macro or harness production code changes were required; the milestone was
+  closed by filling the missing integration coverage and updating the docs.
 
 ## Context and orientation
 

--- a/docs/execplans/9-6-2-integration-tests-covering-gpui-attribute-policy-resolution.md
+++ b/docs/execplans/9-6-2-integration-tests-covering-gpui-attribute-policy-resolution.md
@@ -215,13 +215,13 @@ validation.
 
 - Added GPUI compile-pass fixtures in
   `crates/rstest-bdd/tests/fixtures_macros/` for:
-  - canonical `rstest_bdd_harness_gpui::GpuiAttributePolicy` on `#[scenario]`;
-  - absolute `::rstest_bdd_harness_gpui::GpuiAttributePolicy` on `#[scenario]`;
-  - canonical `rstest_bdd_harness_gpui::GpuiAttributePolicy` on `scenarios!`.
+  - canonical `rstest_bdd_harness_gpui::GpuiAttributePolicy` on `#[scenario]`
+  - absolute `::rstest_bdd_harness_gpui::GpuiAttributePolicy` on `#[scenario]`
+  - canonical `rstest_bdd_harness_gpui::GpuiAttributePolicy` on `scenarios!`
 - Extended `crates/rstest-bdd/tests/scenario_harness_gpui.rs` with:
-  - a generated `scenarios!` GPUI policy runtime case; and
+  - a generated `scenarios!` GPUI policy runtime case
   - an explicit `#[gpui::test]` plus `#[scenario(..., attributes = ...)]`
-    deduplication case.
+    deduplication case
 - Updated `docs/users-guide.md` and `docs/rstest-bdd-design.md` to record the
   supported GPUI path forms and the strengthened validation layer.
 - Updated `docs/roadmap.md` only after the following commands passed:
@@ -433,10 +433,10 @@ set -o pipefail; make test 2>&1 | tee /tmp/9-6-2-make-test.log
 
 Expected signals:
 
-- the focused `trybuild` run reports the GPUI fixtures as passing,
-- the GPUI feature-gated runtime integration test passes,
-- `make check-fmt`, `make lint`, and `make test` all exit successfully, and
-- the documentation-only gates also pass because this milestone edits Markdown.
+- the focused `trybuild` run reports the GPUI fixtures as passing
+- the GPUI feature-gated runtime integration test passes
+- `make check-fmt`, `make lint`, and `make test` all exit successfully
+- the documentation-only gates also pass because this milestone edits Markdown
 
 ### Stage F: close the roadmap item
 

--- a/docs/execplans/9-6-2-integration-tests-covering-gpui-attribute-policy-resolution.md
+++ b/docs/execplans/9-6-2-integration-tests-covering-gpui-attribute-policy-resolution.md
@@ -144,7 +144,7 @@ validation.
 - [x] (2026-03-28) Stage F: marked roadmap item 9.6.2 done and recorded
       outcomes.
 
-## Surprises & Discoveries
+## Surprises & discoveries
 
 - Observation: `crates/rstest-bdd-macros` already has unit tests for GPUI
   policy-path handling, including canonical and absolute paths, in
@@ -177,7 +177,7 @@ validation.
   `docs/` prefix, but the repository file is `docs/rust-doctest-dry-guide.md`.
   Impact: this plan uses the real path under `docs/` as the source of truth.
 
-## Decision Log
+## Decision log
 
 - Decision: treat 9.6.2 as a validation milestone spanning both compile-time
   macro integration and runtime integration. Rationale: the roadmap item says
@@ -211,7 +211,7 @@ validation.
   does not emit a conflicting second GPUI test attribute. Date/Author:
   2026-03-28 / Codex.
 
-## Outcomes & Retrospective
+## Outcomes & retrospective
 
 - Added GPUI compile-pass fixtures in
   `crates/rstest-bdd/tests/fixtures_macros/` for:

--- a/docs/execplans/9-6-2-integration-tests-covering-gpui-attribute-policy-resolution.md
+++ b/docs/execplans/9-6-2-integration-tests-covering-gpui-attribute-policy-resolution.md
@@ -1,0 +1,425 @@
+# ExecPlan 9.6.2: add GPUI attribute-policy resolution integration tests
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+`PLANS.md` is not present in this repository at the time of writing, so this
+ExecPlan is the governing plan for roadmap item 9.6.2.
+
+## Purpose / big picture
+
+Roadmap item 9.6.2 closes the remaining GPUI validation gap in phase 9.6. Phase
+9.4 already delivered `GpuiHarness`, `GpuiAttributePolicy`, macro support for
+the canonical GPUI policy path, and the `examples/gpui-counter` demonstration
+crate. What is still missing is a clearly defined integration test layer that
+proves GPUI attribute-policy resolution works end to end at the macro boundary,
+not only in unit tests.
+
+After this work:
+
+- `rstest-bdd` has explicit integration coverage for GPUI attribute-policy
+  resolution, not just unit coverage in `rstest-bdd-policy` and
+  `rstest-bdd-macros`.
+- The GPUI coverage matrix includes the real macro entry points that users
+  touch: `#[scenario]`, and, if the current gap analysis confirms it is
+  untested, `scenarios!`.
+- The integration surface proves that the first-party GPUI policy path
+  resolves to `#[gpui::test]` in the cases the project documents as supported,
+  and that attribute emission does not regress into duplicate or missing GPUI
+  test attributes.
+- `docs/rstest-bdd-design.md` records the strengthened validation layer for the
+  path-based GPUI policy trust model.
+- `docs/users-guide.md` records the supported GPUI policy usage in the guide's
+  harness section.
+- `docs/roadmap.md` marks 9.6.2 done only after the focused tests and the full
+  required gates pass.
+
+Success is observable when the new GPUI policy-resolution tests fail before the
+implementation, pass afterward, and the repository gates pass:
+`make check-fmt`, `make lint`, and `make test`. Because `make test` uses
+`cargo-nextest` when available and therefore skips the `trybuild` compile-test
+suite, this milestone also requires an explicit
+`cargo test -p rstest-bdd --test trybuild_macros` run as part of focused
+validation.
+
+## Constraints
+
+- Implement roadmap item 9.6.2 only. Do not fold 9.6.3 cookbook work into
+  this change.
+- Treat 9.4.3 and 9.4.4 as delivered foundations. This task strengthens
+  validation and documentation around GPUI policy resolution; it is not a
+  redesign of ADR-005 or ADR-007.
+- Preserve the current trust model documented in `docs/users-guide.md` and
+  `docs/rstest-bdd-design.md`: GPUI attribute-policy resolution during macro
+  expansion is path-based for first-party policy types.
+- Keep GPUI integration in opt-in crates. Core crates must not gain new
+  always-on GPUI runtime responsibilities.
+- Prefer extending existing `rstest-bdd` integration and trybuild suites over
+  inventing a separate bespoke test harness.
+- Validate the feature with both unit-level or compile-time tests and
+  behavioural or runtime tests.
+- Record any design decisions taken in `docs/rstest-bdd-design.md`.
+- Record user-facing usage in `docs/users-guide.md`.
+- Mark roadmap entry 9.6.2 done only after all validation passes.
+- Because this plan touches Markdown, run the documentation gates too:
+  `make fmt`, `make markdownlint`, and `make nixie`.
+- Run long-lived commands with `set -o pipefail` and `tee`.
+
+## Tolerances (exception triggers)
+
+- Scope: if delivering 9.6.2 requires more than 12 files changed or more than
+  600 net lines, stop and re-check whether the work is drifting into a broader
+  policy-resolution redesign.
+- Interfaces: if the test gap can only be closed by changing public APIs in
+  `rstest-bdd-harness-gpui`, `rstest-bdd-harness`, `rstest-bdd-policy`,
+  `rstest-bdd-macros`, `#[scenario]`, or `scenarios!`, stop and split the API
+  change into a separate task unless the failure is a narrow correctness bug.
+- Dependencies: if new external crates are required, stop and escalate.
+- Test topology: if GPUI integration coverage cannot run inside the existing
+  feature-gated `rstest-bdd` test setup, stop and document the exact blocker
+  before adding a second GPUI-specific integration harness.
+- Validation: if `make check-fmt`, `make lint`, or `make test` fails for an
+  unrelated reason, capture logs and stop before updating the roadmap.
+- Iterations: if the same gate fails three consecutive fix attempts, stop and
+  escalate with the recorded log path.
+- Ambiguity: if repository sources disagree on which GPUI path forms are
+  supported end to end, stop and list the competing interpretations before
+  continuing.
+
+## Risks
+
+- Risk: current coverage may already prove the canonical GPUI policy path for
+  one happy path, but still miss important user-facing entry points such as
+  `scenarios!` or absolute-path spelling. Severity: high. Likelihood: high.
+  Mitigation: begin with a gap inventory and make the test matrix explicit
+  before writing code.
+
+- Risk: the project may over-correct by adding only more unit tests in
+  `rstest-bdd-macros`, leaving the roadmap item's "integration tests" intent
+  unmet. Severity: high. Likelihood: medium. Mitigation: require at least one
+  real `rstest-bdd` integration test that executes generated GPUI-backed tests
+  through the public macro surface.
+
+- Risk: `make test` can pass while `trybuild` GPUI fixtures still fail,
+  because `nextest` skips `tests/trybuild_macros.rs`. Severity: high.
+  Likelihood: high. Mitigation: make the focused
+  `cargo test -p rstest-bdd --test trybuild_macros step_macros_compile -- --exact`
+   run a mandatory validation step in this plan.
+
+- Risk: GPUI-specific tests are feature-gated and could be edited without
+  actually running them. Severity: medium. Likelihood: medium. Mitigation:
+  include an explicit feature-enabled focused integration command in the plan.
+
+- Risk: documentation could drift again if the users' guide and design doc are
+  not updated alongside the new test matrix. Severity: medium. Likelihood:
+  medium. Mitigation: update both docs in the same milestone that lands the
+  tests and reference the exact suites that now enforce the contract.
+
+## Progress
+
+- [x] (2026-03-26) Reviewed roadmap item 9.6.2 and prerequisite 9.4.3.
+- [x] (2026-03-26) Reviewed ADR-005, the harness chapter added in 9.6.1, and
+      current GPUI policy-resolution code paths.
+- [x] (2026-03-26) Reviewed current GPUI unit, trybuild, and integration
+      coverage to identify the remaining validation gap.
+- [x] (2026-03-26) Drafted this ExecPlan.
+- [ ] Stage A: confirm the missing GPUI policy-resolution matrix and capture a
+      red test.
+- [ ] Stage B: add GPUI compile-time integration fixtures to the `trybuild`
+      suite.
+- [ ] Stage C: add or extend GPUI runtime integration coverage in `rstest-bdd`
+      so generated GPUI tests execute through public macros.
+- [ ] Stage D: update design and user documentation for the delivered
+      validation surface.
+- [ ] Stage E: run focused GPUI validation plus repository-wide gates.
+- [ ] Stage F: mark roadmap item 9.6.2 done and record outcomes.
+
+## Surprises & Discoveries
+
+- Observation: `crates/rstest-bdd-macros` already has unit tests for GPUI
+  policy-path handling, including canonical and absolute paths, in
+  `crates/rstest-bdd-macros/src/codegen/scenario/tests/gpui_policy.rs`. Impact:
+  9.6.2 should not duplicate that unit coverage; it should extend the
+  integration layer beyond it.
+
+- Observation: `crates/rstest-bdd/tests/scenario_harness_gpui.rs` already
+  proves one canonical GPUI policy path end to end, including an
+  `attributes = rstest_bdd_harness_gpui::GpuiAttributePolicy` case without a
+  harness. Impact: the missing work is the untested resolution matrix around
+  that happy path, not the entire GPUI integration from scratch.
+
+- Observation: the `trybuild` passing fixtures currently include Tokio
+  attribute-policy cases but no GPUI counterparts in
+  `crates/rstest-bdd/tests/fixtures_macros/`. Impact: 9.6.2 should almost
+  certainly add GPUI fixtures there.
+
+- Observation: `make test` is insufficient on its own for this milestone
+  because `tests/trybuild_macros.rs` returns early when `NEXTEST_RUN_ID` is
+  set. Impact: focused `cargo test` commands must remain part of the mandatory
+  validation recipe.
+
+- Observation: the prompt references `rust-doctest-dry-guide.md` without the
+  `docs/` prefix, but the repository file is `docs/rust-doctest-dry-guide.md`.
+  Impact: this plan uses the real path under `docs/` as the source of truth.
+
+## Decision Log
+
+- Decision: treat 9.6.2 as a validation milestone spanning both compile-time
+  macro integration and runtime integration. Rationale: the roadmap item says
+  "integration tests", and the existing gap is specifically between unit-level
+  policy-path checks and end-to-end macro behaviour. Date/Author: 2026-03-26 /
+  Codex.
+
+- Decision: extend the existing `rstest-bdd` trybuild and integration test
+  suites rather than creating a new standalone GPUI-only test crate. Rationale:
+  the repository already uses `crates/rstest-bdd/tests/trybuild_macros.rs` for
+  macro integration and `crates/rstest-bdd/tests/scenario_harness_gpui.rs` for
+  GPUI end-to-end coverage, so the smallest coherent change is to deepen those
+  suites. Date/Author: 2026-03-26 / Codex.
+
+- Decision: require a documented test matrix before writing fixes. Rationale:
+  current sources suggest the remaining gap is not "GPUI policy resolution is
+  entirely untested", but "some supported GPUI resolution paths are not tested
+  at the integration layer". A matrix prevents both over-building and missing a
+  real hole. Date/Author: 2026-03-26 / Codex.
+
+- Decision: keep the docs update small and validation-focused. Rationale:
+  9.6.1 already documented the trust model; 9.6.2 should add only the new
+  supported usage notes and validation references needed to keep the docs
+  current with the stronger GPUI test surface. Date/Author: 2026-03-26 / Codex.
+
+## Outcomes & Retrospective
+
+Pending implementation. This section must be updated after 9.6.2 lands with:
+
+- the exact GPUI policy-resolution cases added,
+- the final validation commands and their outcomes,
+- any code changes required beyond tests,
+- the documentation updates made, and
+- confirmation that `docs/roadmap.md` was updated only after all gates passed.
+
+## Context and orientation
+
+The repository already contains the pieces that this milestone must connect:
+
+- `crates/rstest-bdd-policy/src/lib.rs`
+  - canonical policy-path mapping, including `GPUI_ATTRIBUTE_POLICY_PATH`
+  - unit coverage for `resolve_test_attribute_hint_for_policy_path`
+- `crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs`
+  - the macro-side policy resolver and attribute renderer
+- `crates/rstest-bdd-macros/src/codegen/scenario/tests/gpui_policy.rs`
+  - unit tests for canonical-path, absolute-path, and dedup logic
+- `crates/rstest-bdd/tests/scenario_harness_gpui.rs`
+  - current GPUI runtime integration tests
+- `crates/rstest-bdd/tests/features/gpui_harness.feature`
+  - current GPUI integration feature file
+- `crates/rstest-bdd/tests/fixtures_macros/`
+  - compile-pass and compile-fail macro fixtures used by `trybuild`
+- `crates/rstest-bdd/tests/trybuild_macros.rs`
+  - the integration entry point for compile-time macro tests
+- `docs/users-guide.md`
+  - user-facing harness and GPUI usage guidance
+- `docs/rstest-bdd-design.md`
+  - architecture and validation-layer narrative for the path-based trust model
+- `docs/roadmap.md`
+  - roadmap item 9.6.2, currently unchecked
+
+Terms used in this plan:
+
+- **Canonical GPUI policy path**: the documented first-party path
+  `rstest_bdd_harness_gpui::GpuiAttributePolicy`.
+- **Absolute GPUI policy path**: the same path written with a leading `::`.
+- **Policy resolution**: the proc-macro step that converts an `attributes = ...`
+  path into emitted test attributes such as `#[gpui::test]`.
+- **Integration test**: a test that exercises public macro entry points in a
+  compiled crate or through the `rstest-bdd` integration test harness, rather
+  than calling internal helpers directly.
+
+Reference documents reviewed while drafting this plan:
+
+- `docs/roadmap.md`
+- `docs/rstest-bdd-design.md`
+- `docs/rstest-bdd-language-server-design.md`
+- `docs/rust-testing-with-rstest-fixtures.md`
+- `docs/rust-doctest-dry-guide.md`
+- `docs/complexity-antipatterns-and-refactoring-strategies.md`
+- `docs/gherkin-syntax.md`
+- `docs/adr-005-harness-adapter-crates-for-framework-specific-test-integration.md`
+- `docs/execplans/9-4-2-create-rstest-bdd-harness-gpui.md`
+- `docs/execplans/9-6-1-update-the-harness-adapter-chapter-in-the-users-guide.md`
+
+## Plan of work
+
+### Stage A: confirm the missing GPUI policy-resolution matrix
+
+Goal: convert the vague roadmap item into an explicit, repo-local acceptance
+matrix before editing tests.
+
+Implementation details:
+
+- Re-read the current GPUI unit coverage, `trybuild` pass fixtures, and
+  feature-gated runtime integration tests.
+- Write down which cases are already covered and which are still missing.
+- The matrix must explicitly account for:
+  - canonical GPUI policy path under `#[scenario]`,
+  - absolute GPUI policy path under `#[scenario]` if supported,
+  - user-supplied `#[gpui::test]` deduplication if the runtime surface can
+    prove it,
+  - `scenarios!` GPUI policy usage if it is not already covered elsewhere.
+- Capture at least one red test before fixing anything so the milestone
+  follows a red-green-refactor shape.
+
+Go/no-go validation:
+
+- There is a written list of GPUI policy-resolution cases to cover.
+- At least one missing case is demonstrated by an absent or failing test.
+
+### Stage B: add GPUI compile-time integration fixtures
+
+Goal: give GPUI the same compile-time integration posture that Tokio already
+has in `tests/fixtures_macros/`.
+
+Implementation details:
+
+- Add new compile-pass fixtures under `crates/rstest-bdd/tests/fixtures_macros/`
+  for the GPUI policy-resolution cases selected in Stage A.
+- Register those fixtures in
+  `crates/rstest-bdd/tests/trybuild_macros.rs::run_passing_macro_tests`.
+- Prefer small, single-purpose fixtures mirroring the Tokio naming style, for
+  example:
+  - `scenario_attributes_gpui.rs`
+  - `scenario_attributes_gpui_absolute.rs`
+  - `scenario_attributes_gpui_dedup.rs`
+  - `scenarios_attributes_gpui.rs`
+- Reuse existing feature fixtures where practical; add new `.feature` files
+  only when a case cannot be expressed cleanly with the current ones.
+
+Go/no-go validation:
+
+- The new GPUI `trybuild` fixtures fail before the implementation and pass
+  after it.
+- The fixture names and comments make the supported GPUI path forms obvious to
+  a future maintainer.
+
+### Stage C: add or extend GPUI runtime integration coverage
+
+Goal: prove that generated GPUI-backed tests actually execute through the
+public macro surface with the resolved policy attributes in place.
+
+Implementation details:
+
+- Extend `crates/rstest-bdd/tests/scenario_harness_gpui.rs` when a new case can
+  fit cleanly there; otherwise add one sibling integration file with the same
+  `gpui-harness-tests` feature gate.
+- Add the smallest runtime assertions needed to prove that the generated test
+  was actually executed under GPUI policy resolution.
+- If Stage A confirms a `scenarios!` gap, add a dedicated runtime integration
+  test for `scenarios!` rather than assuming the shared helper logic makes it
+  redundant.
+- Keep GPUI-specific state isolated and parallel-safe, following the existing
+  integration-test style instead of introducing process-global coupling beyond
+  what the current GPUI tests already use.
+
+Go/no-go validation:
+
+- The runtime integration suite exercises every GPUI resolution case promised
+  by the updated docs.
+- GPUI policy tests still pass under the existing `gpui-harness-tests` feature
+  gate.
+
+### Stage D: update design and user documentation
+
+Goal: keep the docs aligned with the stronger GPUI validation surface without
+rewriting the harness chapter.
+
+Implementation details:
+
+- Update `docs/rstest-bdd-design.md` where it describes the validation layers
+  for first-party policy resolution so it names the delivered GPUI integration
+  coverage precisely.
+- Update `docs/users-guide.md` in the GPUI harness section so the guide records
+  the supported GPUI `attributes = ...` usage that the new tests enforce.
+- Keep the wording consistent with the existing trust model: first-party GPUI
+  policy resolution is path-based at macro expansion time.
+
+Go/no-go validation:
+
+- A reader can tell which GPUI policy paths and macro entry points are
+  intentionally supported.
+- The docs do not imply arbitrary third-party policy evaluation during macro
+  expansion.
+
+### Stage E: run focused validation and repository gates
+
+Goal: validate the new GPUI coverage directly, then confirm the whole
+repository remains green.
+
+Implementation details:
+
+- Run the focused suites first:
+
+```bash
+set -o pipefail; cargo test -p rstest-bdd-policy 2>&1 | tee /tmp/9-6-2-policy.log
+set -o pipefail; cargo test -p rstest-bdd-macros --lib gpui_policy 2>&1 | tee /tmp/9-6-2-macros-gpui.log
+set -o pipefail; RUSTFLAGS="-D warnings" cargo test -p rstest-bdd \
+  --test trybuild_macros step_macros_compile -- --exact 2>&1 | \
+  tee /tmp/9-6-2-trybuild.log
+set -o pipefail; RUSTFLAGS="-D warnings" cargo test -p rstest-bdd \
+  --test scenario_harness_gpui --features gpui-harness-tests 2>&1 | \
+  tee /tmp/9-6-2-gpui-integration.log
+```
+
+- If Stage C adds a second GPUI integration test file, run it explicitly here
+  as well.
+- Then run the repository gates:
+
+```bash
+set -o pipefail; make fmt 2>&1 | tee /tmp/9-6-2-make-fmt.log
+set -o pipefail; make markdownlint 2>&1 | tee /tmp/9-6-2-make-markdownlint.log
+set -o pipefail; make nixie 2>&1 | tee /tmp/9-6-2-make-nixie.log
+set -o pipefail; make check-fmt 2>&1 | tee /tmp/9-6-2-make-check-fmt.log
+set -o pipefail; make lint 2>&1 | tee /tmp/9-6-2-make-lint.log
+set -o pipefail; make test 2>&1 | tee /tmp/9-6-2-make-test.log
+```
+
+Expected signals:
+
+- the focused `trybuild` run reports the GPUI fixtures as passing,
+- the GPUI feature-gated runtime integration test passes,
+- `make check-fmt`, `make lint`, and `make test` all exit successfully, and
+- the documentation-only gates also pass because this milestone edits Markdown.
+
+### Stage F: close the roadmap item
+
+Goal: update project status only after the implementation and validation are
+complete.
+
+Implementation details:
+
+- Mark `docs/roadmap.md` item 9.6.2 as done.
+- Update this ExecPlan's `Progress`, `Decision Log`, and
+  `Outcomes & Retrospective` sections with the delivered facts.
+- Record any important new gotcha in project memory if the work uncovers one
+  that future contributors are likely to hit again.
+
+Go/no-go validation:
+
+- The roadmap entry is checked only after all commands in Stage E succeed.
+- The ExecPlan remains self-contained for the next contributor who reads it.
+
+## Acceptance criteria
+
+This milestone is complete only when all of the following are true:
+
+1. `rstest-bdd` has explicit GPUI attribute-policy resolution integration
+   coverage beyond the existing macro unit tests.
+2. The new tests cover the GPUI cases identified as missing in Stage A.
+3. `docs/rstest-bdd-design.md` records the delivered GPUI validation surface.
+4. `docs/users-guide.md` records the supported GPUI attribute-policy usage.
+5. `docs/roadmap.md` marks 9.6.2 done.
+6. The focused GPUI validation commands pass.
+7. `make check-fmt`, `make lint`, and `make test` pass.

--- a/docs/execplans/9-6-2-integration-tests-covering-gpui-attribute-policy-resolution.md
+++ b/docs/execplans/9-6-2-integration-tests-covering-gpui-attribute-policy-resolution.md
@@ -1,8 +1,8 @@
 # ExecPlan 9.6.2: add GPUI attribute-policy resolution integration tests
 
 This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & discoveries`,
+`Decision log`, and `Outcomes & retrospective` must be kept up to date as work
 proceeds.
 
 Status: DONE

--- a/docs/execplans/9-6-2-integration-tests-covering-gpui-attribute-policy-resolution.md
+++ b/docs/execplans/9-6-2-integration-tests-covering-gpui-attribute-policy-resolution.md
@@ -446,8 +446,8 @@ complete.
 Implementation details:
 
 - Mark `docs/roadmap.md` item 9.6.2 as done.
-- Update this ExecPlan's `Progress`, `Decision Log`, and
-  `Outcomes & Retrospective` sections with the delivered facts.
+- Update this ExecPlan's `Progress`, `Decision log`, and
+  `Outcomes & retrospective` sections with the delivered facts.
 - Record any important new gotcha in project memory if the work uncovers one
   that future contributors are likely to hit again.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -609,7 +609,7 @@ opt-in crates rather than the core runtime or macros.
   `docs/rstest-bdd-design.md` records the delivered architecture and validation
   surface, and `make check-fmt`, `make lint`, and `make test` pass.
   Prerequisite: 9.5.3. Delivered 2026-03-22. (Pandalump)
-- [ ] 9.6.2. Add integration tests covering attribute policy resolution for
+- [x] 9.6.2. Add integration tests covering attribute policy resolution for
   GPUI once 9.4 is delivered. Prerequisite: 9.4.3. (Pandalump)
 - [ ] 9.6.3. Add a third-party harness cookbook documenting how to write a
   custom `HarnessAdapter` (for example, `rstest-bdd-harness-bevy`), including

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1745,8 +1745,11 @@ The first official adapters and policies are:
   `examples/gpui-counter` models a simple counter application whose BDD suite
   exercises both `GpuiHarness` and `GpuiAttributePolicy` end-to-end, with step
   definitions that access injected `TestAppContext` through
-  `rstest_bdd_harness_context`. The example requires no native-library setup
-  beyond the workspace GPUI shim.
+  `rstest_bdd_harness_context`. Focused `rstest-bdd` integration coverage also
+  verifies canonical GPUI policy resolution for `scenarios!`, canonical and
+  absolute first-party GPUI policy paths for `#[scenario]`, and deduplication
+  when a generated `#[scenario]` test already has `#[gpui::test]`. The example
+  requires no native-library setup beyond the workspace GPUI shim.
 
 Future adapters (for example, Bevy) are planned to follow the same pattern
 without requiring new dependencies in `rstest-bdd` or `rstest-bdd-macros`.
@@ -1759,7 +1762,8 @@ Validation for the delivered model is intentionally split across layers:
   harness-runner contracts;
 - behavioural and integration tests in `rstest-bdd` verify custom harness
   delegation, `rstest_bdd_harness_context` injection, Tokio runtime
-  compatibility, GPUI integration, and the deprecated runtime alias path.
+  compatibility, GPUI integration, GPUI attribute-policy resolution through
+  both `#[scenario]` and `scenarios!`, and the deprecated runtime alias path.
 
 ## Part 3: Implementation and strategic analysis
 
@@ -2577,7 +2581,7 @@ Delivered behaviour:
   `attributes = ...` configuration is the canonical user-facing model.
 
 The roadmap continues to track follow-on work such as additional cookbook
-material and extra GPUI policy-resolution coverage; see
+material and harness-led attribute-policy defaults; see
 [Phase 9](roadmap.md#9-harness-adapters-and-attribute-plugins) for the
 remaining items and acceptance criteria.
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -935,7 +935,16 @@ fn my_gpui_scenario() {
 `GpuiAttributePolicy` emits `#[rstest::rstest]` and `#[gpui::test]`. The
 canonical `rstest_bdd_harness_gpui::GpuiAttributePolicy` path is recognized by
 the same path-based policy resolution used for Tokio, so the GPUI test
-attribute is available whether the scenario is synchronous or async.
+attribute is available whether the scenario is synchronous or async. For
+`#[scenario]`, the equivalent absolute path
+`::rstest_bdd_harness_gpui::GpuiAttributePolicy` is also supported.
+
+This contract is enforced by focused integration coverage in
+`crates/rstest-bdd/tests/trybuild_macros.rs` and
+`crates/rstest-bdd/tests/scenario_harness_gpui.rs`. Those suites verify GPUI
+attribute-policy resolution for `#[scenario]` and `scenarios!`, plus
+deduplication when a `#[scenario]` test already carries an explicit
+`#[gpui::test]`.
 
 For a complete working example, see the `examples/gpui-counter` crate, which
 models a simple counter application whose BDD suite exercises both


### PR DESCRIPTION
## Summary
- Expands GPUI integration coverage to include canonical and absolute GPUI attribute-policy paths for #[scenario], runtime coverage for scenarios! macros, and dedup scenarios.
- Adds compile-pass GPUI fixtures under crates/rstest-bdd/tests/fixtures_macros for the GPUI policy-resolution matrix (canonical and absolute paths on #[scenario], as well as scenarios! usage).
- Introduces GPUI policy tests and harness scenarios via new feature files and updated scenario harness tests:
  - crates/rstest-bdd/tests/features/gpui_harness_policy_scenarios/harness_context.feature
  - crates/rstest-bdd/tests/features/gpui_policy_scenarios/policy.feature
- Extends testing surface with additional compile-pass fixtures and GPUI runtime coverage, including updates to scenario_harness_gpui.rs and trybuild macros tests.
- Adds a new ExecPlan document for 9.6.2: docs/execplans/9-6-2-integration-tests-covering-gpui-attribute-policy-resolution.md
- Updates docs to reflect strengthened GPUI validation surface:
  - docs/roadmap.md (marks 9.6.2 as done)
  - docs/rstest-bdd-design.md
  - docs/users-guide.md

## Changes
- New: docs/execplans/9-6-2-integration-tests-covering-gpui-attribute-policy-resolution.md
- New: crates/rstest-bdd/tests/features/gpui_harness_policy_scenarios/harness_context.feature
- New: crates/rstest-bdd/tests/features/gpui_policy_scenarios/policy.feature
- New: crates/rstest-bdd/tests/fixtures_macros/scenario_attributes_gpui.rs
- New: crates/rstest-bdd/tests/fixtures_macros/scenario_attributes_gpui_absolute.rs
- New: crates/rstest-bdd/tests/fixtures_macros/scenarios_attributes_gpui.rs
- Modified: crates/rstest-bdd/tests/scenario_harness_gpui.rs
- Modified: crates/rstest-bdd/tests/trybuild_macros.rs
- Updated: docs/execplans/9-6-2-integration-tests-covering-gpui-attribute-policy-resolution.md
- Updated: docs/roadmap.md
- Updated: docs/rstest-bdd-design.md
- Updated: docs/users-guide.md
- Other related test, harness, and docs changes introduced by the 9.6.2 GPUI attribute-policy integration effort (see diff for details).

## Plan of work (high level)
- Stage A: confirm the missing GPUI policy-resolution matrix
- Stage B: add GPUI compile-time integration fixtures under tests/fixtures_macros and wire into trybuild
- Stage C: add/extend GPUI runtime integration coverage to prove end-to-end resolution through public macro surface
- Stage D: update design and user documentation to reflect the stronger GPUI validation surface
- Stage E: run focused validation commands and repository gates (format, lint, tests)
- Stage F: close the roadmap item and record outcomes

## Acceptance criteria
1. rstest-bdd has explicit GPUI attribute-policy resolution integration coverage beyond existing macro unit tests.
2. The new tests cover GPUI cases identified as missing in Stage A.
3. docs/rstest-bdd-design.md records the delivered GPUI validation surface.
4. docs/users-guide.md records the supported GPUI attribute-policy usage.
5. docs/roadmap.md marks 9.6.2 done.
6. Focused GPUI validation commands pass.
7. make check-fmt, make lint, and make test pass.

## Validation / Test plan
- Stage E commands (to be run locally by maintainers):
  - cargo test -p rstest-bdd-policy
  - cargo test -p rstest-bdd-macros --lib gpui_policy
  - cargo test -p rstest-bdd --test trybuild_macros step_macros_compile -- --exact
  - cargo test -p rstest-bdd --test scenario_harness_gpui --features gpui-harness-tests
  - make fmt; make lint; make test

## Rationale / context
- This work extends end-to-end GPUI attribute-policy validation by adding explicit integration tests at the macro surface and aligning documentation with the strengthened validation surface. It preserves the existing trust model and focuses tests on canonical/absolute policy paths, deduplication, and scenarios! usage to ensure no regressions in GPUI policy resolution via the macro system.

📎 **Task**: https://www.devboxer.com/task/6661a726-6c67-48a5-ae32-33884d45cc8a