### PR TITLE
Record beta feedback roadmap outcomes

### DIFF
--- a/crates/rstest-bdd/tests/fixtures_macros/scenario_missing_file.rs
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenario_missing_file.rs
@@ -1,3 +1,6 @@
+//! Trybuild fixture for the `#[scenario]` macro when the requested feature
+//! file does not exist.
+
 use rstest_bdd_macros::scenario;
 
 #[scenario(path = "tests/features/does_not_exist.feature")]

--- a/crates/rstest-bdd/tests/fixtures_macros/scenario_missing_file.stderr
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenario_missing_file.stderr
@@ -1,7 +1,7 @@
 error: feature file not found: $WORKSPACE/target/tests/trybuild/rstest-bdd/tests/features/does_not_exist.feature
- --> tests/fixtures_macros/scenario_missing_file.rs:3:1
+ --> tests/fixtures_macros/scenario_missing_file.rs:6:1
   |
-3 | #[scenario(path = "tests/features/does_not_exist.feature")]
+6 | #[scenario(path = "tests/features/does_not_exist.feature")]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/rstest-bdd/tests/fixtures_macros/scenario_missing_path.rs
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenario_missing_path.rs
@@ -1,3 +1,6 @@
+//! Trybuild fixture for the `#[scenario]` macro when the required feature-file
+//! path argument is omitted.
+
 use rstest_bdd_macros::scenario;
 
 #[scenario(index = 0)]

--- a/crates/rstest-bdd/tests/fixtures_macros/scenario_missing_path.stderr
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenario_missing_path.stderr
@@ -1,7 +1,7 @@
 error: unexpected end of input, `path` argument is required
- --> tests/fixtures_macros/scenario_missing_path.rs:3:1
+ --> tests/fixtures_macros/scenario_missing_path.rs:6:1
   |
-3 | #[scenario(index = 0)]
+6 | #[scenario(index = 0)]
   | ^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the attribute macro `scenario` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/rstest-bdd/tests/fixtures_macros/scenario_missing_step_warning.rs
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenario_missing_step_warning.rs
@@ -1,3 +1,6 @@
+//! Trybuild fixture for the `#[scenario]` macro warning emitted when a feature
+//! file contains a step without a matching registered step definition.
+
 use rstest_bdd_macros::scenario;
 
 #[scenario(path = "../features/macros/unmatched.feature")]

--- a/crates/rstest-bdd/tests/fixtures_macros/scenario_missing_step_warning.stderr
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenario_missing_step_warning.stderr
@@ -1,5 +1,5 @@
 error: forced failure
- --> tests/fixtures_macros/scenario_missing_step_warning.rs:7:1
-  |
-7 | compile_error!("forced failure");
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  --> tests/fixtures_macros/scenario_missing_step_warning.rs:10:1
+   |
+10 | compile_error!("forced failure");
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/rstest-bdd/tests/fixtures_macros/scenario_out_of_order.rs
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenario_out_of_order.rs
@@ -1,3 +1,6 @@
+//! Trybuild fixture for `#[scenario]` step discovery when the step definition
+//! macro is registered after the scenario binding.
+
 use rstest_bdd_macros::{given, scenario};
 
 #[scenario(path = "../features/macros/ambiguous.feature")]

--- a/crates/rstest-bdd/tests/fixtures_macros/scenario_state_default.rs
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenario_state_default.rs
@@ -1,3 +1,6 @@
+//! Trybuild fixture for the `ScenarioState` derive macro when the state type
+//! also derives `Default` and contains a resettable `Slot` field.
+
 use rstest_bdd::Slot;
 use rstest_bdd::ScenarioState as _;
 use rstest_bdd_macros::ScenarioState;

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -697,14 +697,14 @@ changing the public trait contracts.
   custom harness dependency matrix, and fixture-generation tests or docs prove
   first-party adapters compile without a direct base-harness dependency. Design
   Doc: `docs/rstest-bdd-design.md` §2.7.6.3. (Dinolump)
-- [ ] 10.1.2. Display detailed missing-fixture diagnostics for harness context
-  and mutable scenario state, showing the requested fixture name and type,
-  inserted fixtures from `StepContext::available_fixtures()`, and, when
-  `rstest_bdd_harness_context` is absent, suggest selecting the relevant
-  harness. Finish line: a regression test reproduces a missing-fixture failure
-  and asserts the diagnostic contains the requested fixture name, requested
-  type, inserted fixture list, and harness suggestion. Design Doc:
-  `docs/rstest-bdd-design.md` §2.7.6.3. (Telefono)
+- [ ] 10.1.2. Provide detailed missing-fixture diagnostics that include the
+  requested fixture name and type, the list of inserted fixtures from
+  `StepContext::available_fixtures()`, and, when
+  `rstest_bdd_harness_context` is absent, a suggested harness to select. Finish
+  line: a regression test reproduces the missing-fixture failure and asserts
+  the diagnostic contains the requested fixture name, requested type, inserted
+  fixture list, and harness suggestion. Design Doc: `docs/rstest-bdd-design.md`
+  §2.7.6.3. (Telefono)
 - [ ] 10.1.3. The feature-gated GPUI test suite provides realistic harness
   regression coverage beyond the counter example: it creates a window, persists
   durable entity/window handles, reconstructs visual context per step, resets

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -715,7 +715,7 @@ changing the public trait contracts.
   Doc: `docs/rstest-bdd-design.md` §2.7.6.2. (Doggylump)
 - [ ] 10.1.4. Failing GPUI scenarios include the scenario name in logs where
   `GpuiHarness` and `gpui::TestAppContext` permit it, or the harness docs
-  document the upstream limitation so developers can quickly orientate failing
+  document the upstream limitation, so developers can quickly orientate failing
   scenarios. Finish line: a failing-harness regression asserts the scenario
   name appears in emitted diagnostics, or the GPUI harness docs state the
   upstream limitation and link the skipped test. Prerequisite: 9.4.3. Design
@@ -734,7 +734,7 @@ changing the public trait contracts.
   the `E0499`/`E0502` symptoms for two mutable `StepContext` fixtures, why the
   pattern fails, and recommended workarounds before downstream users reach
   compiler-error archaeology. Finish line: `docs/v0-6-0-migration-guide.md`
-  contains the troubleshooting entry and links the borrow-constraint design
+  contains the troubleshooting entry and links to the borrow-constraint design
   subsection. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.1. (Telefono)
 - [ ] 10.2.3. The v0.6.0 migration guide warns users to run downstream tests
   through the repository's CI-equivalent gate and to run feature-gated tests,
@@ -756,7 +756,7 @@ remove the existing `StepContext`, harness, or macro surfaces.
   type mismatch, immutable fixture requested mutably, and already-borrowed
   fixture cases, so generated wrappers produce targeted diagnostics instead of
   collapsing every extraction failure into `MissingFixture`. Finish line: unit
-  tests cover every variant and generated-wrapper tests assert each variant maps
+  tests cover every variant, and generated-wrapper tests assert each variant maps
   to the expected diagnostic. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.4.
   (Telefono)
 - [ ] 11.1.2. Generated code has an additive mutable-borrow helper that reduces
@@ -771,7 +771,7 @@ remove the existing `StepContext`, harness, or macro surfaces.
   `with_mut`, `take`, and `reset` operations for complex adapters without
   per-scenario thread-local `RefCell` boilerplate. Unit tests cover the helper,
   and docs present it as an additive alternative to ad-hoc GPUI world state.
-  Finish line: unit tests exercise all five operations and docs show a GPUI
+  Finish line: unit tests exercise all five operations, and docs show a GPUI
   world-state example using the helper. Design Doc: `docs/rstest-bdd-design.md`
   §2.7.6.4. (Dinolump)
 - [ ] 11.1.4. Users can register per-scenario cleanup for stateful adapters, so
@@ -790,7 +790,7 @@ remove the existing `StepContext`, harness, or macro surfaces.
   examples compile using `#[harness_context]`. Design Doc:
   `docs/rstest-bdd-design.md` §2.7.6.4. (Dinolump)
 - [ ] 11.2.2. The public prelude exposes `StepResult`, `Slot`, `ScenarioState`,
-  harness-context helpers, and marker attributes from 11.2.1 so examples can
+  harness-context helpers, and marker attributes from 11.2.1, so examples can
   import one predictable module without hiding the underlying crates.
   Finish line: compile tests prove examples import only the prelude plus their
   harness crate, and docs list the exported items. Prerequisite: 11.2.1. Design
@@ -830,7 +830,7 @@ predictable.
   Public callers retain value access methods, and internal variants are no
   longer part of the public surface. Prerequisite: 12.1.1. Design Doc:
   `docs/rstest-bdd-design.md` §2.7.6.5. Finish line: public API tests compile
-  against accessor methods and no downstream test can match internal variants.
+  against accessor methods, and no downstream test can match internal variants.
   (Telefono)
 - [ ] 12.1.3. A stable world lifecycle contract guarantees before-scenario
   reset, after-scenario cleanup, and cleanup on failure or skip, so users can

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -690,19 +690,18 @@ changing the public trait contracts.
 
 ### 10.1. Remove avoidable harness adoption friction
 
