### PR TITLE
Support Result- and StepResult-returning fixtures in rstest-bdd

### DIFF
--- a/crates/rstest-bdd-macros/src/macros/scenario/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenario/mod.rs
@@ -141,7 +141,7 @@ fn try_scenario(
             concat!(
                 "scenarios with fallible fixtures (`Result<T, E>` or `StepResult<T, E>`) ",
                 "must return `Result<(), E>` or `StepResult<(), E>` to propagate ",
-                "fixture initialisation errors",
+                "fixture initialization errors",
             ),
         );
         return Err(proc_macro::TokenStream::from(err.into_compile_error()));

--- a/crates/rstest-bdd-macros/src/macros/scenario/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenario/mod.rs
@@ -139,8 +139,8 @@ fn try_scenario(
         let err = syn::Error::new_spanned(
             &sig.output,
             concat!(
-                "scenarios with Result-returning fixtures must return ",
-                "`Result<(), E>` or `StepResult<(), E>` to propagate ",
+                "scenarios with fallible fixtures (`Result<T, E>` or `StepResult<T, E>`) ",
+                "must return `Result<(), E>` or `StepResult<(), E>` to propagate ",
                 "fixture initialisation errors",
             ),
         );

--- a/crates/rstest-bdd-macros/src/macros/scenario/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenario/mod.rs
@@ -140,7 +140,8 @@ fn try_scenario(
             &sig.output,
             concat!(
                 "scenarios with Result-returning fixtures must return ",
-                "`Result<(), E>` to propagate fixture initialisation errors",
+                "`Result<(), E>` or `StepResult<(), E>` to propagate ",
+                "fixture initialisation errors",
             ),
         );
         return Err(proc_macro::TokenStream::from(err.into_compile_error()));

--- a/crates/rstest-bdd-macros/src/macros/scenario/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenario/mod.rs
@@ -134,6 +134,18 @@ fn try_scenario(
 
     let (_args, fixture_setup) = extract_function_fixtures(sig)
         .map_err(|err| proc_macro::TokenStream::from(err.into_compile_error()))?;
+
+    if fixture_setup.has_result_fixtures && !return_kind.is_fallible() {
+        let err = syn::Error::new_spanned(
+            &sig.output,
+            concat!(
+                "scenarios with Result-returning fixtures must return ",
+                "`Result<(), E>` to propagate fixture initialisation errors",
+            ),
+        );
+        return Err(proc_macro::TokenStream::from(err.into_compile_error()));
+    }
+
     let ctx_prelude = fixture_setup.prelude;
     let ctx_inserts = fixture_setup.ctx_inserts;
     let ctx_postlude = fixture_setup.postlude;

--- a/crates/rstest-bdd-macros/src/macros/scenarios/test_generation.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/test_generation.rs
@@ -218,6 +218,8 @@ fn resolve_fixture_error_type(fixtures: &[FixtureSpec]) -> syn::Type {
         .iter()
         .filter_map(|spec| try_extract_result_error_type(&spec.ty))
         .collect();
+    // Sort by normalized key so identical types become adjacent, then dedup
+    error_types.sort_by_key(normalize_type_key);
     error_types.dedup_by(|a, b| normalize_type_key(a) == normalize_type_key(b));
     if error_types.len() == 1 {
         error_types.remove(0)

--- a/crates/rstest-bdd-macros/src/macros/scenarios/test_generation.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/test_generation.rs
@@ -188,6 +188,25 @@ fn build_test_signature(
     }
 }
 
+/// Normalizes a type for structural comparison by converting it to a
+/// canonical string representation with consistent formatting.
+///
+/// This is used for deduplicating error types where `std::io::Error` and
+/// `Error` (when both refer to the same type via imports) should be
+/// considered distinct at the syntax level, but semantically equivalent
+/// paths like `::std::io::Error` and `std::io::Error` should match.
+fn normalize_type_key(ty: &syn::Type) -> String {
+    // Use quote! to get a consistent token representation, then normalize
+    // whitespace and remove leading :: for comparison
+    let rendered = quote!(#ty).to_string();
+    rendered
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .trim_start_matches("::")
+        .to_string()
+}
+
 /// Resolves a unified error type from `Result`-typed fixture specifications.
 ///
 /// When all `Result<T, E>` fixtures share the same error type `E`, returns
@@ -199,7 +218,7 @@ fn resolve_fixture_error_type(fixtures: &[FixtureSpec]) -> syn::Type {
         .iter()
         .filter_map(|spec| try_extract_result_error_type(&spec.ty))
         .collect();
-    error_types.dedup_by(|a, b| quote!(#a).to_string() == quote!(#b).to_string());
+    error_types.dedup_by(|a, b| normalize_type_key(a) == normalize_type_key(b));
     if error_types.len() == 1 {
         error_types.remove(0)
     } else {

--- a/crates/rstest-bdd-macros/src/macros/scenarios/test_generation.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/test_generation.rs
@@ -227,9 +227,24 @@ pub(super) fn generate_scenario_test(
         Err(err) => return err.to_compile_error(),
     };
 
+    // When fixtures return Result, the generated test must propagate
+    // initialisation errors, so we upgrade the return kind and signature.
+    let return_kind = if fixture_setup.has_result_fixtures {
+        sig.output = syn::parse_quote! {
+            -> ::std::result::Result<(), Box<dyn ::std::error::Error>>
+        };
+        ScenarioReturnKind::ResultUnit
+    } else {
+        ScenarioReturnKind::Unit
+    };
+
     let feature_path = ctx.manifest_dir.join(ctx.rel_path).display().to_string();
     let vis = syn::Visibility::Inherited;
-    let block: syn::Block = syn::parse_quote!({});
+    let block: syn::Block = if fixture_setup.has_result_fixtures {
+        syn::parse_quote!({ Ok(()) })
+    } else {
+        syn::parse_quote!({})
+    };
 
     let config = ScenarioConfig {
         attrs: &attrs,
@@ -244,7 +259,7 @@ pub(super) fn generate_scenario_test(
         line,
         tags: &tags,
         runtime: effective_runtime,
-        return_kind: ScenarioReturnKind::Unit,
+        return_kind,
         harness: harness_ref,
         attributes: ctx.attributes,
     };

--- a/crates/rstest-bdd-macros/src/macros/scenarios/test_generation.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/test_generation.rs
@@ -207,6 +207,34 @@ fn resolve_fixture_error_type(fixtures: &[FixtureSpec]) -> syn::Type {
     }
 }
 
+/// Classifies the scenario return kind from the current signature output,
+/// upgrading to `ResultUnit` when Result-returning fixtures require error
+/// propagation and the signature is not already fallible.
+///
+/// When an upgrade is performed, `sig.output` is rewritten in-place to the
+/// resolved `Result<(), E>` type so the generated function signature stays
+/// consistent with the chosen `ScenarioReturnKind`.
+fn resolve_scenario_return_kind(
+    sig: &mut syn::Signature,
+    has_result_fixtures: bool,
+    fixtures: &[FixtureSpec],
+) -> ScenarioReturnKind {
+    let mut return_kind = classify_return_type(&sig.output, None)
+        .map(|rk| match rk {
+            crate::return_classifier::ReturnKind::Unit => ScenarioReturnKind::Unit,
+            _ => ScenarioReturnKind::ResultUnit,
+        })
+        .unwrap_or(ScenarioReturnKind::Unit);
+
+    if has_result_fixtures && !return_kind.is_fallible() {
+        let error_ty = resolve_fixture_error_type(fixtures);
+        sig.output = syn::parse_quote! { -> ::std::result::Result<(), #error_ty> };
+        return_kind = ScenarioReturnKind::ResultUnit;
+    }
+
+    return_kind
+}
+
 /// Generate an rstest-backed test for a single scenario within a feature.
 ///
 /// Derives a unique function using `ctx` to build stable identifiers and
@@ -248,21 +276,8 @@ pub(super) fn generate_scenario_test(
         Err(err) => return err.to_compile_error(),
     };
 
-    // Classify the return kind from the (possibly user-supplied) signature,
-    // then upgrade to ResultUnit only when Result-returning fixtures require
-    // error propagation and the signature is not already fallible.
-    let mut return_kind = classify_return_type(&sig.output, None)
-        .map(|rk| match rk {
-            crate::return_classifier::ReturnKind::Unit => ScenarioReturnKind::Unit,
-            _ => ScenarioReturnKind::ResultUnit,
-        })
-        .unwrap_or(ScenarioReturnKind::Unit);
-
-    if fixture_setup.has_result_fixtures && !return_kind.is_fallible() {
-        let error_ty = resolve_fixture_error_type(ctx.fixtures);
-        sig.output = syn::parse_quote! { -> ::std::result::Result<(), #error_ty> };
-        return_kind = ScenarioReturnKind::ResultUnit;
-    }
+    let return_kind =
+        resolve_scenario_return_kind(&mut sig, fixture_setup.has_result_fixtures, ctx.fixtures);
 
     let feature_path = ctx.manifest_dir.join(ctx.rel_path).display().to_string();
     let vis = syn::Visibility::Inherited;

--- a/crates/rstest-bdd-macros/src/macros/scenarios/test_generation.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/test_generation.rs
@@ -230,9 +230,12 @@ fn resolve_fixture_error_type(fixtures: &[FixtureSpec]) -> syn::Type {
 /// upgrading to `ResultUnit` when Result-returning fixtures require error
 /// propagation and the signature is not already fallible.
 ///
-/// When an upgrade is performed, `sig.output` is rewritten in-place to the
-/// resolved `Result<(), E>` type so the generated function signature stays
-/// consistent with the chosen `ScenarioReturnKind`.
+/// Uses [`classify_return_type`] to determine the initial [`ScenarioReturnKind`]:
+/// `Unit` for unit returns, `ResultUnit` for fallible returns. When
+/// `has_result_fixtures` is true and the return kind is not already fallible,
+/// this function **mutates** `sig.output` in-place via
+/// [`resolve_fixture_error_type`] to upgrade it to `Result<(), E>`, ensuring
+/// the generated function signature can propagate fixture initialization errors.
 fn resolve_scenario_return_kind(
     sig: &mut syn::Signature,
     has_result_fixtures: bool,

--- a/crates/rstest-bdd-macros/src/macros/scenarios/test_generation.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/test_generation.rs
@@ -16,8 +16,10 @@ use crate::codegen::scenario::{
 use crate::parsing::examples::ExampleTable;
 use crate::parsing::feature::ScenarioData;
 use crate::parsing::tags::TagExpression;
+use crate::return_classifier::classify_return_type;
 use crate::utils::fixtures::extract_function_fixtures;
 use crate::utils::ident::sanitize_ident;
+use crate::utils::result_type::try_extract_result_error_type;
 
 use super::macro_args::{
     FixtureSpec, RuntimeCompatibilityAlias, RuntimeMode, runtime_compatibility_alias,
@@ -186,6 +188,25 @@ fn build_test_signature(
     }
 }
 
+/// Resolves a unified error type from `Result`-typed fixture specifications.
+///
+/// When all `Result<T, E>` fixtures share the same error type `E`, returns
+/// that type directly so the generated test signature uses it verbatim.
+/// When fixtures use different error types (or none are Result-typed), falls
+/// back to `Box<dyn ::std::error::Error>`.
+fn resolve_fixture_error_type(fixtures: &[FixtureSpec]) -> syn::Type {
+    let mut error_types: Vec<syn::Type> = fixtures
+        .iter()
+        .filter_map(|spec| try_extract_result_error_type(&spec.ty))
+        .collect();
+    error_types.dedup_by(|a, b| quote!(#a).to_string() == quote!(#b).to_string());
+    if error_types.len() == 1 {
+        error_types.remove(0)
+    } else {
+        syn::parse_quote! { Box<dyn ::std::error::Error> }
+    }
+}
+
 /// Generate an rstest-backed test for a single scenario within a feature.
 ///
 /// Derives a unique function using `ctx` to build stable identifiers and
@@ -227,20 +248,25 @@ pub(super) fn generate_scenario_test(
         Err(err) => return err.to_compile_error(),
     };
 
-    // When fixtures return Result, the generated test must propagate
-    // initialisation errors, so we upgrade the return kind and signature.
-    let return_kind = if fixture_setup.has_result_fixtures {
-        sig.output = syn::parse_quote! {
-            -> ::std::result::Result<(), Box<dyn ::std::error::Error>>
-        };
-        ScenarioReturnKind::ResultUnit
-    } else {
-        ScenarioReturnKind::Unit
-    };
+    // Classify the return kind from the (possibly user-supplied) signature,
+    // then upgrade to ResultUnit only when Result-returning fixtures require
+    // error propagation and the signature is not already fallible.
+    let mut return_kind = classify_return_type(&sig.output, None)
+        .map(|rk| match rk {
+            crate::return_classifier::ReturnKind::Unit => ScenarioReturnKind::Unit,
+            _ => ScenarioReturnKind::ResultUnit,
+        })
+        .unwrap_or(ScenarioReturnKind::Unit);
+
+    if fixture_setup.has_result_fixtures && !return_kind.is_fallible() {
+        let error_ty = resolve_fixture_error_type(ctx.fixtures);
+        sig.output = syn::parse_quote! { -> ::std::result::Result<(), #error_ty> };
+        return_kind = ScenarioReturnKind::ResultUnit;
+    }
 
     let feature_path = ctx.manifest_dir.join(ctx.rel_path).display().to_string();
     let vis = syn::Visibility::Inherited;
-    let block: syn::Block = if fixture_setup.has_result_fixtures {
+    let block: syn::Block = if return_kind.is_fallible() {
         syn::parse_quote!({ Ok(()) })
     } else {
         syn::parse_quote!({})

--- a/crates/rstest-bdd-macros/src/macros/scenarios/test_generation/tests.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/test_generation/tests.rs
@@ -375,10 +375,6 @@ fn resolve_fixture_error_type_mixed_plain_and_result_uses_result_error(#[case] f
     let error_str = quote!(#error_ty).to_string();
     assert!(
         error_str.contains("String"),
-        concat!(
-            "mixed fixtures with one result-like type should use its error type, ",
-            "got: {}"
-        ),
-        error_str
+        "mixed fixtures with one result-like type should use its error type, got: {error_str}"
     );
 }

--- a/crates/rstest-bdd-macros/src/macros/scenarios/test_generation/tests.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/test_generation/tests.rs
@@ -379,36 +379,31 @@ fn resolve_fixture_error_type_mixed_plain_and_result_uses_result_error(#[case] f
     );
 }
 
-#[test]
-fn resolve_fixture_error_type_non_consecutive_duplicates_returns_shared_type() {
-    // Tests that non-consecutive duplicate error types are deduplicated correctly
-    // Pattern: Result<A, E>, Result<B, F>, Result<C, E>
+#[rstest]
+#[case(
+    "Result<Database, std::io::Error>",
+    "Box",
+    "non-consecutive different error types should fall back to Box<dyn Error>"
+)]
+#[case(
+    "Result<Database, String>",
+    "String",
+    "all same error types (even non-consecutive) should return the shared type"
+)]
+fn resolve_fixture_error_type_non_consecutive_three_fixtures(
+    #[case] second_ty: &str,
+    #[case] expected_fragment: &str,
+    #[case] msg: &str,
+) {
     let fixtures = vec![
         make_fixture_spec("first", "Result<MyWorld, String>"),
-        make_fixture_spec("second", "Result<Database, std::io::Error>"),
+        make_fixture_spec("second", second_ty),
         make_fixture_spec("third", "Result<Config, String>"),
     ];
     let error_ty = resolve_fixture_error_type(&fixtures);
     let error_str = quote!(#error_ty).to_string();
     assert!(
-        error_str.contains("Box"),
-        "non-consecutive different error types should fall back to Box<dyn Error>, got: {error_str}"
-    );
-}
-
-#[test]
-fn resolve_fixture_error_type_all_same_non_consecutive_returns_shared_type() {
-    // Tests that when all error types are the same but non-consecutive, we return the shared type
-    // Pattern: Result<A, E>, Result<B, E>, Result<C, E>
-    let fixtures = vec![
-        make_fixture_spec("first", "Result<MyWorld, String>"),
-        make_fixture_spec("second", "Result<Database, String>"),
-        make_fixture_spec("third", "Result<Config, String>"),
-    ];
-    let error_ty = resolve_fixture_error_type(&fixtures);
-    let error_str = quote!(#error_ty).to_string();
-    assert!(
-        error_str.contains("String"),
-        "all same error types (even non-consecutive) should return shared type, got: {error_str}"
+        error_str.contains(expected_fragment),
+        "{msg}, got: {error_str}"
     );
 }

--- a/crates/rstest-bdd-macros/src/macros/scenarios/test_generation/tests.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/test_generation/tests.rs
@@ -378,3 +378,37 @@ fn resolve_fixture_error_type_mixed_plain_and_result_uses_result_error(#[case] f
         "mixed fixtures with one result-like type should use its error type, got: {error_str}"
     );
 }
+
+#[test]
+fn resolve_fixture_error_type_non_consecutive_duplicates_returns_shared_type() {
+    // Tests that non-consecutive duplicate error types are deduplicated correctly
+    // Pattern: Result<A, E>, Result<B, F>, Result<C, E>
+    let fixtures = vec![
+        make_fixture_spec("first", "Result<MyWorld, String>"),
+        make_fixture_spec("second", "Result<Database, std::io::Error>"),
+        make_fixture_spec("third", "Result<Config, String>"),
+    ];
+    let error_ty = resolve_fixture_error_type(&fixtures);
+    let error_str = quote!(#error_ty).to_string();
+    assert!(
+        error_str.contains("Box"),
+        "non-consecutive different error types should fall back to Box<dyn Error>, got: {error_str}"
+    );
+}
+
+#[test]
+fn resolve_fixture_error_type_all_same_non_consecutive_returns_shared_type() {
+    // Tests that when all error types are the same but non-consecutive, we return the shared type
+    // Pattern: Result<A, E>, Result<B, E>, Result<C, E>
+    let fixtures = vec![
+        make_fixture_spec("first", "Result<MyWorld, String>"),
+        make_fixture_spec("second", "Result<Database, String>"),
+        make_fixture_spec("third", "Result<Config, String>"),
+    ];
+    let error_ty = resolve_fixture_error_type(&fixtures);
+    let error_str = quote!(#error_ty).to_string();
+    assert!(
+        error_str.contains("String"),
+        "all same error types (even non-consecutive) should return shared type, got: {error_str}"
+    );
+}

--- a/crates/rstest-bdd-macros/src/macros/scenarios/test_generation/tests.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/test_generation/tests.rs
@@ -6,7 +6,7 @@ use super::super::macro_args::RuntimeMode;
 use super::super::macro_args::runtime_compatibility_alias;
 use super::{
     build_fixture_params, build_lint_attributes, build_test_signature, dedupe_name,
-    resolve_effective_runtime, resolve_harness_path,
+    resolve_effective_runtime, resolve_fixture_error_type, resolve_harness_path,
 };
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
@@ -294,5 +294,79 @@ fn runtime_harness_signature_pipeline(
     assert!(
         sig_str.starts_with(expected_sig_prefix),
         "expected signature starting with {expected_sig_prefix}, got: {sig_str}"
+    );
+}
+
+// -- Tests for resolve_fixture_error_type ---
+
+#[test]
+fn resolve_fixture_error_type_single_result_uses_fixture_error() {
+    let fixtures = vec![make_fixture_spec("world", "Result<MyWorld, String>")];
+    let error_ty = resolve_fixture_error_type(&fixtures);
+    let error_str = quote!(#error_ty).to_string();
+    assert!(
+        error_str.contains("String"),
+        "single Result fixture should use its error type, got: {error_str}"
+    );
+    assert!(
+        !error_str.contains("Box"),
+        "single Result fixture should not use Box<dyn Error>, got: {error_str}"
+    );
+}
+
+#[test]
+fn resolve_fixture_error_type_multiple_same_error_uses_shared_type() {
+    let fixtures = vec![
+        make_fixture_spec("world", "Result<MyWorld, String>"),
+        make_fixture_spec("db", "Result<Database, String>"),
+    ];
+    let error_ty = resolve_fixture_error_type(&fixtures);
+    let error_str = quote!(#error_ty).to_string();
+    assert!(
+        error_str.contains("String"),
+        "fixtures sharing the same error type should use it directly, got: {error_str}"
+    );
+}
+
+#[test]
+fn resolve_fixture_error_type_different_errors_falls_back_to_box() {
+    let fixtures = vec![
+        make_fixture_spec("world", "Result<MyWorld, String>"),
+        make_fixture_spec("db", "Result<Database, std::io::Error>"),
+    ];
+    let error_ty = resolve_fixture_error_type(&fixtures);
+    let error_str = quote!(#error_ty).to_string();
+    assert!(
+        error_str.contains("Box"),
+        "different error types should fall back to Box<dyn Error>, got: {error_str}"
+    );
+}
+
+#[test]
+fn resolve_fixture_error_type_no_result_fixtures_falls_back_to_box() {
+    let fixtures = vec![make_fixture_spec("world", "MyWorld")];
+    let error_ty = resolve_fixture_error_type(&fixtures);
+    let error_str = quote!(#error_ty).to_string();
+    assert!(
+        error_str.contains("Box"),
+        "no Result fixtures should fall back to Box<dyn Error>, got: {error_str}"
+    );
+}
+
+#[test]
+fn resolve_fixture_error_type_mixed_plain_and_result_uses_result_error() {
+    let fixtures = vec![
+        make_fixture_spec("plain", "MyWorld"),
+        make_fixture_spec("fallible", "Result<Database, String>"),
+    ];
+    let error_ty = resolve_fixture_error_type(&fixtures);
+    let error_str = quote!(#error_ty).to_string();
+    assert!(
+        error_str.contains("String"),
+        concat!(
+            "mixed fixtures with one Result should use its error type, ",
+            "got: {}"
+        ),
+        error_str
     );
 }

--- a/crates/rstest-bdd-macros/src/macros/scenarios/test_generation/tests.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/test_generation/tests.rs
@@ -1,5 +1,7 @@
 //! Unit tests for scenario test generation helpers.
 
+use rstest::rstest;
+
 use super::super::macro_args::FixtureSpec;
 use super::super::macro_args::RuntimeCompatibilityAlias;
 use super::super::macro_args::RuntimeMode;
@@ -299,26 +301,34 @@ fn runtime_harness_signature_pipeline(
 
 // -- Tests for resolve_fixture_error_type ---
 
-#[test]
-fn resolve_fixture_error_type_single_result_uses_fixture_error() {
-    let fixtures = vec![make_fixture_spec("world", "Result<MyWorld, String>")];
+#[rstest]
+#[case("Result<MyWorld, String>")]
+#[case("StepResult<MyWorld, String>")]
+fn resolve_fixture_error_type_single_result_uses_fixture_error(#[case] fixture_ty: &str) {
+    let fixtures = vec![make_fixture_spec("world", fixture_ty)];
     let error_ty = resolve_fixture_error_type(&fixtures);
     let error_str = quote!(#error_ty).to_string();
     assert!(
         error_str.contains("String"),
-        "single Result fixture should use its error type, got: {error_str}"
+        "single result-like fixture should use its error type, got: {error_str}"
     );
     assert!(
         !error_str.contains("Box"),
-        "single Result fixture should not use Box<dyn Error>, got: {error_str}"
+        "single result-like fixture should not use Box<dyn Error>, got: {error_str}"
     );
 }
 
-#[test]
-fn resolve_fixture_error_type_multiple_same_error_uses_shared_type() {
+#[rstest]
+#[case("Result<MyWorld, String>", "Result<Database, String>")]
+#[case("StepResult<MyWorld, String>", "StepResult<Database, String>")]
+#[case("Result<MyWorld, String>", "StepResult<Database, String>")]
+fn resolve_fixture_error_type_multiple_same_error_uses_shared_type(
+    #[case] fixture1_ty: &str,
+    #[case] fixture2_ty: &str,
+) {
     let fixtures = vec![
-        make_fixture_spec("world", "Result<MyWorld, String>"),
-        make_fixture_spec("db", "Result<Database, String>"),
+        make_fixture_spec("world", fixture1_ty),
+        make_fixture_spec("db", fixture2_ty),
     ];
     let error_ty = resolve_fixture_error_type(&fixtures);
     let error_str = quote!(#error_ty).to_string();
@@ -353,18 +363,20 @@ fn resolve_fixture_error_type_no_result_fixtures_falls_back_to_box() {
     );
 }
 
-#[test]
-fn resolve_fixture_error_type_mixed_plain_and_result_uses_result_error() {
+#[rstest]
+#[case("Result<Database, String>")]
+#[case("StepResult<Database, String>")]
+fn resolve_fixture_error_type_mixed_plain_and_result_uses_result_error(#[case] fallible_ty: &str) {
     let fixtures = vec![
         make_fixture_spec("plain", "MyWorld"),
-        make_fixture_spec("fallible", "Result<Database, String>"),
+        make_fixture_spec("fallible", fallible_ty),
     ];
     let error_ty = resolve_fixture_error_type(&fixtures);
     let error_str = quote!(#error_ty).to_string();
     assert!(
         error_str.contains("String"),
         concat!(
-            "mixed fixtures with one Result should use its error type, ",
+            "mixed fixtures with one result-like type should use its error type, ",
             "got: {}"
         ),
         error_str

--- a/crates/rstest-bdd-macros/src/return_classifier.rs
+++ b/crates/rstest-bdd-macros/src/return_classifier.rs
@@ -88,7 +88,7 @@ fn classify_result_like(ty: &Type) -> Option<ReturnKind> {
         _ => return None,
     };
 
-    if is_result_path(path) || is_step_result_path(path) {
+    if is_result_like_path(path) {
         let ok_ty = first_type_argument(path)?;
         return Some(if is_unit_type(ok_ty) {
             ReturnKind::ResultUnit
@@ -177,6 +177,12 @@ where
     })
 }
 
+/// Returns `true` when `path` matches a recognised `Result` or `StepResult`
+/// shape, combining both [`is_result_path`] and [`is_step_result_path`].
+pub(crate) fn is_result_like_path(path: &Path) -> bool {
+    is_result_path(path) || is_step_result_path(path)
+}
+
 fn is_result_path(path: &Path) -> bool {
     matches_type_path(path, "Result", |segments| {
         let segments: Vec<_> = segments.iter().map(String::as_str).collect();
@@ -194,7 +200,7 @@ fn is_step_result_path(path: &Path) -> bool {
     })
 }
 
-fn first_type_argument(path: &Path) -> Option<&Type> {
+pub(crate) fn first_type_argument(path: &Path) -> Option<&Type> {
     let segment = path.segments.last()?;
     let args = match &segment.arguments {
         syn::PathArguments::AngleBracketed(args) => &args.args,

--- a/crates/rstest-bdd-macros/src/return_classifier.rs
+++ b/crates/rstest-bdd-macros/src/return_classifier.rs
@@ -201,21 +201,32 @@ fn is_step_result_path(path: &Path) -> bool {
 }
 
 pub(crate) fn first_type_argument(path: &Path) -> Option<&Type> {
+    nth_type_argument(path, 0)
+}
+
+/// Extracts the error type `E` from `Result<T, E>` or `StepResult<T, E>`.
+pub(crate) fn second_type_argument(path: &Path) -> Option<&Type> {
+    nth_type_argument(path, 1)
+}
+
+fn nth_type_argument(path: &Path, n: usize) -> Option<&Type> {
     let segment = path.segments.last()?;
     let args = match &segment.arguments {
         syn::PathArguments::AngleBracketed(args) => &args.args,
         _ => return None,
     };
 
-    args.iter().find_map(|arg| match arg {
-        syn::GenericArgument::Type(ty) => Some(ty),
-        _ => None,
-    })
+    args.iter()
+        .filter_map(|arg| match arg {
+            syn::GenericArgument::Type(ty) => Some(ty),
+            _ => None,
+        })
+        .nth(n)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{ReturnKind, ReturnOverride, classify_return_type};
+    use super::{ReturnKind, ReturnOverride, classify_return_type, second_type_argument};
 
     /// Helper to assert that a given function signature classifies to the expected kind.
     fn assert_classifies_to(
@@ -342,6 +353,28 @@ mod tests {
             Some(ReturnOverride::Value),
             ReturnKind::Value,
         );
+    }
+
+    #[test]
+    fn second_type_argument_extracts_error_type() {
+        let ty: syn::Type = syn::parse_quote! { Result<u8, String> };
+        let syn::Type::Path(tp) = &ty else {
+            panic!("expected Type::Path")
+        };
+        let Some(second) = second_type_argument(&tp.path) else {
+            panic!("should extract second type argument");
+        };
+        let s = quote::quote!(#second).to_string();
+        assert!(s.contains("String"), "expected String, got: {s}");
+    }
+
+    #[test]
+    fn second_type_argument_returns_none_for_single_generic() {
+        let ty: syn::Type = syn::parse_quote! { Option<u8> };
+        let syn::Type::Path(tp) = &ty else {
+            panic!("expected Type::Path")
+        };
+        assert!(second_type_argument(&tp.path).is_none());
     }
 
     #[test]

--- a/crates/rstest-bdd-macros/src/utils/fixtures.rs
+++ b/crates/rstest-bdd-macros/src/utils/fixtures.rs
@@ -16,6 +16,39 @@ pub(crate) struct FixtureBindingCode {
     pub has_result_fixtures: bool,
 }
 
+/// Fixture processing outcome for a single parameter.
+enum FixtureProcessing {
+    /// Fixture is a reference and should be inserted by-reference.
+    Reference,
+    /// Fixture is a `Result<T, E>` or `StepResult<T, E>` and must be unwrapped.
+    ResultType { inner_ty: Box<syn::Type> },
+    /// Fixture is an owned value and should be boxed in a `RefCell`.
+    Owned,
+}
+
+/// Classify a fixture parameter type into its processing category.
+fn classify_fixture_type(ty: &syn::Type) -> syn::Result<FixtureProcessing> {
+    if matches!(ty, syn::Type::Reference(_)) {
+        if is_referenced_result_type(ty) {
+            return Err(syn::Error::new_spanned(
+                ty,
+                concat!(
+                    "fixture parameter borrows a `Result<T, E>`; ",
+                    "use an owned `Result<T, E>` instead so the ",
+                    "scenario can unwrap it with `?`",
+                ),
+            ));
+        }
+        Ok(FixtureProcessing::Reference)
+    } else if let Some(inner_ty) = try_extract_result_inner_type(ty) {
+        Ok(FixtureProcessing::ResultType {
+            inner_ty: Box::new(inner_ty),
+        })
+    } else {
+        Ok(FixtureProcessing::Owned)
+    }
+}
+
 /// Extract function argument identifiers and create insert statements.
 ///
 /// When a fixture parameter has a `Result<T, E>` type, the generated prelude
@@ -45,33 +78,28 @@ pub(crate) fn extract_function_fixtures(
         let name_lit = syn::LitStr::new(&fixture_name, proc_macro2::Span::call_site());
         arg_idents.push(binding.clone());
         let ty = &*pat_ty.ty;
-        if matches!(ty, syn::Type::Reference(_)) {
-            if is_referenced_result_type(ty) {
-                return Err(syn::Error::new_spanned(
-                    ty,
-                    concat!(
-                        "fixture parameter borrows a `Result<T, E>`; ",
-                        "use an owned `Result<T, E>` instead so the ",
-                        "scenario can unwrap it with `?`",
-                    ),
-                ));
+
+        match classify_fixture_type(ty)? {
+            FixtureProcessing::Reference => {
+                inserts.push(quote! { ctx.insert(#name_lit, &#binding); });
             }
-            inserts.push(quote! { ctx.insert(#name_lit, &#binding); });
-        } else if let Some(inner_ty) = try_extract_result_inner_type(ty) {
-            has_result_fixtures = true;
-            let unwrapped = format_ident!("__rstest_bdd_unwrapped_{cell_index}");
-            prelude.push(quote! { let #unwrapped = #binding?; });
-            let (pre, insert, post) =
-                build_non_ref_fixture_binding(&unwrapped, &inner_ty, &name_lit, cell_index);
-            prelude.push(pre);
-            inserts.push(insert);
-            postlude.push(post);
-        } else {
-            let (pre, insert, post) =
-                build_non_ref_fixture_binding(&binding, ty, &name_lit, cell_index);
-            prelude.push(pre);
-            inserts.push(insert);
-            postlude.push(post);
+            FixtureProcessing::ResultType { inner_ty } => {
+                has_result_fixtures = true;
+                let unwrapped = format_ident!("__rstest_bdd_unwrapped_{cell_index}");
+                prelude.push(quote! { let #unwrapped = #binding?; });
+                let (pre, insert, post) =
+                    build_non_ref_fixture_binding(&unwrapped, &inner_ty, &name_lit, cell_index);
+                prelude.push(pre);
+                inserts.push(insert);
+                postlude.push(post);
+            }
+            FixtureProcessing::Owned => {
+                let (pre, insert, post) =
+                    build_non_ref_fixture_binding(&binding, ty, &name_lit, cell_index);
+                prelude.push(pre);
+                inserts.push(insert);
+                postlude.push(post);
+            }
         }
     }
 

--- a/crates/rstest-bdd-macros/src/utils/fixtures.rs
+++ b/crates/rstest-bdd-macros/src/utils/fixtures.rs
@@ -13,7 +13,7 @@ pub(crate) struct FixtureBindingCode {
     /// `true` when at least one fixture parameter has a result-like type
     /// (`Result<T, E>` or `StepResult<T, E>`), meaning the scenario must
     /// return a fallible type so the generated `?` operator can propagate
-    /// initialisation errors.
+    /// initialization errors.
     pub has_result_fixtures: bool,
 }
 

--- a/crates/rstest-bdd-macros/src/utils/fixtures.rs
+++ b/crates/rstest-bdd-macros/src/utils/fixtures.rs
@@ -259,26 +259,28 @@ mod tests {
         assert_eq!(name, "state", "#[from] attribute should take precedence");
     }
 
-    #[test]
-    #[expect(clippy::expect_used, reason = "test asserts Result fixture extraction")]
-    fn result_fixture_sets_has_result_fixtures_flag() {
-        let mut sig: syn::Signature = parse_quote! {
-            fn scenario(world: Result<MyWorld, String>)
-        };
+    #[rstest]
+    #[case(parse_quote! { fn scenario(world: Result<MyWorld, String>) }, true)]
+    #[case(parse_quote! { fn scenario(world: MyWorld) }, false)]
+    fn result_fixture_flag_reflects_return_type(
+        #[case] mut sig: syn::Signature,
+        #[case] expected: bool,
+    ) {
+        #[expect(clippy::expect_used, reason = "test asserts fixture extraction")]
         let (_idents, code) =
             extract_function_fixtures(&mut sig).expect("fixture extraction should succeed");
-        assert!(
-            code.has_result_fixtures,
-            "has_result_fixtures should be true for Result-typed fixtures"
+        assert_eq!(
+            code.has_result_fixtures, expected,
+            "has_result_fixtures should be {expected}"
         );
     }
 
     #[test]
     #[expect(
         clippy::expect_used,
-        reason = "test asserts Result fixture generates unwrap statement"
+        reason = "test asserts Result fixture generates correct bindings"
     )]
-    fn result_fixture_generates_unwrap_in_prelude() {
+    fn result_fixture_extraction_generates_correct_bindings() {
         let mut sig: syn::Signature = parse_quote! {
             fn scenario(world: Result<MyWorld, String>)
         };
@@ -293,19 +295,6 @@ mod tests {
             prelude_str.contains('?'),
             "prelude should contain ? operator for Result unwrap, got: {prelude_str}"
         );
-    }
-
-    #[test]
-    #[expect(
-        clippy::expect_used,
-        reason = "test asserts Result fixture uses inner type for StepContext"
-    )]
-    fn result_fixture_uses_inner_type_for_context_insert() {
-        let mut sig: syn::Signature = parse_quote! {
-            fn scenario(world: Result<MyWorld, String>)
-        };
-        let (_idents, code) =
-            extract_function_fixtures(&mut sig).expect("fixture extraction should succeed");
         let insert_str: String = code.ctx_inserts.iter().map(ToString::to_string).collect();
         assert!(
             insert_str.contains("MyWorld"),
@@ -317,45 +306,15 @@ mod tests {
         );
     }
 
-    #[test]
-    #[expect(
-        clippy::expect_used,
-        reason = "test asserts non-Result fixture does not set flag"
-    )]
-    fn plain_fixture_does_not_set_has_result_fixtures() {
-        let mut sig: syn::Signature = parse_quote! {
-            fn scenario(world: MyWorld)
-        };
-        let (_idents, code) =
-            extract_function_fixtures(&mut sig).expect("fixture extraction should succeed");
-        assert!(
-            !code.has_result_fixtures,
-            "has_result_fixtures should be false for plain fixtures"
-        );
-    }
-
-    #[test]
-    fn ref_result_fixture_emits_compile_error() {
-        let mut sig: syn::Signature = parse_quote! {
-            fn scenario(world: &Result<MyWorld, String>)
-        };
+    #[rstest]
+    #[case(parse_quote! { fn scenario(world: &Result<MyWorld, String>) }, "& Result")]
+    #[case(parse_quote! { fn scenario(world: &mut Result<MyWorld, String>) }, "&mut Result")]
+    fn borrowed_result_fixture_emits_compile_error(
+        #[case] mut sig: syn::Signature,
+        #[case] label: &str,
+    ) {
         let Err(err) = extract_function_fixtures(&mut sig) else {
-            panic!("&Result fixture should be rejected")
-        };
-        let msg = err.to_string();
-        assert!(
-            msg.contains("borrows a `Result<T, E>`"),
-            "error should mention borrowed Result, got: {msg}"
-        );
-    }
-
-    #[test]
-    fn mut_ref_result_fixture_emits_compile_error() {
-        let mut sig: syn::Signature = parse_quote! {
-            fn scenario(world: &mut Result<MyWorld, String>)
-        };
-        let Err(err) = extract_function_fixtures(&mut sig) else {
-            panic!("&mut Result fixture should be rejected")
+            panic!("{label} fixture should be rejected")
         };
         let msg = err.to_string();
         assert!(

--- a/crates/rstest-bdd-macros/src/utils/fixtures.rs
+++ b/crates/rstest-bdd-macros/src/utils/fixtures.rs
@@ -3,13 +3,25 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 
+use crate::utils::result_type::try_extract_result_inner_type;
+
+/// Generated code for wiring scenario fixture parameters into `StepContext`.
 pub(crate) struct FixtureBindingCode {
     pub prelude: Vec<TokenStream2>,
     pub ctx_inserts: Vec<TokenStream2>,
     pub postlude: Vec<TokenStream2>,
+    /// `true` when at least one fixture parameter has a `Result<T, E>` type,
+    /// meaning the scenario must return `Result<(), E>` so the generated `?`
+    /// operator can propagate initialisation errors.
+    pub has_result_fixtures: bool,
 }
 
 /// Extract function argument identifiers and create insert statements.
+///
+/// When a fixture parameter has a `Result<T, E>` type, the generated prelude
+/// unwraps it with `?` and registers the inner `T` in the `StepContext`.
+/// The caller must ensure the scenario returns `Result<(), E>` so the `?`
+/// operator compiles.
 pub(crate) fn extract_function_fixtures(
     sig: &mut syn::Signature,
 ) -> syn::Result<(Vec<syn::Ident>, FixtureBindingCode)> {
@@ -18,6 +30,7 @@ pub(crate) fn extract_function_fixtures(
     let mut inserts = Vec::new();
     let mut prelude = Vec::new();
     let mut postlude = Vec::new();
+    let mut has_result_fixtures = false;
 
     for input in &mut sig.inputs {
         let syn::FnArg::Typed(pat_ty) = input else {
@@ -34,6 +47,15 @@ pub(crate) fn extract_function_fixtures(
         let ty = &*pat_ty.ty;
         if matches!(ty, syn::Type::Reference(_)) {
             inserts.push(quote! { ctx.insert(#name_lit, &#binding); });
+        } else if let Some(inner_ty) = try_extract_result_inner_type(ty) {
+            has_result_fixtures = true;
+            let unwrapped = format_ident!("__rstest_bdd_unwrapped_{cell_index}");
+            prelude.push(quote! { let #unwrapped = #binding?; });
+            let (pre, insert, post) =
+                build_non_ref_fixture_binding(&unwrapped, &inner_ty, &name_lit, cell_index);
+            prelude.push(pre);
+            inserts.push(insert);
+            postlude.push(post);
         } else {
             let (pre, insert, post) =
                 build_non_ref_fixture_binding(&binding, ty, &name_lit, cell_index);
@@ -49,6 +71,7 @@ pub(crate) fn extract_function_fixtures(
             prelude,
             ctx_inserts: inserts,
             postlude,
+            has_result_fixtures,
         },
     ))
 }
@@ -196,5 +219,80 @@ mod tests {
         };
         let name = resolve_fixture_name(pat_ty).expect("fixture name resolution should succeed");
         assert_eq!(name, "state", "#[from] attribute should take precedence");
+    }
+
+    #[test]
+    #[expect(clippy::expect_used, reason = "test asserts Result fixture extraction")]
+    fn result_fixture_sets_has_result_fixtures_flag() {
+        let mut sig: syn::Signature = parse_quote! {
+            fn scenario(world: Result<MyWorld, String>)
+        };
+        let (_idents, code) =
+            extract_function_fixtures(&mut sig).expect("fixture extraction should succeed");
+        assert!(
+            code.has_result_fixtures,
+            "has_result_fixtures should be true for Result-typed fixtures"
+        );
+    }
+
+    #[test]
+    #[expect(
+        clippy::expect_used,
+        reason = "test asserts Result fixture generates unwrap statement"
+    )]
+    fn result_fixture_generates_unwrap_in_prelude() {
+        let mut sig: syn::Signature = parse_quote! {
+            fn scenario(world: Result<MyWorld, String>)
+        };
+        let (_idents, code) =
+            extract_function_fixtures(&mut sig).expect("fixture extraction should succeed");
+        let prelude_str: String = code.prelude.iter().map(ToString::to_string).collect();
+        assert!(
+            prelude_str.contains("__rstest_bdd_unwrapped_0"),
+            "prelude should contain unwrap binding, got: {prelude_str}"
+        );
+        assert!(
+            prelude_str.contains('?'),
+            "prelude should contain ? operator for Result unwrap, got: {prelude_str}"
+        );
+    }
+
+    #[test]
+    #[expect(
+        clippy::expect_used,
+        reason = "test asserts Result fixture uses inner type for StepContext"
+    )]
+    fn result_fixture_uses_inner_type_for_context_insert() {
+        let mut sig: syn::Signature = parse_quote! {
+            fn scenario(world: Result<MyWorld, String>)
+        };
+        let (_idents, code) =
+            extract_function_fixtures(&mut sig).expect("fixture extraction should succeed");
+        let insert_str: String = code.ctx_inserts.iter().map(ToString::to_string).collect();
+        assert!(
+            insert_str.contains("MyWorld"),
+            "context insert should use inner type MyWorld, got: {insert_str}"
+        );
+        assert!(
+            !insert_str.contains("Result"),
+            "context insert should not reference Result wrapper, got: {insert_str}"
+        );
+    }
+
+    #[test]
+    #[expect(
+        clippy::expect_used,
+        reason = "test asserts non-Result fixture does not set flag"
+    )]
+    fn plain_fixture_does_not_set_has_result_fixtures() {
+        let mut sig: syn::Signature = parse_quote! {
+            fn scenario(world: MyWorld)
+        };
+        let (_idents, code) =
+            extract_function_fixtures(&mut sig).expect("fixture extraction should succeed");
+        assert!(
+            !code.has_result_fixtures,
+            "has_result_fixtures should be false for plain fixtures"
+        );
     }
 }

--- a/crates/rstest-bdd-macros/src/utils/fixtures.rs
+++ b/crates/rstest-bdd-macros/src/utils/fixtures.rs
@@ -3,7 +3,7 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 
-use crate::utils::result_type::try_extract_result_inner_type;
+use crate::utils::result_type::{is_referenced_result_type, try_extract_result_inner_type};
 
 /// Generated code for wiring scenario fixture parameters into `StepContext`.
 pub(crate) struct FixtureBindingCode {
@@ -46,6 +46,16 @@ pub(crate) fn extract_function_fixtures(
         arg_idents.push(binding.clone());
         let ty = &*pat_ty.ty;
         if matches!(ty, syn::Type::Reference(_)) {
+            if is_referenced_result_type(ty) {
+                return Err(syn::Error::new_spanned(
+                    ty,
+                    concat!(
+                        "fixture parameter borrows a `Result<T, E>`; ",
+                        "use an owned `Result<T, E>` instead so the ",
+                        "scenario can unwrap it with `?`",
+                    ),
+                ));
+            }
             inserts.push(quote! { ctx.insert(#name_lit, &#binding); });
         } else if let Some(inner_ty) = try_extract_result_inner_type(ty) {
             has_result_fixtures = true;
@@ -293,6 +303,36 @@ mod tests {
         assert!(
             !code.has_result_fixtures,
             "has_result_fixtures should be false for plain fixtures"
+        );
+    }
+
+    #[test]
+    fn ref_result_fixture_emits_compile_error() {
+        let mut sig: syn::Signature = parse_quote! {
+            fn scenario(world: &Result<MyWorld, String>)
+        };
+        let Err(err) = extract_function_fixtures(&mut sig) else {
+            panic!("&Result fixture should be rejected")
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("borrows a `Result<T, E>`"),
+            "error should mention borrowed Result, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn mut_ref_result_fixture_emits_compile_error() {
+        let mut sig: syn::Signature = parse_quote! {
+            fn scenario(world: &mut Result<MyWorld, String>)
+        };
+        let Err(err) = extract_function_fixtures(&mut sig) else {
+            panic!("&mut Result fixture should be rejected")
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("borrows a `Result<T, E>`"),
+            "error should mention borrowed Result, got: {msg}"
         );
     }
 }

--- a/crates/rstest-bdd-macros/src/utils/fixtures.rs
+++ b/crates/rstest-bdd-macros/src/utils/fixtures.rs
@@ -3,7 +3,9 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 
-use crate::utils::result_type::{is_referenced_result_type, try_extract_result_inner_type};
+use crate::utils::result_type::{
+    is_referenced_result_type, try_extract_result_inner_type, ungroup_type,
+};
 
 /// Generated code for wiring scenario fixture parameters into `StepContext`.
 pub(crate) struct FixtureBindingCode {
@@ -29,8 +31,11 @@ enum FixtureProcessing {
 
 /// Classify a fixture parameter type into its processing category.
 fn classify_fixture_type(ty: &syn::Type) -> syn::Result<FixtureProcessing> {
-    if matches!(ty, syn::Type::Reference(_)) {
-        if is_referenced_result_type(ty) {
+    // Normalize the type by removing paren/group wrappers first
+    let normalized_ty = ungroup_type(ty);
+
+    if matches!(normalized_ty, syn::Type::Reference(_)) {
+        if is_referenced_result_type(normalized_ty) {
             return Err(syn::Error::new_spanned(
                 ty,
                 concat!(
@@ -41,7 +46,7 @@ fn classify_fixture_type(ty: &syn::Type) -> syn::Result<FixtureProcessing> {
             ));
         }
         Ok(FixtureProcessing::Reference)
-    } else if let Some(inner_ty) = try_extract_result_inner_type(ty) {
+    } else if let Some(inner_ty) = try_extract_result_inner_type(normalized_ty) {
         Ok(FixtureProcessing::ResultType {
             inner_ty: Box::new(inner_ty),
         })
@@ -277,6 +282,28 @@ mod tests {
         );
     }
 
+    #[rstest]
+    #[case(parse_quote! { fn scenario(world: (&MyWorld)) })]
+    #[case(parse_quote! { fn scenario(world: (&mut MyWorld)) })]
+    fn parenthesized_references_are_treated_as_references(#[case] mut sig: syn::Signature) {
+        #[expect(clippy::expect_used, reason = "test asserts fixture extraction")]
+        let (_idents, code) =
+            extract_function_fixtures(&mut sig).expect("fixture extraction should succeed");
+        // Parenthesized references should be treated as references, not owned
+        // This means they should NOT generate RefCell wrapping in the prelude
+        let prelude_str: String = code.prelude.iter().map(ToString::to_string).collect();
+        assert!(
+            !prelude_str.contains("RefCell"),
+            "parenthesized reference should not generate RefCell wrapping, got: {prelude_str}"
+        );
+        // References are inserted directly without unwrapping
+        let insert_str: String = code.ctx_inserts.iter().map(ToString::to_string).collect();
+        assert!(
+            !insert_str.contains("borrow"),
+            "parenthesized reference should not generate borrow calls, got: {insert_str}"
+        );
+    }
+
     #[test]
     #[expect(
         clippy::expect_used,
@@ -348,6 +375,10 @@ mod tests {
     #[case(parse_quote! { fn scenario(world: &mut Result<MyWorld, String>) }, "&mut Result")]
     #[case(parse_quote! { fn scenario(world: &StepResult<MyWorld, String>) }, "&StepResult")]
     #[case(parse_quote! { fn scenario(world: &mut StepResult<MyWorld, String>) }, "&mut StepResult")]
+    #[case(parse_quote! { fn scenario(world: (&Result<MyWorld, String>)) }, "(&Result)")]
+    #[case(parse_quote! { fn scenario(world: (&mut Result<MyWorld, String>)) }, "(&mut Result)")]
+    #[case(parse_quote! { fn scenario(world: (&StepResult<MyWorld, String>)) }, "(&StepResult)")]
+    #[case(parse_quote! { fn scenario(world: (&mut StepResult<MyWorld, String>)) }, "(&mut StepResult)")]
     fn borrowed_result_fixture_emits_compile_error(
         #[case] mut sig: syn::Signature,
         #[case] label: &str,

--- a/crates/rstest-bdd-macros/src/utils/fixtures.rs
+++ b/crates/rstest-bdd-macros/src/utils/fixtures.rs
@@ -10,9 +10,10 @@ pub(crate) struct FixtureBindingCode {
     pub prelude: Vec<TokenStream2>,
     pub ctx_inserts: Vec<TokenStream2>,
     pub postlude: Vec<TokenStream2>,
-    /// `true` when at least one fixture parameter has a `Result<T, E>` type,
-    /// meaning the scenario must return `Result<(), E>` so the generated `?`
-    /// operator can propagate initialisation errors.
+    /// `true` when at least one fixture parameter has a result-like type
+    /// (`Result<T, E>` or `StepResult<T, E>`), meaning the scenario must
+    /// return a fallible type so the generated `?` operator can propagate
+    /// initialisation errors.
     pub has_result_fixtures: bool,
 }
 
@@ -33,9 +34,9 @@ fn classify_fixture_type(ty: &syn::Type) -> syn::Result<FixtureProcessing> {
             return Err(syn::Error::new_spanned(
                 ty,
                 concat!(
-                    "fixture parameter borrows a `Result<T, E>`; ",
-                    "use an owned `Result<T, E>` instead so the ",
-                    "scenario can unwrap it with `?`",
+                    "fixture parameter borrows a result-like type ",
+                    "(`Result<T, E>` or `StepResult<T, E>`); ",
+                    "use an owned value instead so the scenario can unwrap it with `?`",
                 ),
             ));
         }
@@ -51,10 +52,10 @@ fn classify_fixture_type(ty: &syn::Type) -> syn::Result<FixtureProcessing> {
 
 /// Extract function argument identifiers and create insert statements.
 ///
-/// When a fixture parameter has a `Result<T, E>` type, the generated prelude
-/// unwraps it with `?` and registers the inner `T` in the `StepContext`.
-/// The caller must ensure the scenario returns `Result<(), E>` so the `?`
-/// operator compiles.
+/// When a fixture parameter has a result-like type (`Result<T, E>` or
+/// `StepResult<T, E>`), the generated prelude unwraps it with `?` and
+/// registers the inner `T` in the `StepContext`. The caller must ensure
+/// the scenario returns a fallible type so the `?` operator compiles.
 pub(crate) fn extract_function_fixtures(
     sig: &mut syn::Signature,
 ) -> syn::Result<(Vec<syn::Ident>, FixtureBindingCode)> {
@@ -261,6 +262,7 @@ mod tests {
 
     #[rstest]
     #[case(parse_quote! { fn scenario(world: Result<MyWorld, String>) }, true)]
+    #[case(parse_quote! { fn scenario(world: StepResult<MyWorld, String>) }, true)]
     #[case(parse_quote! { fn scenario(world: MyWorld) }, false)]
     fn result_fixture_flag_reflects_return_type(
         #[case] mut sig: syn::Signature,
@@ -306,9 +308,46 @@ mod tests {
         );
     }
 
+    #[test]
+    #[expect(
+        clippy::expect_used,
+        reason = "test asserts StepResult fixture generates correct bindings"
+    )]
+    fn step_result_fixture_extraction_generates_correct_bindings() {
+        let mut sig: syn::Signature = parse_quote! {
+            fn scenario(world: StepResult<MyWorld, String>)
+        };
+        let (_idents, code) =
+            extract_function_fixtures(&mut sig).expect("fixture extraction should succeed");
+        assert!(
+            code.has_result_fixtures,
+            "StepResult fixture should set has_result_fixtures flag"
+        );
+        let prelude_str: String = code.prelude.iter().map(ToString::to_string).collect();
+        assert!(
+            prelude_str.contains("__rstest_bdd_unwrapped_0"),
+            "prelude should contain unwrap binding for StepResult, got: {prelude_str}"
+        );
+        assert!(
+            prelude_str.contains('?'),
+            "prelude should contain ? operator for StepResult unwrap, got: {prelude_str}"
+        );
+        let insert_str: String = code.ctx_inserts.iter().map(ToString::to_string).collect();
+        assert!(
+            insert_str.contains("MyWorld"),
+            "context insert should use inner type MyWorld, got: {insert_str}"
+        );
+        assert!(
+            !insert_str.contains("StepResult"),
+            "context insert should not reference StepResult wrapper, got: {insert_str}"
+        );
+    }
+
     #[rstest]
-    #[case(parse_quote! { fn scenario(world: &Result<MyWorld, String>) }, "& Result")]
+    #[case(parse_quote! { fn scenario(world: &Result<MyWorld, String>) }, "&Result")]
     #[case(parse_quote! { fn scenario(world: &mut Result<MyWorld, String>) }, "&mut Result")]
+    #[case(parse_quote! { fn scenario(world: &StepResult<MyWorld, String>) }, "&StepResult")]
+    #[case(parse_quote! { fn scenario(world: &mut StepResult<MyWorld, String>) }, "&mut StepResult")]
     fn borrowed_result_fixture_emits_compile_error(
         #[case] mut sig: syn::Signature,
         #[case] label: &str,
@@ -318,8 +357,8 @@ mod tests {
         };
         let msg = err.to_string();
         assert!(
-            msg.contains("borrows a `Result<T, E>`"),
-            "error should mention borrowed Result, got: {msg}"
+            msg.contains("borrows a result-like type"),
+            "error should mention borrowed result-like type, got: {msg}"
         );
     }
 }

--- a/crates/rstest-bdd-macros/src/utils/mod.rs
+++ b/crates/rstest-bdd-macros/src/utils/mod.rs
@@ -4,3 +4,4 @@ pub(crate) mod errors;
 pub(crate) mod fixtures;
 pub(crate) mod ident;
 pub(crate) mod pattern;
+pub(crate) mod result_type;

--- a/crates/rstest-bdd-macros/src/utils/result_type.rs
+++ b/crates/rstest-bdd-macros/src/utils/result_type.rs
@@ -9,6 +9,19 @@ use syn::Type;
 
 use crate::return_classifier::{first_type_argument, is_result_like_path, second_type_argument};
 
+/// Recursively strips `Type::Paren` and `Type::Group` wrappers to reveal
+/// the underlying type.
+///
+/// Parenthesized types like `(Result<T, E>)` and grouped types are
+/// normalized to their inner form so Result detection works consistently.
+fn ungroup_type(ty: &Type) -> &Type {
+    match ty {
+        Type::Paren(paren) => ungroup_type(&paren.elem),
+        Type::Group(group) => ungroup_type(&group.elem),
+        _ => ty,
+    }
+}
+
 /// Returns `true` when the given type is a reference (`&` or `&mut`) whose
 /// referent is a recognised `Result` or `StepResult` shape.
 ///
@@ -25,8 +38,9 @@ use crate::return_classifier::{first_type_argument, is_result_like_path, second_
 /// // Result<MyWorld, String>       → false
 /// ```
 pub(crate) fn is_referenced_result_type(ty: &Type) -> bool {
+    let ty = ungroup_type(ty);
     let inner = match ty {
-        Type::Reference(ref_ty) => &*ref_ty.elem,
+        Type::Reference(ref_ty) => ungroup_type(&ref_ty.elem),
         _ => return false,
     };
     let path = match inner {
@@ -52,6 +66,7 @@ pub(crate) fn is_referenced_result_type(ty: &Type) -> bool {
 /// // &mut MyWorld → None
 /// ```
 pub(crate) fn try_extract_result_inner_type(ty: &Type) -> Option<Type> {
+    let ty = ungroup_type(ty);
     let path = match ty {
         Type::Path(type_path) => &type_path.path,
         _ => return None,
@@ -80,6 +95,7 @@ pub(crate) fn try_extract_result_inner_type(ty: &Type) -> Option<Type> {
 /// // MyWorld → None
 /// ```
 pub(crate) fn try_extract_result_error_type(ty: &Type) -> Option<Type> {
+    let ty = ungroup_type(ty);
     let path = match ty {
         Type::Path(type_path) => &type_path.path,
         _ => return None,
@@ -129,6 +145,7 @@ mod tests {
     #[rstest]
     #[case("Result<MyWorld, String>", "String")]
     #[case("std::result::Result<Config, std::io::Error>", "Error")]
+    #[case("StepResult<MyWorld, MyError>", "MyError")]
     fn extracts_error_type_from_result_like(#[case] input: &str, #[case] expected: &str) {
         let ty = syn::parse_str::<Type>(input).expect("valid type");
         let error = try_extract_result_error_type(&ty);
@@ -211,6 +228,42 @@ mod tests {
         assert!(
             !is_referenced_result_type(&ty),
             "plain type should not be detected as a referenced Result"
+        );
+    }
+
+    // -- Parenthesized and grouped type tests ---
+
+    #[test]
+    fn parenthesized_result_extracts_inner_type() {
+        let ty: Type = parse_quote! { (Result<MyWorld, String>) };
+        let inner = try_extract_result_inner_type(&ty);
+        assert!(
+            inner.is_some(),
+            "parenthesized Result should extract inner type"
+        );
+    }
+
+    #[test]
+    fn parenthesized_ref_result_is_detected() {
+        let ty: Type = parse_quote! { &(Result<MyWorld, String>) };
+        assert!(
+            is_referenced_result_type(&ty),
+            "parenthesized &Result should be detected as referenced Result"
+        );
+    }
+
+    #[test]
+    fn parenthesized_step_result_extracts_error() {
+        let ty: Type = parse_quote! { (StepResult<MyWorld, MyError>) };
+        let error = try_extract_result_error_type(&ty);
+        assert!(
+            error.is_some(),
+            "parenthesized StepResult should extract error type"
+        );
+        let error_str = quote::quote! { #error }.to_string();
+        assert!(
+            error_str.contains("MyError"),
+            "error type should be MyError, got: {error_str}"
         );
     }
 }

--- a/crates/rstest-bdd-macros/src/utils/result_type.rs
+++ b/crates/rstest-bdd-macros/src/utils/result_type.rs
@@ -23,7 +23,7 @@ pub(crate) fn ungroup_type(ty: &Type) -> &Type {
 }
 
 /// Returns `true` when the given type is a reference (`&` or `&mut`) whose
-/// referent is a recognised `Result` or `StepResult` shape.
+/// referent is a recognized `Result` or `StepResult` shape.
 ///
 /// This detects `&Result<T, E>` and `&mut Result<T, E>` so that callers
 /// can reject or special-case referenced Result fixtures rather than
@@ -51,7 +51,7 @@ pub(crate) fn is_referenced_result_type(ty: &Type) -> bool {
 }
 
 /// Internal helper: resolve the type argument selected by `getter` from a
-/// recognised `Result` / `StepResult` type, or return `None` for any other
+/// recognized `Result` / `StepResult` type, or return `None` for any other
 /// input.
 fn extract_result_type_arg(ty: &Type, getter: fn(&syn::Path) -> Option<&Type>) -> Option<Type> {
     let ty = ungroup_type(ty);
@@ -68,7 +68,7 @@ fn extract_result_type_arg(ty: &Type, getter: fn(&syn::Path) -> Option<&Type>) -
 /// Attempt to extract the inner `Ok` type from a `Result`-typed fixture
 /// parameter.
 ///
-/// Returns `Some(inner_type)` when the given type matches a recognised
+/// Returns `Some(inner_type)` when the given type matches a recognized
 /// `Result` or `StepResult` path, and `None` otherwise. The caller uses
 /// the inner type to generate an unwrap statement and register the
 /// fixture under the unwrapped type in `StepContext`.
@@ -87,7 +87,7 @@ pub(crate) fn try_extract_result_inner_type(ty: &Type) -> Option<Type> {
 /// Attempt to extract the error type `E` from a `Result<T, E>`-typed
 /// fixture parameter.
 ///
-/// Returns `Some(error_type)` when the given type matches a recognised
+/// Returns `Some(error_type)` when the given type matches a recognized
 /// `Result` or `StepResult` path, and `None` otherwise. The caller uses
 /// the error type to build a matching return type for the generated
 /// scenario function (e.g. `-> Result<(), E>`).

--- a/crates/rstest-bdd-macros/src/utils/result_type.rs
+++ b/crates/rstest-bdd-macros/src/utils/result_type.rs
@@ -14,7 +14,7 @@ use crate::return_classifier::{first_type_argument, is_result_like_path, second_
 ///
 /// Parenthesized types like `(Result<T, E>)` and grouped types are
 /// normalized to their inner form so Result detection works consistently.
-fn ungroup_type(ty: &Type) -> &Type {
+pub(crate) fn ungroup_type(ty: &Type) -> &Type {
     match ty {
         Type::Paren(paren) => ungroup_type(&paren.elem),
         Type::Group(group) => ungroup_type(&group.elem),

--- a/crates/rstest-bdd-macros/src/utils/result_type.rs
+++ b/crates/rstest-bdd-macros/src/utils/result_type.rs
@@ -50,6 +50,21 @@ pub(crate) fn is_referenced_result_type(ty: &Type) -> bool {
     is_result_like_path(path)
 }
 
+/// Internal helper: resolve the type argument selected by `getter` from a
+/// recognised `Result` / `StepResult` type, or return `None` for any other
+/// input.
+fn extract_result_type_arg(ty: &Type, getter: fn(&syn::Path) -> Option<&Type>) -> Option<Type> {
+    let ty = ungroup_type(ty);
+    let path = match ty {
+        Type::Path(type_path) => &type_path.path,
+        _ => return None,
+    };
+    if !is_result_like_path(path) {
+        return None;
+    }
+    getter(path).cloned()
+}
+
 /// Attempt to extract the inner `Ok` type from a `Result`-typed fixture
 /// parameter.
 ///
@@ -66,17 +81,7 @@ pub(crate) fn is_referenced_result_type(ty: &Type) -> bool {
 /// // &mut MyWorld → None
 /// ```
 pub(crate) fn try_extract_result_inner_type(ty: &Type) -> Option<Type> {
-    let ty = ungroup_type(ty);
-    let path = match ty {
-        Type::Path(type_path) => &type_path.path,
-        _ => return None,
-    };
-
-    if !is_result_like_path(path) {
-        return None;
-    }
-
-    first_type_argument(path).cloned()
+    extract_result_type_arg(ty, first_type_argument)
 }
 
 /// Attempt to extract the error type `E` from a `Result<T, E>`-typed
@@ -95,17 +100,7 @@ pub(crate) fn try_extract_result_inner_type(ty: &Type) -> Option<Type> {
 /// // MyWorld → None
 /// ```
 pub(crate) fn try_extract_result_error_type(ty: &Type) -> Option<Type> {
-    let ty = ungroup_type(ty);
-    let path = match ty {
-        Type::Path(type_path) => &type_path.path,
-        _ => return None,
-    };
-
-    if !is_result_like_path(path) {
-        return None;
-    }
-
-    second_type_argument(path).cloned()
+    extract_result_type_arg(ty, second_type_argument)
 }
 
 #[cfg(test)]
@@ -143,27 +138,26 @@ mod tests {
     }
 
     #[rstest]
-    #[case("Result<MyWorld, String>", "String")]
-    #[case("std::result::Result<Config, std::io::Error>", "Error")]
-    #[case("StepResult<MyWorld, MyError>", "MyError")]
-    fn extracts_error_type_from_result_like(#[case] input: &str, #[case] expected: &str) {
+    #[case("Result<MyWorld, String>", Some("String"))]
+    #[case("std::result::Result<Config, std::io::Error>", Some("Error"))]
+    #[case("StepResult<MyWorld, MyError>", Some("MyError"))]
+    #[case("MyWorld", None)]
+    fn extracts_error_type_from_result_like(#[case] input: &str, #[case] expected: Option<&str>) {
         let ty = syn::parse_str::<Type>(input).expect("valid type");
         let error = try_extract_result_error_type(&ty);
-        assert!(error.is_some(), "should extract error type from {input}");
-        let error_str = quote::quote! { #error }.to_string();
-        assert!(
-            error_str.contains(expected),
-            "error type should contain {expected}, got: {error_str}"
-        );
-    }
-
-    #[test]
-    fn error_type_returns_none_for_plain_type() {
-        let ty = syn::parse_str::<Type>("MyWorld").expect("valid type");
-        assert!(
-            try_extract_result_error_type(&ty).is_none(),
-            "plain type should not yield an error type"
-        );
+        match expected {
+            Some(expected_str) => {
+                assert!(error.is_some(), "should extract error type from {input}");
+                let error_str = quote::quote! { #error }.to_string();
+                assert!(
+                    error_str.contains(expected_str),
+                    "error type should contain {expected_str}, got: {error_str}"
+                );
+            }
+            None => {
+                assert!(error.is_none(), "{input} should not yield an error type");
+            }
+        }
     }
 
     // -- is_referenced_result_type tests ---

--- a/crates/rstest-bdd-macros/src/utils/result_type.rs
+++ b/crates/rstest-bdd-macros/src/utils/result_type.rs
@@ -1,0 +1,100 @@
+//! Utilities for detecting `Result`-typed fixture parameters.
+//!
+//! Reuses the path-matching logic from [`crate::return_classifier`] to
+//! recognize `Result<T, E>` and `StepResult<T, E>` shapes in fixture
+//! parameter types. When a fixture returns a Result, the scenario prelude
+//! can unwrap it with `?` and inject the inner `T` into the `StepContext`.
+
+use syn::Type;
+
+use crate::return_classifier::{first_type_argument, is_result_like_path};
+
+/// Attempt to extract the inner `Ok` type from a `Result`-typed fixture
+/// parameter.
+///
+/// Returns `Some(inner_type)` when the given type matches a recognised
+/// `Result` or `StepResult` path, and `None` otherwise. The caller uses
+/// the inner type to generate an unwrap statement and register the
+/// fixture under the unwrapped type in `StepContext`.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// // Result<MyWorld, String> → Some(MyWorld)
+/// // MyWorld → None
+/// // &mut MyWorld → None
+/// ```
+pub(crate) fn try_extract_result_inner_type(ty: &Type) -> Option<Type> {
+    let path = match ty {
+        Type::Path(type_path) => &type_path.path,
+        _ => return None,
+    };
+
+    if !is_result_like_path(path) {
+        return None;
+    }
+
+    first_type_argument(path).cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_quote;
+
+    #[test]
+    fn extracts_inner_type_from_bare_result() {
+        let ty: Type = parse_quote! { Result<MyWorld, String> };
+        let inner = try_extract_result_inner_type(&ty);
+        assert!(inner.is_some(), "should extract inner type from Result");
+        let inner_str = quote::quote! { #inner }.to_string();
+        assert!(
+            inner_str.contains("MyWorld"),
+            "inner type should be MyWorld, got: {inner_str}"
+        );
+    }
+
+    #[test]
+    fn extracts_inner_type_from_std_result() {
+        let ty: Type = parse_quote! { std::result::Result<Config, std::io::Error> };
+        let inner = try_extract_result_inner_type(&ty);
+        assert!(
+            inner.is_some(),
+            "should extract inner type from std::result::Result"
+        );
+    }
+
+    #[test]
+    fn extracts_inner_type_from_step_result() {
+        let ty: Type = parse_quote! { StepResult<MyWorld, String> };
+        let inner = try_extract_result_inner_type(&ty);
+        assert!(inner.is_some(), "should extract inner type from StepResult");
+    }
+
+    #[test]
+    fn returns_none_for_plain_type() {
+        let ty: Type = parse_quote! { MyWorld };
+        assert!(
+            try_extract_result_inner_type(&ty).is_none(),
+            "plain type should not be treated as Result"
+        );
+    }
+
+    #[test]
+    fn returns_none_for_reference_type() {
+        let ty: Type = parse_quote! { &mut MyWorld };
+        assert!(
+            try_extract_result_inner_type(&ty).is_none(),
+            "reference type should not be treated as Result"
+        );
+    }
+
+    #[test]
+    fn returns_none_for_option_type() {
+        let ty: Type = parse_quote! { Option<MyWorld> };
+        assert!(
+            try_extract_result_inner_type(&ty).is_none(),
+            "Option should not be treated as Result"
+        );
+    }
+}

--- a/crates/rstest-bdd-macros/src/utils/result_type.rs
+++ b/crates/rstest-bdd-macros/src/utils/result_type.rs
@@ -7,7 +7,34 @@
 
 use syn::Type;
 
-use crate::return_classifier::{first_type_argument, is_result_like_path};
+use crate::return_classifier::{first_type_argument, is_result_like_path, second_type_argument};
+
+/// Returns `true` when the given type is a reference (`&` or `&mut`) whose
+/// referent is a recognised `Result` or `StepResult` shape.
+///
+/// This detects `&Result<T, E>` and `&mut Result<T, E>` so that callers
+/// can reject or special-case referenced Result fixtures rather than
+/// silently treating them as plain references.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// // &Result<MyWorld, String>      → true
+/// // &mut Result<MyWorld, String>  → true
+/// // &MyWorld                      → false
+/// // Result<MyWorld, String>       → false
+/// ```
+pub(crate) fn is_referenced_result_type(ty: &Type) -> bool {
+    let inner = match ty {
+        Type::Reference(ref_ty) => &*ref_ty.elem,
+        _ => return false,
+    };
+    let path = match inner {
+        Type::Path(type_path) => &type_path.path,
+        _ => return false,
+    };
+    is_result_like_path(path)
+}
 
 /// Attempt to extract the inner `Ok` type from a `Result`-typed fixture
 /// parameter.
@@ -35,6 +62,34 @@ pub(crate) fn try_extract_result_inner_type(ty: &Type) -> Option<Type> {
     }
 
     first_type_argument(path).cloned()
+}
+
+/// Attempt to extract the error type `E` from a `Result<T, E>`-typed
+/// fixture parameter.
+///
+/// Returns `Some(error_type)` when the given type matches a recognised
+/// `Result` or `StepResult` path, and `None` otherwise. The caller uses
+/// the error type to build a matching return type for the generated
+/// scenario function (e.g. `-> Result<(), E>`).
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// // Result<MyWorld, String> → Some(String)
+/// // Result<MyWorld, std::io::Error> → Some(std::io::Error)
+/// // MyWorld → None
+/// ```
+pub(crate) fn try_extract_result_error_type(ty: &Type) -> Option<Type> {
+    let path = match ty {
+        Type::Path(type_path) => &type_path.path,
+        _ => return None,
+    };
+
+    if !is_result_like_path(path) {
+        return None;
+    }
+
+    second_type_argument(path).cloned()
 }
 
 #[cfg(test)]
@@ -95,6 +150,107 @@ mod tests {
         assert!(
             try_extract_result_inner_type(&ty).is_none(),
             "Option should not be treated as Result"
+        );
+    }
+
+    #[test]
+    fn extracts_error_type_from_bare_result() {
+        let ty: Type = parse_quote! { Result<MyWorld, String> };
+        let error = try_extract_result_error_type(&ty);
+        assert!(error.is_some(), "should extract error type from Result");
+        let error_str = quote::quote! { #error }.to_string();
+        assert!(
+            error_str.contains("String"),
+            "error type should be String, got: {error_str}"
+        );
+    }
+
+    #[test]
+    fn extracts_error_type_from_std_result() {
+        let ty: Type = parse_quote! { std::result::Result<Config, std::io::Error> };
+        let error = try_extract_result_error_type(&ty);
+        assert!(
+            error.is_some(),
+            "should extract error type from std::result::Result"
+        );
+        let error_str = quote::quote! { #error }.to_string();
+        assert!(
+            error_str.contains("Error"),
+            "error type should contain Error, got: {error_str}"
+        );
+    }
+
+    #[test]
+    fn error_type_returns_none_for_plain_type() {
+        let ty: Type = parse_quote! { MyWorld };
+        assert!(
+            try_extract_result_error_type(&ty).is_none(),
+            "plain type should not yield an error type"
+        );
+    }
+
+    // -- is_referenced_result_type tests ---
+
+    #[test]
+    fn detects_shared_ref_to_result() {
+        let ty: Type = parse_quote! { &Result<MyWorld, String> };
+        assert!(
+            is_referenced_result_type(&ty),
+            "&Result<T, E> should be detected as a referenced Result"
+        );
+    }
+
+    #[test]
+    fn detects_mut_ref_to_result() {
+        let ty: Type = parse_quote! { &mut Result<MyWorld, String> };
+        assert!(
+            is_referenced_result_type(&ty),
+            "&mut Result<T, E> should be detected as a referenced Result"
+        );
+    }
+
+    #[test]
+    fn detects_ref_to_std_result() {
+        let ty: Type = parse_quote! { &std::result::Result<MyWorld, String> };
+        assert!(
+            is_referenced_result_type(&ty),
+            "&std::result::Result should be detected as a referenced Result"
+        );
+    }
+
+    #[test]
+    fn detects_ref_to_step_result() {
+        let ty: Type = parse_quote! { &StepResult<MyWorld, String> };
+        assert!(
+            is_referenced_result_type(&ty),
+            "&StepResult should be detected as a referenced Result"
+        );
+    }
+
+    #[test]
+    fn ref_to_plain_type_is_not_referenced_result() {
+        let ty: Type = parse_quote! { &MyWorld };
+        assert!(
+            !is_referenced_result_type(&ty),
+            "&MyWorld should not be detected as a referenced Result"
+        );
+    }
+
+    #[test]
+    fn bare_result_is_not_referenced_result() {
+        let ty: Type = parse_quote! { Result<MyWorld, String> };
+        assert!(
+            !is_referenced_result_type(&ty),
+            "bare Result should not be detected as a referenced Result"
+        );
+    }
+
+    #[test]
+    fn plain_type_is_not_referenced_result() {
+        let ty: Type = parse_quote! { MyWorld };
+        assert!(
+            !is_referenced_result_type(&ty),
+            "plain type should not be detected as a referenced Result"
         );
     }
 }

--- a/crates/rstest-bdd-macros/src/utils/result_type.rs
+++ b/crates/rstest-bdd-macros/src/utils/result_type.rs
@@ -93,96 +93,56 @@ pub(crate) fn try_extract_result_error_type(ty: &Type) -> Option<Type> {
 }
 
 #[cfg(test)]
+#[expect(clippy::expect_used, reason = "test code uses infallible type parsing")]
 mod tests {
     use super::*;
+    use rstest::rstest;
     use syn::parse_quote;
 
-    #[test]
-    fn extracts_inner_type_from_bare_result() {
-        let ty: Type = parse_quote! { Result<MyWorld, String> };
+    #[rstest]
+    #[case("Result<MyWorld, String>", "MyWorld")]
+    #[case("std::result::Result<Config, std::io::Error>", "Config")]
+    #[case("StepResult<MyWorld, String>", "MyWorld")]
+    fn extracts_inner_type_from_result_like(#[case] input: &str, #[case] expected: &str) {
+        let ty = syn::parse_str::<Type>(input).expect("valid type");
         let inner = try_extract_result_inner_type(&ty);
-        assert!(inner.is_some(), "should extract inner type from Result");
+        assert!(inner.is_some(), "should extract inner type from {input}");
         let inner_str = quote::quote! { #inner }.to_string();
         assert!(
-            inner_str.contains("MyWorld"),
-            "inner type should be MyWorld, got: {inner_str}"
+            inner_str.contains(expected),
+            "inner type should contain {expected}, got: {inner_str}"
         );
     }
 
-    #[test]
-    fn extracts_inner_type_from_std_result() {
-        let ty: Type = parse_quote! { std::result::Result<Config, std::io::Error> };
-        let inner = try_extract_result_inner_type(&ty);
-        assert!(
-            inner.is_some(),
-            "should extract inner type from std::result::Result"
-        );
-    }
-
-    #[test]
-    fn extracts_inner_type_from_step_result() {
-        let ty: Type = parse_quote! { StepResult<MyWorld, String> };
-        let inner = try_extract_result_inner_type(&ty);
-        assert!(inner.is_some(), "should extract inner type from StepResult");
-    }
-
-    #[test]
-    fn returns_none_for_plain_type() {
-        let ty: Type = parse_quote! { MyWorld };
+    #[rstest]
+    #[case("MyWorld")]
+    #[case("&mut MyWorld")]
+    #[case("Option<MyWorld>")]
+    fn inner_type_returns_none_for_non_result(#[case] input: &str) {
+        let ty = syn::parse_str::<Type>(input).expect("valid type");
         assert!(
             try_extract_result_inner_type(&ty).is_none(),
-            "plain type should not be treated as Result"
+            "{input} should not be treated as Result"
         );
     }
 
-    #[test]
-    fn returns_none_for_reference_type() {
-        let ty: Type = parse_quote! { &mut MyWorld };
-        assert!(
-            try_extract_result_inner_type(&ty).is_none(),
-            "reference type should not be treated as Result"
-        );
-    }
-
-    #[test]
-    fn returns_none_for_option_type() {
-        let ty: Type = parse_quote! { Option<MyWorld> };
-        assert!(
-            try_extract_result_inner_type(&ty).is_none(),
-            "Option should not be treated as Result"
-        );
-    }
-
-    #[test]
-    fn extracts_error_type_from_bare_result() {
-        let ty: Type = parse_quote! { Result<MyWorld, String> };
+    #[rstest]
+    #[case("Result<MyWorld, String>", "String")]
+    #[case("std::result::Result<Config, std::io::Error>", "Error")]
+    fn extracts_error_type_from_result_like(#[case] input: &str, #[case] expected: &str) {
+        let ty = syn::parse_str::<Type>(input).expect("valid type");
         let error = try_extract_result_error_type(&ty);
-        assert!(error.is_some(), "should extract error type from Result");
+        assert!(error.is_some(), "should extract error type from {input}");
         let error_str = quote::quote! { #error }.to_string();
         assert!(
-            error_str.contains("String"),
-            "error type should be String, got: {error_str}"
-        );
-    }
-
-    #[test]
-    fn extracts_error_type_from_std_result() {
-        let ty: Type = parse_quote! { std::result::Result<Config, std::io::Error> };
-        let error = try_extract_result_error_type(&ty);
-        assert!(
-            error.is_some(),
-            "should extract error type from std::result::Result"
-        );
-        let error_str = quote::quote! { #error }.to_string();
-        assert!(
-            error_str.contains("Error"),
-            "error type should contain Error, got: {error_str}"
+            error_str.contains(expected),
+            "error type should contain {expected}, got: {error_str}"
         );
     }
 
     #[test]
     fn error_type_returns_none_for_plain_type() {
-        let ty: Type = parse_quote! { MyWorld };
+        let ty = syn::parse_str::<Type>("MyWorld").expect("valid type");
         assert!(
             try_extract_result_error_type(&ty).is_none(),
             "plain type should not yield an error type"

--- a/crates/rstest-bdd/tests/features/result_fixture.feature
+++ b/crates/rstest-bdd/tests/features/result_fixture.feature
@@ -1,17 +1,17 @@
 Feature: Result-returning fixture injection
 
-  Scenario: successful fixture initialisation
-    Given a world initialised from a Result fixture
+  Scenario: successful fixture initialization
+    Given a world initialized from a Result fixture
     When the world is mutated
     Then the world reflects the mutation
 
-  Scenario: failing fixture initialisation
-    Given a world initialised from a Result fixture
+  Scenario: failing fixture initialization
+    Given a world initialized from a Result fixture
 
   Scenario: StepResult fixture success
-    Given a world initialised from a StepResult fixture
+    Given a world initialized from a StepResult fixture
     When the StepResult world is mutated
     Then the StepResult world reflects the mutation
 
   Scenario: StepResult fixture error
-    Given a world initialised from a StepResult fixture
+    Given a world initialized from a StepResult fixture

--- a/crates/rstest-bdd/tests/features/result_fixture.feature
+++ b/crates/rstest-bdd/tests/features/result_fixture.feature
@@ -1,0 +1,9 @@
+Feature: Result-returning fixture injection
+
+  Scenario: successful fixture initialisation
+    Given a world initialised from a Result fixture
+    When the world is mutated
+    Then the world reflects the mutation
+
+  Scenario: failing fixture initialisation
+    Given a world initialised from a Result fixture

--- a/crates/rstest-bdd/tests/features/result_fixture.feature
+++ b/crates/rstest-bdd/tests/features/result_fixture.feature
@@ -7,3 +7,11 @@ Feature: Result-returning fixture injection
 
   Scenario: failing fixture initialisation
     Given a world initialised from a Result fixture
+
+  Scenario: StepResult fixture success
+    Given a world initialised from a StepResult fixture
+    When the StepResult world is mutated
+    Then the StepResult world reflects the mutation
+
+  Scenario: StepResult fixture error
+    Given a world initialised from a StepResult fixture

--- a/crates/rstest-bdd/tests/fixtures_macros/result_fixture_requires_result_scenario.rs
+++ b/crates/rstest-bdd/tests/fixtures_macros/result_fixture_requires_result_scenario.rs
@@ -1,10 +1,14 @@
 //! Compile-fail fixture verifying that Result-typed fixtures require a
 //! Result-returning scenario.
 
+use rstest_bdd::StepResult;
 use rstest_bdd_macros::scenario;
 
 #[scenario(path = "basic.feature")]
 fn result_fixture_unit_return(world: Result<u32, String>) {}
+
+#[scenario(path = "basic.feature")]
+fn step_result_fixture_unit_return(world: StepResult<u32, String>) {}
 
 const _: &str = include_str!("basic.feature");
 

--- a/crates/rstest-bdd/tests/fixtures_macros/result_fixture_requires_result_scenario.rs
+++ b/crates/rstest-bdd/tests/fixtures_macros/result_fixture_requires_result_scenario.rs
@@ -1,14 +1,13 @@
 //! Compile-fail fixture verifying that Result-typed fixtures require a
 //! Result-returning scenario.
 
-use rstest_bdd::StepResult;
 use rstest_bdd_macros::scenario;
 
 #[scenario(path = "basic.feature")]
 fn result_fixture_unit_return(world: Result<u32, String>) {}
 
 #[scenario(path = "basic.feature")]
-fn step_result_fixture_unit_return(world: StepResult<u32, String>) {}
+fn step_result_fixture_unit_return(world: rstest_bdd::StepResult<u32, String>) {}
 
 const _: &str = include_str!("basic.feature");
 

--- a/crates/rstest-bdd/tests/fixtures_macros/result_fixture_requires_result_scenario.rs
+++ b/crates/rstest-bdd/tests/fixtures_macros/result_fixture_requires_result_scenario.rs
@@ -1,0 +1,11 @@
+//! Compile-fail fixture verifying that Result-typed fixtures require a
+//! Result-returning scenario.
+
+use rstest_bdd_macros::scenario;
+
+#[scenario(path = "basic.feature")]
+fn result_fixture_unit_return(world: Result<u32, String>) {}
+
+const _: &str = include_str!("basic.feature");
+
+fn main() {}

--- a/crates/rstest-bdd/tests/fixtures_macros/result_fixture_requires_result_scenario.stderr
+++ b/crates/rstest-bdd/tests/fixtures_macros/result_fixture_requires_result_scenario.stderr
@@ -1,0 +1,7 @@
+error: scenarios with Result-returning fixtures must return `Result<(), E>` to propagate fixture initialisation errors
+ --> tests/fixtures_macros/result_fixture_requires_result_scenario.rs:6:1
+  |
+6 | #[scenario(path = "basic.feature")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/rstest-bdd/tests/fixtures_macros/result_fixture_requires_result_scenario.stderr
+++ b/crates/rstest-bdd/tests/fixtures_macros/result_fixture_requires_result_scenario.stderr
@@ -1,7 +1,23 @@
-error: scenarios with Result-returning fixtures must return `Result<(), E>` to propagate fixture initialisation errors
- --> tests/fixtures_macros/result_fixture_requires_result_scenario.rs:6:1
+error: scenarios with Result-returning fixtures must return `Result<(), E>` or `StepResult<(), E>` to propagate fixture initialisation errors
+ --> tests/fixtures_macros/result_fixture_requires_result_scenario.rs:7:1
   |
-6 | #[scenario(path = "basic.feature")]
+7 | #[scenario(path = "basic.feature")]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: scenarios with Result-returning fixtures must return `Result<(), E>` or `StepResult<(), E>` to propagate fixture initialisation errors
+  --> tests/fixtures_macros/result_fixture_requires_result_scenario.rs:10:1
+   |
+10 | #[scenario(path = "basic.feature")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: unused import: `rstest_bdd::StepResult`
+ --> tests/fixtures_macros/result_fixture_requires_result_scenario.rs:4:5
+  |
+4 | use rstest_bdd::StepResult;
+  |     ^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/crates/rstest-bdd/tests/result_fixture.rs
+++ b/crates/rstest-bdd/tests/result_fixture.rs
@@ -26,7 +26,7 @@ impl ResultWorld {
     }
 
     fn try_new_failing() -> Result<Self, String> {
-        Err("fixture initialisation failed".to_string())
+        Err("fixture initialization failed".to_string())
     }
 }
 
@@ -110,6 +110,13 @@ fn assert_scenario_error_propagates<E: std::fmt::Display>(
         err.to_string().contains(expected_fragment),
         "error for '{label}' should contain '{expected_fragment}', got: {err}"
     );
+    let records = drain_reports();
+    assert!(
+        records
+            .iter()
+            .all(|r| !matches!(r.status(), ScenarioStatus::Passed)),
+        "failing scenario '{label}' should not record Passed status"
+    );
 }
 
 #[test]
@@ -123,7 +130,7 @@ fn result_fixture_success_records_pass() {
 fn result_fixture_error_propagates() {
     assert_scenario_error_propagates(
         result_fixture_error,
-        "fixture initialisation failed",
+        "fixture initialization failed",
         "failing Result fixture",
     );
 }
@@ -139,7 +146,7 @@ fn step_result_world() -> StepResult<ResultWorld, String> {
 /// Fixture that always fails, for testing `StepResult` error propagation.
 #[fixture]
 fn failing_step_result_world() -> StepResult<ResultWorld, String> {
-    Err("step-result fixture initialisation failed".to_string())
+    Err("step-result fixture initialization failed".to_string())
 }
 
 #[given("a world initialised from a StepResult fixture")]
@@ -197,7 +204,7 @@ fn step_result_fixture_success_records_pass() {
 fn step_result_fixture_error_propagates() {
     assert_scenario_error_propagates(
         step_result_fixture_error,
-        "step-result fixture initialisation failed",
+        "step-result fixture initialization failed",
         "failing StepResult fixture",
     );
 }

--- a/crates/rstest-bdd/tests/result_fixture.rs
+++ b/crates/rstest-bdd/tests/result_fixture.rs
@@ -5,6 +5,7 @@
 //! inner `T` into step functions via `StepContext`.
 
 use rstest::fixture;
+use rstest_bdd::StepResult;
 use rstest_bdd::reporting::{ScenarioStatus, drain as drain_reports};
 use rstest_bdd_macros::{given, scenario, then, when};
 use serial_test::serial;
@@ -108,5 +109,97 @@ fn result_fixture_error_propagates() {
     assert!(
         err.contains("fixture initialisation failed"),
         "error should contain fixture failure message, got: {err}"
+    );
+}
+
+// -- StepResult<T, E> fixture tests ---
+
+/// Fixture that returns `StepResult<ResultWorld, String>`.
+#[fixture]
+fn step_result_world() -> StepResult<ResultWorld, String> {
+    ResultWorld::try_new()
+}
+
+/// Fixture that always fails, for testing `StepResult` error propagation.
+#[fixture]
+fn failing_step_result_world() -> StepResult<ResultWorld, String> {
+    Err("step-result fixture initialisation failed".to_string())
+}
+
+#[given("a world initialised from a StepResult fixture")]
+fn given_step_result_world(step_result_world: &ResultWorld) {
+    assert_eq!(
+        step_result_world.value, 42,
+        "world from StepResult fixture should be initialised with value 42"
+    );
+}
+
+#[when("the StepResult world is mutated")]
+fn when_step_result_mutated(step_result_world: &mut ResultWorld) {
+    step_result_world.value += 10;
+}
+
+#[then("the StepResult world reflects the mutation")]
+fn then_step_result_mutated(step_result_world: &ResultWorld) {
+    assert_eq!(
+        step_result_world.value, 52,
+        "world value should be 52 after mutation"
+    );
+}
+
+#[scenario(
+    path = "tests/features/result_fixture.feature",
+    name = "StepResult fixture success"
+)]
+#[serial]
+fn step_result_fixture_success(
+    step_result_world: StepResult<ResultWorld, String>,
+) -> StepResult<(), String> {
+    Ok(())
+}
+
+#[scenario(
+    path = "tests/features/result_fixture.feature",
+    name = "StepResult fixture error"
+)]
+#[serial]
+#[ignore = "exercised by step_result_fixture_error_propagates"]
+fn step_result_fixture_error(
+    #[from(failing_step_result_world)] step_result_world: StepResult<ResultWorld, String>,
+) -> StepResult<(), String> {
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn step_result_fixture_success_records_pass() {
+    let _ = drain_reports();
+    let result = step_result_fixture_success();
+    assert!(
+        result.is_ok(),
+        "scenario with successful StepResult fixture should return Ok"
+    );
+    let records = drain_reports();
+    let passed_count = records
+        .iter()
+        .filter(|r| matches!(r.status(), ScenarioStatus::Passed))
+        .count();
+    assert_eq!(
+        1, passed_count,
+        "expected exactly one Passed record for successful StepResult fixture scenario"
+    );
+}
+
+#[test]
+#[serial]
+fn step_result_fixture_error_propagates() {
+    let _ = drain_reports();
+    let result = step_result_fixture_error();
+    let Err(err) = result else {
+        panic!("scenario with failing StepResult fixture should return Err");
+    };
+    assert!(
+        err.contains("step-result fixture initialisation failed"),
+        "error should contain StepResult fixture failure message, got: {err}"
     );
 }

--- a/crates/rstest-bdd/tests/result_fixture.rs
+++ b/crates/rstest-bdd/tests/result_fixture.rs
@@ -1,0 +1,110 @@
+//! End-to-end behavioural tests for Result-returning fixture injection.
+//!
+//! Verifies that `#[scenario]` can accept fixture parameters typed as
+//! `Result<T, E>`, automatically unwrap them with `?`, and inject the
+//! inner `T` into step functions via `StepContext`.
+
+use rstest::fixture;
+use rstest_bdd::reporting::{ScenarioStatus, drain as drain_reports};
+use rstest_bdd_macros::{given, scenario, then, when};
+use serial_test::serial;
+
+/// A simple world type initialised through a fallible constructor.
+#[derive(Default)]
+struct ResultWorld {
+    value: u32,
+}
+
+impl ResultWorld {
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "returns Result to exercise the Result-unwrapping fixture codegen path"
+    )]
+    fn try_new() -> Result<Self, String> { Ok(Self { value: 42 }) }
+
+    fn try_new_failing() -> Result<Self, String> {
+        Err("fixture initialisation failed".to_string())
+    }
+}
+
+/// Fixture that returns `Result<ResultWorld, String>`.
+#[fixture]
+fn world() -> Result<ResultWorld, String> {
+    ResultWorld::try_new()
+}
+
+/// Fixture that always fails, for testing error propagation.
+#[fixture]
+fn failing_world() -> Result<ResultWorld, String> {
+    ResultWorld::try_new_failing()
+}
+
+#[given("a world initialised from a Result fixture")]
+fn given_world(world: &ResultWorld) {
+    assert_eq!(world.value, 42, "world should be initialised with value 42");
+}
+
+#[when("the world is mutated")]
+fn when_mutated(world: &mut ResultWorld) {
+    world.value += 1;
+}
+
+#[then("the world reflects the mutation")]
+fn then_mutated(world: &ResultWorld) {
+    assert_eq!(world.value, 43, "world value should be 43 after mutation");
+}
+
+#[scenario(
+    path = "tests/features/result_fixture.feature",
+    name = "successful fixture initialisation"
+)]
+#[serial]
+fn result_fixture_success(world: Result<ResultWorld, String>) -> Result<(), String> {
+    Ok(())
+}
+
+#[scenario(
+    path = "tests/features/result_fixture.feature",
+    name = "failing fixture initialisation"
+)]
+#[serial]
+#[ignore = "exercised by result_fixture_error_propagates"]
+fn result_fixture_error(
+    #[from(failing_world)] world: Result<ResultWorld, String>,
+) -> Result<(), String> {
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn result_fixture_success_records_pass() {
+    let _ = drain_reports();
+    let result = result_fixture_success();
+    assert!(
+        result.is_ok(),
+        "scenario with successful Result fixture should return Ok"
+    );
+    let records = drain_reports();
+    let passed_count = records
+        .iter()
+        .filter(|r| matches!(r.status(), ScenarioStatus::Passed))
+        .count();
+    assert_eq!(
+        1, passed_count,
+        "expected exactly one Passed record for successful Result fixture scenario"
+    );
+}
+
+#[test]
+#[serial]
+fn result_fixture_error_propagates() {
+    let _ = drain_reports();
+    let result = result_fixture_error();
+    let Err(err) = result else {
+        panic!("scenario with failing Result fixture should return Err");
+    };
+    assert!(
+        err.contains("fixture initialisation failed"),
+        "error should contain fixture failure message, got: {err}"
+    );
+}

--- a/crates/rstest-bdd/tests/result_fixture.rs
+++ b/crates/rstest-bdd/tests/result_fixture.rs
@@ -1,8 +1,8 @@
 //! End-to-end behavioural tests for Result-returning fixture injection.
 //!
 //! Verifies that `#[scenario]` can accept fixture parameters typed as
-//! `Result<T, E>`, automatically unwrap them with `?`, and inject the
-//! inner `T` into step functions via `StepContext`.
+//! `Result<T, E>` or `StepResult<T, E>`, automatically unwrap them with `?`,
+//! and inject the inner `T` into step functions via `StepContext`.
 
 use rstest::fixture;
 use rstest_bdd::StepResult;
@@ -10,7 +10,7 @@ use rstest_bdd::reporting::{ScenarioStatus, drain as drain_reports};
 use rstest_bdd_macros::{given, scenario, then, when};
 use serial_test::serial;
 
-/// A simple world type initialised through a fallible constructor.
+/// A simple world type initialized through a fallible constructor.
 #[derive(Default)]
 struct ResultWorld {
     value: u32,
@@ -42,9 +42,9 @@ fn failing_world() -> Result<ResultWorld, String> {
     ResultWorld::try_new_failing()
 }
 
-#[given("a world initialised from a Result fixture")]
+#[given("a world initialized from a Result fixture")]
 fn given_world(world: &ResultWorld) {
-    assert_eq!(world.value, 42, "world should be initialised with value 42");
+    assert_eq!(world.value, 42, "world should be initialized with value 42");
 }
 
 #[when("the world is mutated")]
@@ -59,7 +59,7 @@ fn then_mutated(world: &ResultWorld) {
 
 #[scenario(
     path = "tests/features/result_fixture.feature",
-    name = "successful fixture initialisation"
+    name = "successful fixture initialization"
 )]
 #[serial]
 fn result_fixture_success(world: Result<ResultWorld, String>) -> Result<(), String> {
@@ -68,7 +68,7 @@ fn result_fixture_success(world: Result<ResultWorld, String>) -> Result<(), Stri
 
 #[scenario(
     path = "tests/features/result_fixture.feature",
-    name = "failing fixture initialisation"
+    name = "failing fixture initialization"
 )]
 #[serial]
 #[ignore = "exercised by result_fixture_error_propagates"]
@@ -149,11 +149,11 @@ fn failing_step_result_world() -> StepResult<ResultWorld, String> {
     Err("step-result fixture initialization failed".to_string())
 }
 
-#[given("a world initialised from a StepResult fixture")]
+#[given("a world initialized from a StepResult fixture")]
 fn given_step_result_world(step_result_world: &ResultWorld) {
     assert_eq!(
         step_result_world.value, 42,
-        "world from StepResult fixture should be initialised with value 42"
+        "world from StepResult fixture should be initialized with value 42"
     );
 }
 

--- a/crates/rstest-bdd/tests/result_fixture.rs
+++ b/crates/rstest-bdd/tests/result_fixture.rs
@@ -78,14 +78,12 @@ fn result_fixture_error(
     Ok(())
 }
 
-#[test]
-#[serial]
-fn result_fixture_success_records_pass() {
+fn assert_scenario_passes<E: std::fmt::Debug>(run: impl FnOnce() -> Result<(), E>, label: &str) {
     let _ = drain_reports();
-    let result = result_fixture_success();
+    let result = run();
     assert!(
         result.is_ok(),
-        "scenario with successful Result fixture should return Ok"
+        "scenario '{label}' should return Ok, got {result:?}"
     );
     let records = drain_reports();
     let passed_count = records
@@ -94,21 +92,39 @@ fn result_fixture_success_records_pass() {
         .count();
     assert_eq!(
         1, passed_count,
-        "expected exactly one Passed record for successful Result fixture scenario"
+        "expected exactly one Passed record for '{label}'"
+    );
+}
+
+fn assert_scenario_error_propagates<E: std::fmt::Display>(
+    run: impl FnOnce() -> Result<(), E>,
+    expected_fragment: &str,
+    label: &str,
+) {
+    let _ = drain_reports();
+    let result = run();
+    let Err(err) = result else {
+        panic!("scenario '{label}' should return Err");
+    };
+    assert!(
+        err.to_string().contains(expected_fragment),
+        "error for '{label}' should contain '{expected_fragment}', got: {err}"
     );
 }
 
 #[test]
 #[serial]
+fn result_fixture_success_records_pass() {
+    assert_scenario_passes(result_fixture_success, "successful Result fixture");
+}
+
+#[test]
+#[serial]
 fn result_fixture_error_propagates() {
-    let _ = drain_reports();
-    let result = result_fixture_error();
-    let Err(err) = result else {
-        panic!("scenario with failing Result fixture should return Err");
-    };
-    assert!(
-        err.contains("fixture initialisation failed"),
-        "error should contain fixture failure message, got: {err}"
+    assert_scenario_error_propagates(
+        result_fixture_error,
+        "fixture initialisation failed",
+        "failing Result fixture",
     );
 }
 
@@ -173,33 +189,15 @@ fn step_result_fixture_error(
 #[test]
 #[serial]
 fn step_result_fixture_success_records_pass() {
-    let _ = drain_reports();
-    let result = step_result_fixture_success();
-    assert!(
-        result.is_ok(),
-        "scenario with successful StepResult fixture should return Ok"
-    );
-    let records = drain_reports();
-    let passed_count = records
-        .iter()
-        .filter(|r| matches!(r.status(), ScenarioStatus::Passed))
-        .count();
-    assert_eq!(
-        1, passed_count,
-        "expected exactly one Passed record for successful StepResult fixture scenario"
-    );
+    assert_scenario_passes(step_result_fixture_success, "successful StepResult fixture");
 }
 
 #[test]
 #[serial]
 fn step_result_fixture_error_propagates() {
-    let _ = drain_reports();
-    let result = step_result_fixture_error();
-    let Err(err) = result else {
-        panic!("scenario with failing StepResult fixture should return Err");
-    };
-    assert!(
-        err.contains("step-result fixture initialisation failed"),
-        "error should contain StepResult fixture failure message, got: {err}"
+    assert_scenario_error_propagates(
+        step_result_fixture_error,
+        "step-result fixture initialisation failed",
+        "failing StepResult fixture",
     );
 }

--- a/crates/rstest-bdd/tests/result_fixture.rs
+++ b/crates/rstest-bdd/tests/result_fixture.rs
@@ -20,7 +20,9 @@ impl ResultWorld {
         clippy::unnecessary_wraps,
         reason = "returns Result to exercise the Result-unwrapping fixture codegen path"
     )]
-    fn try_new() -> Result<Self, String> { Ok(Self { value: 42 }) }
+    fn try_new() -> Result<Self, String> {
+        Ok(Self { value: 42 })
+    }
 
     fn try_new_failing() -> Result<Self, String> {
         Err("fixture initialisation failed".to_string())

--- a/crates/rstest-bdd/tests/trybuild_macros.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros.rs
@@ -100,6 +100,7 @@ fn run_failing_macro_tests(t: &trybuild::TestCases) {
         MacroFixtureCase::from("scenario_harness_not_default.rs"),
         MacroFixtureCase::from("scenario_harness_async_rejected.rs"),
         MacroFixtureCase::from("scenario_harness_tokio_async_rejected.rs"),
+        MacroFixtureCase::from("result_fixture_requires_result_scenario.rs"),
     ] {
         t.compile_fail(macros_fixture(case).as_std_path());
     }

--- a/scripts/rs-length-allowlist.txt
+++ b/scripts/rs-length-allowlist.txt
@@ -11,3 +11,5 @@ crates/rstest-bdd-server/src/indexing/rust.rs
 # Added during tokio-reminders example development (roadmap 9.3.8):
 # Comprehensive doctests for all public methods plus regression test for deferred execution
 examples/tokio-reminders/src/lib.rs
+# Added during Result fixture refactoring: comprehensive test coverage for error type resolution
+crates/rstest-bdd-macros/src/macros/scenarios/test_generation/tests.rs


### PR DESCRIPTION
## Summary
- Adds support for fixtures that return `Result<T, E>` and `StepResult<T, E>` in rstest-bdd.
- When a fixture yields a Result, the framework unwraps it with `?` and injects the inner `T` into the StepContext.
- Scenarios using such fixtures must return `Result<(), E>` or `StepResult<(), E>` so fixture initialization errors can be propagated.

## Changes
### Core macro logic
- Scenario macro now enforces propagation of initialization errors for Result-like fixtures:
  - If a fixture is Result-like and the scenario return type is not fallible, emit compile error:
    `scenarios with fallible fixtures (Result<T, E> or StepResult<T, E>) must return `Result<(), E>` or `StepResult<(), E>` to propagate fixture initialisation errors`.

### Code generation for tests
- When any fixture is Result-like:
  - The generated scenario test signature is upgraded to return a fallible type (either `Result<(), E>` or `StepResult<(), E>` depending on fixture configuration and error types) and the internal return kind is set to `ScenarioReturnKind::ResultUnit`.
  - The test body returns `Ok(())` in the fallible path.

### Result-like detection utilities
- Added `is_result_like_path(path)` in return_classifier to detect both `Result<T, E>` and `StepResult<T, E>` shapes.
- Made `first_type_argument(path)` publicly accessible within the crate for reuse.
- Added a new utility module `utils/result_type.rs` with:
  - `try_extract_result_inner_type(ty: &Type) -> Option<Type>` to obtain the inner `T` from Result-like fixture parameters.
  - `try_extract_result_error_type(ty: &Type) -> Option<Type>` to obtain the error type `E`.

### Fixtures wiring
- Updated fixture wiring to support Result-returning fixtures:
  - Detects `Result<T, E>` fixture parameters.
  - Generates an unwrap binding (e.g. `__rstest_bdd_unwrapped_0`) with `binding?`.
  - Unwrapped inner type `T` is registered into the StepContext, not the `Result` wrapper.
  - Sets `has_result_fixtures = true` so the codegen path can emit the proper return type and prelude.

### Utils and re-exports
- Re-exported the new `result_type` module from the utils crate.

### Tests and examples
- Added end-to-end tests and compile-fail tests for Result-returning fixtures:
  - New feature file: `crates/rstest-bdd/tests/features/result_fixture.feature`.
  - New fixture macro tests: `crates/rstest-bdd-macros/tests/fixtures_macros/result_fixture_requires_result_scenario.rs` and corresponding `.stderr`.
  - End-to-end test: `crates/rstest-bdd/tests/result_fixture.rs` validating success and error propagation.
- Updated trybuild tests to include the new result-fixture compile-fail case.

## Testing plan
- Unit tests for `try_extract_result_inner_type` covering:
  - Bare `Result<T, E>` and `std::result::Result<T, E>`
  - `StepResult<T, E>`
  - Negative cases (plain type, references, Option, etc.)
- Compile-fail tests ensuring that Result fixtures require a Result-returning scenario.
- End-to-end tests validating:
  - Successful initialisation via a Result fixture.
  - Propagation of fixture initialisation errors as Err from the scenario.

## Migration considerations
- This change only affects fixtures declared as `Result<T, E>` (or `StepResult<T, E>`).
- Non-Result fixtures remain unchanged.
- Users introducing Result-typed fixtures should update their scenarios to return `Result<(), E>` (or `StepResult<(), E>`) to allow error propagation.

If there are any project-specific conventions for error types in results, we can adjust the boxed error type in the generated signature accordingly in a follow-up.

📎 **Task**: https://www.devboxer.com/task/38aa0db4-3b8e-48d6-9191-e3cc1fad763d

Closes #470