### PR TITLE
Update v0.6.0 migration guide

### DIFF
--- a/docs/adr-009-consistent-implicit-fixture-name-normalization.md
+++ b/docs/adr-009-consistent-implicit-fixture-name-normalization.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Accepted
+Accepted (2026-04-12): Normalize implicit fixture names with a single leading
+underscore at macro expansion time, while keeping `#[from(...)]` authoritative.
 
 ## Date
 

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -2686,6 +2686,11 @@ Delivered behaviour:
   compatibility syntax for `scenarios!`, but explicit `harness = ...` and
   `attributes = ...` configuration is the canonical user-facing model.
 
+The [v0.6.0 migration guide](v0-6-0-migration-guide.md) is the canonical
+user-facing upgrade path for these delivered changes. It translates the
+fallible scenario, fixture-name normalization, harness adapter, and harness
+context decisions into concrete migration checks.
+
 The roadmap continues to track follow-on work such as additional cookbook
 material and harness-led attribute-policy defaults; see
 [Phase 9](roadmap.md#9-harness-adapters-and-attribute-plugins) for the

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -283,7 +283,7 @@ fn last_input(world: &ReportWorld) {
   `crates/rstest-bdd/tests/mutable_world_macro.rs` for a guarded example and
   `crates/rstest-bdd/tests/mutable_fixture.rs` for the context‑level regression
   test used until the upstream fix lands. Tracking details live in
-  `docs/known-issues.md#rustc-ice-with-mutable-world-macro`.
+  `docs/known-issues.md#rustc-internal-compiler-error-ice-with-mutable-world-macro`.
 - For advanced cases—custom fixture injection or manual borrowing—use
   `StepContext::insert_owned` and `StepContext::borrow_mut` directly; the
   examples above cover most scenarios.

--- a/docs/v0-6-0-migration-guide.md
+++ b/docs/v0-6-0-migration-guide.md
@@ -269,6 +269,17 @@ When `attributes = ...` is omitted, the macro infers
 path. Steps can request the injected `gpui::TestAppContext` with
 `#[from(rstest_bdd_harness_context)]`.
 
+## Further reading
+
+- [Developer guide](developers-guide.md) for macro expansion, fixture
+  registration, and harness implementation details.
+- [ADR 006: fallible scenario functions](adr-006-fallible-scenario-functions.md)
+  for the scenario `Result<(), E>` and `StepResult<(), E>` decision.
+- [ADR 007: harness context injection mechanism](adr-007-harness-context-injection.md)
+  for the `HarnessAdapter::Context` and `rstest_bdd_harness_context` design.
+- [ADR 009: consistent implicit fixture-name normalization](adr-009-consistent-implicit-fixture-name-normalization.md)
+  for the leading-underscore fixture-name normalization rule.
+
 ## Migration checklist
 
 - [ ] Review scenario and step parameters that start with `_`; add explicit

--- a/docs/v0-6-0-migration-guide.md
+++ b/docs/v0-6-0-migration-guide.md
@@ -269,17 +269,6 @@ When `attributes = ...` is omitted, the macro infers
 path. Steps can request the injected `gpui::TestAppContext` with
 `#[from(rstest_bdd_harness_context)]`.
 
-## Further reading
-
-- [Developer guide](developers-guide.md) for macro expansion, fixture
-  registration, and harness implementation details.
-- [ADR 006: fallible scenario functions](adr-006-fallible-scenario-functions.md)
-  for the scenario `Result<(), E>` and `StepResult<(), E>` decision.
-- [ADR 007: harness context injection mechanism](adr-007-harness-context-injection.md)
-  for the `HarnessAdapter::Context` and `rstest_bdd_harness_context` design.
-- [ADR 009: consistent implicit fixture-name normalization](adr-009-consistent-implicit-fixture-name-normalization.md)
-  for the leading-underscore fixture-name normalization rule.
-
 ## Migration checklist
 
 - [ ] Review scenario and step parameters that start with `_`; add explicit
@@ -310,3 +299,10 @@ path. Steps can request the injected `gpui::TestAppContext` with
   expected fixture
   - **Fix:** Use `#[from(_fixture_name)]` when the literal fixture key starts
     with an underscore.
+
+## Further reading
+
+- [Developer's guide](developers-guide.md)
+- [ADR 006 – Fallible scenario functions](adr-006-fallible-scenario-functions.md)
+- [ADR 007 – Harness context injection](adr-007-harness-context-injection.md)
+- [ADR 009 – Consistent implicit fixture-name normalisation](adr-009-consistent-implicit-fixture-name-normalization.md)

--- a/docs/v0-6-0-migration-guide.md
+++ b/docs/v0-6-0-migration-guide.md
@@ -1,31 +1,56 @@
 # v0.6.0 migration guide
 
-This guide highlights breaking changes between `v0.5.x` and `v0.6.0` that
-affect day-to-day usage of `rstest-bdd`.
+This guide covers user-facing changes made after the `v0.5.0` tag and before
+`v0.6.0`. It groups the changes by the amount of migration work they require:
+breaking changes, additive features that extend existing practice, and features
+that need a new testing practice to be useful.
 
-## Summary of changes
+## Breaking changes
 
-- Custom harness adapters now report harness infrastructure failures through
-  `HarnessResult<T>` instead of returning `T` directly.
+- Implicit fixture names now normalize exactly one leading underscore.
+  Parameters named `world` and `_world` both resolve to the implicit fixture
+  key `world`; `__world` resolves to `_world`. Explicit `#[from(...)]` fixture
+  names remain exact.
+- The legacy `scenarios!(..., runtime = "tokio-current-thread")` form now acts
+  as a deprecated compatibility alias for
+  `harness = rstest_bdd_harness_tokio::TokioHarness`. Generated tests are
+  synchronous and run inside the Tokio harness.
+- Custom implementations of the unreleased `HarnessAdapter` development API
+  must return `HarnessResult<T>` from `run`. This affects projects that adopted
+  the harness API from the `v0.6.0` development branch before the final release.
 
-## Affected cases
+### Update underscore-prefixed implicit fixtures
 
-Projects are affected if they define a custom type that implements
-`rstest_bdd_harness::HarnessAdapter`.
+If a scenario or step parameter used a leading underscore only to silence the
+Rust unused-variable lint, no source change is needed:
 
-## Required changes
+```rust,no_run
+#[scenario(path = "tests/features/search.feature")]
+fn search_works(_world: SearchWorld) {}
+```
 
-### 7) Update custom `HarnessAdapter` implementations
+The parameter above now requests the `world` fixture key. If the code intended
+to request a literal `_world` fixture key, make that intent explicit:
 
-`HarnessAdapter::run` now returns `HarnessResult<T>`, which is an alias for
+```rust,no_run
+#[scenario(path = "tests/features/search.feature")]
+fn search_works(#[from(_world)] world: SearchWorld) {}
+```
+
+Use the same pattern in step functions when a literal underscore-prefixed key
+is required. This keeps unused-binding naming and fixture selection separate.
+
+### Update custom harness adapters
+
+`HarnessAdapter::run` now returns `HarnessResult<T>`, an alias for
 `Result<T, HarnessError>`, instead of returning `T` directly. This makes
 harness infrastructure failures explicit: runtime construction failures, for
 example, are propagated as `Err(HarnessError::RuntimeBuildFailed(_))` rather
 than surfacing as opaque panics.
 
-**Before:**
+Before:
 
-```rust
+```rust,no_run
 use rstest_bdd_harness::{HarnessAdapter, StdScenarioRunRequest};
 
 struct MyHarness;
@@ -39,9 +64,9 @@ impl HarnessAdapter for MyHarness {
 }
 ```
 
-**After:**
+After:
 
-```rust
+```rust,no_run
 use rstest_bdd_harness::{HarnessAdapter, HarnessResult, StdScenarioRunRequest};
 
 struct MyHarness;
@@ -49,7 +74,10 @@ struct MyHarness;
 impl HarnessAdapter for MyHarness {
     type Context = ();
 
-    fn run<T>(&self, request: StdScenarioRunRequest<'_, T>) -> HarnessResult<T> {
+    fn run<T>(
+        &self,
+        request: StdScenarioRunRequest<'_, T>,
+    ) -> HarnessResult<T> {
         Ok(request.run_without_context())
     }
 }
@@ -58,24 +86,216 @@ impl HarnessAdapter for MyHarness {
 Harnesses that build runtimes or other infrastructure should map construction
 errors into `HarnessError` and use `?`:
 
-```rust
+```rust,no_run
 use rstest_bdd_harness::{HarnessError, HarnessResult};
 
-# fn build_runtime() -> HarnessResult<tokio::runtime::Runtime> {
-let runtime = tokio::runtime::Builder::new_current_thread()
-    .enable_all()
-    .build()
-    .map_err(HarnessError::RuntimeBuildFailed)?;
-# Ok(runtime)
-# }
+fn build_runtime() -> HarnessResult<tokio::runtime::Runtime> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(HarnessError::RuntimeBuildFailed)
+}
 ```
+
+Harnesses selected by `#[scenario(..., harness = ...)]` or
+`scenarios!(..., harness = ...)` are instantiated with `Default`, so custom
+harness types used through the macros must implement both `HarnessAdapter` and
+`Default`.
+
+## New features you can adopt by extending existing practice
+
+- `rstest-bdd-harness` provides shared harness adapter and attribute-policy
+  interfaces. Suites that already use `#[scenario]` or `scenarios!` can keep
+  their existing test shape and add harness configuration only where needed.
+- `#[scenario]` and `scenarios!` accept `harness = ...` and `attributes = ...`
+  arguments. These are additive macro arguments; existing scenario definitions
+  without them continue to run inline.
+- Known first-party harness paths infer their matching attribute policies when
+  `attributes = ...` is omitted: `rstest_bdd_harness::StdHarness`,
+  `rstest_bdd_harness_tokio::TokioHarness`, and
+  `rstest_bdd_harness_gpui::GpuiHarness`.
+- The language server accepts `--workspace-root` and
+  `RSTEST_BDD_LSP_WORKSPACE_ROOT` to override workspace discovery, and
+  `--debounce-ms` to tune file-change processing delay. Existing editor
+  integrations can adopt these as normal command-line or environment
+  configuration.
+- The `examples/tokio-reminders` and `examples/gpui-counter` crates provide
+  working examples for the new Tokio and GPUI harness integrations.
+
+## New features requiring new practices
+
+- Result-returning fixtures can now be passed to scenario functions as
+  `Result<T, E>` or `StepResult<T, E>`, but the scenario must also return a
+  fallible type so generated fixture unwrapping can use `?`.
+- Harness adapters can inject typed context through
+  `HarnessAdapter::Context`. Steps request that value with the reserved
+  `rstest_bdd_harness_context` fixture key.
+- Tokio integration should use the explicit
+  `rstest_bdd_harness_tokio::TokioHarness` form instead of the deprecated
+  `runtime = "tokio-current-thread"` compatibility syntax.
+- GPUI integration should use the opt-in `rstest-bdd-harness-gpui` crate and,
+  when native GPUI is used outside this workspace's shim, account for the
+  platform libraries required by upstream GPUI.
+- Third-party attribute policies still need explicit user documentation. The
+  macros trait-check user-provided policy types, but path-based code generation
+  only recognizes canonical first-party policy paths today.
+
+### Adopt fallible fixtures
+
+Use result-like fixture parameters when fixture construction can fail and the
+scenario should propagate that error directly:
+
+```rust,no_run
+use rstest::fixture;
+use rstest_bdd::StepResult;
+use rstest_bdd_macros::scenario;
+
+struct World;
+
+#[fixture]
+fn world() -> Result<World, String> {
+    Ok(World)
+}
+
+#[scenario(path = "tests/features/search.feature")]
+fn search_works(world: Result<World, String>) -> Result<(), String> {
+    Ok(())
+}
+```
+
+The generated scenario unwraps `world` with `?` before inserting the inner
+`World` value into `StepContext`. Borrowed result-like fixtures are rejected:
+use `Result<T, E>` or `StepResult<T, E>` by value rather than `&Result<T, E>`
+or `&StepResult<T, E>`.
+
+### Adopt harness context
+
+Harnesses that provide framework or application state should expose it through
+`HarnessAdapter::Context` and call `request.run(context)`:
+
+```rust,no_run
+use rstest_bdd_harness::{HarnessAdapter, HarnessResult, ScenarioRunRequest};
+
+#[derive(Default)]
+struct AppHarness;
+
+struct AppContext {
+    counter: usize,
+}
+
+impl HarnessAdapter for AppHarness {
+    type Context = AppContext;
+
+    fn run<T>(
+        &self,
+        request: ScenarioRunRequest<'_, Self::Context, T>,
+    ) -> HarnessResult<T> {
+        Ok(request.run(AppContext { counter: 7 }))
+    }
+}
+```
+
+Step functions request the harness-provided context with `#[from(...)]`:
+
+```rust,no_run
+use rstest_bdd_macros::given;
+
+#[given("the app counter starts at {n}")]
+fn starts_at(
+    #[from(rstest_bdd_harness_context)] app: &AppContext,
+    n: usize,
+) {
+    assert_eq!(app.counter, n);
+}
+```
+
+Harnesses that do not inject context should keep `type Context = ()` and call
+`request.run_without_context()`.
+
+### Migrate Tokio scenarios to explicit harness configuration
+
+Replace the deprecated `runtime = "tokio-current-thread"` syntax:
+
+```rust,no_run
+use rstest_bdd_macros::scenarios;
+
+scenarios!(
+    "tests/features/reminders",
+    runtime = "tokio-current-thread"
+);
+```
+
+with explicit harness selection:
+
+```rust,no_run
+use rstest_bdd_macros::scenarios;
+
+scenarios!(
+    "tests/features/reminders",
+    harness = rstest_bdd_harness_tokio::TokioHarness,
+);
+```
+
+`TokioHarness` runs synchronous scenario closures inside a Tokio current-thread
+runtime with a `LocalSet`. Step functions can use
+`tokio::runtime::Handle::current()` and `tokio::task::spawn_local`. Immediate
+`async fn` step definitions can complete under the harness, but multi-poll
+async steps that yield `Pending` are not supported in this mode. Use explicit
+`.await` coordination in the code under test, or use an async scenario with an
+external Tokio test attribute when the scenario itself must be asynchronous.
+
+### Adopt GPUI harness configuration
+
+Add the GPUI harness crate as a dev-dependency and select the first-party
+harness in scenarios that need GPUI test context injection:
+
+```toml
+[dev-dependencies]
+rstest-bdd-harness-gpui = "0.6.0"
+```
+
+```rust,no_run
+use rstest_bdd_macros::scenario;
+
+#[scenario(
+    path = "tests/features/counter.feature",
+    harness = rstest_bdd_harness_gpui::GpuiHarness,
+)]
+fn counter_updates() {}
+```
+
+When `attributes = ...` is omitted, the macro infers
+`rstest_bdd_harness_gpui::GpuiAttributePolicy` for the canonical `GpuiHarness`
+path. Steps can request the injected `gpui::TestAppContext` with
+`#[from(rstest_bdd_harness_context)]`.
 
 ## Migration checklist
 
-- [ ] Custom `HarnessAdapter` implementations updated to return
+- [ ] Review scenario and step parameters that start with `_`; add explicit
+  `#[from(_name)]` where the literal underscore-prefixed fixture key is
+  required.
+- [ ] Replace `scenarios!(..., runtime = "tokio-current-thread")` with
+  `harness = rstest_bdd_harness_tokio::TokioHarness`.
+- [ ] Update custom `HarnessAdapter` implementations to return
   `HarnessResult<T>` and wrap infallible paths in `Ok(...)`.
+- [ ] Use `request.run(context)` for harnesses with typed context and
+  `request.run_without_context()` for unit-context harnesses.
+- [ ] Make scenarios return `Result` or `StepResult` before passing
+  `Result<T, E>` or `StepResult<T, E>` fixtures by value.
+- [ ] Add `rstest-bdd-harness-tokio` or `rstest-bdd-harness-gpui` only to test
+  targets that need those framework integrations.
 
 ## Common errors and fixes
 
 - **Error:** type mismatch: expected `HarnessResult<T>`, found `T`
   - **Fix:** Wrap the return expression in `Ok(...)`.
+- **Error:** the trait bound `MyHarness: Default` is not satisfied
+  - **Fix:** Derive or implement `Default` for harness types selected by macro
+    `harness = ...` arguments.
+- **Error:** fixture parameter borrows a result-like type
+  - **Fix:** Pass the fixture as owned `Result<T, E>` or `StepResult<T, E>`,
+    and make the scenario return a compatible fallible type.
+- **Error:** an underscore-prefixed parameter no longer resolves to the
+  expected fixture
+  - **Fix:** Use `#[from(_fixture_name)]` when the literal fixture key starts
+    with an underscore.

--- a/docs/v0-6-0-migration-guide.md
+++ b/docs/v0-6-0-migration-guide.md
@@ -102,7 +102,7 @@ Harnesses selected by `#[scenario(..., harness = ...)]` or
 harness types used through the macros must implement both `HarnessAdapter` and
 `Default`.
 
-## New features you can adopt by extending existing practice
+## New features available by extending existing practice
 
 - `rstest-bdd-harness` provides shared harness adapter and attribute-policy
   interfaces. Suites that already use `#[scenario]` or `scenarios!` can keep


### PR DESCRIPTION
## Summary

This branch updates the v0.6.0 migration guide so release reviewers can see the user-facing changes since `v0.5.0` grouped by migration impact: breaking changes, additive features that extend existing practice, and features that require new testing practices.

No issue, roadmap task, or execplan is attached to this branch.

## Review walkthrough

- Start with [docs/v0-6-0-migration-guide.md](https://github.com/leynos/rstest-bdd/blob/dde1557cb9839695e8f30f86ade3dfc6cb2e3fd5/docs/v0-6-0-migration-guide.md#L1) for the new document structure and the three requested change groups.
- Review the breaking-change notes in [docs/v0-6-0-migration-guide.md](https://github.com/leynos/rstest-bdd/blob/dde1557cb9839695e8f30f86ade3dfc6cb2e3fd5/docs/v0-6-0-migration-guide.md#L8) for underscore fixture normalisation, Tokio runtime compatibility syntax, and custom harness adapter migration.
- Review the adoption guidance in [docs/v0-6-0-migration-guide.md](https://github.com/leynos/rstest-bdd/blob/dde1557cb9839695e8f30f86ade3dfc6cb2e3fd5/docs/v0-6-0-migration-guide.md#L103) for harness configuration, fallible fixtures, harness context, Tokio, and GPUI practices.

## Validation

- `make check-fmt`: passed.
- `make markdownlint`: passed.
- `make nixie`: passed.
- `make lint`: passed.
- `make test`: passed; 1355 Rust tests passed, 7 skipped, and 62 Python release-automation tests passed.
- `make fmt`: attempted; it failed on existing Markdown MD013 line-length findings outside [docs/v0-6-0-migration-guide.md](https://github.com/leynos/rstest-bdd/blob/dde1557cb9839695e8f30f86ade3dfc6cb2e3fd5/docs/v0-6-0-migration-guide.md). The changed guide passes `markdownlint`.

## Notes

The branch uses a single documentation commit: `dde1557 Update v0.6.0 migration guide`.