-- [ ] 10.1.1. Clarify or hide the base harness-crate dependency for
-  first-party adapters. Normal GPUI and Tokio users should either need only the
-  adapter crate in their `Cargo.toml`, or the migration guide must state
-  exactly when `rstest-bdd-harness` is required. Finish line: the dependency
-  matrix in `docs/v0-6-0-migration-guide.md` covers plain BDD, Tokio, GPUI, and
-  custom harnesses; generated-code behaviour is tested or documented. Design
-  Doc: `docs/rstest-bdd-design.md` §2.7.6.3. (Dinolump)
-- [ ] 10.1.2. Improve missing-fixture diagnostics for harness context and
-  mutable scenario state. Use `StepContext::available_fixtures()` in generated
-  error paths so users see the requested fixture, requested type, and fixtures
-  that were actually inserted. Finish line: diagnostics explain a missing
-  `rstest_bdd_harness_context` and suggest selecting the relevant harness.
-  Design Doc: `docs/rstest-bdd-design.md` §2.7.6.3. (Telefono)
+- [ ] 10.1.1. Users of first-party adapters can depend only on the adapter
+  crate in `Cargo.toml`; `rstest-bdd-harness` is required only for custom
+  harness implementations or explicit use of the base harness API. Finish line:
+  the dependency matrix in `docs/v0-6-0-migration-guide.md` covers plain BDD,
+  Tokio, GPUI, and custom harnesses; documented or generated-code behaviour
+  matches that dependency boundary. Design Doc: `docs/rstest-bdd-design.md`
+  §2.7.6.3. (Dinolump)
+- [ ] 10.1.2. Display detailed missing-fixture diagnostics for harness context
+  and mutable scenario state, showing the requested fixture name and type,
+  inserted fixtures from `StepContext::available_fixtures()`, and, when
+  `rstest_bdd_harness_context` is absent, suggest selecting the relevant
+  harness. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.3. (Telefono)
 - [ ] 10.1.3. Add a realistic GPUI harness regression that exercises the
   downstream migration shape: create a window, store durable entity/window
   handles, reconstruct visual context per step, and reset scenario state before

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -679,3 +679,176 @@ implementation commitments.
   first-party integrations, examples no longer require both parameters by
   default, and `make markdownlint` passes. Prerequisite: 9.7.3. Design Doc:
   `docs/adr-008-harness-led-attribute-policy-defaults.md`. (Dinolump)
+
+## 10. First-cut beta feedback: v0.6.0-beta2 quick wins
+
+The first downstream beta migration showed that the harness architecture is
+usable, but that stateful GPUI adoption needs clearer defaults, diagnostics,
+and examples before the final v0.6.0 release. This phase prioritizes small,
+non-breaking changes that make the current model easier to adopt without
+changing the public trait contracts.
+
+### 10.1. Remove avoidable harness adoption friction
+
+- [ ] 10.1.1. Clarify or hide the base harness-crate dependency for
+  first-party adapters. Normal GPUI and Tokio users should either need only the
+  adapter crate in their `Cargo.toml`, or the migration guide must state
+  exactly when `rstest-bdd-harness` is required. Finish line: the dependency
+  matrix in `docs/v0-6-0-migration-guide.md` covers plain BDD, Tokio, GPUI, and
+  custom harnesses; generated-code behaviour is tested or documented. Design
+  Doc: `docs/rstest-bdd-design.md` §2.7.6. (Dinolump)
+- [ ] 10.1.2. Improve missing-fixture diagnostics for harness context and
+  mutable scenario state. Use `StepContext::available_fixtures()` in generated
+  error paths so users see the requested fixture, requested type, and fixtures
+  that were actually inserted. Finish line: diagnostics explain a missing
+  `rstest_bdd_harness_context` and suggest selecting the relevant harness.
+  Design Doc: `docs/rstest-bdd-design.md` §2.7.6. (Telefono)
+- [ ] 10.1.3. Add a realistic GPUI harness regression that exercises the
+  downstream migration shape: create a window, store durable entity/window
+  handles, reconstruct visual context per step, and reset scenario state before
+  assigning it. Finish line: the feature-gated GPUI suite covers more than the
+  counter example and documents the reset protocol in comments. Prerequisite:
+  9.4.5. Design Doc: `docs/rstest-bdd-design.md` §2.7.6. (Doggylump)
+- [ ] 10.1.4. Pass scenario metadata into `GpuiHarness` where GPUI permits it,
+  or document why upstream `gpui::TestAppContext` cannot currently expose the
+  scenario name. Finish line: failing GPUI scenarios are easier to orientate in
+  logs, or the limitation is captured in the harness docs. Prerequisite: 9.4.3.
+  Design Doc: `docs/rstest-bdd-design.md` §2.7.5. (Buzzy Bee)
+
+### 10.2. Update adoption documentation before v0.6.0 final
+
+- [ ] 10.2.1. Add a GPUI migration playbook to the user guide and migration
+  guide. Cover `GpuiHarness`, the reserved harness-context fixture key, durable
+  entity/window handles, `VisualTestContext` reconstruction, and the explicit
+  world-reset protocol. Finish line: users can migrate a stateful GPUI test
+  without reading macro expansion or GPUI harness source. Design Doc:
+  `docs/rstest-bdd-design.md` §2.7.6. (Dinolump)
+- [ ] 10.2.2. Add a "mutable harness context plus world state" troubleshooting
+  entry. Include the `E0499`/`E0502` symptom class, explain why two mutable
+  `StepContext` fixtures are difficult today, and point to sanctioned
+  workarounds. Finish line: the migration guide explains the failure before a
+  downstream user reaches compiler-error archaeology. Design Doc:
+  `docs/rstest-bdd-design.md` §2.7.6. (Telefono)
+- [ ] 10.2.3. Add a migration checklist reminder to run downstream tests through
+  the repository's CI-equivalent gate. Finish line: the v0.6.0 migration guide
+  explicitly warns that feature-gated test helpers may require
+  `cargo test --all-features` or a project `make test` target before API
+  diagnosis is meaningful. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.
+  (Doggylump)
+
+## 11. Early-life support: v0.6.1 additive hardening
+
+The v0.6.1 line should stay semver-compatible. It can add helper APIs,
+diagnostics, examples, and generated-wrapper improvements, but it must not
+remove the existing `StepContext`, harness, or macro surfaces.
+
+### 11.1. Add borrow and state helpers without breaking callers
+
+- [ ] 11.1.1. Introduce a structured `FixtureBorrowError` for generated and
+  manual fixture extraction. Distinguish missing fixture, type mismatch,
+  immutable fixture requested mutably, and already-borrowed fixture cases.
+  Finish line: generated wrappers can produce targeted diagnostics instead of
+  collapsing every extraction failure into `MissingFixture`. Design Doc:
+  `docs/rstest-bdd-design.md` §2.7.6. (Telefono)
+- [ ] 11.1.2. Add an additive mutable-borrow helper for generated code that
+  reduces unnecessary `&mut StepContext` contention where possible. Preserve
+  the existing `borrow_mut(&mut self, ...)` API. Finish line: regression tests
+  cover mutable harness context plus scenario state, or document precisely why
+  the full fix must wait for v0.7.0. Design Doc: `docs/rstest-bdd-design.md`
+  §2.7.6. (Pandalump)
+- [ ] 11.1.3. Add a scenario-local state helper with explicit reset semantics
+  for complex adapters. The helper should support `set`, `with`, `with_mut`,
+  `take`, and `reset` without requiring users to hand-roll thread-local
+  `RefCell` boilerplate. Finish line: the helper is covered by unit tests and
+  documented as an additive alternative to ad-hoc GPUI world state. Design Doc:
+  `docs/rstest-bdd-design.md` §2.7.6. (Dinolump)
+- [ ] 11.1.4. Add an opt-in reset hook or reset marker for generated scenarios.
+  Finish line: users can register per-scenario cleanup for stateful adapters
+  without relying on every `#[given]` implementation to remember the reset
+  call. Prerequisite: 11.1.3. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.
+  (Doggylump)
+
+### 11.2. Smooth integration ergonomics
+
+- [ ] 11.2.1. Add an explicit harness-context parameter marker, such as
+  `#[harness_context]`, while keeping `#[from(rstest_bdd_harness_context)]`
+  supported. Finish line: examples lead with the readable marker and generated
+  code continues to use the reserved fixture key internally. Design Doc:
+  `docs/rstest-bdd-design.md` §2.7.6. (Dinolump)
+- [ ] 11.2.2. Add a public prelude for common integration imports. Include
+  `StepResult`, `Slot`, `ScenarioState`, harness-context helpers, and any
+  marker attribute that lands in 11.2.1. Finish line: examples can use one
+  predictable import without hiding the underlying crates. Prerequisite:
+  11.2.1. Design Doc: `docs/rstest-bdd-design.md` §2.7.6. (Dinolump)
+- [ ] 11.2.3. Harden attribute-policy and harness-path diagnostics for renamed
+  or re-exported first-party paths. Finish line: users selecting a known
+  first-party harness through a non-canonical path get actionable guidance to
+  add `attributes = ...` explicitly. Design Doc: `docs/rstest-bdd-design.md`
+  §§2.7.3-2.7.6. (Telefono)
+- [ ] 11.2.4. Expand the compatibility matrix for downstream shapes: mutable
+  world, fallible fixture, Tokio harness, GPUI harness with shared context,
+  GPUI harness with mutable context and scenario state, and scenario outline.
+  Finish line: CI proves these shapes remain viable across v0.6.x patches.
+  Design Doc: `docs/rstest-bdd-design.md` §2.7.6. (Buzzy Bee)
+
+## 12. Pre-1.0.0 API consolidation: v0.7.0 ambitions
+
+The v0.7.0 line is the last planned place for migration-guide-worthy API
+cleanup before v1.0.0. This phase intentionally collects changes that would be
+too disruptive for v0.6.x but would make the v1 surface smaller and more
+predictable.
+
+### 12.1. Redesign state and context borrowing
+
+- [ ] 12.1.1. Redesign `StepContext` around guard-based interior borrowing so
+  distinct mutable fixtures can be borrowed concurrently. Replace
+  `Option`-based borrow APIs with `Result`-returning APIs that carry
+  `FixtureBorrowError`. Finish line: a step can legally borrow mutable harness
+  context and mutable world state when the fixture keys differ, with regression
+  coverage for generated wrappers. Design Doc: `docs/rstest-bdd-design.md`
+  §2.7.6. (Pandalump, Telefono)
+- [ ] 12.1.2. Make `FixtureRefMut` opaque if needed to support the redesigned
+  borrow internals. Finish line: public callers retain value access methods,
+  but enum variants no longer freeze the internal representation. Prerequisite:
+  12.1.1. Design Doc: `docs/rstest-bdd-design.md` §2.7.6. (Telefono)
+- [ ] 12.1.3. Introduce a first-class world lifecycle contract. Support
+  before-scenario reset, after-scenario cleanup, and cleanup on failure or
+  skip. Finish line: users can model scenario state without thread-local reset
+  conventions, and the migration guide explains how v0.6 workarounds map to the
+  v0.7 lifecycle. Prerequisite: 12.1.1. Design Doc: `docs/rstest-bdd-design.md`
+  §2.7.6. (Doggylump)
+
+### 12.2. Simplify harness and generated-test APIs
+
+- [ ] 12.2.1. Replace the user-facing reserved harness fixture key with typed
+  extractors such as `Harness<T>` or `HarnessMut<T>`, or with a stable
+  attribute marker. Finish line: users no longer need to spell
+  `rstest_bdd_harness_context` in ordinary harness-backed steps. Requires
+  11.2.1 or equivalent design validation. Design Doc:
+  `docs/rstest-bdd-design.md` §2.7.6. (Dinolump, Telefono)
+- [ ] 12.2.2. Remove the macro-selected harness `Default` requirement by
+  supporting a factory expression or equivalent configuration contract. Finish
+  line: configurable harnesses no longer require zero-sized wrapper types
+  solely for macro instantiation. Design Doc: `docs/rstest-bdd-design.md`
+  §§2.7.3, 2.7.6. (Pandalump)
+- [ ] 12.2.3. Replace path-recognized attribute-policy inference with a
+  declarative extension model that third-party harness crates can participate
+  in. Finish line: first-party and third-party integrations use one explicit
+  metadata mechanism instead of macro-local path tables. Design Doc:
+  `docs/rstest-bdd-design.md` §§2.7.3-2.7.6. (Telefono)
+- [ ] 12.2.4. Unify generated tests for `#[scenario]`, `scenarios!`, scenarios,
+  and outline rows around a stable generated-test model. Finish line: each
+  generated Rust test has a readable name and isolated lifecycle, and failure
+  reports no longer depend on hidden loops over unrelated scenarios. Design
+  Doc: `docs/rstest-bdd-design.md` §2.7.6. (Doggylump)
+- [ ] 12.2.5. Decide the async harness trait surface before v1.0.0. Either keep
+  harnesses synchronous with documented async limitations, or introduce an
+  async harness trait and migration path. Finish line: Tokio and future async
+  adapters have a coherent v1 story for multi-poll steps, cancellation, and
+  runtime ownership. Design Doc: `docs/rstest-bdd-design.md` §§2.5, 2.7.6.
+  (Buzzy Bee)
+- [ ] 12.2.6. Rationalize crate topology for the v1 user experience. Evaluate
+  feature-gated first-party integrations on `rstest-bdd` versus the current
+  explicit adapter-crate model. Finish line: the v1 packaging decision is
+  recorded in an ADR and reflected in migration docs. Design Doc:
+  `docs/rstest-bdd-design.md` §2.7.6. (Pandalump)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -696,19 +696,19 @@ changing the public trait contracts.
   exactly when `rstest-bdd-harness` is required. Finish line: the dependency
   matrix in `docs/v0-6-0-migration-guide.md` covers plain BDD, Tokio, GPUI, and
   custom harnesses; generated-code behaviour is tested or documented. Design
