### PR TITLE
ADR-008 harness-led defaults: ExecPlan, path resolution, tests, docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Install Nixie
         if: ${{ matrix.tools }}
-        run: uv tool install --from git+https://github.com/leynos/nixie nixie
+        run: uv tool install nixie-cli==1.0.0
 
       - name: Nixie
         if: ${{ matrix.tools }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,6 +1497,9 @@ dependencies = [
 [[package]]
 name = "rstest-bdd-policy"
 version = "0.5.0"
+dependencies = [
+ "rstest",
+]
 
 [[package]]
 name = "rstest-bdd-server"

--- a/crates/rstest-bdd-macros/src/codegen/scenario.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario.rs
@@ -67,6 +67,8 @@ pub(crate) struct ScenarioConfig<'a> {
     pub(crate) tags: &'a [String],
     /// Runtime mode for test execution (sync or async/Tokio).
     pub(crate) runtime: RuntimeMode,
+    /// Runtime mode used when resolving generated test attributes.
+    pub(crate) attribute_runtime: RuntimeMode,
     /// Return shape expected from the scenario body.
     pub(crate) return_kind: ScenarioReturnKind,
     /// Optional harness adapter type path for compile-time trait assertion.
@@ -211,7 +213,8 @@ where
     let body = generate_test_tokens(&test_config, ctx.prelude, ctx.inserts, ctx.postlude);
     let test_attrs = generate_test_attrs(
         config.attrs,
-        config.runtime,
+        config.attribute_runtime,
+        config.harness,
         config.attributes,
         config.runtime.is_async(),
     );
@@ -303,7 +306,8 @@ where
 
     let test_attrs = generate_test_attrs(
         config.attrs,
-        config.runtime,
+        config.attribute_runtime,
+        config.harness,
         config.attributes,
         config.runtime.is_async(),
     );

--- a/crates/rstest-bdd-macros/src/codegen/scenario.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario.rs
@@ -26,7 +26,7 @@ pub(crate) use crate::macros::scenarios::ScenariosRuntimeMode as RuntimeMode;
 use crate::macros::scenarios::ScenariosTestAttributeHint as TestAttributeHint;
 
 use crate::parsing::placeholder::contains_placeholders;
-use test_attrs::generate_test_attrs;
+use test_attrs::{TestAttrPolicy, generate_test_attrs};
 
 /// Return kinds supported by scenario bodies.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -213,9 +213,11 @@ where
     let body = generate_test_tokens(&test_config, ctx.prelude, ctx.inserts, ctx.postlude);
     let test_attrs = generate_test_attrs(
         config.attrs,
-        config.attribute_runtime,
-        config.harness,
-        config.attributes,
+        &TestAttrPolicy {
+            runtime: config.attribute_runtime,
+            harness: config.harness,
+            attributes: config.attributes,
+        },
         config.runtime.is_async(),
     );
     let trait_assertions = generate_trait_assertions(config.harness, config.attributes);
@@ -306,9 +308,11 @@ where
 
     let test_attrs = generate_test_attrs(
         config.attrs,
-        config.attribute_runtime,
-        config.harness,
-        config.attributes,
+        &TestAttrPolicy {
+            runtime: config.attribute_runtime,
+            harness: config.harness,
+            attributes: config.attributes,
+        },
         config.runtime.is_async(),
     );
     let trait_assertions = generate_trait_assertions(config.harness, config.attributes);

--- a/crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs
@@ -2,7 +2,9 @@
 
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use rstest_bdd_policy::resolve_test_attribute_hint_for_policy_path;
+use rstest_bdd_policy::{
+    resolve_test_attribute_hint_for_harness_path, resolve_test_attribute_hint_for_policy_path,
+};
 
 use super::{RuntimeMode, TestAttributeHint};
 
@@ -56,21 +58,41 @@ impl ResolvedAttributePolicy {
 }
 
 fn resolve_attribute_hint_from_policy_path(path: &syn::Path) -> Option<TestAttributeHint> {
+    resolve_attribute_hint_from_path(path, resolve_test_attribute_hint_for_policy_path)
+}
+
+fn resolve_attribute_hint_from_harness_path(path: &syn::Path) -> Option<TestAttributeHint> {
+    resolve_attribute_hint_from_path(path, resolve_test_attribute_hint_for_harness_path)
+}
+
+fn resolve_attribute_hint_from_path(
+    path: &syn::Path,
+    resolver: fn(&[&str]) -> Option<TestAttributeHint>,
+) -> Option<TestAttributeHint> {
     let segment_names: Vec<_> = path
         .segments
         .iter()
         .map(|segment| segment.ident.to_string())
         .collect();
     let segment_refs: Vec<_> = segment_names.iter().map(String::as_str).collect();
-    resolve_test_attribute_hint_for_policy_path(&segment_refs)
+    resolver(&segment_refs)
 }
 
 fn resolve_attribute_policy(
     runtime: RuntimeMode,
+    harness: Option<&syn::Path>,
     attributes: Option<&syn::Path>,
 ) -> ResolvedAttributePolicy {
     let hint = attributes.map_or_else(
-        || runtime.test_attribute_hint(),
+        || {
+            harness.map_or_else(
+                || runtime.test_attribute_hint(),
+                |path| {
+                    resolve_attribute_hint_from_harness_path(path)
+                        .unwrap_or_else(|| runtime.test_attribute_hint())
+                },
+            )
+        },
         |path| {
             resolve_attribute_hint_from_policy_path(path).unwrap_or(TestAttributeHint::RstestOnly)
         },
@@ -97,13 +119,14 @@ fn render_policy_attribute(attribute: PolicyAttribute) -> TokenStream2 {
 pub(super) fn generate_test_attrs(
     attrs: &[syn::Attribute],
     runtime: RuntimeMode,
+    harness: Option<&syn::Path>,
     attributes: Option<&syn::Path>,
     is_async: bool,
 ) -> TokenStream2 {
     // Match only tokio::test to avoid false positives like #[test] or #[test_case].
     let has_tokio_test = attrs.iter().any(is_tokio_test_attr);
     let has_gpui_test = attrs.iter().any(is_gpui_test_attr);
-    let resolved_policy = resolve_attribute_policy(runtime, attributes);
+    let resolved_policy = resolve_attribute_policy(runtime, harness, attributes);
 
     let generated_attrs: Vec<_> = resolved_policy
         .test_attributes()

--- a/crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs
@@ -78,18 +78,21 @@ fn resolve_attribute_hint_from_path(
     resolver(&segment_refs)
 }
 
-fn resolve_attribute_policy(
-    runtime: RuntimeMode,
-    harness: Option<&syn::Path>,
-    attributes: Option<&syn::Path>,
-) -> ResolvedAttributePolicy {
-    let hint = attributes.map_or_else(
+/// Policy-resolution inputs bundled for ADR-008 precedence.
+pub(super) struct TestAttrPolicy<'a> {
+    pub(super) runtime: RuntimeMode,
+    pub(super) harness: Option<&'a syn::Path>,
+    pub(super) attributes: Option<&'a syn::Path>,
+}
+
+fn resolve_attribute_policy(policy: &TestAttrPolicy<'_>) -> ResolvedAttributePolicy {
+    let hint = policy.attributes.map_or_else(
         || {
-            harness.map_or_else(
-                || runtime.test_attribute_hint(),
+            policy.harness.map_or_else(
+                || policy.runtime.test_attribute_hint(),
                 |path| {
                     resolve_attribute_hint_from_harness_path(path)
-                        .unwrap_or_else(|| runtime.test_attribute_hint())
+                        .unwrap_or_else(|| policy.runtime.test_attribute_hint())
                 },
             )
         },
@@ -118,15 +121,13 @@ fn render_policy_attribute(attribute: PolicyAttribute) -> TokenStream2 {
 
 pub(super) fn generate_test_attrs(
     attrs: &[syn::Attribute],
-    runtime: RuntimeMode,
-    harness: Option<&syn::Path>,
-    attributes: Option<&syn::Path>,
+    policy: &TestAttrPolicy<'_>,
     is_async: bool,
 ) -> TokenStream2 {
     // Match only tokio::test to avoid false positives like #[test] or #[test_case].
     let has_tokio_test = attrs.iter().any(is_tokio_test_attr);
     let has_gpui_test = attrs.iter().any(is_gpui_test_attr);
-    let resolved_policy = resolve_attribute_policy(runtime, harness, attributes);
+    let resolved_policy = resolve_attribute_policy(policy);
 
     let generated_attrs: Vec<_> = resolved_policy
         .test_attributes()

--- a/crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs
@@ -80,8 +80,14 @@ fn resolve_attribute_hint_from_path(
 
 /// Policy-resolution inputs bundled for ADR-008 precedence.
 pub(super) struct TestAttrPolicy<'a> {
+    /// Attribute-resolution fallback `RuntimeMode` used when no higher-priority
+    /// harness or explicit attribute policy path resolves a `TestAttributeHint`.
     pub(super) runtime: RuntimeMode,
+    /// User-supplied harness type path, such as
+    /// `rstest_bdd_harness_tokio::TokioHarness`.
     pub(super) harness: Option<&'a syn::Path>,
+    /// Explicit attribute policy path supplied by the macro caller; this has
+    /// the highest ADR-008 precedence when present.
     pub(super) attributes: Option<&'a syn::Path>,
 }
 
@@ -119,6 +125,30 @@ fn render_policy_attribute(attribute: PolicyAttribute) -> TokenStream2 {
     }
 }
 
+/// Generates framework test attributes according to the ADR-008 policy order.
+///
+/// The emitted `TokenStream2` always includes `#[rstest::rstest]`, then layers
+/// any Tokio or GPUI test attribute selected by explicit `attributes`,
+/// first-party `harness`, or `RuntimeMode` fallback precedence. Existing user
+/// attributes are inspected so generated output does not duplicate
+/// `#[tokio::test]` or `#[gpui::test]`, and Tokio attributes are omitted for
+/// synchronous test signatures.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// let tokens = generate_test_attrs(
+///     &[],
+///     &TestAttrPolicy {
+///         runtime: RuntimeMode::TokioCurrentThread,
+///         harness: None,
+///         attributes: None,
+///     },
+///     true,
+/// );
+///
+/// assert!(tokens.to_string().contains("tokio :: test"));
+/// ```
 pub(super) fn generate_test_attrs(
     attrs: &[syn::Attribute],
     policy: &TestAttrPolicy<'_>,

--- a/crates/rstest-bdd-macros/src/codegen/scenario/tests.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/tests.rs
@@ -4,6 +4,7 @@ use super::*;
 use crate::parsing::feature::ParsedStep;
 
 mod gpui_policy;
+mod harness_defaults;
 
 #[expect(clippy::expect_used, reason = "test helper with descriptive failures")]
 fn kw(ts: &TokenStream2) -> crate::StepKeyword {
@@ -103,7 +104,7 @@ fn has_tokio_test_detection(#[case] attr_str: &str, #[case] expected_tokio: bool
 
     // When runtime is TokioCurrentThread and tokio::test is already present,
     // we should NOT emit another tokio::test attribute.
-    let tokens = generate_test_attrs(&attrs, RuntimeMode::TokioCurrentThread, None, true);
+    let tokens = generate_test_attrs(&attrs, RuntimeMode::TokioCurrentThread, None, None, true);
     let has_tokio_in_output = tokens_contain(&tokens, "tokio :: test");
 
     if expected_tokio {
@@ -133,7 +134,7 @@ fn generate_test_attrs_output(
     #[case] expect_tokio_test: bool,
 ) {
     let attrs: Vec<syn::Attribute> = attr_strs.iter().map(|s| parse_attr(s)).collect();
-    let tokens = generate_test_attrs(&attrs, runtime, None, runtime.is_async());
+    let tokens = generate_test_attrs(&attrs, runtime, None, None, runtime.is_async());
     let output = tokens.to_string();
 
     // All outputs should contain rstest::rstest
@@ -191,7 +192,7 @@ fn generate_test_attrs_respects_attributes_policy(
     #[case] expect_tokio_test: bool,
 ) {
     let policy = policy_path.as_ref();
-    let tokens = generate_test_attrs(&[], RuntimeMode::TokioCurrentThread, policy, true);
+    let tokens = generate_test_attrs(&[], RuntimeMode::TokioCurrentThread, None, policy, true);
     let output = tokens.to_string();
 
     assert!(
@@ -212,7 +213,7 @@ fn generate_test_attrs_respects_attributes_policy(
 #[case::runtime_tokio_on_sync_function(None)]
 fn generate_test_attrs_omits_tokio_for_sync_functions(#[case] policy_path: Option<syn::Path>) {
     let policy = policy_path.as_ref();
-    let tokens = generate_test_attrs(&[], RuntimeMode::TokioCurrentThread, policy, false);
+    let tokens = generate_test_attrs(&[], RuntimeMode::TokioCurrentThread, None, policy, false);
     let output = tokens.to_string();
 
     assert!(
@@ -234,6 +235,7 @@ fn generate_test_attrs_dedupes_tokio_policy_and_user_attribute() {
     let generated_attrs = generate_test_attrs(
         &attrs,
         RuntimeMode::TokioCurrentThread,
+        None,
         Some(&policy_path),
         true,
     );

--- a/crates/rstest-bdd-macros/src/codegen/scenario/tests.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/tests.rs
@@ -5,6 +5,7 @@ use crate::parsing::feature::ParsedStep;
 
 mod gpui_policy;
 mod harness_defaults;
+mod runtime_split;
 
 #[expect(clippy::expect_used, reason = "test helper with descriptive failures")]
 fn kw(ts: &TokenStream2) -> crate::StepKeyword {

--- a/crates/rstest-bdd-macros/src/codegen/scenario/tests.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/tests.rs
@@ -1,5 +1,5 @@
 //! Tests exercising scenario code-generation utilities.
-use super::test_attrs::generate_test_attrs;
+use super::test_attrs::{TestAttrPolicy, generate_test_attrs};
 use super::*;
 use crate::parsing::feature::ParsedStep;
 
@@ -104,7 +104,15 @@ fn has_tokio_test_detection(#[case] attr_str: &str, #[case] expected_tokio: bool
 
     // When runtime is TokioCurrentThread and tokio::test is already present,
     // we should NOT emit another tokio::test attribute.
-    let tokens = generate_test_attrs(&attrs, RuntimeMode::TokioCurrentThread, None, None, true);
+    let tokens = generate_test_attrs(
+        &attrs,
+        &TestAttrPolicy {
+            runtime: RuntimeMode::TokioCurrentThread,
+            harness: None,
+            attributes: None,
+        },
+        true,
+    );
     let has_tokio_in_output = tokens_contain(&tokens, "tokio :: test");
 
     if expected_tokio {
@@ -134,7 +142,15 @@ fn generate_test_attrs_output(
     #[case] expect_tokio_test: bool,
 ) {
     let attrs: Vec<syn::Attribute> = attr_strs.iter().map(|s| parse_attr(s)).collect();
-    let tokens = generate_test_attrs(&attrs, runtime, None, None, runtime.is_async());
+    let tokens = generate_test_attrs(
+        &attrs,
+        &TestAttrPolicy {
+            runtime,
+            harness: None,
+            attributes: None,
+        },
+        runtime.is_async(),
+    );
     let output = tokens.to_string();
 
     // All outputs should contain rstest::rstest
@@ -192,7 +208,15 @@ fn generate_test_attrs_respects_attributes_policy(
     #[case] expect_tokio_test: bool,
 ) {
     let policy = policy_path.as_ref();
-    let tokens = generate_test_attrs(&[], RuntimeMode::TokioCurrentThread, None, policy, true);
+    let tokens = generate_test_attrs(
+        &[],
+        &TestAttrPolicy {
+            runtime: RuntimeMode::TokioCurrentThread,
+            harness: None,
+            attributes: policy,
+        },
+        true,
+    );
     let output = tokens.to_string();
 
     assert!(
@@ -213,7 +237,15 @@ fn generate_test_attrs_respects_attributes_policy(
 #[case::runtime_tokio_on_sync_function(None)]
 fn generate_test_attrs_omits_tokio_for_sync_functions(#[case] policy_path: Option<syn::Path>) {
     let policy = policy_path.as_ref();
-    let tokens = generate_test_attrs(&[], RuntimeMode::TokioCurrentThread, None, policy, false);
+    let tokens = generate_test_attrs(
+        &[],
+        &TestAttrPolicy {
+            runtime: RuntimeMode::TokioCurrentThread,
+            harness: None,
+            attributes: policy,
+        },
+        false,
+    );
     let output = tokens.to_string();
 
     assert!(
@@ -234,9 +266,11 @@ fn generate_test_attrs_dedupes_tokio_policy_and_user_attribute() {
     let policy_path = parse_path("rstest_bdd_harness_tokio::TokioAttributePolicy");
     let generated_attrs = generate_test_attrs(
         &attrs,
-        RuntimeMode::TokioCurrentThread,
-        None,
-        Some(&policy_path),
+        &TestAttrPolicy {
+            runtime: RuntimeMode::TokioCurrentThread,
+            harness: None,
+            attributes: Some(&policy_path),
+        },
         true,
     );
 

--- a/crates/rstest-bdd-macros/src/codegen/scenario/tests/gpui_policy.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/tests/gpui_policy.rs
@@ -11,7 +11,7 @@ use super::{RuntimeMode, generate_test_attrs, parse_path};
 )))]
 fn generate_test_attrs_respects_gpui_policy_paths(#[case] policy_path: Option<syn::Path>) {
     let policy = policy_path.as_ref();
-    let tokens = generate_test_attrs(&[], RuntimeMode::TokioCurrentThread, policy, true);
+    let tokens = generate_test_attrs(&[], RuntimeMode::TokioCurrentThread, None, policy, true);
     let output = tokens.to_string();
 
     assert!(
@@ -31,7 +31,7 @@ fn generate_test_attrs_respects_gpui_policy_paths(#[case] policy_path: Option<sy
 #[test]
 fn generate_test_attrs_emits_gpui_for_sync_functions() {
     let policy_path = parse_path("rstest_bdd_harness_gpui::GpuiAttributePolicy");
-    let tokens = generate_test_attrs(&[], RuntimeMode::Sync, Some(&policy_path), false);
+    let tokens = generate_test_attrs(&[], RuntimeMode::Sync, None, Some(&policy_path), false);
     let output = tokens.to_string();
 
     assert!(
@@ -50,7 +50,8 @@ fn generate_test_attrs_dedupes_gpui_policy_and_user_attribute() {
     let attrs = vec![gpui_attr];
 
     let policy_path = parse_path("rstest_bdd_harness_gpui::GpuiAttributePolicy");
-    let generated_attrs = generate_test_attrs(&attrs, RuntimeMode::Sync, Some(&policy_path), false);
+    let generated_attrs =
+        generate_test_attrs(&attrs, RuntimeMode::Sync, None, Some(&policy_path), false);
     let output = quote::quote! { #(#attrs)* #generated_attrs }.to_string();
 
     assert!(

--- a/crates/rstest-bdd-macros/src/codegen/scenario/tests/gpui_policy.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/tests/gpui_policy.rs
@@ -1,6 +1,6 @@
 //! GPUI-specific attribute policy tests for scenario test-attribute generation.
 
-use super::{RuntimeMode, generate_test_attrs, parse_path};
+use super::{RuntimeMode, TestAttrPolicy, generate_test_attrs, parse_path};
 
 #[rstest::rstest]
 #[case::with_gpui_policy_emits_gpui(Some(parse_path(
@@ -11,7 +11,15 @@ use super::{RuntimeMode, generate_test_attrs, parse_path};
 )))]
 fn generate_test_attrs_respects_gpui_policy_paths(#[case] policy_path: Option<syn::Path>) {
     let policy = policy_path.as_ref();
-    let tokens = generate_test_attrs(&[], RuntimeMode::TokioCurrentThread, None, policy, true);
+    let tokens = generate_test_attrs(
+        &[],
+        &TestAttrPolicy {
+            runtime: RuntimeMode::TokioCurrentThread,
+            harness: None,
+            attributes: policy,
+        },
+        true,
+    );
     let output = tokens.to_string();
 
     assert!(
@@ -31,7 +39,15 @@ fn generate_test_attrs_respects_gpui_policy_paths(#[case] policy_path: Option<sy
 #[test]
 fn generate_test_attrs_emits_gpui_for_sync_functions() {
     let policy_path = parse_path("rstest_bdd_harness_gpui::GpuiAttributePolicy");
-    let tokens = generate_test_attrs(&[], RuntimeMode::Sync, None, Some(&policy_path), false);
+    let tokens = generate_test_attrs(
+        &[],
+        &TestAttrPolicy {
+            runtime: RuntimeMode::Sync,
+            harness: None,
+            attributes: Some(&policy_path),
+        },
+        false,
+    );
     let output = tokens.to_string();
 
     assert!(
@@ -50,8 +66,15 @@ fn generate_test_attrs_dedupes_gpui_policy_and_user_attribute() {
     let attrs = vec![gpui_attr];
 
     let policy_path = parse_path("rstest_bdd_harness_gpui::GpuiAttributePolicy");
-    let generated_attrs =
-        generate_test_attrs(&attrs, RuntimeMode::Sync, None, Some(&policy_path), false);
+    let generated_attrs = generate_test_attrs(
+        &attrs,
+        &TestAttrPolicy {
+            runtime: RuntimeMode::Sync,
+            harness: None,
+            attributes: Some(&policy_path),
+        },
+        false,
+    );
     let output = quote::quote! { #(#attrs)* #generated_attrs }.to_string();
 
     assert!(

--- a/crates/rstest-bdd-macros/src/codegen/scenario/tests/harness_defaults.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/tests/harness_defaults.rs
@@ -1,0 +1,79 @@
+//! Tests for harness-led default attribute-policy precedence.
+
+use super::{RuntimeMode, generate_test_attrs};
+
+#[expect(clippy::expect_used, reason = "test helper with descriptive failures")]
+fn parse_path(s: &str) -> syn::Path {
+    syn::parse_str::<syn::Path>(s).expect("valid path")
+}
+
+#[rstest::rstest]
+#[case::tokio_harness_beats_sync_runtime(
+    RuntimeMode::Sync,
+    Some(parse_path("rstest_bdd_harness_tokio::TokioHarness")),
+    None,
+    true,
+    false
+)]
+#[case::gpui_harness_beats_tokio_runtime(
+    RuntimeMode::TokioCurrentThread,
+    Some(parse_path("rstest_bdd_harness_gpui::GpuiHarness")),
+    None,
+    false,
+    true
+)]
+#[case::std_harness_beats_tokio_runtime(
+    RuntimeMode::TokioCurrentThread,
+    Some(parse_path("rstest_bdd_harness::StdHarness")),
+    None,
+    false,
+    false
+)]
+#[case::unknown_harness_falls_back_to_runtime(
+    RuntimeMode::TokioCurrentThread,
+    Some(parse_path("my::Harness")),
+    None,
+    true,
+    false
+)]
+#[case::explicit_unknown_attributes_override_known_harness(
+    RuntimeMode::TokioCurrentThread,
+    Some(parse_path("rstest_bdd_harness_tokio::TokioHarness")),
+    Some(parse_path("my::Policy")),
+    false,
+    false
+)]
+#[case::explicit_attributes_override_known_harness(
+    RuntimeMode::Sync,
+    Some(parse_path("rstest_bdd_harness_gpui::GpuiHarness")),
+    Some(parse_path("rstest_bdd_harness_tokio::TokioAttributePolicy")),
+    true,
+    false
+)]
+fn generate_test_attrs_honours_harness_precedence(
+    #[case] runtime: RuntimeMode,
+    #[case] harness_path: Option<syn::Path>,
+    #[case] policy_path: Option<syn::Path>,
+    #[case] expect_tokio_test: bool,
+    #[case] expect_gpui_test: bool,
+) {
+    let harness = harness_path.as_ref();
+    let policy = policy_path.as_ref();
+    let tokens = generate_test_attrs(&[], runtime, harness, policy, true);
+    let output = tokens.to_string();
+
+    assert!(
+        output.contains("rstest :: rstest"),
+        "should contain rstest::rstest: {output}"
+    );
+    assert_eq!(
+        output.contains("tokio :: test"),
+        expect_tokio_test,
+        "tokio::test presence mismatch for runtime={runtime:?}, harness={harness_path:?}, policy={policy_path:?}: {output}"
+    );
+    assert_eq!(
+        output.contains("gpui :: test"),
+        expect_gpui_test,
+        "gpui::test presence mismatch for runtime={runtime:?}, harness={harness_path:?}, policy={policy_path:?}: {output}"
+    );
+}

--- a/crates/rstest-bdd-macros/src/codegen/scenario/tests/harness_defaults.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/tests/harness_defaults.rs
@@ -1,6 +1,6 @@
 //! Tests for harness-led default attribute-policy precedence.
 
-use super::{RuntimeMode, generate_test_attrs};
+use super::{RuntimeMode, TestAttrPolicy, generate_test_attrs};
 
 #[expect(clippy::expect_used, reason = "test helper with descriptive failures")]
 fn parse_path(s: &str) -> syn::Path {
@@ -59,7 +59,15 @@ fn generate_test_attrs_honours_harness_precedence(
 ) {
     let harness = harness_path.as_ref();
     let policy = policy_path.as_ref();
-    let tokens = generate_test_attrs(&[], runtime, harness, policy, true);
+    let tokens = generate_test_attrs(
+        &[],
+        &TestAttrPolicy {
+            runtime,
+            harness,
+            attributes: policy,
+        },
+        true,
+    );
     let output = tokens.to_string();
 
     assert!(

--- a/crates/rstest-bdd-macros/src/codegen/scenario/tests/runtime_split.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/tests/runtime_split.rs
@@ -1,0 +1,57 @@
+//! Tests covering the `ScenarioConfig` execution-runtime split.
+
+use super::{
+    FeaturePath, RuntimeMode, ScenarioConfig, ScenarioName, ScenarioReturnKind, TestAttrPolicy,
+    blank, generate_test_attrs,
+};
+
+#[test]
+fn scenario_config_keeps_attribute_runtime_separate_from_execution_runtime() {
+    let attrs: Vec<syn::Attribute> = Vec::new();
+    let vis: syn::Visibility = syn::parse_quote!();
+    let sig: syn::Signature = syn::parse_quote!(async fn split_runtime_test());
+    let block: syn::Block = syn::parse_quote!({});
+    let tags: Vec<String> = Vec::new();
+    let config = ScenarioConfig {
+        attrs: &attrs,
+        vis: &vis,
+        sig: &sig,
+        block: &block,
+        feature_path: FeaturePath::new("tests/features/runtime_split.feature".to_owned()),
+        scenario_name: ScenarioName::new("attribute runtime split".to_owned()),
+        steps: vec![blank()],
+        examples: None,
+        allow_skipped: false,
+        line: 1,
+        tags: &tags,
+        runtime: RuntimeMode::TokioCurrentThread,
+        attribute_runtime: RuntimeMode::Sync,
+        return_kind: ScenarioReturnKind::Unit,
+        harness: None,
+        attributes: None,
+    };
+
+    let attrs = generate_test_attrs(
+        config.attrs,
+        &TestAttrPolicy {
+            runtime: config.attribute_runtime,
+            harness: config.harness,
+            attributes: config.attributes,
+        },
+        config.runtime.is_async(),
+    );
+    let output = attrs.to_string();
+
+    assert!(
+        config.runtime.is_async(),
+        "expected execution runtime to keep async generation enabled"
+    );
+    assert!(
+        output.contains("rstest :: rstest"),
+        "expected generated attributes to include rstest::rstest, got: {output}"
+    );
+    assert!(
+        !output.contains("tokio :: test"),
+        "expected generated attributes to follow attribute_runtime instead of execution runtime, got: {output}"
+    );
+}

--- a/crates/rstest-bdd-macros/src/macros/scenario/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenario/mod.rs
@@ -164,6 +164,7 @@ fn try_scenario(
         line,
         tags: &tags,
         runtime,
+        attribute_runtime: runtime,
         return_kind,
         harness: harness.as_ref(),
         attributes: attributes.as_ref(),

--- a/crates/rstest-bdd-macros/src/macros/scenarios/test_generation.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/test_generation.rs
@@ -325,6 +325,7 @@ pub(super) fn generate_scenario_test(
         tags: &tags,
         runtime: effective_runtime,
         return_kind,
+        attribute_runtime: ctx.runtime,
         harness: harness_ref,
         attributes: ctx.attributes,
     };

--- a/crates/rstest-bdd-macros/src/macros/scenarios/test_generation.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/test_generation.rs
@@ -243,12 +243,11 @@ fn resolve_scenario_return_kind(
     has_result_fixtures: bool,
     fixtures: &[FixtureSpec],
 ) -> ScenarioReturnKind {
-    let mut return_kind = classify_return_type(&sig.output, None)
-        .map(|rk| match rk {
+    let mut return_kind =
+        classify_return_type(&sig.output, None).map_or(ScenarioReturnKind::Unit, |rk| match rk {
             crate::return_classifier::ReturnKind::Unit => ScenarioReturnKind::Unit,
             _ => ScenarioReturnKind::ResultUnit,
-        })
-        .unwrap_or(ScenarioReturnKind::Unit);
+        });
 
     if has_result_fixtures && !return_kind.is_fallible() {
         let error_ty = resolve_fixture_error_type(fixtures);

--- a/crates/rstest-bdd-policy/Cargo.toml
+++ b/crates/rstest-bdd-policy/Cargo.toml
@@ -16,3 +16,6 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+
+[dev-dependencies]
+rstest.workspace = true

--- a/crates/rstest-bdd-policy/src/lib.rs
+++ b/crates/rstest-bdd-policy/src/lib.rs
@@ -82,12 +82,21 @@ pub enum TestAttributeHint {
 pub const DEFAULT_ATTRIBUTE_POLICY_PATH: &[&str] =
     &["rstest_bdd_harness", "DefaultAttributePolicy"];
 
+/// Canonical path segments for `StdHarness`.
+pub const STD_HARNESS_PATH: &[&str] = &["rstest_bdd_harness", "StdHarness"];
+
 /// Canonical path segments for `TokioAttributePolicy`.
 pub const TOKIO_ATTRIBUTE_POLICY_PATH: &[&str] =
     &["rstest_bdd_harness_tokio", "TokioAttributePolicy"];
 
+/// Canonical path segments for `TokioHarness`.
+pub const TOKIO_HARNESS_PATH: &[&str] = &["rstest_bdd_harness_tokio", "TokioHarness"];
+
 /// Canonical path segments for `GpuiAttributePolicy`.
 pub const GPUI_ATTRIBUTE_POLICY_PATH: &[&str] = &["rstest_bdd_harness_gpui", "GpuiAttributePolicy"];
+
+/// Canonical path segments for `GpuiHarness`.
+pub const GPUI_HARNESS_PATH: &[&str] = &["rstest_bdd_harness_gpui", "GpuiHarness"];
 
 const KNOWN_ATTRIBUTE_POLICY_HINTS: [(&[&str], TestAttributeHint); 3] = [
     (DEFAULT_ATTRIBUTE_POLICY_PATH, TestAttributeHint::RstestOnly),
@@ -99,6 +108,15 @@ const KNOWN_ATTRIBUTE_POLICY_HINTS: [(&[&str], TestAttributeHint); 3] = [
         GPUI_ATTRIBUTE_POLICY_PATH,
         TestAttributeHint::RstestWithGpuiTest,
     ),
+];
+
+const KNOWN_HARNESS_HINTS: [(&[&str], TestAttributeHint); 3] = [
+    (STD_HARNESS_PATH, TestAttributeHint::RstestOnly),
+    (
+        TOKIO_HARNESS_PATH,
+        TestAttributeHint::RstestWithTokioCurrentThread,
+    ),
+    (GPUI_HARNESS_PATH, TestAttributeHint::RstestWithGpuiTest),
 ];
 
 /// Resolves a canonical attribute policy path into a test-attribute hint.
@@ -133,12 +151,44 @@ pub fn resolve_test_attribute_hint_for_policy_path(
         .find_map(|(known_path, hint)| (path_segments == *known_path).then_some(*hint))
 }
 
+/// Resolves a canonical harness path into a test-attribute hint.
+///
+/// Path segments should be provided without a leading `::`.
+///
+/// # Examples
+///
+/// ```
+/// use rstest_bdd_policy::{
+///     resolve_test_attribute_hint_for_harness_path, TestAttributeHint,
+/// };
+///
+/// assert_eq!(
+///     resolve_test_attribute_hint_for_harness_path(&[
+///         "rstest_bdd_harness_tokio",
+///         "TokioHarness",
+///     ]),
+///     Some(TestAttributeHint::RstestWithTokioCurrentThread)
+/// );
+/// assert_eq!(
+///     resolve_test_attribute_hint_for_harness_path(&["my", "Harness"]),
+///     None
+/// );
+/// ```
+#[must_use]
+pub fn resolve_test_attribute_hint_for_harness_path(
+    path_segments: &[&str],
+) -> Option<TestAttributeHint> {
+    KNOWN_HARNESS_HINTS
+        .iter()
+        .find_map(|(known_path, hint)| (path_segments == *known_path).then_some(*hint))
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        DEFAULT_ATTRIBUTE_POLICY_PATH, GPUI_ATTRIBUTE_POLICY_PATH, RuntimeMode,
-        TOKIO_ATTRIBUTE_POLICY_PATH, TestAttributeHint,
-        resolve_test_attribute_hint_for_policy_path,
+        DEFAULT_ATTRIBUTE_POLICY_PATH, GPUI_ATTRIBUTE_POLICY_PATH, GPUI_HARNESS_PATH, RuntimeMode,
+        STD_HARNESS_PATH, TOKIO_ATTRIBUTE_POLICY_PATH, TOKIO_HARNESS_PATH, TestAttributeHint,
+        resolve_test_attribute_hint_for_harness_path, resolve_test_attribute_hint_for_policy_path,
     };
 
     #[test]
@@ -208,6 +258,46 @@ mod tests {
     fn partial_attribute_policy_path_returns_none() {
         assert_eq!(
             resolve_test_attribute_hint_for_policy_path(&["TokioAttributePolicy"]),
+            None
+        );
+    }
+
+    #[test]
+    fn resolves_std_harness_path() {
+        assert_eq!(
+            resolve_test_attribute_hint_for_harness_path(STD_HARNESS_PATH),
+            Some(TestAttributeHint::RstestOnly)
+        );
+    }
+
+    #[test]
+    fn resolves_tokio_harness_path() {
+        assert_eq!(
+            resolve_test_attribute_hint_for_harness_path(TOKIO_HARNESS_PATH),
+            Some(TestAttributeHint::RstestWithTokioCurrentThread)
+        );
+    }
+
+    #[test]
+    fn resolves_gpui_harness_path() {
+        assert_eq!(
+            resolve_test_attribute_hint_for_harness_path(GPUI_HARNESS_PATH),
+            Some(TestAttributeHint::RstestWithGpuiTest)
+        );
+    }
+
+    #[test]
+    fn unknown_harness_path_returns_none() {
+        assert_eq!(
+            resolve_test_attribute_hint_for_harness_path(&["my", "Harness"]),
+            None
+        );
+    }
+
+    #[test]
+    fn partial_harness_path_returns_none() {
+        assert_eq!(
+            resolve_test_attribute_hint_for_harness_path(&["TokioHarness"]),
             None
         );
     }

--- a/crates/rstest-bdd-policy/src/lib.rs
+++ b/crates/rstest-bdd-policy/src/lib.rs
@@ -190,6 +190,7 @@ mod tests {
         STD_HARNESS_PATH, TOKIO_ATTRIBUTE_POLICY_PATH, TOKIO_HARNESS_PATH, TestAttributeHint,
         resolve_test_attribute_hint_for_harness_path, resolve_test_attribute_hint_for_policy_path,
     };
+    use rstest::rstest;
 
     #[test]
     fn runtime_mode_sync_is_default() {
@@ -222,83 +223,35 @@ mod tests {
         );
     }
 
-    #[test]
-    fn resolves_default_attribute_policy_path() {
-        assert_eq!(
-            resolve_test_attribute_hint_for_policy_path(DEFAULT_ATTRIBUTE_POLICY_PATH),
-            Some(TestAttributeHint::RstestOnly)
-        );
+    #[rstest]
+    #[case(DEFAULT_ATTRIBUTE_POLICY_PATH, Some(TestAttributeHint::RstestOnly))]
+    #[case(
+        TOKIO_ATTRIBUTE_POLICY_PATH,
+        Some(TestAttributeHint::RstestWithTokioCurrentThread)
+    )]
+    #[case(
+        GPUI_ATTRIBUTE_POLICY_PATH,
+        Some(TestAttributeHint::RstestWithGpuiTest)
+    )]
+    #[case(&["my", "Policy"], None)]
+    #[case(&["TokioAttributePolicy"], None)]
+    fn resolves_attribute_policy_paths(
+        #[case] path: &[&str],
+        #[case] expected: Option<TestAttributeHint>,
+    ) {
+        assert_eq!(resolve_test_attribute_hint_for_policy_path(path), expected);
     }
 
-    #[test]
-    fn resolves_tokio_attribute_policy_path() {
-        assert_eq!(
-            resolve_test_attribute_hint_for_policy_path(TOKIO_ATTRIBUTE_POLICY_PATH),
-            Some(TestAttributeHint::RstestWithTokioCurrentThread)
-        );
-    }
-
-    #[test]
-    fn resolves_gpui_attribute_policy_path() {
-        assert_eq!(
-            resolve_test_attribute_hint_for_policy_path(GPUI_ATTRIBUTE_POLICY_PATH),
-            Some(TestAttributeHint::RstestWithGpuiTest)
-        );
-    }
-
-    #[test]
-    fn unknown_attribute_policy_path_returns_none() {
-        assert_eq!(
-            resolve_test_attribute_hint_for_policy_path(&["my", "Policy"]),
-            None
-        );
-    }
-
-    #[test]
-    fn partial_attribute_policy_path_returns_none() {
-        assert_eq!(
-            resolve_test_attribute_hint_for_policy_path(&["TokioAttributePolicy"]),
-            None
-        );
-    }
-
-    #[test]
-    fn resolves_std_harness_path() {
-        assert_eq!(
-            resolve_test_attribute_hint_for_harness_path(STD_HARNESS_PATH),
-            Some(TestAttributeHint::RstestOnly)
-        );
-    }
-
-    #[test]
-    fn resolves_tokio_harness_path() {
-        assert_eq!(
-            resolve_test_attribute_hint_for_harness_path(TOKIO_HARNESS_PATH),
-            Some(TestAttributeHint::RstestWithTokioCurrentThread)
-        );
-    }
-
-    #[test]
-    fn resolves_gpui_harness_path() {
-        assert_eq!(
-            resolve_test_attribute_hint_for_harness_path(GPUI_HARNESS_PATH),
-            Some(TestAttributeHint::RstestWithGpuiTest)
-        );
-    }
-
-    #[test]
-    fn unknown_harness_path_returns_none() {
-        assert_eq!(
-            resolve_test_attribute_hint_for_harness_path(&["my", "Harness"]),
-            None
-        );
-    }
-
-    #[test]
-    fn partial_harness_path_returns_none() {
-        assert_eq!(
-            resolve_test_attribute_hint_for_harness_path(&["TokioHarness"]),
-            None
-        );
+    #[rstest]
+    #[case(STD_HARNESS_PATH, Some(TestAttributeHint::RstestOnly))]
+    #[case(
+        TOKIO_HARNESS_PATH,
+        Some(TestAttributeHint::RstestWithTokioCurrentThread)
+    )]
+    #[case(GPUI_HARNESS_PATH, Some(TestAttributeHint::RstestWithGpuiTest))]
+    #[case(&["my", "Harness"], None)]
+    #[case(&["TokioHarness"], None)]
+    fn resolves_harness_paths(#[case] path: &[&str], #[case] expected: Option<TestAttributeHint>) {
+        assert_eq!(resolve_test_attribute_hint_for_harness_path(path), expected);
     }
 }

--- a/crates/rstest-bdd/tests/features/gpui_harness_default_scenarios/defaults.feature
+++ b/crates/rstest-bdd/tests/features/gpui_harness_default_scenarios/defaults.feature
@@ -1,0 +1,6 @@
+Feature: GPUI harness scenarios macro defaults
+
+  Scenario: GPUI harness provides context through default attributes
+    Given a GPUI test is running
+    When I access the GPUI test context
+    Then the GPUI test context is valid

--- a/crates/rstest-bdd/tests/features/tokio_harness_scenarios/defaults.feature
+++ b/crates/rstest-bdd/tests/features/tokio_harness_scenarios/defaults.feature
@@ -1,0 +1,6 @@
+Feature: Tokio harness scenarios macro defaults
+
+  Scenario: Tokio scenarios macro uses harness-led defaults
+    Given the Tokio runtime is active
+    When a Tokio handle is obtained
+    Then the handle confirms current-thread execution

--- a/crates/rstest-bdd/tests/fixtures_macros/result_fixture_requires_result_scenario.stderr
+++ b/crates/rstest-bdd/tests/fixtures_macros/result_fixture_requires_result_scenario.stderr
@@ -1,23 +1,15 @@
-error: scenarios with Result-returning fixtures must return `Result<(), E>` or `StepResult<(), E>` to propagate fixture initialisation errors
- --> tests/fixtures_macros/result_fixture_requires_result_scenario.rs:7:1
+error: scenarios with fallible fixtures (`Result<T, E>` or `StepResult<T, E>`) must return `Result<(), E>` or `StepResult<(), E>` to propagate fixture initialization errors
+ --> tests/fixtures_macros/result_fixture_requires_result_scenario.rs:6:1
   |
-7 | #[scenario(path = "basic.feature")]
+6 | #[scenario(path = "basic.feature")]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: scenarios with Result-returning fixtures must return `Result<(), E>` or `StepResult<(), E>` to propagate fixture initialisation errors
-  --> tests/fixtures_macros/result_fixture_requires_result_scenario.rs:10:1
-   |
-10 | #[scenario(path = "basic.feature")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-warning: unused import: `rstest_bdd::StepResult`
- --> tests/fixtures_macros/result_fixture_requires_result_scenario.rs:4:5
+error: scenarios with fallible fixtures (`Result<T, E>` or `StepResult<T, E>`) must return `Result<(), E>` or `StepResult<(), E>` to propagate fixture initialization errors
+ --> tests/fixtures_macros/result_fixture_requires_result_scenario.rs:9:1
   |
-4 | use rstest_bdd::StepResult;
-  |     ^^^^^^^^^^^^^^^^^^^^^^
+9 | #[scenario(path = "basic.feature")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+  = note: this error originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/rstest-bdd/tests/fixtures_macros/scenario_harness_gpui_default.rs
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenario_harness_gpui_default.rs
@@ -1,0 +1,22 @@
+//! Compile-pass fixture validating that `#[scenario]` accepts a first-party
+//! GPUI harness without an explicit attribute policy.
+use rstest_bdd_macros::{given, scenario, then, when};
+
+#[given("a precondition")]
+fn precondition() {}
+
+#[when("an action occurs")]
+fn action() {}
+
+#[then("a result is produced")]
+fn result() {}
+
+#[scenario(
+    path = "basic.feature",
+    harness = rstest_bdd_harness_gpui::GpuiHarness,
+)]
+fn with_gpui_harness_default_attributes() {}
+
+const _: &str = include_str!("basic.feature");
+
+fn main() {}

--- a/crates/rstest-bdd/tests/fixtures_macros/scenario_harness_tokio_default.rs
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenario_harness_tokio_default.rs
@@ -1,0 +1,22 @@
+//! Compile-pass fixture validating that `#[scenario]` accepts a first-party
+//! Tokio harness without an explicit attribute policy.
+use rstest_bdd_macros::{given, scenario, then, when};
+
+#[given("a precondition")]
+fn precondition() {}
+
+#[when("an action occurs")]
+fn action() {}
+
+#[then("a result is produced")]
+fn result() {}
+
+#[scenario(
+    path = "basic.feature",
+    harness = rstest_bdd_harness_tokio::TokioHarness,
+)]
+fn with_tokio_harness_default_attributes() {}
+
+const _: &str = include_str!("basic.feature");
+
+fn main() {}

--- a/crates/rstest-bdd/tests/fixtures_macros/scenarios_harness_gpui_default.rs
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenarios_harness_gpui_default.rs
@@ -1,0 +1,19 @@
+//! Compile-pass fixture validating that `scenarios!` accepts a first-party
+//! GPUI harness without an explicit attribute policy.
+use rstest_bdd_macros::{given, scenarios, then, when};
+
+#[given("a precondition")]
+fn precondition() {}
+
+#[when("an action occurs")]
+fn action() {}
+
+#[then("a result is produced")]
+fn result() {}
+
+scenarios!(
+    "tests/features/auto",
+    harness = rstest_bdd_harness_gpui::GpuiHarness,
+);
+
+fn main() {}

--- a/crates/rstest-bdd/tests/scenario_harness_gpui.rs
+++ b/crates/rstest-bdd/tests/scenario_harness_gpui.rs
@@ -186,3 +186,8 @@ scenarios!(
     harness = rstest_bdd_harness_gpui::GpuiHarness,
     attributes = rstest_bdd_harness_gpui::GpuiAttributePolicy,
 );
+
+scenarios!(
+    "tests/features/gpui_harness_default_scenarios",
+    harness = rstest_bdd_harness_gpui::GpuiHarness,
+);

--- a/crates/rstest-bdd/tests/scenario_harness_tokio.rs
+++ b/crates/rstest-bdd/tests/scenario_harness_tokio.rs
@@ -8,7 +8,7 @@
 //! - `spawn_local` succeeds in step functions, confirming the `LocalSet` +
 //!   `current_thread` wiring.
 
-use rstest_bdd_macros::{given, scenario, then, when};
+use rstest_bdd_macros::{given, scenario, scenarios, then, when};
 
 #[given("the Tokio runtime is active")]
 fn tokio_runtime_is_active() {
@@ -83,3 +83,8 @@ async fn async_steps_completed() {
     harness = rstest_bdd_harness_tokio::TokioHarness,
 )]
 fn scenario_async_steps_under_tokio_harness() {}
+
+scenarios!(
+    "tests/features/tokio_harness_scenarios",
+    harness = rstest_bdd_harness_tokio::TokioHarness,
+);

--- a/crates/rstest-bdd/tests/trybuild_macros.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros.rs
@@ -64,6 +64,8 @@ fn run_passing_macro_tests(t: &trybuild::TestCases) {
         MacroFixtureCase::from("scenarios_fixtures.rs"),
         MacroFixtureCase::from("scenarios_autodiscovery.rs"),
         MacroFixtureCase::from("scenario_harness_params.rs"),
+        MacroFixtureCase::from("scenario_harness_tokio_default.rs"),
+        MacroFixtureCase::from("scenario_harness_gpui_default.rs"),
         MacroFixtureCase::from("scenario_attributes_tokio.rs"),
         MacroFixtureCase::from("scenario_attributes_tokio_sync.rs"),
         MacroFixtureCase::from("scenario_attributes_tokio_dedup.rs"),
@@ -71,6 +73,7 @@ fn run_passing_macro_tests(t: &trybuild::TestCases) {
         MacroFixtureCase::from("scenario_attributes_gpui_absolute.rs"),
         MacroFixtureCase::from("execution_policy_reexports.rs"),
         MacroFixtureCase::from("scenarios_harness_params.rs"),
+        MacroFixtureCase::from("scenarios_harness_gpui_default.rs"),
         MacroFixtureCase::from("scenarios_attributes_gpui.rs"),
     ] {
         t.pass(macros_fixture(case).as_std_path());

--- a/docs/execplans/adr-008-harness-led-attribute-policy-defaults.md
+++ b/docs/execplans/adr-008-harness-led-attribute-policy-defaults.md
@@ -1,0 +1,460 @@
+# ExecPlan: implement ADR-008 harness-led attribute-policy defaults
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+`PLANS.md` is not present in this repository at the time of writing, so this
+ExecPlan is the governing plan for ADR-008 delivery once the ADR is accepted
+and the user approves execution.
+
+## Purpose / big picture
+
+ADR-008 changes the common first-party integration workflow for `#[scenario]`
+and `scenarios!`. After this work, a user who selects a first-party harness
+does not need to repeat the matching first-party attribute policy just to get
+the normal emitted test attributes. These forms should work as the preferred
+documentation path:
+
+```rust,no_run
+# use rstest_bdd_macros::scenario;
+#[scenario(
+    path = "tests/features/my_async.feature",
+    harness = rstest_bdd_harness_tokio::TokioHarness,
+)]
+fn my_tokio_scenario() {}
+```
+
+and:
+
+```rust,no_run
+# use rstest_bdd_macros::scenario;
+#[scenario(
+    path = "tests/features/my_ui.feature",
+    harness = rstest_bdd_harness_gpui::GpuiHarness,
+)]
+fn my_gpui_scenario() {}
+```
+
+Explicit `attributes = ...` remains authoritative, `attributes`-only
+configuration remains supported, and unknown third-party harnesses must still
+fall back to explicit policy selection rather than pretending the macro can
+infer arbitrary defaults.
+
+Success is observable in three ways:
+
+1. Unit tests prove the exact precedence order from ADR-008:
+   explicit `attributes` override, known first-party harness defaults come
+   next, the deprecated Tokio runtime alias remains below explicit harness
+   selection, and the final fallback is the existing runtime-mode or
+   synchronous behaviour.
+2. Public-macro coverage proves the harness-only first-party forms compile and
+   run for both `#[scenario]` and `scenarios!`, while explicit override cases
+   still behave correctly.
+3. `docs/users-guide.md` clearly teaches harness-led defaults as the normal
+   first-party configuration and still documents `attributes = ...` as the
+   override and third-party escape hatch.
+
+## Constraints
+
+- Implement only ADR-008 and roadmap workstream 9.7. Do not fold unrelated
+  harness redesign, runtime alias redesign, or new third-party extension
+  machinery into this change.
+- Preserve the architectural separation from ADR-005: `HarnessAdapter`
+  remains the runtime delegation boundary and `AttributePolicy` remains the
+  emitted-attribute boundary.
+- Preserve the exact ADR-008 precedence order:
+  1. explicit `attributes = ...`
+  2. known first-party `harness = ...` mapping
+  3. deprecated `runtime = "tokio-current-thread"` compatibility alias
+  4. existing runtime-mode or synchronous fallback
+- Keep `attributes`-only and `harness`-only configurations supported.
+- Keep the current path-based trust model. The macro must not attempt to
+  execute arbitrary third-party `AttributePolicy::test_attributes()`
+  implementations at expansion time.
+- Preserve the current deduplication rules for emitted `#[tokio::test]` and
+  `#[gpui::test]`.
+- Do not add new external dependencies.
+- Cover the feature with unit tests and behavioural tests. Because emitted
+  attributes are a compile-time concern, include trybuild coverage as the
+  public-macro proof layer between those two.
+- Update `docs/users-guide.md` as part of the implementation. Update
+  `docs/rstest-bdd-design.md` as well so the internal design record matches the
+  shipped behaviour.
+- Run all applicable gates before considering the work complete:
+  `make fmt`, `make check-fmt`, `make lint`, `make test`, `make markdownlint`,
+  and `make nixie`.
+- Run long-lived commands with `set -o pipefail` and `tee` so failures are
+  preserved in log files.
+
+## Tolerances
+
+- Scope: if the implementation grows beyond 16 files changed or 900 net
+  lines, stop and re-check whether the work has turned into a broader
+  harness-policy refactor.
+- Interface: if shipping ADR-008 requires new user-facing macro syntax,
+  changes to `HarnessAdapter` or `AttributePolicy`, or a new public crate API,
+  stop and split that API work into a separate decision.
+- Dependencies: if any new external crate is required, stop and escalate.
+- Resolution model: if the first-party harness mapping cannot live in shared
+  non-proc-macro code without introducing a dependency cycle, stop and record
+  the exact cycle before continuing.
+- Behavioural proof: if the public-macro behaviour cannot be shown with the
+  existing `rstest-bdd` integration suite and trybuild harness, stop before
+  inventing a second bespoke test runner.
+- Validation: if `make test` fails for an unrelated pre-existing reason, such
+  as the known workspace-level nextest timeout in `cargo-bdd::cli`, capture the
+  log and stop before claiming completion.
+- Iterations: if the same gate fails three consecutive times after attempted
+  fixes, stop and escalate with the log path and current hypothesis.
+- Governance: do not mark roadmap item 9.7 complete unless ADR-008 has moved
+  out of `Proposed` status or the maintainers explicitly authorize delivery
+  while the ADR status lags.
+
+## Risks
+
+- Risk: the macro currently resolves test attributes from explicit
+  `attributes` or `RuntimeMode` only, so a narrow patch in one call site could
+  leave `#[scenario]` and `scenarios!` with different precedence. Severity:
+  high. Likelihood: medium. Mitigation: drive both macro entry points through
+  one shared resolution helper and test the full precedence matrix.
+- Risk: Tokio harness-only scenarios remain synchronous, so inferred Tokio
+  attributes are filtered out for sync signatures. A runtime-only test could
+  pass without proving the new inference logic. Severity: high. Likelihood:
+  high. Mitigation: add unit tests for hint resolution and trybuild coverage
+  for emitted-attribute cases, then use behavioural tests as smoke tests over
+  the public macros.
+- Risk: the deprecated runtime alias already resolves to `TokioHarness` inside
+  `scenarios!`. If the new harness-led default logic keys off the wrong value,
+  explicit harnesses and the alias could interfere with one another. Severity:
+  medium. Likelihood: medium. Mitigation: write direct helper tests for
+  explicit-harness precedence over the alias before changing the code.
+- Risk: GPUI and Tokio tests rely on feature-gated or framework-specific
+  suites that are easy to edit without running. Severity: medium. Likelihood:
+  medium. Mitigation: include focused `cargo test` commands for the exact
+  suites as mandatory validation, not optional spot checks.
+- Risk: `make test` uses `cargo-nextest`, which skips
+  `crates/rstest-bdd/tests/trybuild_macros.rs`. Severity: high. Likelihood:
+  high. Mitigation: keep a separate
+  `cargo test -p rstest-bdd --test trybuild_macros step_macros_compile -- --exact`
+   command in the required validation recipe.
+- Risk: the user guide could drift if only the ADR and design doc are updated.
+  Severity: medium. Likelihood: medium. Mitigation: make the user-guide update
+  a first-class milestone and do not close the work until its examples and
+  preference order are updated.
+
+## Progress
+
+- [x] (2026-04-09) Reviewed ADR-008, roadmap item 9.7, and adjacent execplans
+      for policy emission and GPUI coverage.
+- [x] (2026-04-09) Reviewed the current user-guide and design-doc sections for
+      harness and attribute-policy behaviour.
+- [x] (2026-04-09) Inspected the current implementation surface in
+      `rstest-bdd-policy`, `rstest-bdd-macros`, and the existing Tokio/GPUI
+      test suites.
+- [x] (2026-04-09) Drafted this ExecPlan.
+- [ ] Stage A: add shared first-party harness-path hint resolution in
+      `rstest-bdd-policy`.
+- [ ] Stage B: refactor macro test-attribute resolution to honour ADR-008
+      precedence for both `#[scenario]` and `scenarios!`.
+- [ ] Stage C: add unit, trybuild, and behavioural coverage for harness-led
+      defaults and explicit overrides.
+- [ ] Stage D: update `docs/users-guide.md` and `docs/rstest-bdd-design.md`
+      to teach the delivered behaviour.
+- [ ] Stage E: run focused validation plus repository-wide gates and, if
+      allowed by ADR status, update roadmap state.
+
+## Surprises & Discoveries
+
+- Observation: `crates/rstest-bdd-policy/src/lib.rs` already centralizes the
+  canonical first-party attribute-policy path mapping through
+  `resolve_test_attribute_hint_for_policy_path()`. Impact: the smallest,
+  lowest-risk ADR-008 implementation is to add first-party harness mapping in
+  the same shared crate instead of reintroducing macro-local mapping tables.
+- Observation: `crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs`
+  currently resolves attributes with
+  `attributes.map_or_else(|| runtime .test_attribute_hint(), ...)`. Impact:
+  harness-led defaults do not exist yet, and there is one clear helper boundary
+  to refactor.
+- Observation: `scenarios!` already resolves the deprecated runtime alias to a
+  concrete harness path in
+  `crates/rstest-bdd-macros/src/macros/scenarios/test_generation.rs` before it
+  constructs `ScenarioConfig`. Impact: the shared precedence helper should
+  operate on `ScenarioConfig.harness`, not duplicate alias logic inside
+  `generate_test_attrs()`.
+- Observation: `crates/rstest-bdd/tests/scenario_harness_tokio.rs` and
+  `crates/rstest-bdd/tests/scenario_harness_gpui.rs` already contain harness
+  smoke tests for `#[scenario]`, but they do not define the full harness-led
+  default and override matrix. Impact: extend those suites rather than create
+  new standalone integration binaries.
+- Observation: `make test` skips the trybuild macro suite under nextest.
+  Impact: the implementation must always run a focused `cargo test` command for
+  `trybuild_macros` in addition to the normal repository gates.
+
+## Decision Log
+
+- Decision: place first-party harness-to-hint mapping in
+  `crates/rstest-bdd-policy/src/lib.rs` next to the existing policy-path
+  mapping. Rationale: the mapping is shared semantic policy data, not macro
+  codegen logic, and keeping it in the shared crate prevents `#[scenario]` and
+  `scenarios!` from drifting apart. Date/Author: 2026-04-09 / Codex.
+- Decision: implement ADR-008 precedence in one macro-local helper that
+  receives runtime, resolved harness path, and explicit attribute-policy path.
+  Rationale: the precedence rules are subtle enough that duplicating them
+  across call sites would be a regression trap. Date/Author: 2026-04-09 / Codex.
+- Decision: use trybuild fixtures as the primary public proof of emitted
+  attribute inference, then use behavioural tests as end-to-end smoke tests.
+  Rationale: emitted attributes are mostly visible at compile time, especially
+  for Tokio where sync signatures filter out `#[tokio::test]`, so runtime-only
+  assertions are not sufficient. Date/Author: 2026-04-09 / Codex.
+- Decision: update the user guide to lead with harness-only first-party
+  examples, while still retaining one explicit-override example per framework
+  and the third-party caveat. Rationale: this is the user-visible point of the
+  ADR and must be obvious in the primary guide, not hidden only in the design
+  doc. Date/Author: 2026-04-09 / Codex.
+
+## Outcomes & Retrospective
+
+No implementation has started yet. When execution is complete, replace this
+placeholder with the shipped behaviour, the final validation transcript, and
+any follow-on work that should be split into a separate change.
+
+## Context and orientation
+
+The implementation touches one shared policy crate, one macro-layer resolution
+module, the existing public test suites, and the main user-facing documents.
+
+`crates/rstest-bdd-policy/src/lib.rs` currently defines:
+
+- `RuntimeMode`
+- `TestAttributeHint`
+- `DEFAULT_ATTRIBUTE_POLICY_PATH`
+- `TOKIO_ATTRIBUTE_POLICY_PATH`
+- `GPUI_ATTRIBUTE_POLICY_PATH`
+- `resolve_test_attribute_hint_for_policy_path()`
+
+This is the natural place to add canonical first-party harness path constants
+and a matching harness-path resolver.
+
+`crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs` currently owns
+attribute emission:
+
+- `resolve_attribute_hint_from_policy_path()`
+- `resolve_attribute_policy()`
+- `generate_test_attrs()`
+
+Today, `resolve_attribute_policy()` only sees `RuntimeMode` and the explicit
+`attributes` path. ADR-008 requires this module to honour explicit
+`attributes`, then inferred first-party harness defaults, then the runtime
+fallbacks.
+
+`crates/rstest-bdd-macros/src/codegen/scenario.rs` calls
+`generate_test_attrs()` from both `generate_regular_scenario_code()` and
+`generate_outline_scenario_code()`. `ScenarioConfig` already carries both
+`harness` and `attributes`, so the `#[scenario]` path can pass the selected
+harness directly once the helper signature is updated.
+
+`crates/rstest-bdd-macros/src/macros/scenarios/test_generation.rs` resolves the
+deprecated `runtime = "tokio-current-thread"` alias through
+`resolve_harness_path()` before it builds `ScenarioConfig`. That means the
+`scenarios!` flow can reuse the same `generate_test_attrs()` precedence logic
+without learning anything special about the alias.
+
+The public test surface is already in place:
+
+- `crates/rstest-bdd-macros/src/codegen/scenario/tests.rs`
+- `crates/rstest-bdd-macros/src/codegen/scenario/tests/gpui_policy.rs`
+- `crates/rstest-bdd-macros/src/macros/scenarios/test_generation/tests.rs`
+- `crates/rstest-bdd/tests/trybuild_macros.rs`
+- `crates/rstest-bdd/tests/scenario_harness_tokio.rs`
+- `crates/rstest-bdd/tests/scenario_harness_gpui.rs`
+- `crates/rstest-bdd/tests/fixtures_macros/`
+
+The documentation that must change is:
+
+- `docs/users-guide.md`
+- `docs/rstest-bdd-design.md`
+
+If roadmap status is updated after execution, the relevant file is
+`docs/roadmap.md`, but only if ADR-008 has been accepted or the maintainers
+explicitly authorize roadmap closure while the ADR status trails behind.
+
+## Plan of work
+
+### Stage A: add shared harness-path hint resolution
+
+Goal: extend the shared policy crate so first-party harness types map to the
+same `TestAttributeHint` values already used by the first-party attribute
+policies.
+
+Implementation details:
+
+1. Add canonical path constants for the first-party harness types:
+   `StdHarness`, `TokioHarness`, and `GpuiHarness`.
+2. Add a shared lookup table and a public helper such as
+   `resolve_test_attribute_hint_for_harness_path()`.
+3. Keep the helper path-based and segment-based, matching the current
+   `resolve_test_attribute_hint_for_policy_path()` contract.
+4. Add unit tests for:
+   - the three canonical first-party harness paths
+   - unknown third-party harness paths
+   - partial-name or wrong-prefix paths that must not match
+
+Go/no-go validation:
+
+- `cargo test -p rstest-bdd-policy` passes with the new resolver tests.
+
+### Stage B: teach macro codegen ADR-008 precedence
+
+Goal: make `generate_test_attrs()` resolve the effective attribute hint from
+explicit policy, inferred first-party harness default, and the existing runtime
+fallback, in that order.
+
+Implementation details:
+
+1. Refactor `crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs` so
+   the resolution helper accepts:
+   - `runtime: RuntimeMode`
+   - `harness: Option<&syn::Path>`
+   - `attributes: Option<&syn::Path>`
+2. Keep the exact ADR-008 order in one helper:
+   - explicit `attributes`
+   - known first-party harness
+   - runtime-derived hint
+3. Reuse the existing `syn::Path` segment extraction approach for both policy
+   and harness paths so absolute paths remain normalized naturally through
+   `syn::Path::segments`.
+4. Update both `generate_regular_scenario_code()` and
+   `generate_outline_scenario_code()` to pass `config.harness`.
+5. Preserve the current emitted-attribute filtering:
+   - do not emit `#[tokio::test]` for sync signatures
+   - do not duplicate an explicit user-written `#[tokio::test]`
+   - do not duplicate an explicit user-written `#[gpui::test]`
+6. Add unit tests in the macro crate for:
+   - `StdHarness` infers rstest-only output
+   - `TokioHarness` infers Tokio policy when the signature is async
+   - `GpuiHarness` infers GPUI policy for sync and async cases
+   - explicit `attributes = rstest_bdd_harness::DefaultAttributePolicy`
+     overrides `TokioHarness` and `GpuiHarness`
+   - explicit first-party framework policies override `StdHarness`
+   - unknown third-party harnesses fall back to the runtime-derived hint
+   - explicit harness still outranks the deprecated runtime alias once the
+     resolved harness path reaches `ScenarioConfig`
+
+Go/no-go validation:
+
+- `cargo test -p rstest-bdd-macros --lib` passes.
+- The new unit tests fail before the code change and pass after it.
+
+### Stage C: add trybuild and behavioural coverage
+
+Goal: prove the new behaviour through the public macro surface instead of only
+through helper-level unit tests.
+
+Implementation details:
+
+1. Extend `crates/rstest-bdd/tests/trybuild_macros.rs` with new compile-pass
+   fixtures for the harness-led default paths. The fixture set should cover:
+   - `#[scenario]` with `TokioHarness` and no `attributes`
+   - `#[scenario]` with `GpuiHarness` and no `attributes`
+   - `scenarios!` with `TokioHarness` and no `attributes`
+   - `scenarios!` with `GpuiHarness` and no `attributes`
+   - at least one explicit override case where a first-party harness is paired
+     with `rstest_bdd_harness::DefaultAttributePolicy`
+2. Prefer compile-pass fixtures over snapshot-based compile-fail fixtures here,
+   because the question is "does the generated code compile with the inferred
+   test attributes?" rather than "what exact diagnostic text is emitted?"
+3. Extend `crates/rstest-bdd/tests/scenario_harness_tokio.rs` with a
+   `scenarios!`-based harness-only smoke test so both public entry points are
+   exercised after the precedence refactor.
+4. Extend `crates/rstest-bdd/tests/scenario_harness_gpui.rs` with a matching
+   `scenarios!`-based harness-only smoke test and one explicit-override smoke
+   test if needed to keep the override path live at runtime.
+5. Keep the behavioural assertions small and framework-specific:
+   Tokio tests should keep proving active runtime plus `spawn_local` support;
+   GPUI tests should keep proving injected `TestAppContext` access and scenario
+   execution.
+6. Treat trybuild as the primary proof of inferred or overridden emitted
+   attributes. Behavioural tests are there to prove that the public macros
+   still execute correctly once the resolution logic is refactored.
+
+Go/no-go validation:
+
+- `RUSTFLAGS="-D warnings" cargo test -p rstest-bdd --test trybuild_macros
+  step_macros_compile -- --exact` passes.
+- `RUSTFLAGS="-D warnings" cargo test -p rstest-bdd --test
+  scenario_harness_tokio` passes.
+- `RUSTFLAGS="-D warnings" cargo test -p rstest-bdd --test
+  scenario_harness_gpui --features gpui-harness-tests` passes.
+
+### Stage D: update the user guide and design doc
+
+Goal: make the shipped behaviour obvious to users and keep the design doc in
+sync with the implementation.
+
+Implementation details:
+
+1. Update `docs/users-guide.md` in the "Harness adapter and attribute policy",
+   "Using the Tokio harness", and "Using the GPUI harness" sections so the
+   preference order leads with:
+   - omit both for the default synchronous path
+   - use `harness = ...` alone for first-party Tokio and GPUI
+   - add `attributes = ...` only when intentionally overriding the default
+2. Keep one explicit override example for Tokio and one for GPUI.
+3. Keep the third-party caveat explicit: unknown third-party harnesses do not
+   imply attribute defaults today, so custom integrations still need explicit
+   `attributes = ...` when emitted framework attributes matter.
+4. Update `docs/rstest-bdd-design.md` section 2.7.3 so it no longer says the
+   user-facing guidance should lead with paired `harness = ...` and
+   `attributes = ...` configuration.
+5. Document the exact precedence order from ADR-008 in both docs so runtime
+   alias behaviour stays unambiguous.
+
+Go/no-go validation:
+
+- The revised examples in `docs/users-guide.md` use harness-only first-party
+  configuration by default.
+- The docs still describe explicit overrides and third-party limitations
+  clearly.
+
+### Stage E: final validation and close-out
+
+Goal: prove the repository is in a releasable state after the change.
+
+Run these commands and inspect the logs before closing the work:
+
+```bash
+set -o pipefail; cargo test -p rstest-bdd-policy 2>&1 | tee /tmp/adr-008-policy.log
+set -o pipefail; cargo test -p rstest-bdd-macros --lib 2>&1 | tee /tmp/adr-008-macros.log
+set -o pipefail; RUSTFLAGS="-D warnings" cargo test -p rstest-bdd \
+  --test trybuild_macros step_macros_compile -- --exact 2>&1 | \
+  tee /tmp/adr-008-trybuild.log
+set -o pipefail; RUSTFLAGS="-D warnings" cargo test -p rstest-bdd \
+  --test scenario_harness_tokio 2>&1 | tee /tmp/adr-008-tokio.log
+set -o pipefail; RUSTFLAGS="-D warnings" cargo test -p rstest-bdd \
+  --test scenario_harness_gpui --features gpui-harness-tests 2>&1 | \
+  tee /tmp/adr-008-gpui.log
+set -o pipefail; make fmt 2>&1 | tee /tmp/adr-008-make-fmt.log
+set -o pipefail; make markdownlint 2>&1 | tee /tmp/adr-008-make-markdownlint.log
+set -o pipefail; make nixie 2>&1 | tee /tmp/adr-008-make-nixie.log
+set -o pipefail; make check-fmt 2>&1 | tee /tmp/adr-008-make-check-fmt.log
+set -o pipefail; make lint 2>&1 | tee /tmp/adr-008-make-lint.log
+set -o pipefail; make test 2>&1 | tee /tmp/adr-008-make-test.log
+```
+
+If `make fmt`, `make check-fmt`, `make lint`, or `make test` fails because
+`mdformat-all`, `uvx`, or `uv` is missing in the environment, stop and restore
+the documented wrapper setup before rerunning the gates. Do not silently skip
+those targets.
+
+Close-out checklist for the implementing agent:
+
+1. Update the `Progress` section with actual completion timestamps.
+2. Replace `Outcomes & Retrospective` with the delivered results and any
+   follow-on work.
+3. If ADR-008 is accepted during execution, update the relevant roadmap items
+   in `docs/roadmap.md`. If it is still only proposed, leave the roadmap as a
+   contingent plan and record that decision in `Decision Log`.

--- a/docs/execplans/adr-008-harness-led-attribute-policy-defaults.md
+++ b/docs/execplans/adr-008-harness-led-attribute-policy-defaults.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: IMPLEMENTED
 
 `PLANS.md` is not present in this repository at the time of writing, so this
 ExecPlan is the governing plan for ADR-008 delivery once the ADR is accepted
@@ -156,16 +156,15 @@ Success is observable in three ways:
       `rstest-bdd-policy`, `rstest-bdd-macros`, and the existing Tokio/GPUI
       test suites.
 - [x] (2026-04-09) Drafted this ExecPlan.
-- [ ] Stage A: add shared first-party harness-path hint resolution in
-      `rstest-bdd-policy`.
-- [ ] Stage B: refactor macro test-attribute resolution to honour ADR-008
-      precedence for both `#[scenario]` and `scenarios!`.
-- [ ] Stage C: add unit, trybuild, and behavioural coverage for harness-led
-      defaults and explicit overrides.
-- [ ] Stage D: update `docs/users-guide.md` and `docs/rstest-bdd-design.md`
-      to teach the delivered behaviour.
-- [ ] Stage E: run focused validation plus repository-wide gates and, if
-      allowed by ADR status, update roadmap state.
+- [x] (2026-04-11) Stage A: add shared first-party harness-path hint
+      resolution in `rstest-bdd-policy`.
+- [x] (2026-04-11) Stage B: refactor macro test-attribute resolution to honour
+      ADR-008 precedence for both `#[scenario]` and `scenarios!`.
+- [x] (2026-04-11) Stage C: add unit, trybuild, and behavioural coverage for
+      harness-led defaults and explicit overrides.
+- [x] (2026-04-11) Stage D: update `docs/users-guide.md` and
+      `docs/rstest-bdd-design.md` to teach the delivered behaviour.
+- [x] (2026-04-11) Stage E: run focused validation plus repository-wide gates.
 
 ## Surprises & Discoveries
 
@@ -193,6 +192,11 @@ Success is observable in three ways:
 - Observation: `make test` skips the trybuild macro suite under nextest.
   Impact: the implementation must always run a focused `cargo test` command for
   `trybuild_macros` in addition to the normal repository gates.
+- Observation: `scenarios!` lowers the deprecated Tokio runtime alias to a
+  synchronous effective runtime before `ScenarioConfig` reaches shared codegen.
+  Impact: preserving ADR-008 precedence required a second runtime field
+  dedicated to attribute resolution so the alias hint survives while the
+  generated function signature remains synchronous.
 
 ## Decision Log
 
@@ -218,9 +222,48 @@ Success is observable in three ways:
 
 ## Outcomes & Retrospective
 
-No implementation has started yet. When execution is complete, replace this
-placeholder with the shipped behaviour, the final validation transcript, and
-any follow-on work that should be split into a separate change.
+ADR-008 shipped on 2026-04-11 with the intended harness-led default behaviour.
+`rstest-bdd-policy` now owns both first-party policy-path and harness-path
+resolution, mapping:
+
+- `rstest_bdd_harness::StdHarness` -> rstest-only
+- `rstest_bdd_harness_tokio::TokioHarness` -> Tokio current-thread
+- `rstest_bdd_harness_gpui::GpuiHarness` -> GPUI test
+
+`rstest-bdd-macros` now resolves emitted test attributes in the documented
+precedence order:
+
+1. explicit `attributes = ...`
+2. known first-party `harness = ...` default mapping
+3. deprecated `runtime = "tokio-current-thread"` compatibility alias
+4. runtime-mode or synchronous fallback
+
+The macro layer gained focused unit coverage for the full precedence matrix, a
+separate test module to keep file sizes within repository limits, compile-pass
+fixtures for first-party harness-only forms, and behavioural integration
+coverage for harness-only `scenarios!` flows in both Tokio and GPUI suites. The
+user guide and design document now teach harness-only first-party configuration
+as the normal path while retaining explicit `attributes = ...` as the override
+and third-party escape hatch.
+
+Validation completed with:
+
+- `set -o pipefail; cargo test -p rstest-bdd-policy 2>&1 | tee /tmp/adr008-policy-test.log`
+- `set -o pipefail; cargo test -p rstest-bdd-macros --lib 2>&1 | tee /tmp/adr008-macros-lib-test.log`
+- `set -o pipefail; cargo test -p rstest-bdd --test scenario_harness_tokio`
+  `2>&1 | tee /tmp/adr008-tokio-int-test.log`
+- `set -o pipefail; cargo test -p rstest-bdd --test scenario_harness_gpui`
+  `--features gpui-harness-tests` `2>&1 | tee /tmp/adr008-gpui-int-test.log`
+- `set -o pipefail; cargo test -p rstest-bdd --test trybuild_macros`
+  `step_macros_compile -- --exact 2>&1 | tee /tmp/adr008-trybuild.log`
+- `set -o pipefail; make fmt 2>&1 | tee /tmp/adr008-make-fmt-2.log`
+- `set -o pipefail; make check-fmt 2>&1 | tee /tmp/adr008-make-check-fmt-2.log`
+- `set -o pipefail; make lint 2>&1 | tee /tmp/adr008-make-lint-3.log`
+- `set -o pipefail; make markdownlint 2>&1 | tee /tmp/adr008-make-markdownlint.log`
+- `set -o pipefail; make nixie 2>&1 | tee /tmp/adr008-make-nixie.log`
+- `set -o pipefail; make test 2>&1 | tee /tmp/adr008-make-test.log`
+
+No follow-on implementation was required to close this ADR scope.
 
 ## Context and orientation
 

--- a/docs/execplans/adr-008-harness-led-attribute-policy-defaults.md
+++ b/docs/execplans/adr-008-harness-led-attribute-policy-defaults.md
@@ -7,9 +7,9 @@ proceeds.
 
 Status: IMPLEMENTED
 
-`PLANS.md` is not present in this repository at the time of writing, so this
-ExecPlan is the governing plan for ADR-008 delivery once the ADR is accepted
-and the user approves execution.
+`PLANS.md` is not present in this repository. This ExecPlan governed ADR-008
+delivery for this workstream and remains as the implementation record after
+completion.
 
 ## Purpose / big picture
 

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1680,7 +1680,7 @@ The canonical path-to-hint mapping lives in `rstest-bdd-policy`, so adding
 first-party policy mappings no longer requires editing macro-local resolution
 tables.
 
-If `attributes` is omitted, resolution now follows the ADR-008 precedence order:
+Attribute resolution follows the ADR-008 precedence order:
 
 1. explicit `attributes = ...`
 2. known first-party `harness = ...` mapping

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1714,7 +1714,7 @@ compile-time dependency on `rstest-bdd-harness` so it can emit fully-qualified
 trait paths in const assertions and harness delegation code. This is acceptable
 because `rstest-bdd-harness` is dependency-light per ADR-005.
 
-#### 2.7.5 ADR-008 codegen refactoring: harness-led attribute defaults
+#### 2.7.4 ADR-008 codegen refactoring: harness-led attribute defaults
 
 ADR-008 did not only change user-facing precedence; it also refactored the
 macro codegen path so that the implementation could express that precedence
@@ -1724,7 +1724,10 @@ without further stretching the `scenario` module. In
 `pub(super)` visibility, keeping it internal to the `scenario` codegen module
 while giving the grouping a name that matches ADR-008 terminology. The struct
 contains three policy-resolution inputs: `runtime: RuntimeMode`, which is the
-fallback execution mode when no harness or explicit attribute path is supplied;
+`TestAttrPolicy.runtime` field used for attribute-resolution fallback
+semantics, fed from `attribute_runtime` when no harness or explicit attribute
+path is supplied; execution behaviour belongs to `ScenarioConfig.runtime` and
+the async pipeline described in §2.7.3 Macro integration;
 `harness: Option<&'a syn::Path>`, which carries the user-provided harness type
 path such as `rstest_bdd_harness_tokio::TokioHarness`; and
 `attributes: Option<&'a syn::Path>`, which carries the explicit attribute
@@ -1785,7 +1788,7 @@ result would silently bypass the harness default. Keeping this mapping in
 layer independent of `syn` and `proc-macro2` and leaves the same
 `TestAttributeHint` lookup reusable for future non-macro consumers.
 
-#### 2.7.4 First-party plugin targets
+#### 2.7.5 First-party plugin targets
 
 The first official adapters and policies are:
 

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1724,10 +1724,11 @@ without further stretching the `scenario` module. In
 `pub(super)` visibility, keeping it internal to the `scenario` codegen module
 while giving the grouping a name that matches ADR-008 terminology. The struct
 contains three policy-resolution inputs: `runtime: RuntimeMode`, which is the
-`TestAttrPolicy.runtime` field used for attribute-resolution fallback
-semantics, fed from `attribute_runtime` when no harness or explicit attribute
-path is supplied; execution behaviour belongs to `ScenarioConfig.runtime` and
-the async pipeline described in §2.7.3 Macro integration;
+field that governs attribute-resolution fallback semantics when no harness or
+explicit attribute path is supplied, populated from
+`ScenarioConfig.attribute_runtime`; execution behaviour belongs to
+`ScenarioConfig.runtime` and the async pipeline described in §2.7.3 Macro
+integration;
 `harness: Option<&'a syn::Path>`, which carries the user-provided harness type
 path such as `rstest_bdd_harness_tokio::TokioHarness`; and
 `attributes: Option<&'a syn::Path>`, which carries the explicit attribute

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1680,16 +1680,30 @@ The canonical path-to-hint mapping lives in `rstest-bdd-policy`, so adding
 first-party policy mappings no longer requires editing macro-local resolution
 tables.
 
-If `attributes` is omitted, `RuntimeMode` remains the compatibility fallback:
-Tokio runtime mode resolves to Tokio current-thread attributes, while sync mode
-resolves to rstest-only. `#[tokio::test]` is omitted for synchronous test
-signatures because Tokio requires `async fn`.
+If `attributes` is omitted, resolution now follows the ADR-008 precedence order:
 
-The user-facing guidance for this feature should lead with `harness = ...`
-configuration for first-party integrations, add `attributes = ...` only when a
-non-default policy is required, and treat `runtime = "tokio-current-thread"` as
-deprecated compatibility syntax for `scenarios!`. This keeps the user guide
-aligned with the delivered API rather than with the historical migration path.
+1. explicit `attributes = ...`
+2. known first-party `harness = ...` mapping
+3. deprecated `runtime = "tokio-current-thread"` compatibility alias
+4. existing runtime-mode or synchronous fallback
+
+The canonical first-party harness mappings also live in `rstest-bdd-policy`:
+
+- `rstest_bdd_harness::StdHarness` -> rstest-only
+- `rstest_bdd_harness_tokio::TokioHarness` -> Tokio current-thread
+- `rstest_bdd_harness_gpui::GpuiHarness` -> GPUI test
+
+Unknown harness paths still fall back to runtime compatibility behaviour
+because procedural macros do not evaluate arbitrary third-party
+`AttributePolicy::test_attributes()` implementations during expansion.
+`#[tokio::test]` is omitted for synchronous test signatures because Tokio
+requires `async fn`.
+
+The user-facing guidance for this feature should lead with harness-only
+first-party configuration, with explicit `attributes = ...` documented as the
+override and third-party escape hatch. The deprecated
+`runtime = "tokio-current-thread"` form remains compatibility syntax for
+`scenarios!`, not the primary configuration surface.
 
 **`rstest::rstest` is always emitted.** The `#[rstest::rstest]` attribute is
 unconditional because the framework fundamentally relies on rstest for fixture
@@ -1728,8 +1742,9 @@ The first official adapters and policies are:
   not guarantee full `LocalSet` drain for multi-poll futures such as
   timer-driven work. The user-facing demonstration crate under
   `examples/tokio-reminders` models a local reminder queue whose BDD suite
-  exercises `TokioHarness` and `TokioAttributePolicy` end-to-end, while the
-  crate's unit tests cover the explicit `flush().await` coordination pattern.
+  exercises `TokioHarness` with harness-led default attributes end-to-end,
+  while the crate's unit tests cover the explicit `flush().await` coordination
+  pattern.
 - `rstest-bdd-harness-gpui` (implemented, phase 9.4): provides `GpuiHarness`
   and `GpuiAttributePolicy`. `GpuiHarness` implements `HarnessAdapter` by
   running each `ScenarioRunRequest` inside `gpui::run_test`, building a
@@ -1745,12 +1760,13 @@ The first official adapters and policies are:
   feature-gated (`native-gpui-tests` and `gpui-harness-tests`) as explicit
   opt-in suites. A user-facing demonstration crate under
   `examples/gpui-counter` models a simple counter application whose BDD suite
-  exercises both `GpuiHarness` and `GpuiAttributePolicy` end-to-end, with step
-  definitions that access injected `TestAppContext` through
+  exercises `GpuiHarness` with harness-led default attributes end-to-end, with
+  step definitions that access injected `TestAppContext` through
   `rstest_bdd_harness_context`. Focused `rstest-bdd` integration coverage also
   verifies canonical GPUI policy resolution for `scenarios!`, canonical and
-  absolute first-party GPUI policy paths for `#[scenario]`, and deduplication
-  when a generated `#[scenario]` test already has `#[gpui::test]`. The example
+  absolute first-party GPUI policy paths for `#[scenario]`, harness-led
+  defaults for both `#[scenario]` and `scenarios!`, and deduplication when a
+  generated `#[scenario]` test already has `#[gpui::test]`. The example
   requires no native-library setup beyond the workspace GPUI shim.
 
 Future adapters (for example, Bevy) are planned to follow the same pattern

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1714,6 +1714,77 @@ compile-time dependency on `rstest-bdd-harness` so it can emit fully-qualified
 trait paths in const assertions and harness delegation code. This is acceptable
 because `rstest-bdd-harness` is dependency-light per ADR-005.
 
+#### 2.7.5 ADR-008 codegen refactoring: harness-led attribute defaults
+
+ADR-008 did not only change user-facing precedence; it also refactored the
+macro codegen path so that the implementation could express that precedence
+without further stretching the `scenario` module. In
+`crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs`,
+`generate_test_attrs` now takes a `TestAttrPolicy<'a>` parameter object with
+`pub(super)` visibility, keeping it internal to the `scenario` codegen module
+while giving the grouping a name that matches ADR-008 terminology. The struct
+contains three policy-resolution inputs: `runtime: RuntimeMode`, which is the
+fallback execution mode when no harness or explicit attribute path is supplied;
+`harness: Option<&'a syn::Path>`, which carries the user-provided harness type
+path such as `rstest_bdd_harness_tokio::TokioHarness`; and
+`attributes: Option<&'a syn::Path>`, which carries the explicit attribute
+policy path and therefore has the highest precedence. This replaced the older
+five-argument `generate_test_attrs` signature with a three-parameter interface,
+bringing the function back under the project's four-argument cohesion
+threshold while making the policy inputs explicit as one coherent object.
+
+The resulting resolution logic in `resolve_attribute_policy` now mirrors the
+precedence described in §2.7.3 Macro integration and builds on the
+`RuntimeMode` and `TestAttributeHint` model from §2.6.2 RuntimeMode and
+TestAttributeHint. The waterfall has four levels. First, an explicit
+`attributes = ...` path is resolved through
+`resolve_attribute_hint_from_policy_path` and overrides everything else.
+Second, when `attributes` is `None`, a known first-party harness path is
+resolved via `resolve_test_attribute_hint_for_harness_path` in
+`rstest-bdd-policy`. Third, if no explicit path or known harness mapping is
+present, the deprecated `runtime = "tokio-current-thread"` alias still reaches
+Tokio behaviour through `RuntimeMode::test_attribute_hint()` when the runtime
+is `TokioCurrentThread`. Fourth, all remaining cases fall back to the sync or
+generic-async baseline, which emits `#[rstest::rstest]` only. This preserves
+ADR-008's "explicit policy beats harness default beats compatibility alias
+beats fallback" ordering while still producing `TokenStream2` output from one
+macro-local code path.
+
+ADR-008 also introduced a deliberate split inside `ScenarioConfig` between
+`runtime: RuntimeMode` and `attribute_runtime: RuntimeMode`. The `runtime`
+field governs execution: whether the generated test body is `async fn`, which
+executor drives the body, and how the surrounding scenario machinery treats the
+function. The `attribute_runtime` field governs emitted test attributes:
+whether the generated function receives rstest-only, Tokio current-thread, or
+GPUI annotations. The two values are usually identical, but they may diverge
+when execution and attribute selection are intentionally decoupled, such as
+when a synchronous attribute policy is paired with an async execution harness
+or when `scenarios!` receives the deprecated
+`runtime = "tokio-current-thread"` token and must still emit Tokio attributes
+without changing the execution model selected elsewhere. Accordingly,
+`generate_test_attrs` receives `config.attribute_runtime` through
+`TestAttrPolicy.runtime`, while `config.runtime.is_async()` is still passed
+separately as the `is_async` boolean. That split keeps attribute selection from
+accidentally collapsing back into execution scheduling.
+
+The harness-side lookup that makes the second precedence level work lives in
+`crates/rstest-bdd-policy/src/lib.rs` as
+`resolve_test_attribute_hint_for_harness_path`. It accepts a `&[&str]` of path
+segments and returns `Option<TestAttributeHint>`, with the canonical mappings
+held in the `KNOWN_HARNESS_HINTS` table:
+`STD_HARNESS_PATH` (`["rstest_bdd_harness", "StdHarness"]`) maps to
+`TestAttributeHint::RstestOnly`, `TOKIO_HARNESS_PATH`
+(`["rstest_bdd_harness_tokio", "TokioHarness"]`) maps to
+`TestAttributeHint::RstestWithTokioCurrentThread`, and `GPUI_HARNESS_PATH`
+(`["rstest_bdd_harness_gpui", "GpuiHarness"]`) maps to
+`TestAttributeHint::RstestWithGpuiTest`. Unknown third-party paths return
+`None`, causing `resolve_attribute_policy` to continue down to the runtime
+fallback. The helper is annotated `#[must_use]` because discarding a `Some`
+result would silently bypass the harness default. Keeping this mapping in
+`rstest-bdd-policy`, rather than in the macros crate, also keeps the policy
+layer independent of `syn` and `proc-macro2` and leaves the same
+`TestAttributeHint` lookup reusable for future non-macro consumers.
+
 #### 2.7.4 First-party plugin targets
 
 The first official adapters and policies are:

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -740,8 +740,10 @@ to any specific runtime.
 Use them in this order of preference:
 
 - Omit both when the default synchronous `StdHarness` path is sufficient.
-- Prefer explicit `harness = ...` and `attributes = ...` when opting into a
-  framework integration such as Tokio or GPUI.
+- For first-party integrations, prefer `harness = ...` on its own and let the
+  macro infer the matching default attribute policy.
+- Add `attributes = ...` only when you need to override the inferred default
+  or select an attribute policy without harness delegation.
 - Treat `runtime = "tokio-current-thread"` as legacy compatibility syntax for
   `scenarios!`, not as the canonical configuration surface.
 
@@ -770,18 +772,26 @@ attributes. Currently this resolution is path-based:
   `#[gpui::test]` for synchronous and async scenario signatures, and
 - default and unknown policy paths emit `#[rstest::rstest]` only.
 
-When `attributes` is omitted, `RuntimeMode` compatibility behaviour remains in
-place. This keeps the first-party Tokio compatibility path working while
-leaving third-party policy resolution explicit about its current limitation:
-arbitrary user-defined `AttributePolicy::test_attributes()` implementations are
-not evaluated during macro expansion.
+When `attributes` is omitted, known first-party harnesses infer matching
+default attribute policies:
+
+- `rstest_bdd_harness::StdHarness` resolves to rstest-only emission,
+- `rstest_bdd_harness_tokio::TokioHarness` resolves to the Tokio
+  current-thread policy, and
+- `rstest_bdd_harness_gpui::GpuiHarness` resolves to the GPUI test policy.
+
+If the harness path is not one of those known first-party paths, the macro
+falls back to the existing `RuntimeMode` compatibility behaviour. This keeps
+the first-party Tokio compatibility path working while leaving third-party
+policy resolution explicit about its current limitation: arbitrary user-defined
+`AttributePolicy::test_attributes()` implementations are not evaluated during
+macro expansion.
 
 ```rust,no_run
 # use rstest_bdd_macros::scenario;
 #[scenario(
     path = "features/search.feature",
     harness = rstest_bdd_harness::StdHarness,
-    attributes = rstest_bdd_harness::DefaultAttributePolicy,
 )]
 fn test_with_harness() {}
 ```
@@ -793,7 +803,6 @@ Both parameters are also accepted by `scenarios!`:
 scenarios!(
     "tests/features/auto",
     harness = rstest_bdd_harness::StdHarness,
-    attributes = rstest_bdd_harness::DefaultAttributePolicy,
 );
 ```
 
@@ -841,14 +850,13 @@ It is available as a dev-dependency:
 rstest-bdd-harness-tokio = "0.5.0"
 ```
 
-`TokioHarness` and `TokioAttributePolicy` can then be used in scenarios:
+`TokioHarness` can then be used directly in scenarios:
 
 ```rust,no_run
 # use rstest_bdd_macros::scenario;
 #[scenario(
     path = "tests/features/my_async.feature",
     harness = rstest_bdd_harness_tokio::TokioHarness,
-    attributes = rstest_bdd_harness_tokio::TokioAttributePolicy,
 )]
 fn my_tokio_scenario() {
     // Steps execute inside a Tokio current-thread runtime.
@@ -857,9 +865,23 @@ fn my_tokio_scenario() {
 ```
 
 `TokioHarness` builds a single-threaded Tokio runtime with a `LocalSet` per
-scenario invocation and executes the scenario runner inside it.
-`TokioAttributePolicy` emits `#[rstest::rstest]` and
+scenario invocation and executes the scenario runner inside it. When
+`attributes` is omitted, the macro infers
+`rstest_bdd_harness_tokio::TokioAttributePolicy` for this first-party harness.
+That policy emits `#[rstest::rstest]` and
 `#[tokio::test(flavor = "current_thread")]`.
+
+If you need to override the default explicitly, `attributes =` still wins:
+
+```rust,no_run
+# use rstest_bdd_macros::scenario;
+#[scenario(
+    path = "tests/features/my_async.feature",
+    harness = rstest_bdd_harness_tokio::TokioHarness,
+    attributes = rstest_bdd_harness_tokio::TokioAttributePolicy,
+)]
+fn my_tokio_scenario_with_explicit_override() {}
+```
 
 The explicit harness form above is the preferred configuration for new suites.
 The older `runtime = "tokio-current-thread"` form remains available only as a
@@ -872,10 +894,10 @@ example timers) may still be pending when `run()` returns, so steps should
 prefer explicit `.await`-based coordination when completion is required.
 
 For a complete working example, see the `examples/tokio-reminders` crate. Its
-BDD suite uses `TokioHarness` and `TokioAttributePolicy` together to exercise
-queued reminder behaviour under a Tokio current-thread runtime, while the
-crate's unit tests and doctest show the explicit `flush().await` pattern for
-multi-poll work that must complete before assertions run.
+BDD suite uses `TokioHarness` to exercise queued reminder behaviour under a
+Tokio current-thread runtime, while the crate's unit tests and doctest show the
+explicit `flush().await` pattern for multi-poll work that must complete before
+assertions run.
 
 > **Note:** combining `harness` with `async fn` scenario signatures produces
 > a compile error because `TokioHarness` runs synchronous scenario closures
@@ -916,14 +938,13 @@ as a dev-dependency:
 rstest-bdd-harness-gpui = "0.5.0"
 ```
 
-`GpuiHarness` and `GpuiAttributePolicy` can then be used in scenarios:
+`GpuiHarness` can then be used directly in scenarios:
 
 ```rust,no_run
 # use rstest_bdd_macros::scenario;
 #[scenario(
     path = "tests/features/my_ui.feature",
     harness = rstest_bdd_harness_gpui::GpuiHarness,
-    attributes = rstest_bdd_harness_gpui::GpuiAttributePolicy,
 )]
 fn my_gpui_scenario() {
     // Steps execute with a gpui::TestAppContext injected by GpuiHarness.
@@ -931,13 +952,18 @@ fn my_gpui_scenario() {
 ```
 
 `GpuiHarness` delegates each scenario through `gpui::run_test`, constructs a
-`gpui::TestAppContext`, and passes it through `HarnessAdapter::Context`.
-`GpuiAttributePolicy` emits `#[rstest::rstest]` and `#[gpui::test]`. The
-canonical `rstest_bdd_harness_gpui::GpuiAttributePolicy` path is recognized by
-the same path-based policy resolution used for Tokio, so the GPUI test
-attribute is available whether the scenario is synchronous or async. For
-`#[scenario]`, the equivalent absolute path
-`::rstest_bdd_harness_gpui::GpuiAttributePolicy` is also supported.
+`gpui::TestAppContext`, and passes it through `HarnessAdapter::Context`. When
+`attributes` is omitted, the macro infers
+`rstest_bdd_harness_gpui::GpuiAttributePolicy`. That policy emits
+`#[rstest::rstest]` and `#[gpui::test]`. The canonical
+`rstest_bdd_harness_gpui::GpuiAttributePolicy` path is recognized by the same
+path-based policy resolution used for Tokio, so the GPUI test attribute is
+available whether the scenario is synchronous or async. For `#[scenario]`, the
+equivalent absolute path `::rstest_bdd_harness_gpui::GpuiAttributePolicy` is
+also supported.
+
+If you need to override the inferred default explicitly, keep using
+`attributes = rstest_bdd_harness_gpui::GpuiAttributePolicy`.
 
 This contract is enforced by focused integration coverage in
 `crates/rstest-bdd/tests/trybuild_macros.rs` and

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -871,14 +871,15 @@ scenario invocation and executes the scenario runner inside it. When
 That policy emits `#[rstest::rstest]` and
 `#[tokio::test(flavor = "current_thread")]`.
 
-If the default must be overridden explicitly, `attributes =` still wins:
+If the inferred Tokio default must be overridden explicitly, the
+`#[scenario(..., attributes = ...)]` attribute can select a different policy:
 
 ```rust,no_run
 # use rstest_bdd_macros::scenario;
 #[scenario(
     path = "tests/features/my_async.feature",
     harness = rstest_bdd_harness_tokio::TokioHarness,
-    attributes = rstest_bdd_harness_tokio::TokioAttributePolicy,
+    attributes = rstest_bdd_harness::DefaultAttributePolicy,
 )]
 fn my_tokio_scenario_with_explicit_override() {}
 ```
@@ -962,8 +963,18 @@ available whether the scenario is synchronous or async. For `#[scenario]`, the
 equivalent absolute path `::rstest_bdd_harness_gpui::GpuiAttributePolicy` is
 also supported.
 
-If the inferred default must be overridden explicitly, keep using
-`attributes = rstest_bdd_harness_gpui::GpuiAttributePolicy`.
+If the inferred GPUI default must be overridden explicitly, the
+`#[scenario(..., attributes = ...)]` attribute can select a different policy:
+
+```rust,no_run
+# use rstest_bdd_macros::scenario;
+#[scenario(
+    path = "tests/features/my_ui.feature",
+    harness = rstest_bdd_harness_gpui::GpuiHarness,
+    attributes = rstest_bdd_harness::DefaultAttributePolicy,
+)]
+fn my_gpui_scenario_with_explicit_override() {}
+```
 
 This contract is enforced by focused integration coverage in
 `crates/rstest-bdd/tests/trybuild_macros.rs` and

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -871,7 +871,7 @@ scenario invocation and executes the scenario runner inside it. When
 That policy emits `#[rstest::rstest]` and
 `#[tokio::test(flavor = "current_thread")]`.
 
-If you need to override the default explicitly, `attributes =` still wins:
+If the default must be overridden explicitly, `attributes =` still wins:
 
 ```rust,no_run
 # use rstest_bdd_macros::scenario;
@@ -962,7 +962,7 @@ available whether the scenario is synchronous or async. For `#[scenario]`, the
 equivalent absolute path `::rstest_bdd_harness_gpui::GpuiAttributePolicy` is
 also supported.
 
-If you need to override the inferred default explicitly, keep using
+If the inferred default must be overridden explicitly, keep using
 `attributes = rstest_bdd_harness_gpui::GpuiAttributePolicy`.
 
 This contract is enforced by focused integration coverage in

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -742,8 +742,8 @@ Use them in this order of preference:
 - Omit both when the default synchronous `StdHarness` path is sufficient.
 - For first-party integrations, prefer `harness = ...` on its own and let the
   macro infer the matching default attribute policy.
-- Add `attributes = ...` only when you need to override the inferred default
-  or select an attribute policy without harness delegation.
+- Add `attributes = ...` only when overriding the inferred default or
+  selecting an attribute policy without harness delegation.
 - Treat `runtime = "tokio-current-thread"` as legacy compatibility syntax for
   `scenarios!`, not as the canonical configuration surface.
 


### PR DESCRIPTION
## Summary
- Addressed code review feedback for ADR-008 by clearly separating runtime execution decisions from attribute-policy resolution, introducing shared harness-path resolution, and propagating this through macro codegen. Added ExecPlan document and expanded docs to reflect the finalized precedence and behaviour. Included harness-default coverage for Tokio and GPUI, plus tests and fixtures for explicit overrides.

## Changes
- New file: docs/execplans/adr-008-harness-led-attribute-policy-defaults.md
- Updated docs/rstest-bdd-design.md to reflect the new harness-led precedence and default policy behavior for first-party harnesses.
- Updated docs/users-guide.md to document harness-led defaults, the precedence order, and explicit override behavior, with examples for Tokio and GPUI harnesses.
- Updated crates/rstest-bdd-policy/src/lib.rs to add canonical first-party harness path constants and a public helper resolve_test_attribute_hint_for_harness_path(), mirroring the existing policy-path resolution.
- Updated crates/rstest-bdd-macros to thread attribute-runtime through generation paths, pass harness path into test-attribute resolution, and extend unit tests with harness-default scenarios.
- Added unit tests and fixtures for harness-led defaults:
  - New tests: harness_defaults.rs (unit tests for harness precedence)
  - New fixtures and test modules for GPUI and Tokio harness defaults (e.g., scenario_harness_gpui_default.rs, scenario_harness_tokio_default.rs, scenarios_harness_gpui_default.rs)
  - Extended trybuild fixtures to cover harness-default paths (e.g., scenario_harness_tokio_default.rs, scenario_harness_gpui_default.rs)
- Updated macro codegen flow to carry and use the new attribute-runtime/harness-path resolution, ensuring explicit attributes override first-party harness defaults, which override runtime fallbacks.
- Updated various tests and fixtures to exercise the new precedence matrix for both #[scenario] and scenarios! usage with first-party harness defaults.
- Refactored scenario codegen to support a distinct attribute-runtime surface while preserving existing execution-runtime logic.
- Introduced new tests and fixtures to validate harness-led defaults across both #[scenario] and scenarios!

## Rationale
- Centralizes and formalizes the precedence for harness-led defaults in a single shared policy surface (rstest-bdd-policy) and propagates it into macro codegen. This reduces duplication, ensures consistent behavior across #[scenario] and scenarios!, and keeps explicit user policy overrides authoritative. The changes align with ADR-008 and preserve backward compatibility for third-party policies while enabling harness-led defaults for first-party integrations.

## Plan of work (Stage A–E)
- Stage A: add shared harness-path hint resolution in rstest-bdd-policy
  - Extend policy crate with canonical first-party harness paths and a resolver helper.
- Stage B: teach macro codegen ADR-008 precedence
  - Refactor generate_test_attrs() path to honour explicit attributes, first-party harness defaults, then runtime fallbacks.
- Stage C: add trybuild and behavioural coverage
  - Extend public macro tests with trybuild fixtures and behavioural tests for harness-led defaults.
- Stage D: update the user guide and design doc
  - Update docs/users-guide.md and docs/rstest-bdd-design.md to reflect the new precedence and usage.
- Stage E: final validation and close-out
  - Run gates and document outcomes; update roadmap if applicable.

## Testing / Validation plan
- Stage A–E include unit tests, trybuild coverage, and behavioural tests as described in the ExecPlan.
- Ensure gates are run before completing delivery: fmt, check-fmt, lint, tests, markdownlint, nixie, etc.

## Risks
- Risks and mitigations are documented within the ExecPlan. The plan emphasizes staged delivery to avoid regressions and maintain ADR-008 scope.

## Documentation impact
- User guide and design doc updates implemented to reflect harness-led defaults and precedence order. The ExecPlan itself describes governance and validation strategy.

## How to review
- Review the ExecPlan document and the accompanying changes to policy, macros, and tests for correctness, completeness, and alignment with ADR-008.
- Verify the new ExecPlan file path and its consistency with repository conventions.

## If ADR-008 is accepted, consider
- updating the roadmap in docs/roadmap.md and closing the ExecPlan as completed with a link to the final outcomes.

---
Generated by the Plan automation and updated to reflect the implemented state of ADR-008 harness-led attribute-policy defaults.

📎 Task: https://www.devboxer.com/task/65fecd80-ab89-4a39-953b-2fd9b9868293

## Summary by Sourcery

Implement harness-led default attribute-policy resolution for first-party harnesses and document the finalized ADR-008 execution plan and behavior.

New Features:
- Infer default test attribute policies from canonical first-party harness paths for Std, Tokio, and GPUI harnesses when attributes are omitted.
- Introduce an ExecPlan document formalizing ADR-008 harness-led default attribute-policy resolution and governance.

Enhancements:
- Centralize harness-to-attribute hint resolution in rstest-bdd-policy alongside existing policy-path resolution.
- Refactor macro test-attribute generation to use a shared TestAttrPolicy configuration and ADR-008 precedence (explicit attributes, harness defaults, then runtime).
- Clarify and update user and design documentation to describe harness-led defaults, precedence rules, and recommended configuration patterns for first-party integrations.

Tests:
- Add macro-level unit tests to validate harness-led precedence over runtime and explicit overrides for attribute policies.
- Extend trybuild fixtures and integration tests for #[scenario] and scenarios! using first-party harnesses without explicit attribute policies for Tokio and GPUI.
- Add new feature files and scenarios to exercise harness-default behavior in Tokio and GPUI harness suites.

📎 Task: https://www.devboxer.com/task/1ce788c4-f2d0-4619-942a-0c29122871d6
