### PR TITLE
Add semantic behaviour tests for async loops (#395)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,17 @@ Before submitting a pull request:
 The CI pipeline runs the same commands and will fail if any step reports an
 error.
 
+## Testing Guidelines
+
+- Prefer semantic behaviour tests for scenario execution changes. Assert
+  runtime-observable outcomes such as skip propagation, step ordering, fixture
+  lifecycle, and panic metadata rather than relying only on generated code
+  shape.
+- Keep structural macro tests for compile errors, emitted attributes, and other
+  code generation details that are genuinely implementation-specific.
+- See [Testing Strategy](docs/testing-strategy.md) for the preferred patterns
+  and invariants to cover.
+
 ## Localisation guidelines
 
 - Keep feature files and step definitions in the same language. If you add a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Before submitting a pull request:
 The CI pipeline runs the same commands and will fail if any step reports an
 error.
 
-## Testing Guidelines
+## Testing guidelines
 
 - Prefer semantic behaviour tests for scenario execution changes. Assert
   runtime-observable outcomes such as skip propagation, step ordering, fixture

--- a/crates/rstest-bdd-macros/src/macros/scenarios/test_generation.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/test_generation.rs
@@ -16,7 +16,7 @@ use crate::codegen::scenario::{
 use crate::parsing::examples::ExampleTable;
 use crate::parsing::feature::ScenarioData;
 use crate::parsing::tags::TagExpression;
-use crate::return_classifier::classify_return_type;
+use crate::return_classifier::{ReturnKind, classify_return_type};
 use crate::utils::fixtures::extract_function_fixtures;
 use crate::utils::ident::sanitize_ident;
 use crate::utils::result_type::try_extract_result_error_type;
@@ -233,7 +233,9 @@ fn resolve_fixture_error_type(fixtures: &[FixtureSpec]) -> syn::Type {
 /// propagation and the signature is not already fallible.
 ///
 /// Uses [`classify_return_type`] to determine the initial [`ScenarioReturnKind`]:
-/// `Unit` for unit returns, `ResultUnit` for fallible returns. When
+/// `Unit` only for [`ReturnKind::Unit`], and [`ScenarioReturnKind::ResultUnit`]
+/// for all other return kinds, including [`ReturnKind::Value`],
+/// `ReturnKind::ResultUnit`, and `ReturnKind::ResultValue`. When
 /// `has_result_fixtures` is true and the return kind is not already fallible,
 /// this function **mutates** `sig.output` in-place via
 /// [`resolve_fixture_error_type`] to upgrade it to `Result<(), E>`, ensuring
@@ -245,7 +247,7 @@ fn resolve_scenario_return_kind(
 ) -> ScenarioReturnKind {
     let mut return_kind =
         classify_return_type(&sig.output, None).map_or(ScenarioReturnKind::Unit, |rk| match rk {
-            crate::return_classifier::ReturnKind::Unit => ScenarioReturnKind::Unit,
+            ReturnKind::Unit => ScenarioReturnKind::Unit,
             _ => ScenarioReturnKind::ResultUnit,
         });
 

--- a/crates/rstest-bdd/tests/async_semantic_behaviour.rs
+++ b/crates/rstest-bdd/tests/async_semantic_behaviour.rs
@@ -18,8 +18,8 @@ use serial_test::serial;
 use async_semantic_behaviour_support::assert_bypassed_step_recorded;
 use async_semantic_behaviour_support::{
     CleanupProbe, ERROR_SCENARIO_NAME, FEATURE_PATH, SKIP_SCENARIO_LINE, SKIP_SCENARIO_NAME,
-    SemanticValue, assert_feature_path_suffix, cleanup_drops, clear_events, push_event,
-    reset_cleanup_drops, snapshot_events,
+    SemanticValue, assert_feature_path_suffix, assert_message_mentions_feature_path, cleanup_drops,
+    clear_events, push_event, reset_cleanup_drops, snapshot_events,
 };
 
 #[fixture]
@@ -309,10 +309,7 @@ fn error_propagation_includes_step_and_scenario_context() {
         message.contains(ERROR_SCENARIO_NAME),
         "panic message should include the scenario name: {message}",
     );
-    assert!(
-        message.contains(FEATURE_PATH),
-        "panic message should include the feature path: {message}",
-    );
+    assert_message_mentions_feature_path(&message, FEATURE_PATH);
     assert_eq!(
         snapshot_events(),
         vec!["failure:given".to_string(), "failure:when".to_string()],

--- a/crates/rstest-bdd/tests/async_semantic_behaviour.rs
+++ b/crates/rstest-bdd/tests/async_semantic_behaviour.rs
@@ -17,9 +17,9 @@ use serial_test::serial;
 #[cfg(feature = "diagnostics")]
 use async_semantic_behaviour_support::assert_bypassed_step_recorded;
 use async_semantic_behaviour_support::{
-    CleanupProbe, ERROR_SCENARIO_NAME, FEATURE_PATH, SKIP_SCENARIO_LINE, SKIP_SCENARIO_NAME,
-    SemanticValue, assert_feature_path_suffix, assert_message_mentions_feature_path, cleanup_drops,
-    clear_events, push_event, reset_cleanup_drops, snapshot_events,
+    CleanupProbe, ERROR_SCENARIO_NAME, FEATURE_PATH, SKIP_SCENARIO_NAME, SemanticValue,
+    assert_feature_path_suffix, assert_handler_failure_context, cleanup_drops, clear_events,
+    push_event, reset_cleanup_drops, scenario_line, snapshot_events,
 };
 
 #[fixture]
@@ -170,7 +170,6 @@ async fn semantic_async_skip_scenario() {
     path = "tests/features/async_semantic_behaviour.feature",
     name = "async steps preserve declaration order"
 )]
-#[serial]
 fn semantic_step_ordering_outline(
     #[from(semantic_order_fixture)] semantic_order_fixture: RefCell<Vec<String>>,
     item: String,
@@ -245,6 +244,7 @@ fn semantic_cleanup_failure_scenario(
 fn skip_propagation_preserves_message_and_bypass_metadata() {
     let _ = drain_reports();
     semantic_async_skip_scenario();
+    let skip_scenario_line = scenario_line(SKIP_SCENARIO_NAME);
 
     assert_eq!(
         snapshot_events(),
@@ -258,7 +258,7 @@ fn skip_propagation_preserves_message_and_bypass_metadata() {
     };
     assert_feature_path_suffix(record.feature_path(), FEATURE_PATH);
     assert_eq!(record.scenario_name(), SKIP_SCENARIO_NAME);
-    assert_eq!(record.line(), SKIP_SCENARIO_LINE);
+    assert_eq!(record.line(), skip_scenario_line);
     let details = assert_scenario_skipped!(
         record.status(),
         message = "semantic async skip message",
@@ -270,14 +270,13 @@ fn skip_propagation_preserves_message_and_bypass_metadata() {
     #[cfg(feature = "diagnostics")]
     assert_bypassed_step_recorded(
         SKIP_SCENARIO_NAME,
-        SKIP_SCENARIO_LINE,
+        skip_scenario_line,
         "semantic async trailing step should never run",
         "semantic async skip message",
     );
 }
 
 #[test]
-#[serial]
 fn error_propagation_includes_step_and_scenario_context() {
     let panic = match catch_unwind(semantic_async_error_scenario) {
         Ok(()) => panic!("expected async scenario to panic"),
@@ -285,31 +284,15 @@ fn error_propagation_includes_step_and_scenario_context() {
     };
     let message = panic_message(panic.as_ref());
 
-    assert!(
-        message.contains("Step failed at index"),
-        "panic message should include the failing step index label: {message}",
+    assert_handler_failure_context(
+        &message,
+        FEATURE_PATH,
+        ERROR_SCENARIO_NAME,
+        "When",
+        "semantic async failing step runs",
+        "semantic_async_failing_step",
+        "semantic async failure",
     );
-    assert!(
-        message.contains("When"),
-        "panic message should include the failing step keyword: {message}",
-    );
-    assert!(
-        message.contains("semantic async failing step runs"),
-        "panic message should include the failing step text: {message}",
-    );
-    assert!(
-        message.contains("semantic_async_failing_step"),
-        "panic message should include the failing step function: {message}",
-    );
-    assert!(
-        message.contains("semantic async failure"),
-        "panic message should preserve the handler error message: {message}",
-    );
-    assert!(
-        message.contains(ERROR_SCENARIO_NAME),
-        "panic message should include the scenario name: {message}",
-    );
-    assert_message_mentions_feature_path(&message, FEATURE_PATH);
     assert_eq!(
         snapshot_events(),
         vec!["failure:given".to_string(), "failure:when".to_string()],
@@ -318,7 +301,6 @@ fn error_propagation_includes_step_and_scenario_context() {
 }
 
 #[test]
-#[serial]
 fn cleanup_probe_drops_after_successful_scenario_completion() {
     reset_cleanup_drops();
     semantic_cleanup_success_scenario();
@@ -330,13 +312,13 @@ fn cleanup_probe_drops_after_successful_scenario_completion() {
 }
 
 #[test]
-#[serial]
 fn cleanup_probe_drops_after_failed_scenario_completion() {
     reset_cleanup_drops();
     let result = catch_unwind(semantic_cleanup_failure_scenario);
     assert!(result.is_err(), "expected cleanup scenario to fail");
-    assert!(
-        cleanup_drops() > 0,
-        "fixtures should be dropped even when scenario execution fails",
+    assert_eq!(
+        cleanup_drops(),
+        1,
+        "fixtures should be dropped exactly once even when scenario execution fails",
     );
 }

--- a/crates/rstest-bdd/tests/async_semantic_behaviour.rs
+++ b/crates/rstest-bdd/tests/async_semantic_behaviour.rs
@@ -74,10 +74,11 @@ fn semantic_order_fixture_starts_clean(
 }
 
 #[when(expr = "semantic async order fixture records {item:string}")]
-fn semantic_order_fixture_records(
+async fn semantic_order_fixture_records(
     #[from(semantic_order_fixture)] order_fixture: &RefCell<Vec<String>>,
     item: String,
 ) {
+    tokio::task::yield_now().await;
     order_fixture.borrow_mut().push(format!("when:{item}"));
 }
 
@@ -162,6 +163,7 @@ fn semantic_cleanup_step_fails(
     path = "tests/features/async_semantic_behaviour.feature",
     name = "async skip propagation preserves metadata"
 )]
+#[serial]
 async fn semantic_async_skip_scenario() {
     panic!("scenario body should not execute after a skip request");
 }
@@ -224,6 +226,7 @@ async fn semantic_async_error_scenario() {
     path = "tests/features/async_semantic_behaviour.feature",
     name = "cleanup probe completes successfully"
 )]
+#[ignore = "exercised by cleanup_probe_drops_after_successful_scenario_completion"]
 fn semantic_cleanup_success_scenario(
     #[from(semantic_cleanup_probe)] _semantic_cleanup_probe: CleanupProbe,
 ) {

--- a/crates/rstest-bdd/tests/async_semantic_behaviour.rs
+++ b/crates/rstest-bdd/tests/async_semantic_behaviour.rs
@@ -1,0 +1,345 @@
+//! Behavioural coverage for async-loop semantics that should stay stable across
+//! code generation refactors.
+
+#[path = "common/async_semantic_behaviour_support.rs"]
+mod async_semantic_behaviour_support;
+
+use std::cell::RefCell;
+use std::panic::catch_unwind;
+
+use rstest::fixture;
+use rstest_bdd::assert_scenario_skipped;
+use rstest_bdd::panic_message;
+use rstest_bdd::reporting::drain as drain_reports;
+use rstest_bdd_macros::{given, scenario, then, when};
+use serial_test::serial;
+
+#[cfg(feature = "diagnostics")]
+use async_semantic_behaviour_support::assert_bypassed_step_recorded;
+use async_semantic_behaviour_support::{
+    CleanupProbe, ERROR_SCENARIO_NAME, FEATURE_PATH, SKIP_SCENARIO_LINE, SKIP_SCENARIO_NAME,
+    SemanticValue, assert_feature_path_suffix, cleanup_drops, clear_events, push_event,
+    reset_cleanup_drops, snapshot_events,
+};
+
+#[fixture]
+fn semantic_order_fixture() -> RefCell<Vec<String>> {
+    RefCell::new(vec!["fixture-created".into()])
+}
+
+#[fixture]
+fn semantic_value_fixture() -> SemanticValue {
+    SemanticValue(1)
+}
+
+#[fixture]
+fn semantic_shared_counter() -> RefCell<usize> {
+    RefCell::new(0)
+}
+
+#[fixture]
+fn semantic_cleanup_probe() -> CleanupProbe {
+    CleanupProbe
+}
+
+#[given("semantic async skip state is reset")]
+fn semantic_skip_state_reset() {
+    clear_events();
+    push_event("skip:given");
+}
+
+#[when("semantic async skip is requested")]
+async fn semantic_skip_requested() {
+    push_event("skip:when");
+    tokio::task::yield_now().await;
+    rstest_bdd::skip!("semantic async skip message");
+}
+
+#[then("semantic async trailing step should never run")]
+fn semantic_skip_trailing_step() {
+    push_event("skip:then");
+    panic!("skip propagation failed to stop trailing steps");
+}
+
+#[given("semantic async order fixture starts with its creation marker")]
+fn semantic_order_fixture_starts_clean(
+    #[from(semantic_order_fixture)] order_fixture: &RefCell<Vec<String>>,
+) {
+    assert_eq!(
+        order_fixture.borrow().as_slice(),
+        ["fixture-created"],
+        "fixture should be available before declaration-order checks run",
+    );
+    order_fixture.borrow_mut().push("given".into());
+}
+
+#[when(expr = "semantic async order fixture records {item:string}")]
+fn semantic_order_fixture_records(
+    #[from(semantic_order_fixture)] order_fixture: &RefCell<Vec<String>>,
+    item: String,
+) {
+    order_fixture.borrow_mut().push(format!("when:{item}"));
+}
+
+#[then(expr = "semantic async order fixture includes {item:string} in sequence")]
+fn semantic_order_fixture_includes(
+    #[from(semantic_order_fixture)] order_fixture: &RefCell<Vec<String>>,
+    item: String,
+) {
+    order_fixture.borrow_mut().push(format!("then:{item}"));
+}
+
+#[given("semantic async base value is 1")]
+fn semantic_base_value_is_one(semantic_value_fixture: SemanticValue) {
+    assert_eq!(semantic_value_fixture, SemanticValue(1));
+}
+
+#[when("semantic async derived value is produced")]
+async fn semantic_derived_value_is_produced(
+    semantic_value_fixture: SemanticValue,
+) -> SemanticValue {
+    tokio::task::yield_now().await;
+    SemanticValue(semantic_value_fixture.0 + 1)
+}
+
+#[then("semantic async next step receives value 2")]
+fn semantic_next_step_receives_value(semantic_value_fixture: SemanticValue) {
+    assert_eq!(semantic_value_fixture, SemanticValue(2));
+}
+
+#[given("semantic async shared counter starts at 0")]
+fn semantic_shared_counter_starts_at_zero(semantic_shared_counter: &RefCell<usize>) {
+    assert_eq!(*semantic_shared_counter.borrow(), 0);
+}
+
+#[when("semantic async shared counter increments")]
+async fn semantic_shared_counter_increments(semantic_shared_counter: &RefCell<usize>) {
+    {
+        let mut counter = semantic_shared_counter.borrow_mut();
+        *counter += 1;
+    }
+    tokio::task::yield_now().await;
+}
+
+#[then("semantic async shared counter equals 2")]
+fn semantic_shared_counter_equals_two(semantic_shared_counter: &RefCell<usize>) {
+    assert_eq!(*semantic_shared_counter.borrow(), 2);
+}
+
+#[given("semantic async failure state is reset")]
+fn semantic_failure_state_reset() {
+    clear_events();
+    push_event("failure:given");
+}
+
+#[when("semantic async failing step runs")]
+async fn semantic_async_failing_step() -> Result<(), &'static str> {
+    push_event("failure:when");
+    tokio::task::yield_now().await;
+    Err("semantic async failure")
+}
+
+#[then("semantic async failure trailing step should never run")]
+fn semantic_failure_trailing_step() {
+    push_event("failure:then");
+    panic!("error propagation failed to stop trailing steps");
+}
+
+#[given("semantic cleanup probe is available")]
+fn semantic_cleanup_probe_is_available(
+    #[from(semantic_cleanup_probe)] _semantic_cleanup_probe: &CleanupProbe,
+) {
+}
+
+#[when("semantic cleanup step fails")]
+fn semantic_cleanup_step_fails(
+    #[from(semantic_cleanup_probe)] _semantic_cleanup_probe: &CleanupProbe,
+) -> Result<(), &'static str> {
+    Err("cleanup probe failure")
+}
+
+#[scenario(
+    path = "tests/features/async_semantic_behaviour.feature",
+    name = "async skip propagation preserves metadata"
+)]
+async fn semantic_async_skip_scenario() {
+    panic!("scenario body should not execute after a skip request");
+}
+
+#[scenario(
+    path = "tests/features/async_semantic_behaviour.feature",
+    name = "async steps preserve declaration order"
+)]
+#[serial]
+fn semantic_step_ordering_outline(
+    #[from(semantic_order_fixture)] semantic_order_fixture: RefCell<Vec<String>>,
+    item: String,
+) {
+    let expected = vec![
+        "fixture-created".to_string(),
+        "given".to_string(),
+        format!("when:{item}"),
+        format!("then:{item}"),
+    ];
+    assert_eq!(
+        semantic_order_fixture.into_inner(),
+        expected,
+        "steps should execute in declaration order and preserve fixtures across the outline case",
+    );
+}
+
+#[scenario(
+    path = "tests/features/async_semantic_behaviour.feature",
+    name = "async returned fixtures reach the next step"
+)]
+#[tokio::test(flavor = "current_thread")]
+async fn semantic_async_returned_fixture_scenario(semantic_value_fixture: SemanticValue) {
+    let _ = semantic_value_fixture;
+}
+
+#[scenario(
+    path = "tests/features/async_semantic_behaviour.feature",
+    name = "async RefCell fixtures survive cross-step borrows"
+)]
+#[tokio::test(flavor = "current_thread")]
+async fn semantic_async_refcell_fixture_scenario(
+    #[from(semantic_shared_counter)] semantic_shared_counter: RefCell<usize>,
+) {
+    assert_eq!(
+        semantic_shared_counter.into_inner(),
+        2,
+        "RefCell-backed fixtures should remain borrowable across async step boundaries",
+    );
+}
+
+#[scenario(
+    path = "tests/features/async_semantic_behaviour.feature",
+    name = "async failure surfaces scenario metadata"
+)]
+#[ignore = "exercised by error_propagation_includes_step_and_scenario_context"]
+async fn semantic_async_error_scenario() {
+    panic!("scenario body should not execute after an earlier failure");
+}
+
+#[scenario(
+    path = "tests/features/async_semantic_behaviour.feature",
+    name = "cleanup probe completes successfully"
+)]
+fn semantic_cleanup_success_scenario(
+    #[from(semantic_cleanup_probe)] _semantic_cleanup_probe: CleanupProbe,
+) {
+}
+
+#[scenario(
+    path = "tests/features/async_semantic_behaviour.feature",
+    name = "cleanup probe fails after setup"
+)]
+#[ignore = "exercised by cleanup_probe_drops_after_failed_scenario_completion"]
+fn semantic_cleanup_failure_scenario(
+    #[from(semantic_cleanup_probe)] _semantic_cleanup_probe: CleanupProbe,
+) {
+}
+
+#[test]
+#[serial]
+fn skip_propagation_preserves_message_and_bypass_metadata() {
+    let _ = drain_reports();
+    semantic_async_skip_scenario();
+
+    assert_eq!(
+        snapshot_events(),
+        vec!["skip:given".to_string(), "skip:when".to_string()],
+        "skip propagation should stop later steps from running",
+    );
+
+    let records = drain_reports();
+    let [record] = records.as_slice() else {
+        panic!("expected a single skip record");
+    };
+    assert_feature_path_suffix(record.feature_path(), FEATURE_PATH);
+    assert_eq!(record.scenario_name(), SKIP_SCENARIO_NAME);
+    assert_eq!(record.line(), SKIP_SCENARIO_LINE);
+    let details = assert_scenario_skipped!(
+        record.status(),
+        message = "semantic async skip message",
+        allow_skipped = true,
+        forced_failure = false,
+    );
+    assert_eq!(details.message(), Some("semantic async skip message"));
+
+    #[cfg(feature = "diagnostics")]
+    assert_bypassed_step_recorded(
+        SKIP_SCENARIO_NAME,
+        SKIP_SCENARIO_LINE,
+        "semantic async trailing step should never run",
+        "semantic async skip message",
+    );
+}
+
+#[test]
+#[serial]
+fn error_propagation_includes_step_and_scenario_context() {
+    let panic = match catch_unwind(semantic_async_error_scenario) {
+        Ok(()) => panic!("expected async scenario to panic"),
+        Err(panic) => panic,
+    };
+    let message = panic_message(panic.as_ref());
+
+    assert!(
+        message.contains("Step failed at index"),
+        "panic message should include the failing step index label: {message}",
+    );
+    assert!(
+        message.contains("When"),
+        "panic message should include the failing step keyword: {message}",
+    );
+    assert!(
+        message.contains("semantic async failing step runs"),
+        "panic message should include the failing step text: {message}",
+    );
+    assert!(
+        message.contains("semantic_async_failing_step"),
+        "panic message should include the failing step function: {message}",
+    );
+    assert!(
+        message.contains("semantic async failure"),
+        "panic message should preserve the handler error message: {message}",
+    );
+    assert!(
+        message.contains(ERROR_SCENARIO_NAME),
+        "panic message should include the scenario name: {message}",
+    );
+    assert!(
+        message.contains(FEATURE_PATH),
+        "panic message should include the feature path: {message}",
+    );
+    assert_eq!(
+        snapshot_events(),
+        vec!["failure:given".to_string(), "failure:when".to_string()],
+        "failure propagation should stop later steps from running",
+    );
+}
+
+#[test]
+#[serial]
+fn cleanup_probe_drops_after_successful_scenario_completion() {
+    reset_cleanup_drops();
+    semantic_cleanup_success_scenario();
+    assert_eq!(
+        cleanup_drops(),
+        1,
+        "fixtures should be dropped after successful scenario completion",
+    );
+}
+
+#[test]
+#[serial]
+fn cleanup_probe_drops_after_failed_scenario_completion() {
+    reset_cleanup_drops();
+    let result = catch_unwind(semantic_cleanup_failure_scenario);
+    assert!(result.is_err(), "expected cleanup scenario to fail");
+    assert!(
+        cleanup_drops() > 0,
+        "fixtures should be dropped even when scenario execution fails",
+    );
+}