-  Doc: `docs/rstest-bdd-design.md` §2.7.6. (Dinolump)
+  Doc: `docs/rstest-bdd-design.md` §2.7.6.3. (Dinolump)
 - [ ] 10.1.2. Improve missing-fixture diagnostics for harness context and
   mutable scenario state. Use `StepContext::available_fixtures()` in generated
   error paths so users see the requested fixture, requested type, and fixtures
   that were actually inserted. Finish line: diagnostics explain a missing
   `rstest_bdd_harness_context` and suggest selecting the relevant harness.
-  Design Doc: `docs/rstest-bdd-design.md` §2.7.6. (Telefono)
+  Design Doc: `docs/rstest-bdd-design.md` §2.7.6.3. (Telefono)
 - [ ] 10.1.3. Add a realistic GPUI harness regression that exercises the
   downstream migration shape: create a window, store durable entity/window
   handles, reconstruct visual context per step, and reset scenario state before
   assigning it. Finish line: the feature-gated GPUI suite covers more than the
   counter example and documents the reset protocol in comments. Prerequisite:
-  9.4.5. Design Doc: `docs/rstest-bdd-design.md` §2.7.6. (Doggylump)
+  9.4.5. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.2. (Doggylump)
 - [ ] 10.1.4. Pass scenario metadata into `GpuiHarness` where GPUI permits it,
   or document why upstream `gpui::TestAppContext` cannot currently expose the
   scenario name. Finish line: failing GPUI scenarios are easier to orientate in
@@ -722,18 +722,18 @@ changing the public trait contracts.
   entity/window handles, `VisualTestContext` reconstruction, and the explicit
   world-reset protocol. Finish line: users can migrate a stateful GPUI test
   without reading macro expansion or GPUI harness source. Design Doc:
-  `docs/rstest-bdd-design.md` §2.7.6. (Dinolump)
+  `docs/rstest-bdd-design.md` §2.7.6.2. (Dinolump)
 - [ ] 10.2.2. Add a "mutable harness context plus world state" troubleshooting
   entry. Include the `E0499`/`E0502` symptom class, explain why two mutable
   `StepContext` fixtures are difficult today, and point to sanctioned
   workarounds. Finish line: the migration guide explains the failure before a
   downstream user reaches compiler-error archaeology. Design Doc:
-  `docs/rstest-bdd-design.md` §2.7.6. (Telefono)
+  `docs/rstest-bdd-design.md` §2.7.6.1. (Telefono)
 - [ ] 10.2.3. Add a migration checklist reminder to run downstream tests through
   the repository's CI-equivalent gate. Finish line: the v0.6.0 migration guide
   explicitly warns that feature-gated test helpers may require
   `cargo test --all-features` or a project `make test` target before API
-  diagnosis is meaningful. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.
+  diagnosis is meaningful. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.3.
   (Doggylump)
 
 ## 11. Early-life support: v0.6.1 additive hardening
@@ -749,23 +749,24 @@ remove the existing `StepContext`, harness, or macro surfaces.
   immutable fixture requested mutably, and already-borrowed fixture cases.
   Finish line: generated wrappers can produce targeted diagnostics instead of
   collapsing every extraction failure into `MissingFixture`. Design Doc:
-  `docs/rstest-bdd-design.md` §2.7.6. (Telefono)
+  `docs/rstest-bdd-design.md` §2.7.6.4. (Telefono)
 - [ ] 11.1.2. Add an additive mutable-borrow helper for generated code that
   reduces unnecessary `&mut StepContext` contention where possible. Preserve
   the existing `borrow_mut(&mut self, ...)` API. Finish line: regression tests
   cover mutable harness context plus scenario state, or document precisely why
   the full fix must wait for v0.7.0. Design Doc: `docs/rstest-bdd-design.md`
-  §2.7.6. (Pandalump)
+  §2.7.6.4. (Pandalump)
 - [ ] 11.1.3. Add a scenario-local state helper with explicit reset semantics
   for complex adapters. The helper should support `set`, `with`, `with_mut`,
   `take`, and `reset` without requiring users to hand-roll thread-local
   `RefCell` boilerplate. Finish line: the helper is covered by unit tests and
   documented as an additive alternative to ad-hoc GPUI world state. Design Doc:
-  `docs/rstest-bdd-design.md` §2.7.6. (Dinolump)
+  `docs/rstest-bdd-design.md` §2.7.6.4. (Dinolump)
 - [ ] 11.1.4. Add an opt-in reset hook or reset marker for generated scenarios.
   Finish line: users can register per-scenario cleanup for stateful adapters
   without relying on every `#[given]` implementation to remember the reset
-  call. Prerequisite: 11.1.3. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.
+  call. Prerequisite: 11.1.3. Design Doc: `docs/rstest-bdd-design.md`
+  §2.7.6.4.
   (Doggylump)
 
 ### 11.2. Smooth integration ergonomics
@@ -774,22 +775,22 @@ remove the existing `StepContext`, harness, or macro surfaces.
   `#[harness_context]`, while keeping `#[from(rstest_bdd_harness_context)]`
   supported. Finish line: examples lead with the readable marker and generated
   code continues to use the reserved fixture key internally. Design Doc:
-  `docs/rstest-bdd-design.md` §2.7.6. (Dinolump)
+  `docs/rstest-bdd-design.md` §2.7.6.4. (Dinolump)
 - [ ] 11.2.2. Add a public prelude for common integration imports. Include
   `StepResult`, `Slot`, `ScenarioState`, harness-context helpers, and any
   marker attribute that lands in 11.2.1. Finish line: examples can use one
   predictable import without hiding the underlying crates. Prerequisite:
-  11.2.1. Design Doc: `docs/rstest-bdd-design.md` §2.7.6. (Dinolump)
+  11.2.1. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.4. (Dinolump)
 - [ ] 11.2.3. Harden attribute-policy and harness-path diagnostics for renamed
   or re-exported first-party paths. Finish line: users selecting a known
   first-party harness through a non-canonical path get actionable guidance to
   add `attributes = ...` explicitly. Design Doc: `docs/rstest-bdd-design.md`
-  §§2.7.3-2.7.6. (Telefono)
+  §§2.7.3-2.7.6.4. (Telefono)
 - [ ] 11.2.4. Expand the compatibility matrix for downstream shapes: mutable
   world, fallible fixture, Tokio harness, GPUI harness with shared context,
   GPUI harness with mutable context and scenario state, and scenario outline.
   Finish line: CI proves these shapes remain viable across v0.6.x patches.
-  Design Doc: `docs/rstest-bdd-design.md` §2.7.6. (Buzzy Bee)
+  Design Doc: `docs/rstest-bdd-design.md` §2.7.6.4. (Buzzy Bee)
 
 ## 12. Pre-1.0.0 API consolidation: v0.7.0 ambitions
 
@@ -806,17 +807,17 @@ predictable.
   `FixtureBorrowError`. Finish line: a step can legally borrow mutable harness
   context and mutable world state when the fixture keys differ, with regression
   coverage for generated wrappers. Design Doc: `docs/rstest-bdd-design.md`
-  §2.7.6. (Pandalump, Telefono)
+  §2.7.6.5. (Pandalump, Telefono)
 - [ ] 12.1.2. Make `FixtureRefMut` opaque if needed to support the redesigned
   borrow internals. Finish line: public callers retain value access methods,
   but enum variants no longer freeze the internal representation. Prerequisite:
-  12.1.1. Design Doc: `docs/rstest-bdd-design.md` §2.7.6. (Telefono)
+  12.1.1. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.5. (Telefono)
 - [ ] 12.1.3. Introduce a first-class world lifecycle contract. Support
   before-scenario reset, after-scenario cleanup, and cleanup on failure or
   skip. Finish line: users can model scenario state without thread-local reset
   conventions, and the migration guide explains how v0.6 workarounds map to the
   v0.7 lifecycle. Prerequisite: 12.1.1. Design Doc: `docs/rstest-bdd-design.md`
-  §2.7.6. (Doggylump)
+  §2.7.6.5. (Doggylump)
 
 ### 12.2. Simplify harness and generated-test APIs
 
@@ -825,30 +826,30 @@ predictable.
   attribute marker. Finish line: users no longer need to spell
   `rstest_bdd_harness_context` in ordinary harness-backed steps. Requires
   11.2.1 or equivalent design validation. Design Doc:
-  `docs/rstest-bdd-design.md` §2.7.6. (Dinolump, Telefono)
+  `docs/rstest-bdd-design.md` §2.7.6.5. (Dinolump, Telefono)
 - [ ] 12.2.2. Remove the macro-selected harness `Default` requirement by
   supporting a factory expression or equivalent configuration contract. Finish
   line: configurable harnesses no longer require zero-sized wrapper types
   solely for macro instantiation. Design Doc: `docs/rstest-bdd-design.md`
-  §§2.7.3, 2.7.6. (Pandalump)
+  §§2.7.3, 2.7.6.5. (Pandalump)
 - [ ] 12.2.3. Replace path-recognized attribute-policy inference with a
   declarative extension model that third-party harness crates can participate
   in. Finish line: first-party and third-party integrations use one explicit
   metadata mechanism instead of macro-local path tables. Design Doc:
-  `docs/rstest-bdd-design.md` §§2.7.3-2.7.6. (Telefono)
+  `docs/rstest-bdd-design.md` §§2.7.3-2.7.6.5. (Telefono)
 - [ ] 12.2.4. Unify generated tests for `#[scenario]`, `scenarios!`, scenarios,
   and outline rows around a stable generated-test model. Finish line: each
   generated Rust test has a readable name and isolated lifecycle, and failure
   reports no longer depend on hidden loops over unrelated scenarios. Design
-  Doc: `docs/rstest-bdd-design.md` §2.7.6. (Doggylump)
+  Doc: `docs/rstest-bdd-design.md` §2.7.6.5. (Doggylump)
 - [ ] 12.2.5. Decide the async harness trait surface before v1.0.0. Either keep
   harnesses synchronous with documented async limitations, or introduce an
   async harness trait and migration path. Finish line: Tokio and future async
   adapters have a coherent v1 story for multi-poll steps, cancellation, and
-  runtime ownership. Design Doc: `docs/rstest-bdd-design.md` §§2.5, 2.7.6.
+  runtime ownership. Design Doc: `docs/rstest-bdd-design.md` §§2.5, 2.7.6.5.
   (Buzzy Bee)
 - [ ] 12.2.6. Rationalize crate topology for the v1 user experience. Evaluate
   feature-gated first-party integrations on `rstest-bdd` versus the current
   explicit adapter-crate model. Finish line: the v1 packaging decision is
   recorded in an ADR and reflected in migration docs. Design Doc:
-  `docs/rstest-bdd-design.md` §2.7.6. (Pandalump)
+  `docs/rstest-bdd-design.md` §2.7.6.5. (Pandalump)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -702,40 +702,37 @@ changing the public trait contracts.
   inserted fixtures from `StepContext::available_fixtures()`, and, when
   `rstest_bdd_harness_context` is absent, suggest selecting the relevant
   harness. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.3. (Telefono)
-- [ ] 10.1.3. Add a realistic GPUI harness regression that exercises the
-  downstream migration shape: create a window, store durable entity/window
-  handles, reconstruct visual context per step, and reset scenario state before
-  assigning it. Finish line: the feature-gated GPUI suite covers more than the
-  counter example and documents the reset protocol in comments. Prerequisite:
-  9.4.5. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.2. (Doggylump)
-- [ ] 10.1.4. Pass scenario metadata into `GpuiHarness` where GPUI permits it,
-  or document why upstream `gpui::TestAppContext` cannot currently expose the
-  scenario name. Finish line: failing GPUI scenarios are easier to orientate in
-  logs, or the limitation is captured in the harness docs. Prerequisite: 9.4.3.
-  Design Doc: `docs/rstest-bdd-design.md` §2.7.5. (Buzzy Bee)
+- [ ] 10.1.3. The feature-gated GPUI test suite provides realistic harness
+  regression coverage beyond the counter example: it creates a window, persists
+  durable entity/window handles, reconstructs visual context per step, resets
+  scenario state before assignment, and documents the reset protocol in
+  comments. Prerequisite: 9.4.5. Design Doc: `docs/rstest-bdd-design.md`
+  §2.7.6.2. (Doggylump)
+- [ ] 10.1.4. Failing GPUI scenarios include the scenario name in logs where
+  `GpuiHarness` and `gpui::TestAppContext` permit it, or the harness docs
+  document the upstream limitation so developers can quickly orientate failing
+  scenarios. Prerequisite: 9.4.3. Design Doc: `docs/rstest-bdd-design.md`
+  §2.7.5. (Buzzy Bee)
 
 ### 10.2. Update adoption documentation before v0.6.0 final
 
-- [ ] 10.2.1. Add a GPUI migration playbook to the user guide and migration
-  guide. Cover `GpuiHarness`, the reserved harness-context fixture key, durable
+- [ ] 10.2.1. Users can migrate a stateful GPUI test without reading macro
+  expansion or GPUI harness source. The user guide and migration guide cover
+  `GpuiHarness`, the reserved harness-context fixture key, durable
   entity/window handles, `VisualTestContext` reconstruction, and the explicit
-  world-reset protocol. Finish line: users can migrate a stateful GPUI test
-  without reading macro expansion or GPUI harness source. Design Doc:
-  `docs/rstest-bdd-design.md` §2.7.6.2. (Dinolump)
-- [ ] 10.2.2. Add a "mutable harness context plus world state" troubleshooting
-  entry. Include the `E0499`/`E0502` symptom class, explain why two mutable
-  `StepContext` fixtures are difficult today, and point to sanctioned
-  workarounds. Finish line: the migration guide explains the failure before a
-  downstream user reaches compiler-error archaeology. Design Doc:
-  `docs/rstest-bdd-design.md` §2.7.6.1. (Telefono)
-- [ ] 10.2.3. Add a migration checklist reminder to run downstream tests through
-  the repository's CI-equivalent gate. Finish line: the v0.6.0 migration guide
-  explicitly warns that feature-gated test helpers may require
-  `cargo test --all-features` or a project `make test` target before API
-  diagnosis is meaningful. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.3.
-  (Doggylump)
+  world-reset protocol. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.2.
+  (Dinolump)
+- [ ] 10.2.2. The migration guide provides a troubleshooting entry explaining
+  the `E0499`/`E0502` symptoms for two mutable `StepContext` fixtures, why the
+  pattern fails, and recommended workarounds before downstream users reach
+  compiler-error archaeology. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.1.
+  (Telefono)
+- [ ] 10.2.3. The v0.6.0 migration guide warns users to run downstream tests
+  through the repository's CI-equivalent gate and to run feature-gated tests,
+  such as `cargo test --all-features` or a project `make test`, before API
+  diagnosis. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.3. (Doggylump)
 
-## 11. Early-life support: v0.6.1 additive hardening
+## 11. Early life support: v0.6.1 additive hardening
 
 The v0.6.1 line should stay semver-compatible. It can add helper APIs,
 diagnostics, examples, and generated-wrapper improvements, but it must not