--- a/crates/rstest-bdd/tests/async_semantic_behaviour.rs
+++ b/crates/rstest-bdd/tests/async_semantic_behaviour.rs
@@ -281,6 +281,7 @@ fn skip_propagation_preserves_message_and_bypass_metadata() {
 }
 
 #[test]
+#[serial]
 fn error_propagation_includes_step_and_scenario_context() {
     let panic = match catch_unwind(semantic_async_error_scenario) {
         Ok(()) => panic!("expected async scenario to panic"),
@@ -309,6 +310,7 @@ fn error_propagation_includes_step_and_scenario_context() {
 }
 
 #[test]
+#[serial]
 fn cleanup_probe_drops_after_successful_scenario_completion() {
     reset_cleanup_drops();
     semantic_cleanup_success_scenario();
@@ -320,6 +322,7 @@ fn cleanup_probe_drops_after_successful_scenario_completion() {
 }
 
 #[test]
+#[serial]
 fn cleanup_probe_drops_after_failed_scenario_completion() {
     reset_cleanup_drops();
     let result = catch_unwind(semantic_cleanup_failure_scenario);

--- a/crates/rstest-bdd/tests/async_semantic_behaviour.rs
+++ b/crates/rstest-bdd/tests/async_semantic_behaviour.rs
@@ -15,11 +15,11 @@ use rstest_bdd_macros::{given, scenario, then, when};
 use serial_test::serial;
 
 #[cfg(feature = "diagnostics")]
-use async_semantic_behaviour_support::assert_bypassed_step_recorded;
+use async_semantic_behaviour_support::{BypassedStepQuery, assert_bypassed_step_recorded};
 use async_semantic_behaviour_support::{
-    CleanupProbe, ERROR_SCENARIO_NAME, FEATURE_PATH, SKIP_SCENARIO_NAME, SemanticValue,
-    assert_feature_path_suffix, assert_handler_failure_context, cleanup_drops, clear_events,
-    push_event, reset_cleanup_drops, scenario_line, snapshot_events,
+    CleanupProbe, ERROR_SCENARIO_NAME, FEATURE_PATH, SKIP_SCENARIO_NAME, ScenarioRef,
+    SemanticValue, StepRef, assert_feature_path_suffix, assert_handler_failure_context,
+    cleanup_drops, clear_events, push_event, reset_cleanup_drops, scenario_line, snapshot_events,
 };
 
 #[fixture]
@@ -163,6 +163,7 @@ fn semantic_cleanup_step_fails(
     path = "tests/features/async_semantic_behaviour.feature",
     name = "async skip propagation preserves metadata"
 )]
+#[ignore = "exercised by skip_propagation_preserves_message_and_bypass_metadata"]
 #[serial]
 async fn semantic_async_skip_scenario() {
     panic!("scenario body should not execute after a skip request");
@@ -271,12 +272,12 @@ fn skip_propagation_preserves_message_and_bypass_metadata() {
     assert_eq!(details.message(), Some("semantic async skip message"));
 
     #[cfg(feature = "diagnostics")]
-    assert_bypassed_step_recorded(
-        SKIP_SCENARIO_NAME,
-        skip_scenario_line,
-        "semantic async trailing step should never run",
-        "semantic async skip message",
-    );
+    assert_bypassed_step_recorded(BypassedStepQuery {
+        scenario_name: SKIP_SCENARIO_NAME,
+        scenario_line: skip_scenario_line,
+        step_pattern: "semantic async trailing step should never run",
+        reason: "semantic async skip message",
+    });
 }
 
 #[test]
@@ -289,12 +290,16 @@ fn error_propagation_includes_step_and_scenario_context() {
 
     assert_handler_failure_context(
         &message,
-        FEATURE_PATH,
-        ERROR_SCENARIO_NAME,
-        "When",
-        "semantic async failing step runs",
-        "semantic_async_failing_step",
-        "semantic async failure",
+        ScenarioRef {
+            name: ERROR_SCENARIO_NAME,
+            feature_suffix: FEATURE_PATH,
+        },
+        StepRef {
+            keyword: "When",
+            text: "semantic async failing step runs",
+            function_name: "semantic_async_failing_step",
+            handler_error: "semantic async failure",
+        },
     );
     assert_eq!(
         snapshot_events(),

--- a/crates/rstest-bdd/tests/common/async_semantic_behaviour_support.rs
+++ b/crates/rstest-bdd/tests/common/async_semantic_behaviour_support.rs
@@ -62,6 +62,14 @@ pub(crate) fn assert_feature_path_suffix(actual: &str, expected_suffix: &str) {
     );
 }
 
+pub(crate) fn assert_message_mentions_feature_path(message: &str, expected_suffix: &str) {
+    let normalized_message = message.replace('\\', "/");
+    assert!(
+        normalized_message.contains(expected_suffix),
+        "panic message should include the feature path {expected_suffix}: {message}",
+    );
+}
+
 #[cfg(feature = "diagnostics")]
 pub(crate) fn assert_bypassed_step_recorded(
     scenario_name: &str,

--- a/crates/rstest-bdd/tests/common/async_semantic_behaviour_support.rs
+++ b/crates/rstest-bdd/tests/common/async_semantic_behaviour_support.rs
@@ -1,19 +1,25 @@
 //! Shared support for async semantic behaviour tests.
 
+use std::cell::RefCell;
 use std::path::Path;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{LazyLock, Mutex, MutexGuard};
 
+use regex::Regex;
 #[cfg(feature = "diagnostics")]
 use serde_json::Value;
 
 pub(crate) const FEATURE_PATH: &str = "tests/features/async_semantic_behaviour.feature";
 pub(crate) const SKIP_SCENARIO_NAME: &str = "async skip propagation preserves metadata";
-pub(crate) const SKIP_SCENARIO_LINE: u32 = 4;
 pub(crate) const ERROR_SCENARIO_NAME: &str = "async failure surfaces scenario metadata";
 
-static EVENTS: LazyLock<Mutex<Vec<String>>> = LazyLock::new(|| Mutex::new(Vec::new()));
-static CLEANUP_DROPS: AtomicUsize = AtomicUsize::new(0);
+#[derive(Default)]
+struct TestState {
+    events: Vec<String>,
+    cleanup_drops: usize,
+}
+
+thread_local! {
+    static TEST_STATE: RefCell<TestState> = RefCell::new(TestState::default());
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct SemanticValue(pub(crate) i32);
@@ -22,35 +28,36 @@ pub(crate) struct CleanupProbe;
 
 impl Drop for CleanupProbe {
     fn drop(&mut self) {
-        CLEANUP_DROPS.fetch_add(1, Ordering::SeqCst);
-    }
-}
-
-fn events_guard() -> MutexGuard<'static, Vec<String>> {
-    match EVENTS.lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
+        TEST_STATE.with(|state| {
+            state.borrow_mut().cleanup_drops += 1;
+        });
     }
 }
 
 pub(crate) fn clear_events() {
-    events_guard().clear();
+    TEST_STATE.with(|state| {
+        state.borrow_mut().events.clear();
+    });
 }
 
 pub(crate) fn push_event(event: impl Into<String>) {
-    events_guard().push(event.into());
+    TEST_STATE.with(|state| {
+        state.borrow_mut().events.push(event.into());
+    });
 }
 
 pub(crate) fn snapshot_events() -> Vec<String> {
-    events_guard().clone()
+    TEST_STATE.with(|state| state.borrow().events.clone())
 }
 
 pub(crate) fn reset_cleanup_drops() {
-    CLEANUP_DROPS.store(0, Ordering::SeqCst);
+    TEST_STATE.with(|state| {
+        state.borrow_mut().cleanup_drops = 0;
+    });
 }
 
 pub(crate) fn cleanup_drops() -> usize {
-    CLEANUP_DROPS.load(Ordering::SeqCst)
+    TEST_STATE.with(|state| state.borrow().cleanup_drops)
 }
 
 pub(crate) fn assert_feature_path_suffix(actual: &str, expected_suffix: &str) {
@@ -62,12 +69,60 @@ pub(crate) fn assert_feature_path_suffix(actual: &str, expected_suffix: &str) {
     );
 }
 
-pub(crate) fn assert_message_mentions_feature_path(message: &str, expected_suffix: &str) {
-    let normalized_message = message.replace('\\', "/");
-    assert!(
-        normalized_message.contains(expected_suffix),
-        "panic message should include the feature path {expected_suffix}: {message}",
+pub(crate) fn assert_handler_failure_context(
+    message: &str,
+    expected_suffix: &str,
+    scenario_name: &str,
+    step_keyword: &str,
+    step_text: &str,
+    function_name: &str,
+    handler_error: &str,
+) {
+    let normalized_message = normalize_message(message);
+    let pattern = format!(
+        r"Step failed at index .*?: .*?{step_keyword}.*?{step_text}.*?{function_name}.*?{handler_error}.*?\(feature: .*?{expected_suffix}, scenario: .*?{scenario_name}\)",
+        step_keyword = regex::escape(step_keyword),
+        step_text = regex::escape(step_text),
+        function_name = regex::escape(function_name),
+        handler_error = regex::escape(handler_error),
+        expected_suffix = regex::escape(expected_suffix),
+        scenario_name = regex::escape(scenario_name),
     );
+    let matcher = Regex::new(&pattern)
+        .unwrap_or_else(|error| panic!("handler-failure matcher should compile: {error}"));
+    assert!(
+        matcher.is_match(&normalized_message),
+        "panic message should include the handler failure context: {message}",
+    );
+}
+
+pub(crate) fn scenario_line(scenario_name: &str) -> u32 {
+    let feature_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(FEATURE_PATH);
+    let feature = std::fs::read_to_string(&feature_path)
+        .unwrap_or_else(|error| panic!("feature file should be readable: {error}"));
+    feature
+        .lines()
+        .enumerate()
+        .find_map(|(index, line)| {
+            parse_scenario_heading(line)
+                .filter(|name| *name == scenario_name)
+                .map(|_| index + 1)
+        })
+        .and_then(|line| u32::try_from(line).ok())
+        .unwrap_or_else(|| panic!("scenario '{scenario_name}' should exist in {FEATURE_PATH}"))
+}
+
+fn parse_scenario_heading(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start();
+    trimmed
+        .strip_prefix("Scenario: ")
+        .or_else(|| trimmed.strip_prefix("Scenario Outline: "))
+}
+
+fn normalize_message(message: &str) -> String {
+    message
+        .replace('\\', "/")
+        .replace(['\u{2068}', '\u{2069}'], "")
 }
 
 #[cfg(feature = "diagnostics")]

--- a/crates/rstest-bdd/tests/common/async_semantic_behaviour_support.rs
+++ b/crates/rstest-bdd/tests/common/async_semantic_behaviour_support.rs
@@ -1,0 +1,97 @@
+//! Shared support for async semantic behaviour tests.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{LazyLock, Mutex, MutexGuard};
+
+#[cfg(feature = "diagnostics")]
+use serde_json::Value;
+
+pub(crate) const FEATURE_PATH: &str = "tests/features/async_semantic_behaviour.feature";
+pub(crate) const SKIP_SCENARIO_NAME: &str = "async skip propagation preserves metadata";
+pub(crate) const SKIP_SCENARIO_LINE: u32 = 4;
+pub(crate) const ERROR_SCENARIO_NAME: &str = "async failure surfaces scenario metadata";
+
+static EVENTS: LazyLock<Mutex<Vec<String>>> = LazyLock::new(|| Mutex::new(Vec::new()));
+static CLEANUP_DROPS: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SemanticValue(pub(crate) i32);
+
+pub(crate) struct CleanupProbe;
+
+impl Drop for CleanupProbe {
+    fn drop(&mut self) {
+        CLEANUP_DROPS.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+fn events_guard() -> MutexGuard<'static, Vec<String>> {
+    match EVENTS.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+pub(crate) fn clear_events() {
+    events_guard().clear();
+}
+
+pub(crate) fn push_event(event: impl Into<String>) {
+    events_guard().push(event.into());
+}
+
+pub(crate) fn snapshot_events() -> Vec<String> {
+    events_guard().clone()
+}
+
+pub(crate) fn reset_cleanup_drops() {
+    CLEANUP_DROPS.store(0, Ordering::SeqCst);
+}
+
+pub(crate) fn cleanup_drops() -> usize {
+    CLEANUP_DROPS.load(Ordering::SeqCst)
+}
+
+pub(crate) fn assert_feature_path_suffix(actual: &str, expected_suffix: &str) {
+    let actual_path = Path::new(actual);
+    let expected = Path::new(expected_suffix);
+    assert!(
+        actual_path.ends_with(expected),
+        "feature path should reference {expected_suffix}, got {actual}",
+    );
+}
+
+#[cfg(feature = "diagnostics")]
+pub(crate) fn assert_bypassed_step_recorded(
+    scenario_name: &str,
+    scenario_line: u32,
+    step_pattern: &str,
+    reason: &str,
+) {
+    let dump = match rstest_bdd::dump_registry() {
+        Ok(dump) => dump,
+        Err(error) => panic!("registry dump should serialize: {error}"),
+    };
+    let parsed: Value = match serde_json::from_str(&dump) {
+        Ok(parsed) => parsed,
+        Err(error) => panic!("registry dump should be valid JSON: {error}"),
+    };
+    let bypassed_steps = parsed
+        .get("bypassed_steps")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("registry dump should include bypassed_steps"));
+    assert!(
+        bypassed_steps.iter().any(|entry| {
+            entry.get("scenario_name") == Some(&Value::String(scenario_name.into()))
+                && entry.get("scenario_line").and_then(Value::as_u64)
+                    == Some(u64::from(scenario_line))
+                && entry.get("pattern") == Some(&Value::String(step_pattern.into()))
+                && entry
+                    .get("reason")
+                    .and_then(Value::as_str)
+                    .is_some_and(|message| message.contains(reason))
+        }),
+        "expected a bypassed-step record for scenario '{scenario_name}' and pattern '{step_pattern}'",
+    );
+}

--- a/crates/rstest-bdd/tests/common/async_semantic_behaviour_support.rs
+++ b/crates/rstest-bdd/tests/common/async_semantic_behaviour_support.rs
@@ -17,8 +17,17 @@ struct TestState {
     cleanup_drops: usize,
 }
 
+impl TestState {
+    const fn new() -> Self {
+        Self {
+            events: Vec::new(),
+            cleanup_drops: 0,
+        }
+    }
+}
+
 thread_local! {
-    static TEST_STATE: RefCell<TestState> = RefCell::new(TestState::default());
+    static TEST_STATE: RefCell<TestState> = const { RefCell::new(TestState::new()) };
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/rstest-bdd/tests/common/async_semantic_behaviour_support.rs
+++ b/crates/rstest-bdd/tests/common/async_semantic_behaviour_support.rs
@@ -54,26 +54,36 @@ impl Drop for CleanupProbe {
 /// Identifies the scenario under test for assertion helpers.
 #[derive(Clone, Copy)]
 pub(crate) struct ScenarioRef<'a> {
+    /// The scenario name as it appears in the feature file.
     pub(crate) name: &'a str,
+    /// The expected suffix of the feature file path.
     pub(crate) feature_suffix: &'a str,
 }
 
 /// Identifies the step that is expected to have failed.
 #[derive(Clone, Copy)]
 pub(crate) struct StepRef<'a> {
+    /// The Gherkin keyword of the step (e.g. `"When"`, `"Then"`).
     pub(crate) keyword: &'a str,
+    /// The step text as it appears in the feature file.
     pub(crate) text: &'a str,
+    /// The Rust function name of the step handler.
     pub(crate) function_name: &'a str,
+    /// The error message or substring expected in the handler failure.
     pub(crate) handler_error: &'a str,
 }
 
+/// Identifies a bypassed step record expected in diagnostics output.
 #[cfg(feature = "diagnostics")]
 #[derive(Clone, Copy)]
-/// Identifies a bypassed step record expected in diagnostics output.
 pub(crate) struct BypassedStepQuery<'a> {
+    /// The name of the scenario that owns the bypassed step.
     pub(crate) scenario_name: &'a str,
+    /// The 1-based line number of the scenario in the feature file.
     pub(crate) scenario_line: u32,
+    /// The step pattern as recorded in the diagnostics registry.
     pub(crate) step_pattern: &'a str,
+    /// A substring expected to appear in the bypass reason message.
     pub(crate) reason: &'a str,
 }
 

--- a/crates/rstest-bdd/tests/common/async_semantic_behaviour_support.rs
+++ b/crates/rstest-bdd/tests/common/async_semantic_behaviour_support.rs
@@ -34,6 +34,31 @@ impl Drop for CleanupProbe {
     }
 }
 
+/// Identifies the scenario under test for assertion helpers.
+#[derive(Clone, Copy)]
+pub(crate) struct ScenarioRef<'a> {
+    pub(crate) name: &'a str,
+    pub(crate) feature_suffix: &'a str,
+}
+
+/// Identifies the step that is expected to have failed.
+#[derive(Clone, Copy)]
+pub(crate) struct StepRef<'a> {
+    pub(crate) keyword: &'a str,
+    pub(crate) text: &'a str,
+    pub(crate) function_name: &'a str,
+    pub(crate) handler_error: &'a str,
+}
+
+#[cfg(feature = "diagnostics")]
+#[derive(Clone, Copy)]
+pub(crate) struct BypassedStepQuery<'a> {
+    pub(crate) scenario_name: &'a str,
+    pub(crate) scenario_line: u32,
+    pub(crate) step_pattern: &'a str,
+    pub(crate) reason: &'a str,
+}
+
 pub(crate) fn clear_events() {
     TEST_STATE.with(|state| {
         state.borrow_mut().events.clear();
@@ -71,16 +96,22 @@ pub(crate) fn assert_feature_path_suffix(actual: &str, expected_suffix: &str) {
 
 pub(crate) fn assert_handler_failure_context(
     message: &str,
-    expected_suffix: &str,
-    scenario_name: &str,
-    step_keyword: &str,
-    step_text: &str,
-    function_name: &str,
-    handler_error: &str,
+    scenario: ScenarioRef<'_>,
+    step: StepRef<'_>,
 ) {
+    let ScenarioRef {
+        name: scenario_name,
+        feature_suffix: expected_suffix,
+    } = scenario;
+    let StepRef {
+        keyword: step_keyword,
+        text: step_text,
+        function_name,
+        handler_error,
+    } = step;
     let normalized_message = normalize_message(message);
     let pattern = format!(
-        r"Step failed at index .*?: .*?{step_keyword}.*?{step_text}.*?{function_name}.*?{handler_error}.*?\(feature: .*?{expected_suffix}, scenario: .*?{scenario_name}\)",
+        r"{step_keyword}.*?{step_text}.*?{function_name}.*?{handler_error}.*?{expected_suffix}.*?{scenario_name}",
         step_keyword = regex::escape(step_keyword),
         step_text = regex::escape(step_text),
         function_name = regex::escape(function_name),
@@ -126,12 +157,13 @@ fn normalize_message(message: &str) -> String {
 }
 
 #[cfg(feature = "diagnostics")]
-pub(crate) fn assert_bypassed_step_recorded(
-    scenario_name: &str,
-    scenario_line: u32,
-    step_pattern: &str,
-    reason: &str,
-) {
+pub(crate) fn assert_bypassed_step_recorded(query: BypassedStepQuery<'_>) {
+    let BypassedStepQuery {
+        scenario_name,
+        scenario_line,
+        step_pattern,
+        reason,
+    } = query;
     let dump = match rstest_bdd::dump_registry() {
         Ok(dump) => dump,
         Err(error) => panic!("registry dump should serialize: {error}"),

--- a/crates/rstest-bdd/tests/common/async_semantic_behaviour_support.rs
+++ b/crates/rstest-bdd/tests/common/async_semantic_behaviour_support.rs
@@ -130,7 +130,7 @@ pub(crate) fn assert_feature_path_suffix(actual: &str, expected_suffix: &str) {
 
 /// Asserts that `message` contains the expected failure context for a step handler.
 ///
-/// Normalises `message` (converts backslashes to `/`, strips Unicode directional marks)
+/// Normalizes `message` (converts backslashes to `/`, strips Unicode directional marks)
 /// and verifies it matches a regex built from the supplied [`ScenarioRef`] and [`StepRef`].
 ///
 /// # Panics
@@ -206,7 +206,6 @@ fn normalize_message(message: &str) -> String {
         .replace(['\u{2068}', '\u{2069}'], "")
 }
 
-#[cfg(feature = "diagnostics")]
 /// Asserts that the diagnostics registry contains a bypassed-step record
 /// matching all fields of `query`.
 ///
@@ -217,6 +216,7 @@ fn normalize_message(message: &str) -> String {
 /// # Panics
 ///
 /// Panics if the dump fails, the JSON is invalid, or no matching entry is found.
+#[cfg(feature = "diagnostics")]
 pub(crate) fn assert_bypassed_step_recorded(query: BypassedStepQuery<'_>) {
     let BypassedStepQuery {
         scenario_name,

--- a/crates/rstest-bdd/tests/common/async_semantic_behaviour_support.rs
+++ b/crates/rstest-bdd/tests/common/async_semantic_behaviour_support.rs
@@ -7,8 +7,11 @@ use regex::Regex;
 #[cfg(feature = "diagnostics")]
 use serde_json::Value;
 
+/// Relative path from `CARGO_MANIFEST_DIR` to the async semantic behaviour feature file.
 pub(crate) const FEATURE_PATH: &str = "tests/features/async_semantic_behaviour.feature";
+/// Canonical name of the skip-propagation scenario in the feature file.
 pub(crate) const SKIP_SCENARIO_NAME: &str = "async skip propagation preserves metadata";
+/// Canonical name of the error-propagation scenario in the feature file.
 pub(crate) const ERROR_SCENARIO_NAME: &str = "async failure surfaces scenario metadata";
 
 #[derive(Default)]
@@ -30,9 +33,14 @@ thread_local! {
     static TEST_STATE: RefCell<TestState> = const { RefCell::new(TestState::new()) };
 }
 
+/// Newtype for an integer fixture value used to verify that async step handlers
+/// can return a value that is injected as a fixture into the next step.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct SemanticValue(pub(crate) i32);
 
+/// Marker struct whose [`Drop`] implementation increments the per-thread
+/// `cleanup_drops` counter, allowing tests to assert that fixtures are
+/// dropped exactly once on both success and failure paths.
 pub(crate) struct CleanupProbe;
 
 impl Drop for CleanupProbe {
@@ -69,32 +77,48 @@ pub(crate) struct BypassedStepQuery<'a> {
     pub(crate) reason: &'a str,
 }
 
+/// Resets the per-thread event log.
+///
+/// Call at the start of any test that asserts on event ordering.
 pub(crate) fn clear_events() {
     TEST_STATE.with(|state| {
         state.borrow_mut().events.clear();
     });
 }
 
+/// Appends `event` to the per-thread event log.
+///
+/// Call from within step handlers to record execution order.
 pub(crate) fn push_event(event: impl Into<String>) {
     TEST_STATE.with(|state| {
         state.borrow_mut().events.push(event.into());
     });
 }
 
+/// Returns a snapshot of the per-thread event log without clearing it.
 pub(crate) fn snapshot_events() -> Vec<String> {
     TEST_STATE.with(|state| state.borrow().events.clone())
 }
 
+/// Resets the per-thread [`CleanupProbe`] drop counter to zero.
+///
+/// Call before the scenario under test so that assertions start from a known state.
 pub(crate) fn reset_cleanup_drops() {
     TEST_STATE.with(|state| {
         state.borrow_mut().cleanup_drops = 0;
     });
 }
 
+/// Returns the number of times [`CleanupProbe`] has been dropped in this thread.
 pub(crate) fn cleanup_drops() -> usize {
     TEST_STATE.with(|state| state.borrow().cleanup_drops)
 }
 
+/// Asserts that `actual` ends with `expected_suffix` using [`Path::ends_with`].
+///
+/// # Panics
+///
+/// Panics with a descriptive message if `actual` does not end with `expected_suffix`.
 pub(crate) fn assert_feature_path_suffix(actual: &str, expected_suffix: &str) {
     let actual_path = Path::new(actual);
     let expected = Path::new(expected_suffix);
@@ -104,6 +128,14 @@ pub(crate) fn assert_feature_path_suffix(actual: &str, expected_suffix: &str) {
     );
 }
 
+/// Asserts that `message` contains the expected failure context for a step handler.
+///
+/// Normalises `message` (converts backslashes to `/`, strips Unicode directional marks)
+/// and verifies it matches a regex built from the supplied [`ScenarioRef`] and [`StepRef`].
+///
+/// # Panics
+///
+/// Panics if the regex fails to compile or if `message` does not match.
 pub(crate) fn assert_handler_failure_context(
     message: &str,
     scenario: ScenarioRef<'_>,
@@ -137,6 +169,14 @@ pub(crate) fn assert_handler_failure_context(
     );
 }
 
+/// Returns the 1-based line number of `scenario_name` in [`FEATURE_PATH`].
+///
+/// Reads the feature file relative to `CARGO_MANIFEST_DIR` and scans for
+/// a `Scenario:` or `Scenario Outline:` heading matching `scenario_name`.
+///
+/// # Panics
+///
+/// Panics if the feature file cannot be read or if no matching scenario is found.
 pub(crate) fn scenario_line(scenario_name: &str) -> u32 {
     let feature_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(FEATURE_PATH);
     let feature = std::fs::read_to_string(&feature_path)
@@ -167,6 +207,16 @@ fn normalize_message(message: &str) -> String {
 }
 
 #[cfg(feature = "diagnostics")]
+/// Asserts that the diagnostics registry contains a bypassed-step record
+/// matching all fields of `query`.
+///
+/// Dumps the registry via `rstest_bdd::dump_registry`, parses the JSON, and
+/// searches `bypassed_steps` for an entry matching `scenario_name`,
+/// `scenario_line`, `step_pattern`, and a `reason` substring.
+///
+/// # Panics
+///
+/// Panics if the dump fails, the JSON is invalid, or no matching entry is found.
 pub(crate) fn assert_bypassed_step_recorded(query: BypassedStepQuery<'_>) {
     let BypassedStepQuery {
         scenario_name,

--- a/crates/rstest-bdd/tests/common/async_semantic_behaviour_support.rs
+++ b/crates/rstest-bdd/tests/common/async_semantic_behaviour_support.rs
@@ -52,6 +52,7 @@ pub(crate) struct StepRef<'a> {
 
 #[cfg(feature = "diagnostics")]
 #[derive(Clone, Copy)]
+/// Identifies a bypassed step record expected in diagnostics output.
 pub(crate) struct BypassedStepQuery<'a> {
     pub(crate) scenario_name: &'a str,
     pub(crate) scenario_line: u32,

--- a/crates/rstest-bdd/tests/features/async_semantic_behaviour.feature
+++ b/crates/rstest-bdd/tests/features/async_semantic_behaviour.feature
@@ -1,0 +1,40 @@
+Feature: Async semantic behaviour
+
+  @allow_skipped
+  Scenario: async skip propagation preserves metadata
+    Given semantic async skip state is reset
+    When semantic async skip is requested
+    Then semantic async trailing step should never run
+
+  Scenario Outline: async steps preserve declaration order
+    Given semantic async order fixture starts with its creation marker
+    When semantic async order fixture records "<item>"
+    Then semantic async order fixture includes "<item>" in sequence
+
+    Examples:
+      | item  |
+      | alpha |
+      | beta  |
+
+  Scenario: async returned fixtures reach the next step
+    Given semantic async base value is 1
+    When semantic async derived value is produced
+    Then semantic async next step receives value 2
+
+  Scenario: async RefCell fixtures survive cross-step borrows
+    Given semantic async shared counter starts at 0
+    When semantic async shared counter increments
+    And semantic async shared counter increments
+    Then semantic async shared counter equals 2
+
+  Scenario: async failure surfaces scenario metadata
+    Given semantic async failure state is reset
+    When semantic async failing step runs
+    Then semantic async failure trailing step should never run
+
+  Scenario: cleanup probe completes successfully
+    Given semantic cleanup probe is available
+
+  Scenario: cleanup probe fails after setup
+    Given semantic cleanup probe is available
+    When semantic cleanup step fails

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1,0 +1,129 @@
+# Developer Guide
+
+## Internal test infrastructure
+
+The async semantic behaviour tests use a shared support module at
+`crates/rstest-bdd/tests/common/async_semantic_behaviour_support.rs`. Use the
+helpers and types below when writing or extending semantic tests; do not access
+`TEST_STATE` directly.
+
+### Constants
+
+| Constant              | Value / purpose                                                                                                                                                    |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `FEATURE_PATH`        | Relative path (from `CARGO_MANIFEST_DIR`) to the async semantic behaviour feature file. Pass to `assert_feature_path_suffix` and as `ScenarioRef::feature_suffix`. |
+| `SKIP_SCENARIO_NAME`  | Canonical name of the skip-propagation scenario. Use wherever a scenario name is required for that scenario.                                                       |
+| `ERROR_SCENARIO_NAME` | Canonical name of the error-propagation scenario. Use wherever a scenario name is required for that scenario.                                                      |
+
+### Parameter structs
+
+Prefer struct-literal syntax at call sites so that each field is labelled.
+
+#### `ScenarioRef<'a>`
+
+Bundles the two string fields that identify a scenario in assertion helpers.
+
+```rust
+ScenarioRef {
+    name:           ERROR_SCENARIO_NAME,
+    feature_suffix: FEATURE_PATH,
+}
+```
+
+Fields: `name: &'a str`, `feature_suffix: &'a str`.
+
+#### `StepRef<'a>`
+
+Bundles the four string fields that identify a step in failure-context
+assertions.
+
+```rust
+StepRef {
+    keyword:       "When",
+    text:          "a step fails with an error",
+    function_name: "step_that_fails",
+    handler_error: "deliberate failure",
+}
+```
+
+Fields: `keyword: &'a str`, `text: &'a str`, `function_name: &'a str`,
+`handler_error: &'a str`.
+
+#### `BypassedStepQuery<'a>` _(requires `diagnostics` feature)_
+
+Bundles the four fields needed to look up a bypassed-step record in the
+diagnostics registry dump.
+
+Fields: `scenario_name: &'a str`, `scenario_line: u32`,
+`step_pattern: &'a str`, `reason: &'a str`.
+
+### Helper types
+
+#### `SemanticValue(i32)`
+
+Newtype wrapper for an integer fixture value. Used to verify that async step
+handlers can return a value that is injected as a fixture into subsequent steps.
+
+#### `CleanupProbe`
+
+A zero-size marker struct whose `Drop` implementation increments the per-thread
+`cleanup_drops` counter. Inject it as a fixture and call
+`reset_cleanup_drops()` before the scenario under test, then assert
+`cleanup_drops() == 1` after it completes (or after `catch_unwind` returns for
+failure paths).
+
+### Assertion helpers
+
+#### `assert_feature_path_suffix(actual, expected_suffix)`
+
+Asserts that `actual` ends with `expected_suffix` using `Path::ends_with`.
+Panics with a descriptive message on mismatch.
+
+#### `assert_handler_failure_context(message, ScenarioRef, StepRef)`
+
+Normalises `message` (converts backslashes to forward slashes, strips Unicode
+directional marks) and asserts it matches a regex covering the step keyword,
+step text, function name, handler error, feature path suffix, and scenario
+name. Panics on regex compile failure or mismatch.
+
+#### `assert_bypassed_step_recorded(BypassedStepQuery)` _(requires `diagnostics` feature)_
+
+Dumps the diagnostics registry, parses it as JSON, and asserts that
+`bypassed_steps` contains an entry matching all four fields of the query.
+Panics if no matching entry is found.
+
+### Event utilities
+
+| Function                           | Purpose                                                                           |
+| ---------------------------------- | --------------------------------------------------------------------------------- |
+| `clear_events()`                   | Resets the per-thread event log. Call at the start of any test that reads events. |
+| `push_event(event)`                | Appends a string to the per-thread event log. Call from within step handlers.     |
+| `snapshot_events() -> Vec<String>` | Returns a clone of the current event log without clearing it.                     |
+
+### Cleanup utilities
+
+| Function                   | Purpose                                                                          |
+| -------------------------- | -------------------------------------------------------------------------------- |
+| `reset_cleanup_drops()`    | Resets the per-thread drop counter to zero. Call before the scenario under test. |
+| `cleanup_drops() -> usize` | Returns the number of times `CleanupProbe` has been dropped in this thread.      |
+
+### Line-number utility
+
+#### `scenario_line(scenario_name) -> u32`
+
+Reads `FEATURE_PATH` relative to `CARGO_MANIFEST_DIR`, scans for a `Scenario:`
+or `Scenario Outline:` heading whose name matches `scenario_name`, and returns
+the 1-based line number. Panics if the scenario is not found. Use this instead
+of hard-coded line numbers so that tests remain valid when the feature file is
+edited.
+
+### Thread-local state and test isolation
+
+All mutable state (`events`, `cleanup_drops`) is held in a single
+`thread_local! { RefCell<TestState> }`. State is per-thread and does not leak
+between concurrently running threads. Any test that reads from or writes to
+shared state must:
+
+1. Call `clear_events()` and/or `reset_cleanup_drops()` at the start.
+2. Be annotated with `#[serial]` to prevent interleaving with other
+   tests on the same thread pool.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1,4 +1,4 @@
-# Developer Guide
+# Developer guide
 
 ## Internal test infrastructure
 
@@ -81,7 +81,7 @@ Panics with a descriptive message on mismatch.
 
 #### `assert_handler_failure_context(message, ScenarioRef, StepRef)`
 
-Normalises `message` (converts backslashes to forward slashes, strips Unicode
+Normalizes `message` (converts backslashes to forward slashes, strips Unicode
 directional marks) and asserts it matches a regex covering the step keyword,
 step text, function name, handler error, feature path suffix, and scenario
 name. Panics on regex compile failure or mismatch.

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -1,4 +1,4 @@
-# Testing Strategy
+# Testing strategy
 
 This project uses both structural macro tests and semantic behaviour tests.
 They serve different purposes and should not be substituted for one another.
@@ -20,7 +20,7 @@ These assertions are more resilient to refactors in the generated step loop,
 because they validate the contract users observe rather than the exact tokens
 that happen to implement it.
 
-## Invariants to Prefer
+## Invariants to prefer
 
 When adding scenario execution coverage, prefer tests that enforce invariants
 like these:
@@ -35,7 +35,7 @@ like these:
   returned from one step should be available to later steps, and owned fixtures
   should still drop when a scenario fails.
 
-## Recommended Patterns
+## Recommended patterns
 
 - Use real feature files plus `#[scenario]` or `scenarios!` so the runtime path
   matches production behaviour.
@@ -48,7 +48,7 @@ like these:
 - For cleanup assertions, use lightweight RAII probes with `Drop` side effects
   rather than internal implementation hooks.
 
-## Good and Fragile Assertions
+## Good and fragile assertions
 
 Good semantic assertions:
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -1,0 +1,67 @@
+# Testing Strategy
+
+This project uses both structural macro tests and semantic behaviour tests.
+They serve different purposes and should not be substituted for one another.
+
+Structural tests are appropriate when validating code generation details such
+as compile errors, emitted attributes, or token-level transformations. They are
+useful for macro internals, but they are intentionally close to the current
+implementation shape.
+
+Semantic behaviour tests assert runtime-observable outcomes instead:
+
+- whether steps stop after a skip or failure
+- whether step ordering matches the feature declaration order
+- whether fixtures remain available across step boundaries
+- whether panic and error messages preserve scenario context
+- whether cleanup still happens when execution exits early
+
+These assertions are more resilient to refactors in the generated step loop,
+because they validate the contract users observe rather than the exact tokens
+that happen to implement it.
+
+## Invariants to Prefer
+
+When adding scenario execution coverage, prefer tests that enforce invariants
+like these:
+
+- Skip propagation: a skipped step must halt later steps, preserve its message,
+  and record any bypassed steps in diagnostics output.
+- Step ordering: background, Given, When, Then, and outline/example execution
+  must preserve declaration order.
+- Error propagation: handler failures should surface feature path, scenario
+  name, step index, and step context in the final panic message.
+- Fixture lifecycle: mutable fixtures should survive cross-step borrows, values
+  returned from one step should be available to later steps, and owned fixtures
+  should still drop when a scenario fails.
+
+## Recommended Patterns
+
+- Use real feature files plus `#[scenario]` or `scenarios!` so the runtime path
+  matches production behaviour.
+- Prefer event logs, counters, and final fixture assertions over token-stream
+  inspection.
+- For panic assertions, wrap scenario execution with `catch_unwind` or inspect
+  Tokio `JoinError` panics, then assert on the rendered message.
+- For skip assertions, inspect reporter output and, when diagnostics are
+  enabled, assert against bypassed-step metadata from `dump_registry()`.
+- For cleanup assertions, use lightweight RAII probes with `Drop` side effects
+  rather than internal implementation hooks.
+
+## Good and Fragile Assertions
+
+Good semantic assertions:
+
+- "the trailing step did not run after `skip!()`"
+- "the panic includes the failing step text and scenario name"
+- "the `RefCell` fixture still contains the expected value in the scenario body"
+
+Fragile structural assertions:
+
+- "the generated loop contains a particular helper name"
+- "the macro emitted tokens in a specific statement order"
+- "the expansion uses a particular temporary variable layout"
+
+The review discussion that led to issue `#395` is a concrete reminder that
+documentation and runtime behaviour can drift independently of code shape.
+Semantic tests are the backstop that keeps those contracts aligned.

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -69,9 +69,9 @@ Semantic tests are the backstop that keeps those contracts aligned.
 ## Test support infrastructure
 
 Async semantic behaviour tests share a support module at
-`tests/common/async_semantic_behaviour_support.rs`. The types and helpers below
-should be used instead of raw strings wherever assertions require structured
-context.
+`crates/rstest-bdd/tests/common/async_semantic_behaviour_support.rs`. The types
+and helpers below should be used instead of raw strings wherever assertions
+require structured context.
 
 ### Parameter structs
 
@@ -102,7 +102,7 @@ assert_handler_failure_context(
 | Function                                                                        | What it checks                                                                                                                                                    |
 | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `assert_feature_path_suffix(actual, expected_suffix)`                           | Verifies that a file path ends with the expected suffix using `Path::ends_with`.                                                                                  |
-| `assert_handler_failure_context(message, ScenarioRef, StepRef)`                 | Normalises a panic message and asserts it matches a regex covering step keyword, step text, function name, handler error, feature path suffix, and scenario name. |
+| `assert_handler_failure_context(message, ScenarioRef, StepRef)`                 | Normalizes a panic message and asserts it matches a regex covering step keyword, step text, function name, handler error, feature path suffix, and scenario name. |
 | `assert_bypassed_step_recorded(BypassedStepQuery)` _(diagnostics feature only)_ | Parses the diagnostics registry JSON and asserts a matching bypassed-step entry exists.                                                                           |
 
 ### Event and cleanup utilities

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -16,7 +16,7 @@ Semantic behaviour tests assert runtime-observable outcomes instead:
 - whether panic and error messages preserve scenario context
 - whether cleanup still happens when execution exits early
 
-These assertions are more resilient to refactors in the generated step loop,
+These assertions are more resilient to refactors in the generated step loop
 because they validate the contract users observe rather than the exact tokens
 that happen to implement it.
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -65,3 +65,61 @@ Fragile structural assertions:
 The review discussion that led to issue `#395` is a concrete reminder that
 documentation and runtime behaviour can drift independently of code shape.
 Semantic tests are the backstop that keeps those contracts aligned.
+
+## Test support infrastructure
+
+Async semantic behaviour tests share a support module at
+`tests/common/async_semantic_behaviour_support.rs`. The types and helpers below
+should be used instead of raw strings wherever assertions require structured
+context.
+
+### Parameter structs
+
+| Type                                                 | Purpose                                                                                                          |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `ScenarioRef<'a>`                                    | Bundles the scenario `name` and `feature_suffix` used in failure-context assertions.                             |
+| `StepRef<'a>`                                        | Bundles the step `keyword`, `text`, `function_name`, and `handler_error` for failure-context assertions.         |
+| `BypassedStepQuery<'a>` _(diagnostics feature only)_ | Bundles `scenario_name`, `scenario_line`, `step_pattern`, and `reason` for bypassed-step diagnostics assertions. |
+
+Prefer struct-literal syntax at call sites so that each field is labelled and
+the intent is clear:
+
+```rust
+assert_handler_failure_context(
+    &message,
+    ScenarioRef { name: ERROR_SCENARIO_NAME, feature_suffix: FEATURE_PATH },
+    StepRef {
+        keyword:       "When",
+        text:          "a step fails with an error",
+        function_name: "step_that_fails",
+        handler_error: "deliberate failure",
+    },
+);
+```
+
+### Assertion helpers
+
+| Function                                                                        | What it checks                                                                                                                                                    |
+| ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `assert_feature_path_suffix(actual, expected_suffix)`                           | Verifies that a file path ends with the expected suffix using `Path::ends_with`.                                                                                  |
+| `assert_handler_failure_context(message, ScenarioRef, StepRef)`                 | Normalises a panic message and asserts it matches a regex covering step keyword, step text, function name, handler error, feature path suffix, and scenario name. |
+| `assert_bypassed_step_recorded(BypassedStepQuery)` _(diagnostics feature only)_ | Parses the diagnostics registry JSON and asserts a matching bypassed-step entry exists.                                                                           |
+
+### Event and cleanup utilities
+
+| Function                              | Purpose                                                                                                           |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `clear_events()`                      | Resets the per-thread event log; call at the start of every test that reads from it.                              |
+| `push_event(event)`                   | Appends a string to the per-thread event log from within a step handler.                                          |
+| `snapshot_events() -> Vec<String>`    | Returns a snapshot of the current event log without clearing it.                                                  |
+| `reset_cleanup_drops()`               | Resets the per-thread drop counter; call before the scenario under test.                                          |
+| `cleanup_drops() -> usize`            | Returns the number of times `CleanupProbe` has been dropped in this thread.                                       |
+| `scenario_line(scenario_name) -> u32` | Reads the feature file and returns the 1-based line number of the named scenario; avoids hard-coded line numbers. |
+
+### Thread-local state
+
+All mutable state (`events`, `cleanup_drops`) is held in a single
+`thread_local! { TestState }`. Isolation is therefore per-thread; any test that
+reads from shared state must call the corresponding reset helper before running
+its scenario. Tests that mutate shared state must be annotated with `#[serial]`
+to prevent interleaving with other tests on the same thread pool.

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -119,7 +119,8 @@ assert_handler_failure_context(
 ### Thread-local state
 
 All mutable state (`events`, `cleanup_drops`) is held in a single
-`thread_local! { TestState }`. Isolation is therefore per-thread; any test that
-reads from shared state must call the corresponding reset helper before running
-its scenario. Tests that mutate shared state must be annotated with `#[serial]`
-to prevent interleaving with other tests on the same thread pool.
+`thread_local! { static TEST_STATE: RefCell<TestState> = ... }` binding.
+Isolation is therefore per-thread; any test that reads from shared state must
+call the corresponding reset helper before running its scenario. Tests that
+mutate shared state must be annotated with `#[serial]` to prevent interleaving
+with other tests on the same thread pool.


### PR DESCRIPTION
## Summary
- Introduces asynchronous semantic behaviour tests to validate runtime contracts of async loop execution, including skip propagation, step ordering, cross-step borrowing of fixtures, failure propagation, and cleanup guarantees.
- Adds a dedicated test module, shared test support utilities, a feature file, and a testing strategy document to distinguish semantic behaviour checks from structural macro tests.

## Changes

### Tests
- New: crates/rstest-bdd/tests/async_semantic_behaviour.rs
  - Semantic, runtime-focused tests for async loop behavior (skip, order, fixture lifecycle, and error handling).
  - Includes scenarios that verify skip metadata, declaration order preservation, cross-step borrows with RefCell fixtures, and propagation of failures with context.
  - Uses serial and Tokio-based async tests to exercise concurrency boundaries.
- New: crates/rstest-bdd/tests/common/async_semantic_behaviour_support.rs
  - Shared support for semantic tests: event logging, cleanup probe tracking via Drop, feature path and scenario constants, and helpers to inspect bypass metadata when diagnostics are enabled.
  - Provides utilities to reset and inspect state across test scenarios.
- New: crates/rstest-bdd/tests/features/async_semantic_behaviour.feature
  - Feature file describing scenarios for async skip propagation, step ordering, returned fixtures, RefCell behavior across steps, and cleanup probes.
- New: docs/testing-strategy.md
  - Formal testing strategy distinguishing semantic behaviour tests from structural macro tests.
  - Outlines invariant-based testing patterns and recommended practices for runtime-observable assertions.

### Documentation & Guidelines
- Updated CONTRIBUTING.md with Testing Guidelines emphasizing semantic behaviour tests for scenario execution changes and keeping structural macro tests for code-generation details. (References/testing strategy now documented in docs/testing-strategy.md.)
- Added docs/developers-guide.md outlining internal test infrastructure and guidance for semantic tests.

## Why
- To ensure async loop semantics remain stable across refactors by validating runtime contracts rather than relying solely on macro-token generation details.
- To provide a clear separation between semantic behaviour tests (runtime invariants) and structural tests (compile-time/token-level checks).

## How to run
- Default: cargo test -p rstest-bdd
- Enable diagnostics bypass metadata tests: cargo test -p rstest-bdd --features diagnostics
- If running the whole workspace: cargo test --workspace --all-features

## Risk & Mitigations
- Tests rely on serialization of bypass metadata when diagnostics are enabled; ensure the diagnostics feature is active in CI for those checks.
- Some async tests use serial execution to avoid flakiness due to shared state; this is isolated to ensure deterministic outcomes.

## Test plan
- [x] Run semantic tests locally with and without the diagnostics feature to verify bypass metadata assertions.
- [x] Validate skip propagation, assertion of captured events, and that cleanup drops occur per scenario completion.
- [x] Confirm that RefCell-backed fixtures remain borrowable across async step boundaries.
- [x] Ensure error propagation includes step context, scenario name, and feature path in panics.


📎 **Task**: https://www.devboxer.com/task/903c7fc9-446f-44a2-b72d-ce0fa985099f

Closes #395