@@ -743,53 +740,49 @@ remove the existing `StepContext`, harness, or macro surfaces.
 
 ### 11.1. Add borrow and state helpers without breaking callers
 
-- [ ] 11.1.1. Introduce a structured `FixtureBorrowError` for generated and
-  manual fixture extraction. Distinguish missing fixture, type mismatch,
-  immutable fixture requested mutably, and already-borrowed fixture cases.
-  Finish line: generated wrappers can produce targeted diagnostics instead of
+- [ ] 11.1.1. `FixtureBorrowError` provides a structured error surface for
+  generated and manual fixture extraction, with variants for missing fixture,
+  type mismatch, immutable fixture requested mutably, and already-borrowed
+  fixture cases, so generated wrappers produce targeted diagnostics instead of
   collapsing every extraction failure into `MissingFixture`. Design Doc:
   `docs/rstest-bdd-design.md` §2.7.6.4. (Telefono)
-- [ ] 11.1.2. Add an additive mutable-borrow helper for generated code that
-  reduces unnecessary `&mut StepContext` contention where possible. Preserve
-  the existing `borrow_mut(&mut self, ...)` API. Finish line: regression tests
-  cover mutable harness context plus scenario state, or document precisely why
-  the full fix must wait for v0.7.0. Design Doc: `docs/rstest-bdd-design.md`
-  §2.7.6.4. (Pandalump)
-- [ ] 11.1.3. Add a scenario-local state helper with explicit reset semantics
-  for complex adapters. The helper should support `set`, `with`, `with_mut`,
-  `take`, and `reset` without requiring users to hand-roll thread-local
-  `RefCell` boilerplate. Finish line: the helper is covered by unit tests and
-  documented as an additive alternative to ad-hoc GPUI world state. Design Doc:
-  `docs/rstest-bdd-design.md` §2.7.6.4. (Dinolump)
-- [ ] 11.1.4. Add an opt-in reset hook or reset marker for generated scenarios.
-  Finish line: users can register per-scenario cleanup for stateful adapters
-  without relying on every `#[given]` implementation to remember the reset
-  call. Prerequisite: 11.1.3. Design Doc: `docs/rstest-bdd-design.md`
-  §2.7.6.4.
-  (Doggylump)
+- [ ] 11.1.2. Generated code has an additive mutable-borrow helper that reduces
+  unnecessary `&mut StepContext` contention where possible while preserving the
+  existing `borrow_mut(&mut self, ...)` API. Regression tests cover mutable
+  harness context plus scenario state, or docs explain precisely why the full
+  fix must wait for v0.7.0. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.4.
+  (Pandalump)
+- [ ] 11.1.3. The scenario-local state helper exposes `set`, `with`,
+  `with_mut`, `take`, and `reset` operations for complex adapters without
+  per-scenario thread-local `RefCell` boilerplate. Unit tests cover the helper,
+  and docs present it as an additive alternative to ad-hoc GPUI world state.
+  Design Doc: `docs/rstest-bdd-design.md` §2.7.6.4. (Dinolump)
+- [ ] 11.1.4. Users can register per-scenario cleanup for stateful adapters, so
+  scenarios can reset automatically without every `#[given]` implementation
+  remembering the reset call. Prerequisite: 11.1.3. Design Doc:
+  `docs/rstest-bdd-design.md` §2.7.6.4. (Doggylump)
 
 ### 11.2. Smooth integration ergonomics
 
-- [ ] 11.2.1. Add an explicit harness-context parameter marker, such as
-  `#[harness_context]`, while keeping `#[from(rstest_bdd_harness_context)]`
-  supported. Finish line: examples lead with the readable marker and generated
-  code continues to use the reserved fixture key internally. Design Doc:
-  `docs/rstest-bdd-design.md` §2.7.6.4. (Dinolump)
-- [ ] 11.2.2. Add a public prelude for common integration imports. Include
-  `StepResult`, `Slot`, `ScenarioState`, harness-context helpers, and any
-  marker attribute that lands in 11.2.1. Finish line: examples can use one
-  predictable import without hiding the underlying crates. Prerequisite:
-  11.2.1. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.4. (Dinolump)
-- [ ] 11.2.3. Harden attribute-policy and harness-path diagnostics for renamed
-  or re-exported first-party paths. Finish line: users selecting a known
-  first-party harness through a non-canonical path get actionable guidance to
-  add `attributes = ...` explicitly. Design Doc: `docs/rstest-bdd-design.md`
-  §§2.7.3-2.7.6.4. (Telefono)
-- [ ] 11.2.4. Expand the compatibility matrix for downstream shapes: mutable
-  world, fallible fixture, Tokio harness, GPUI harness with shared context,
-  GPUI harness with mutable context and scenario state, and scenario outline.
-  Finish line: CI proves these shapes remain viable across v0.6.x patches.
-  Design Doc: `docs/rstest-bdd-design.md` §2.7.6.4. (Buzzy Bee)
+- [ ] 11.2.1. Developers can annotate parameters with `#[harness_context]`,
+  with backwards-compatible support for `#[from(rstest_bdd_harness_context)]`.
+  Examples use the readable marker, and generated code keeps the reserved
+  fixture key internally. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.4.
+  (Dinolump)
+- [ ] 11.2.2. The public prelude exposes `StepResult`, `Slot`, `ScenarioState`,
+  harness-context helpers, and marker attributes from 11.2.1 so examples can
+  import one predictable module without hiding the underlying crates.
+  Prerequisite: 11.2.1. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.4.
+  (Dinolump)
+- [ ] 11.2.3. Diagnostics detect non-canonical harness paths and missing or
+  ambiguous attribute-policy annotations, with actionable guidance such as
+  adding `attributes = ...` explicitly or using the canonical path. Design Doc:
+  `docs/rstest-bdd-design.md` §§2.7.3-2.7.6.4. (Telefono)
+- [ ] 11.2.4. The test suite demonstrates v0.6.x compatibility for mutable
+  world, fallible fixture, Tokio harness, GPUI harness with shared context, GPUI
+  harness with mutable context and scenario state, and scenario outline shapes.
+  CI proves these shapes remain viable across patches. Design Doc:
+  `docs/rstest-bdd-design.md` §2.7.6.4. (Buzzy Bee)
 
 ## 12. Pre-1.0.0 API consolidation: v0.7.0 ambitions
 
@@ -800,55 +793,49 @@ predictable.
 
 ### 12.1. Redesign state and context borrowing
 
-- [ ] 12.1.1. Redesign `StepContext` around guard-based interior borrowing so
-  distinct mutable fixtures can be borrowed concurrently. Replace
-  `Option`-based borrow APIs with `Result`-returning APIs that carry
-  `FixtureBorrowError`. Finish line: a step can legally borrow mutable harness
-  context and mutable world state when the fixture keys differ, with regression
-  coverage for generated wrappers. Design Doc: `docs/rstest-bdd-design.md`
-  §2.7.6.5. (Pandalump, Telefono)
-- [ ] 12.1.2. Make `FixtureRefMut` opaque if needed to support the redesigned
-  borrow internals. Finish line: public callers retain value access methods,
-  but enum variants no longer freeze the internal representation. Prerequisite:
-  12.1.1. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.5. (Telefono)
-- [ ] 12.1.3. Introduce a first-class world lifecycle contract. Support
-  before-scenario reset, after-scenario cleanup, and cleanup on failure or
-  skip. Finish line: users can model scenario state without thread-local reset
-  conventions, and the migration guide explains how v0.6 workarounds map to the
-  v0.7 lifecycle. Prerequisite: 12.1.1. Design Doc: `docs/rstest-bdd-design.md`
-  §2.7.6.5. (Doggylump)
+- [ ] 12.1.1. `StepContext` supports guard-based interior borrowing, so callers
+  can concurrently borrow distinct mutable fixtures, including mutable harness
+  context and mutable world state when fixture keys differ. Previous
+  `Option`-based borrow APIs are replaced with `Result`-returning APIs carrying
+  `FixtureBorrowError`, with generated-wrapper regression coverage. Design Doc:
+  `docs/rstest-bdd-design.md` §2.7.6.5. (Pandalump, Telefono)
+- [ ] 12.1.2. `FixtureRefMut` exposes a stable, opaque public API that preserves
+  value-accessor methods while hiding internal enum and representation details.
+  Public callers retain value access methods, and internal variants are no
+  longer part of the public surface. Prerequisite: 12.1.1. Design Doc:
+  `docs/rstest-bdd-design.md` §2.7.6.5. (Telefono)
+- [ ] 12.1.3. A stable world lifecycle contract guarantees before-scenario
+  reset, after-scenario cleanup, and cleanup on failure or skip, so users can
+  model scenario state without thread-local reset conventions. The migration
+  guide explains how v0.6 workarounds map to the v0.7 lifecycle. Prerequisite:
+  12.1.1. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.5. (Doggylump)
 
 ### 12.2. Simplify harness and generated-test APIs
 
-- [ ] 12.2.1. Replace the user-facing reserved harness fixture key with typed
-  extractors such as `Harness<T>` or `HarnessMut<T>`, or with a stable
-  attribute marker. Finish line: users no longer need to spell
-  `rstest_bdd_harness_context` in ordinary harness-backed steps. Requires
-  11.2.1 or equivalent design validation. Design Doc:
-  `docs/rstest-bdd-design.md` §2.7.6.5. (Dinolump, Telefono)
-- [ ] 12.2.2. Remove the macro-selected harness `Default` requirement by
-  supporting a factory expression or equivalent configuration contract. Finish
-  line: configurable harnesses no longer require zero-sized wrapper types
-  solely for macro instantiation. Design Doc: `docs/rstest-bdd-design.md`
-  §§2.7.3, 2.7.6.5. (Pandalump)
-- [ ] 12.2.3. Replace path-recognized attribute-policy inference with a
-  declarative extension model that third-party harness crates can participate
-  in. Finish line: first-party and third-party integrations use one explicit
-  metadata mechanism instead of macro-local path tables. Design Doc:
-  `docs/rstest-bdd-design.md` §§2.7.3-2.7.6.5. (Telefono)
-- [ ] 12.2.4. Unify generated tests for `#[scenario]`, `scenarios!`, scenarios,
-  and outline rows around a stable generated-test model. Finish line: each
-  generated Rust test has a readable name and isolated lifecycle, and failure
-  reports no longer depend on hidden loops over unrelated scenarios. Design
-  Doc: `docs/rstest-bdd-design.md` §2.7.6.5. (Doggylump)
-- [ ] 12.2.5. Decide the async harness trait surface before v1.0.0. Either keep
-  harnesses synchronous with documented async limitations, or introduce an
-  async harness trait and migration path. Finish line: Tokio and future async
-  adapters have a coherent v1 story for multi-poll steps, cancellation, and
-  runtime ownership. Design Doc: `docs/rstest-bdd-design.md` §§2.5, 2.7.6.5.
-  (Buzzy Bee)
-- [ ] 12.2.6. Rationalize crate topology for the v1 user experience. Evaluate
-  feature-gated first-party integrations on `rstest-bdd` versus the current
-  explicit adapter-crate model. Finish line: the v1 packaging decision is
-  recorded in an ADR and reflected in migration docs. Design Doc:
+- [ ] 12.2.1. Users can annotate steps with typed harness extractors such as
+  `Harness<T>` or `HarnessMut<T>`, or with a stable attribute marker, so
+  ordinary harness-backed steps receive harness fixtures automatically without
+  spelling `rstest_bdd_harness_context`. Requires 11.2.1 or equivalent design
+  validation. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.5. (Dinolump,
+  Telefono)
+- [ ] 12.2.2. Harnesses can supply a factory expression or equivalent
+  configuration contract to instantiate configurable harnesses, so they no
+  longer require zero-sized wrapper types solely for macro instantiation.
+  Design Doc: `docs/rstest-bdd-design.md` §§2.7.3, 2.7.6.5. (Pandalump)
+- [ ] 12.2.3. A declarative extension model lets first-party and third-party
+  harness crates participate through one explicit metadata mechanism instead of
+  macro-local path tables. Design Doc: `docs/rstest-bdd-design.md`
+  §§2.7.3-2.7.6.5. (Telefono)
+- [ ] 12.2.4. The generated-test model gives each `#[scenario]`, `scenarios!`,
+  scenario, and outline row a readable Rust test name, isolated lifecycle, and
+  failure reports that no longer depend on hidden loops over unrelated
+  scenarios. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.5. (Doggylump)
+- [ ] 12.2.5. The recorded async harness trait surface gives Tokio and future
+  async adapters coherent migration, multi-poll, cancellation, and runtime
+  ownership semantics, whether the v1 contract remains synchronous or moves to
+  an async harness trait. Design Doc: `docs/rstest-bdd-design.md` §§2.5,
+  2.7.6.5. (Buzzy Bee)
+- [ ] 12.2.6. The v1 packaging model records whether first-party integrations
+  are feature-gated on `rstest-bdd` or remain explicit adapter crates, and the
+  choice is captured in an ADR and migration guidance. Design Doc:
   `docs/rstest-bdd-design.md` §2.7.6.5. (Pandalump)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -693,26 +693,33 @@ changing the public trait contracts.
 - [ ] 10.1.1. Users of first-party adapters can depend only on the adapter
   crate in `Cargo.toml`; `rstest-bdd-harness` is required only for custom
   harness implementations or explicit use of the base harness API. Finish line:
-  the dependency matrix in `docs/v0-6-0-migration-guide.md` covers plain BDD,
-  Tokio, GPUI, and custom harnesses; documented or generated-code behaviour
-  matches that dependency boundary. Design Doc: `docs/rstest-bdd-design.md`
-  §2.7.6.3. (Dinolump)
+  `docs/v0-6-0-migration-guide.md` contains the plain BDD, Tokio, GPUI, and
+  custom harness dependency matrix, and fixture-generation tests or docs prove
+  first-party adapters compile without a direct base-harness dependency. Design
+  Doc: `docs/rstest-bdd-design.md` §2.7.6.3. (Dinolump)
 - [ ] 10.1.2. Display detailed missing-fixture diagnostics for harness context
   and mutable scenario state, showing the requested fixture name and type,
   inserted fixtures from `StepContext::available_fixtures()`, and, when
   `rstest_bdd_harness_context` is absent, suggest selecting the relevant
-  harness. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.3. (Telefono)
+  harness. Finish line: a regression test reproduces a missing-fixture failure
+  and asserts the diagnostic contains the requested fixture name, requested
+  type, inserted fixture list, and harness suggestion. Design Doc:
+  `docs/rstest-bdd-design.md` §2.7.6.3. (Telefono)
 - [ ] 10.1.3. The feature-gated GPUI test suite provides realistic harness
   regression coverage beyond the counter example: it creates a window, persists
   durable entity/window handles, reconstructs visual context per step, resets
   scenario state before assignment, and documents the reset protocol in
-  comments. Prerequisite: 9.4.5. Design Doc: `docs/rstest-bdd-design.md`
-  §2.7.6.2. (Doggylump)
+  comments. Finish line: the automated GPUI suite passes in CI with a scenario
+  that creates a window, carries handles across steps, reconstructs visual
+  context, and includes reset-protocol comments. Prerequisite: 9.4.5. Design
+  Doc: `docs/rstest-bdd-design.md` §2.7.6.2. (Doggylump)
 - [ ] 10.1.4. Failing GPUI scenarios include the scenario name in logs where
   `GpuiHarness` and `gpui::TestAppContext` permit it, or the harness docs
   document the upstream limitation so developers can quickly orientate failing
-  scenarios. Prerequisite: 9.4.3. Design Doc: `docs/rstest-bdd-design.md`
-  §2.7.5. (Buzzy Bee)
+  scenarios. Finish line: a failing-harness regression asserts the scenario
+  name appears in emitted diagnostics, or the GPUI harness docs state the
+  upstream limitation and link the skipped test. Prerequisite: 9.4.3. Design
+  Doc: `docs/rstest-bdd-design.md` §2.7.5. (Buzzy Bee)
 
 ### 10.2. Update adoption documentation before v0.6.0 final
 
@@ -720,17 +727,21 @@ changing the public trait contracts.
   expansion or GPUI harness source. The user guide and migration guide cover
   `GpuiHarness`, the reserved harness-context fixture key, durable
   entity/window handles, `VisualTestContext` reconstruction, and the explicit
-  world-reset protocol. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.2.
-  (Dinolump)
+  world-reset protocol. Finish line: `make markdownlint` passes and the user
+  guide plus migration guide each include a GPUI playbook covering all listed
+  topics. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.2. (Dinolump)
 - [ ] 10.2.2. The migration guide provides a troubleshooting entry explaining
   the `E0499`/`E0502` symptoms for two mutable `StepContext` fixtures, why the
   pattern fails, and recommended workarounds before downstream users reach
-  compiler-error archaeology. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.1.
-  (Telefono)
+  compiler-error archaeology. Finish line: `docs/v0-6-0-migration-guide.md`
+  contains the troubleshooting entry and links the borrow-constraint design
+  subsection. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.1. (Telefono)
 - [ ] 10.2.3. The v0.6.0 migration guide warns users to run downstream tests
   through the repository's CI-equivalent gate and to run feature-gated tests,
   such as `cargo test --all-features` or a project `make test`, before API
-  diagnosis. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.3. (Doggylump)
+  diagnosis. Finish line: the migration checklist names both command shapes and
+  `make markdownlint` passes. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.3.
+  (Doggylump)
 
 ## 11. Early life support: v0.6.1 additive hardening
 
@@ -744,45 +755,57 @@ remove the existing `StepContext`, harness, or macro surfaces.
   generated and manual fixture extraction, with variants for missing fixture,
   type mismatch, immutable fixture requested mutably, and already-borrowed
   fixture cases, so generated wrappers produce targeted diagnostics instead of
-  collapsing every extraction failure into `MissingFixture`. Design Doc:
-  `docs/rstest-bdd-design.md` §2.7.6.4. (Telefono)
+  collapsing every extraction failure into `MissingFixture`. Finish line: unit
+  tests cover every variant and generated-wrapper tests assert each variant maps
+  to the expected diagnostic. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.4.
+  (Telefono)
 - [ ] 11.1.2. Generated code has an additive mutable-borrow helper that reduces
   unnecessary `&mut StepContext` contention where possible while preserving the
   existing `borrow_mut(&mut self, ...)` API. Regression tests cover mutable
   harness context plus scenario state, or docs explain precisely why the full
-  fix must wait for v0.7.0. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.4.
-  (Pandalump)
+  fix must wait for v0.7.0. Finish line: generated-code tests pass for the
+  helper without breaking the existing `borrow_mut` API, or the documented
+  deferral includes a failing-shape test. Design Doc: `docs/rstest-bdd-design.md`
+  §2.7.6.4. (Pandalump)
 - [ ] 11.1.3. The scenario-local state helper exposes `set`, `with`,
   `with_mut`, `take`, and `reset` operations for complex adapters without
   per-scenario thread-local `RefCell` boilerplate. Unit tests cover the helper,
   and docs present it as an additive alternative to ad-hoc GPUI world state.
-  Design Doc: `docs/rstest-bdd-design.md` §2.7.6.4. (Dinolump)
+  Finish line: unit tests exercise all five operations and docs show a GPUI
+  world-state example using the helper. Design Doc: `docs/rstest-bdd-design.md`
+  §2.7.6.4. (Dinolump)
 - [ ] 11.1.4. Users can register per-scenario cleanup for stateful adapters, so
   scenarios can reset automatically without every `#[given]` implementation
   remembering the reset call. Prerequisite: 11.1.3. Design Doc:
-  `docs/rstest-bdd-design.md` §2.7.6.4. (Doggylump)
+  `docs/rstest-bdd-design.md` §2.7.6.4. Finish line: an integration test shows
+  cleanup running after success and failure, and the docs state the required
+  registration order. (Doggylump)
 
 ### 11.2. Smooth integration ergonomics
 
 - [ ] 11.2.1. Developers can annotate parameters with `#[harness_context]`,
   with backwards-compatible support for `#[from(rstest_bdd_harness_context)]`.
   Examples use the readable marker, and generated code keeps the reserved
-  fixture key internally. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.4.
-  (Dinolump)
+  fixture key internally. Finish line: macro tests cover both marker forms and
+  examples compile using `#[harness_context]`. Design Doc:
+  `docs/rstest-bdd-design.md` §2.7.6.4. (Dinolump)
 - [ ] 11.2.2. The public prelude exposes `StepResult`, `Slot`, `ScenarioState`,
   harness-context helpers, and marker attributes from 11.2.1 so examples can
   import one predictable module without hiding the underlying crates.
-  Prerequisite: 11.2.1. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.4.
-  (Dinolump)
+  Finish line: compile tests prove examples import only the prelude plus their
+  harness crate, and docs list the exported items. Prerequisite: 11.2.1. Design
+  Doc: `docs/rstest-bdd-design.md` §2.7.6.4. (Dinolump)
 - [ ] 11.2.3. Diagnostics detect non-canonical harness paths and missing or
   ambiguous attribute-policy annotations, with actionable guidance such as
-  adding `attributes = ...` explicitly or using the canonical path. Design Doc:
-  `docs/rstest-bdd-design.md` §§2.7.3-2.7.6.4. (Telefono)
+  adding `attributes = ...` explicitly or using the canonical path. Finish
+  line: trybuild tests cover non-canonical, missing, and ambiguous policy cases
+  and assert the suggested fix text. Design Doc: `docs/rstest-bdd-design.md`
+  §§2.7.3-2.7.6.4. (Telefono)
 - [ ] 11.2.4. The test suite demonstrates v0.6.x compatibility for mutable
   world, fallible fixture, Tokio harness, GPUI harness with shared context, GPUI
   harness with mutable context and scenario state, and scenario outline shapes.
-  CI proves these shapes remain viable across patches. Design Doc:
-  `docs/rstest-bdd-design.md` §2.7.6.4. (Buzzy Bee)
+  Finish line: CI runs and passes one compatibility test for each listed shape.
+  Design Doc: `docs/rstest-bdd-design.md` §2.7.6.4. (Buzzy Bee)
 
 ## 12. Pre-1.0.0 API consolidation: v0.7.0 ambitions
 
@@ -797,18 +820,25 @@ predictable.
   can concurrently borrow distinct mutable fixtures, including mutable harness
   context and mutable world state when fixture keys differ. Previous
   `Option`-based borrow APIs are replaced with `Result`-returning APIs carrying
-  `FixtureBorrowError`, with generated-wrapper regression coverage. Design Doc:
-  `docs/rstest-bdd-design.md` §2.7.6.5. (Pandalump, Telefono)
+  `FixtureBorrowError`, with generated-wrapper regression coverage. Finish
+  line: runtime unit tests prove concurrent distinct mutable borrows succeed,
+  same-fixture conflicts fail, and generated-wrapper tests cover harness context
+  plus world state. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.5.
+  (Pandalump, Telefono)
 - [ ] 12.1.2. `FixtureRefMut` exposes a stable, opaque public API that preserves
   value-accessor methods while hiding internal enum and representation details.
   Public callers retain value access methods, and internal variants are no
   longer part of the public surface. Prerequisite: 12.1.1. Design Doc:
-  `docs/rstest-bdd-design.md` §2.7.6.5. (Telefono)
+  `docs/rstest-bdd-design.md` §2.7.6.5. Finish line: public API tests compile
+  against accessor methods and no downstream test can match internal variants.
+  (Telefono)
 - [ ] 12.1.3. A stable world lifecycle contract guarantees before-scenario
   reset, after-scenario cleanup, and cleanup on failure or skip, so users can
   model scenario state without thread-local reset conventions. The migration
   guide explains how v0.6 workarounds map to the v0.7 lifecycle. Prerequisite:
-  12.1.1. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.5. (Doggylump)
+  12.1.1. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.5. Finish line:
+  lifecycle tests pass for success, assertion failure, and skip, and the
+  migration guide includes the v0.6-to-v0.7 mapping. (Doggylump)
 
 ### 12.2. Simplify harness and generated-test APIs
 
@@ -816,26 +846,35 @@ predictable.
   `Harness<T>` or `HarnessMut<T>`, or with a stable attribute marker, so
   ordinary harness-backed steps receive harness fixtures automatically without
   spelling `rstest_bdd_harness_context`. Requires 11.2.1 or equivalent design
-  validation. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.5. (Dinolump,
-  Telefono)
+  validation. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.5. Finish line:
+  macro tests cover `Harness<T>`, `HarnessMut<T>`, and the marker path without
+  user-visible reserved-key spelling. (Dinolump, Telefono)
 - [ ] 12.2.2. Harnesses can supply a factory expression or equivalent
   configuration contract to instantiate configurable harnesses, so they no
   longer require zero-sized wrapper types solely for macro instantiation.
-  Design Doc: `docs/rstest-bdd-design.md` §§2.7.3, 2.7.6.5. (Pandalump)
+  Finish line: compile tests instantiate a configured harness through the new
+  contract and reject an invalid factory with a targeted diagnostic. Design Doc:
+  `docs/rstest-bdd-design.md` §§2.7.3, 2.7.6.5. (Pandalump)
 - [ ] 12.2.3. A declarative extension model lets first-party and third-party
   harness crates participate through one explicit metadata mechanism instead of
-  macro-local path tables. Design Doc: `docs/rstest-bdd-design.md`
+  macro-local path tables. Finish line: one first-party and one example
+  third-party harness use the metadata mechanism in tests, and docs describe
+  the extension contract. Design Doc: `docs/rstest-bdd-design.md`
   §§2.7.3-2.7.6.5. (Telefono)
 - [ ] 12.2.4. The generated-test model gives each `#[scenario]`, `scenarios!`,
   scenario, and outline row a readable Rust test name, isolated lifecycle, and
   failure reports that no longer depend on hidden loops over unrelated
-  scenarios. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.5. (Doggylump)
+  scenarios. Finish line: integration tests assert generated names, lifecycle
+  isolation, and per-row failure reporting for `#[scenario]` and `scenarios!`.
+  Design Doc: `docs/rstest-bdd-design.md` §2.7.6.5. (Doggylump)
 - [ ] 12.2.5. The recorded async harness trait surface gives Tokio and future
   async adapters coherent migration, multi-poll, cancellation, and runtime
   ownership semantics, whether the v1 contract remains synchronous or moves to
-  an async harness trait. Design Doc: `docs/rstest-bdd-design.md` §§2.5,
-  2.7.6.5. (Buzzy Bee)
+  an async harness trait. Finish line: an ADR records the decision, Tokio tests
+  cover the selected semantics, and migration docs explain the rejected path.
+  Design Doc: `docs/rstest-bdd-design.md` §§2.5, 2.7.6.5. (Buzzy Bee)
 - [ ] 12.2.6. The v1 packaging model records whether first-party integrations
   are feature-gated on `rstest-bdd` or remain explicit adapter crates, and the
-  choice is captured in an ADR and migration guidance. Design Doc:
-  `docs/rstest-bdd-design.md` §2.7.6.5. (Pandalump)
+  choice is captured in an ADR and migration guidance. Finish line: the ADR,
+  migration guide, and publish/package tests all reflect the same packaging
+  model. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.5. (Pandalump)

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1872,6 +1872,8 @@ between the delivered harness architecture and stateful user-interface tests.
 The typed `HarnessAdapter::Context` handoff works, but the step-facing API
 still makes complex GPUI scenarios harder than the counter example suggests.
 
+##### 2.7.6.1 Borrow constraint exposed by GPUI adoption
+
 The important constraint is `StepContext::borrow_mut`. Its current signature
 takes `&mut self` and returns a guard whose lifetime is tied to that borrow.
 Generated step wrappers therefore cannot comfortably borrow two mutable
@@ -1880,6 +1882,28 @@ fixtures from the same `StepContext` at once. A step that requests both
 `world: &mut UiWorld` can fail with `E0499` or `E0502`, even when the fixtures
 are logically distinct. This is a design limitation of the current context API,
 not a GPUI-only behaviour.
+
+The problematic shape is ordinary-looking step code:
+
+```rust
+#[given("the shell is open")]
+fn given_shell_open(
+    #[from(rstest_bdd_harness_context)] cx: &mut gpui::TestAppContext,
+    world: &mut UiWorld,
+) -> StepResult<()> {
+    let (shell, visual_cx) = cx.add_window_view(|_, cx| Shell::new(cx));
+    world.shell = Some(shell);
+    world.visual_cx = Some(visual_cx);
+    Ok(())
+}
+```
+
+Generated wrappers must borrow mutable harness context and mutable world state
+from the same `StepContext` before calling that function. The current
+`borrow_mut(&mut self, ...)` contract makes that pair the troublesome part, not
+the step body itself.
+
+##### 2.7.6.2 Interim GPUI state pattern
 
 Until the borrow API is redesigned, GPUI guidance should recommend one of two
 state patterns:
@@ -1901,6 +1925,54 @@ BDD tests should store durable handles such as `Entity<T>` and
 and the harness-provided `TestAppContext` inside each step that needs visual
 interaction.
 
+The recommended v0.6-compatible shape keeps only durable handles in resettable
+scenario state. In schematic form:
+
+```rust
+thread_local! {
+    static WORLD: RefCell<UiWorld> = RefCell::new(UiWorld::default());
+}
+
+fn reset_world() {
+    WORLD.with(|world| *world.borrow_mut() = UiWorld::default());
+}
+
+#[given("the shell is open")]
+fn given_shell_open(
+    #[from(rstest_bdd_harness_context)] cx: &mut gpui::TestAppContext,
+) -> StepResult<()> {
+    reset_world();
+
+    let (shell, _visual_cx) = cx.add_window_view(|_, cx| Shell::new(cx));
+    let window = cx.windows().first().copied().ok_or("missing window")?;
+
+    WORLD.with(|world| {
+        let mut world = world.borrow_mut();
+        world.shell = Some(shell);
+        world.window = Some(window);
+    });
+
+    Ok(())
+}
+
+#[when("the user presses Tab")]
+fn press_tab(
+    #[from(rstest_bdd_harness_context)] cx: &mut gpui::TestAppContext,
+) -> StepResult<()> {
+    let window = WORLD.with(|world| world.borrow().window.ok_or("missing window"))?;
+    let mut visual_cx = gpui::VisualTestContext::from_window(window, cx);
+
+    visual_cx.simulate_keystrokes("tab");
+    Ok(())
+}
+```
+
+The reset must run before assigning new scenario state. The world stores the
+window handle, not `VisualTestContext`, so later steps can rebuild the visual
+context from the handle and the current harness context.
+
+##### 2.7.6.3 v0.6.0-beta2 quick wins
+
 The release strategy is therefore split by compatibility risk:
 
 - **v0.6.0-beta2 quick wins:** improve adoption diagnostics and examples
@@ -1909,11 +1981,17 @@ The release strategy is therefore split by compatibility risk:
   `StepContext::available_fixtures()`, a realistic GPUI smoke test that stores
   entity/window handles and resets world state, and migration-guide coverage
   for feature-gated downstream tests such as `cargo test --all-features`.
+
+##### 2.7.6.4 v0.6.1 early-life support helpers
+
 - **v0.6.1 early-life support:** add semver-compatible helper APIs. Candidate
   additions include an explicit harness-context parameter marker, a prelude for
   common integration imports, a typed borrow-error enum, a scenario-local state
   helper with reset semantics, and generated-wrapper coverage for mutable
   harness context plus scenario state.
+
+##### 2.7.6.5 v0.7.0 pre-1.0.0 redesign
+
 - **v0.7.0 / pre-1.0.0:** reserve breaking cleanups for a migration guide. The
   main target is a `StepContext` redesign where fixture borrowing is
   guard-based and can borrow distinct mutable fixtures concurrently. Other

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1865,6 +1865,64 @@ Validation for the delivered model is intentionally split across layers:
   compatibility, GPUI integration, GPUI attribute-policy resolution through
   both `#[scenario]` and `scenarios!`, and the deprecated runtime alias path.
 
+#### 2.7.6 First-cut beta feedback and adoption implications
+
+The first downstream beta migration against `rstest-bdd` 0.6.0 exposed a gap
+between the delivered harness architecture and stateful user-interface tests.
+The typed `HarnessAdapter::Context` handoff works, but the step-facing API
+still makes complex GPUI scenarios harder than the counter example suggests.
+
+The important constraint is `StepContext::borrow_mut`. Its current signature
+takes `&mut self` and returns a guard whose lifetime is tied to that borrow.
+Generated step wrappers therefore cannot comfortably borrow two mutable
+fixtures from the same `StepContext` at once. A step that requests both
+`#[from(rstest_bdd_harness_context)] cx: &mut gpui::TestAppContext` and
+`world: &mut UiWorld` can fail with `E0499` or `E0502`, even when the fixtures
+are logically distinct. This is a design limitation of the current context API,
+not a GPUI-only behaviour.
+
+Until the borrow API is redesigned, GPUI guidance should recommend one of two
+state patterns:
+
+- keep ordinary domain state in regular `rstest` fixtures when steps do not
+  also need mutable harness context; or
+- use interior-mutable or thread-local scenario state with an explicit reset
+  protocol when a step must also borrow mutable harness context.
+
+Thread-local scenario state is an adoption workaround, not a replacement for
+the typed harness-context architecture selected by ADR-007. Any thread-local
+world must be reset before assigning scenario state, so failed or skipped
+scenarios cannot leak handles into a later scenario on the same test thread.
+
+The same downstream migration also clarified a reusable GPUI pattern:
+`VisualTestContext` should not be treated as durable world state. Stateful GPUI
+BDD tests should store durable handles such as `Entity<T>` and
+`AnyWindowHandle`, then reconstruct `VisualTestContext` from the window handle
+and the harness-provided `TestAppContext` inside each step that needs visual
+interaction.
+
+The release strategy is therefore split by compatibility risk:
+
+- **v0.6.0-beta2 quick wins:** improve adoption diagnostics and examples
+  without changing public contracts. The highest-value items are a dependency
+  matrix for harness crates, clearer missing-fixture diagnostics that include
+  `StepContext::available_fixtures()`, a realistic GPUI smoke test that stores
+  entity/window handles and resets world state, and migration-guide coverage
+  for feature-gated downstream tests such as `cargo test --all-features`.
+- **v0.6.1 early-life support:** add semver-compatible helper APIs. Candidate
+  additions include an explicit harness-context parameter marker, a prelude for
+  common integration imports, a typed borrow-error enum, a scenario-local state
+  helper with reset semantics, and generated-wrapper coverage for mutable
+  harness context plus scenario state.
+- **v0.7.0 / pre-1.0.0:** reserve breaking cleanups for a migration guide. The
+  main target is a `StepContext` redesign where fixture borrowing is
+  guard-based and can borrow distinct mutable fixtures concurrently. Other
+  candidates are typed harness-context extractors that hide the reserved
+  fixture key, configurable harness construction without a `Default`
+  requirement, a declarative attribute-policy extension model, first-class
+  world lifecycle hooks, and a unified generated-test model for scenarios and
+  outline rows.
+
 ## Part 3: Implementation and strategic analysis
 
 This final part outlines a practical implementation strategy for `rstest-bdd`


### PR DESCRIPTION
## Summary

This branch records the first-cut v0.6.0 beta feedback outcomes in the design document and roadmap. It captures the `StepContext::borrow_mut` limitation that made stateful GPUI adoption harder than the simple harness examples suggest, then turns that finding into prioritised follow-up work for v0.6.0-beta2 quick wins, v0.6.1 early-life support, and v0.7.0 pre-1.0.0 consolidation.

No issue or execplan is linked for this branch; it is a documentation update derived from beta adoption feedback.

## Review walkthrough

- Start with [docs/rstest-bdd-design.md](https://github.com/leynos/rstest-bdd/blob/30dc9d11e855d56c5792ecd5bff36f9fbe5f4f91/docs/rstest-bdd-design.md#L1868) to review the new adoption analysis, including the mutable `StepContext` borrow constraint, explicit reset guidance, and durable GPUI handle pattern.
- Then review [docs/roadmap.md](https://github.com/leynos/rstest-bdd/blob/30dc9d11e855d56c5792ecd5bff36f9fbe5f4f91/docs/roadmap.md#L683) for the v0.6.0-beta2 quick wins.
- Continue with [docs/roadmap.md](https://github.com/leynos/rstest-bdd/blob/30dc9d11e855d56c5792ecd5bff36f9fbe5f4f91/docs/roadmap.md#L739) for the v0.6.1 early-life support work.
- Finish with [docs/roadmap.md](https://github.com/leynos/rstest-bdd/blob/30dc9d11e855d56c5792ecd5bff36f9fbe5f4f91/docs/roadmap.md#L794) for the v0.7.0 pre-1.0.0 API consolidation ambitions.

## Validation

- `make markdownlint`: passed with `Summary: 0 error(s)`.
- `make nixie`: passed with all diagrams validated successfully.
- `make check-fmt`: passed.
- `git diff --check -- docs/roadmap.md docs/rstest-bdd-design.md`: passed.

## Notes

The repository-wide `make fmt` target was also run. It exited non-zero on pre-existing, unrelated Markdown MD013 line-length findings elsewhere in the repository. No unrelated formatter changes remain in this branch.

## Summary by Sourcery

Record first-cut v0.6.0 beta feedback and translate it into concrete roadmap items across upcoming 0.6.0-beta2, 0.6.1, and 0.7.0 releases.

Documentation:
- Document beta adoption findings around StepContext mutable borrowing limits and recommended GPUI state management patterns in the design guide.
- Expand the roadmap with phased work items for 0.6.0-beta2, 0.6.1, and 0.7.0 to improve harness adoption, diagnostics, helper APIs, and pre-1.0 API consolidation.