### PR TITLE
Allow adapter-only first-party harness use (10.1.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,7 +760,6 @@ dependencies = [
  "gpui",
  "rstest",
  "rstest-bdd",
- "rstest-bdd-harness",
  "rstest-bdd-harness-gpui",
  "rstest-bdd-macros",
 ]
@@ -2148,7 +2147,6 @@ version = "0.6.0-beta1"
 dependencies = [
  "rstest",
  "rstest-bdd",
- "rstest-bdd-harness",
  "rstest-bdd-harness-tokio",
  "rstest-bdd-macros",
  "thiserror 1.0.69",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,6 +1575,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro-error",
  "proc-macro2",
+ "proptest",
  "quote",
  "regex",
  "rstest",

--- a/crates/rstest-bdd-harness-gpui/src/lib.rs
+++ b/crates/rstest-bdd-harness-gpui/src/lib.rs
@@ -9,3 +9,8 @@ mod policy;
 
 pub use gpui_harness::GpuiHarness;
 pub use policy::GpuiAttributePolicy;
+pub use rstest_bdd_harness::{
+    AttributePolicy, HarnessAdapter, HarnessError, HarnessResult, ScenarioMetadata,
+    ScenarioRunRequest, ScenarioRunner, StdScenarioRunRequest, StdScenarioRunner, TestAttribute,
+    tracing,
+};

--- a/crates/rstest-bdd-harness-tokio/src/lib.rs
+++ b/crates/rstest-bdd-harness-tokio/src/lib.rs
@@ -8,4 +8,9 @@ mod policy;
 mod tokio_harness;
 
 pub use policy::TokioAttributePolicy;
+pub use rstest_bdd_harness::{
+    AttributePolicy, HarnessAdapter, HarnessError, HarnessResult, ScenarioMetadata,
+    ScenarioRunRequest, ScenarioRunner, StdScenarioRunRequest, StdScenarioRunner, TestAttribute,
+    tracing,
+};
 pub use tokio_harness::TokioHarness;

--- a/crates/rstest-bdd-harness/src/trybuild_staging/mod.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/mod.rs
@@ -83,19 +83,19 @@ pub(super) fn copy_entry(entry: &fs::DirEntry, destination: &Path) -> io::Result
 fn canonical_destination_for_overlap(destination: &Path) -> io::Result<PathBuf> {
     match fs::canonicalize(destination) {
         Ok(path) => Ok(path),
-        Err(err) if err.kind() == io::ErrorKind::NotFound => {
-            let parent = destination.parent().filter(|p| !p.as_os_str().is_empty());
-            let base = match parent {
-                Some(p) => fs::canonicalize(p)?,
-                None => fs::canonicalize(std::env::current_dir()?)?,
-            };
-            Ok(match destination.file_name() {
-                Some(name) => base.join(name),
-                None => base,
-            })
-        }
+        Err(err) if err.kind() == io::ErrorKind::NotFound => canonical_missing_path(destination),
         Err(err) => Err(err),
     }
+}
+
+fn canonical_missing_path(path: &Path) -> io::Result<PathBuf> {
+    let Some(name) = path.file_name() else {
+        return fs::canonicalize(std::env::current_dir()?);
+    };
+    let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) else {
+        return Ok(fs::canonicalize(std::env::current_dir()?)?.join(name));
+    };
+    Ok(canonical_destination_for_overlap(parent)?.join(name))
 }
 
 fn paths_overlap(a: &Path, b: &Path) -> bool {

--- a/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
@@ -107,6 +107,20 @@ fn copy_dir_tree_replaces_existing_directory(replace_dir_staging: ReplaceDstStag
     assert!(!dst.join("stale").exists());
 }
 
+#[rstest]
+fn copy_dir_tree_creates_missing_destination_parents(replace_dir_staging: ReplaceDstStaging) {
+    let ReplaceDstStaging { src, dst, .. } = replace_dir_staging;
+    let nested_dst = dst.join("nested").join("tree");
+    #[expect(
+        clippy::expect_used,
+        reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
+    )]
+    {
+        copy_dir_tree(&src, &nested_dst).expect("copy_dir_tree");
+    }
+    assert!(nested_dst.join("sub").join("a.txt").exists());
+}
+
 #[fixture]
 fn replace_file_dest_staging() -> ReplaceDstStaging {
     #[expect(

--- a/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
@@ -1,13 +1,29 @@
 //! Unit tests for [`super::copy_file`] and [`super::copy_dir_tree`] staging helpers.
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use rstest::fixture;
 use rstest::rstest;
 use tempfile::TempDir;
 
 use super::{copy_dir_tree, copy_file};
+
+#[expect(
+    clippy::expect_used,
+    reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
+)]
+fn copy_dir_tree_ok(src: &Path, dst: &Path) {
+    copy_dir_tree(src, dst).expect("copy_dir_tree");
+}
+
+#[expect(
+    clippy::expect_used,
+    reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
+)]
+fn copy_file_ok(src: &Path, dst: &Path) {
+    copy_file(src, dst).expect("copy_file");
+}
 
 struct CopyFileStaging {
     _root: TempDir,
@@ -38,13 +54,7 @@ fn copy_file_staging() -> CopyFileStaging {
 #[rstest]
 fn copy_file_overwrites_existing_destination(copy_file_staging: CopyFileStaging) {
     let CopyFileStaging { src, dst, .. } = copy_file_staging;
-    #[expect(
-        clippy::expect_used,
-        reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
-    )]
-    {
-        copy_file(&src, &dst).expect("copy_file");
-    }
+    copy_file_ok(&src, &dst);
     #[expect(
         clippy::expect_used,
         reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
@@ -95,13 +105,7 @@ fn replace_dir_staging() -> ReplaceDstStaging {
 #[rstest]
 fn copy_dir_tree_replaces_existing_directory(replace_dir_staging: ReplaceDstStaging) {
     let ReplaceDstStaging { src, dst, .. } = replace_dir_staging;
-    #[expect(
-        clippy::expect_used,
-        reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
-    )]
-    {
-        copy_dir_tree(&src, &dst).expect("copy_dir_tree");
-    }
+    copy_dir_tree_ok(&src, &dst);
     assert!(dst.join("sub").join("a.txt").exists());
     // Stale directory must be gone.
     assert!(!dst.join("stale").exists());
@@ -111,13 +115,7 @@ fn copy_dir_tree_replaces_existing_directory(replace_dir_staging: ReplaceDstStag
 fn copy_dir_tree_creates_missing_destination_parents(replace_dir_staging: ReplaceDstStaging) {
     let ReplaceDstStaging { src, dst, .. } = replace_dir_staging;
     let nested_dst = dst.join("nested").join("tree");
-    #[expect(
-        clippy::expect_used,
-        reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
-    )]
-    {
-        copy_dir_tree(&src, &nested_dst).expect("copy_dir_tree");
-    }
+    copy_dir_tree_ok(&src, &nested_dst);
     assert!(nested_dst.join("sub").join("a.txt").exists());
 }
 
@@ -144,13 +142,7 @@ fn replace_file_dest_staging() -> ReplaceDstStaging {
 #[rstest]
 fn copy_dir_tree_replaces_existing_file_destination(replace_file_dest_staging: ReplaceDstStaging) {
     let ReplaceDstStaging { src, dst, .. } = replace_file_dest_staging;
-    #[expect(
-        clippy::expect_used,
-        reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
-    )]
-    {
-        copy_dir_tree(&src, &dst).expect("copy_dir_tree");
-    }
+    copy_dir_tree_ok(&src, &dst);
     assert!(dst.join("f.txt").exists());
 }
 

--- a/crates/rstest-bdd-macros/Cargo.toml
+++ b/crates/rstest-bdd-macros/Cargo.toml
@@ -44,6 +44,7 @@ newt-hype.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+proptest.workspace = true
 rstest.workspace = true
 serial_test.workspace = true
 tempfile.workspace = true

--- a/crates/rstest-bdd-macros/src/codegen/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/mod.rs
@@ -3,8 +3,8 @@
 //! This module emits fully-qualified paths (`::rstest_bdd::…`) so the macros crate
 //! does not depend on the runtime crate at compile-time.
 
+use proc_macro_crate::{FoundCrate, crate_name};
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
-use proc_macro_crate::{crate_name, FoundCrate};
 use quote::quote;
 
 struct CrateSpec {
@@ -146,7 +146,7 @@ fn handle_missing_crate(spec: &CrateSpec, err: &proc_macro_crate::Error) -> Toke
 #[cfg(test)]
 mod tests {
     use super::{
-        handle_missing_crate, GPUI_HARNESS, RSTEST_BDD, RSTEST_BDD_HARNESS, TOKIO_HARNESS,
+        GPUI_HARNESS, RSTEST_BDD, RSTEST_BDD_HARNESS, TOKIO_HARNESS, handle_missing_crate,
     };
     use proc_macro_crate::Error;
     use std::path::PathBuf;

--- a/crates/rstest-bdd-macros/src/codegen/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/mod.rs
@@ -3,40 +3,57 @@
 //! This module emits fully-qualified paths (`::rstest_bdd::…`) so the macros crate
 //! does not depend on the runtime crate at compile-time.
 
-use proc_macro_crate::{FoundCrate, crate_name};
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
+use proc_macro_crate::{crate_name, FoundCrate};
 use quote::quote;
+
+struct CrateSpec {
+    package_name: &'static str,
+    default_crate_name: &'static str,
+    adapter_type_names: &'static [&'static str],
+}
 
 pub(crate) mod scenario;
 pub(crate) mod wrapper;
 
-const TOKIO_HARNESS_PACKAGE: &str = "rstest-bdd-harness-tokio";
-const TOKIO_HARNESS_CRATE: &str = "rstest_bdd_harness_tokio";
-const TOKIO_HARNESS_TYPES: &[&str] = &["TokioHarness", "TokioAttributePolicy"];
-const GPUI_HARNESS_PACKAGE: &str = "rstest-bdd-harness-gpui";
-const GPUI_HARNESS_CRATE: &str = "rstest_bdd_harness_gpui";
-const GPUI_HARNESS_TYPES: &[&str] = &["GpuiHarness", "GpuiAttributePolicy"];
+const RSTEST_BDD: CrateSpec = CrateSpec {
+    package_name: "rstest-bdd",
+    default_crate_name: "rstest_bdd",
+    adapter_type_names: &[],
+};
+const RSTEST_BDD_HARNESS: CrateSpec = CrateSpec {
+    package_name: "rstest-bdd-harness",
+    default_crate_name: "rstest_bdd_harness",
+    adapter_type_names: &[],
+};
+const TOKIO_HARNESS: CrateSpec = CrateSpec {
+    package_name: "rstest-bdd-harness-tokio",
+    default_crate_name: "rstest_bdd_harness_tokio",
+    adapter_type_names: &["TokioHarness", "TokioAttributePolicy"],
+};
+const GPUI_HARNESS: CrateSpec = CrateSpec {
+    package_name: "rstest-bdd-harness-gpui",
+    default_crate_name: "rstest_bdd_harness_gpui",
+    adapter_type_names: &["GpuiHarness", "GpuiAttributePolicy"],
+};
 
 /// Return a token stream pointing to the `rstest_bdd` crate or its renamed form.
 pub(crate) fn rstest_bdd_path() -> TokenStream2 {
-    resolve_crate_path("rstest-bdd", "rstest_bdd")
+    resolve_crate_path(&RSTEST_BDD)
 }
 
 /// Return a token stream pointing to the `rstest_bdd_harness` crate or its
 /// renamed form.
 pub(crate) fn rstest_bdd_harness_path() -> TokenStream2 {
-    resolve_crate_path("rstest-bdd-harness", "rstest_bdd_harness")
+    resolve_crate_path(&RSTEST_BDD_HARNESS)
 }
 
 /// Try to return a token stream pointing to the requested crate or renamed
 /// dependency without panicking when the consumer does not depend on it.
-pub(crate) fn try_resolve_crate_path(
-    crate_name_str: &str,
-    default_ident: &str,
-) -> Option<TokenStream2> {
-    crate_name(crate_name_str)
+fn try_resolve_crate_path(spec: &CrateSpec) -> Option<TokenStream2> {
+    crate_name(spec.package_name)
         .ok()
-        .map(|found| found_crate_path(found, default_ident))
+        .map(|found| found_crate_path(found, spec))
 }
 
 /// Return a token stream pointing to the `rstest_bdd_harness_tokio` crate or
@@ -46,7 +63,7 @@ pub(crate) fn try_resolve_crate_path(
 /// resolve `TokioHarness` via proper crate lookup, supporting downstream
 /// crates that rename the dependency in their `Cargo.toml`.
 pub(crate) fn rstest_bdd_harness_tokio_path() -> TokenStream2 {
-    resolve_crate_path("rstest-bdd-harness-tokio", "rstest_bdd_harness_tokio")
+    resolve_crate_path(&TOKIO_HARNESS)
 }
 
 /// Return the crate root that provides base harness API for the given harness
@@ -57,17 +74,9 @@ pub(crate) fn rstest_bdd_harness_api_path_for(adapter_path: &syn::Path) -> Token
 
 fn first_party_adapter_api_path(adapter_path: &syn::Path) -> Option<TokenStream2> {
     let root = adapter_path.segments.first()?;
-    if first_party_adapter_path_matches(
-        adapter_path,
-        TOKIO_HARNESS_PACKAGE,
-        TOKIO_HARNESS_CRATE,
-        TOKIO_HARNESS_TYPES,
-    ) || first_party_adapter_path_matches(
-        adapter_path,
-        GPUI_HARNESS_PACKAGE,
-        GPUI_HARNESS_CRATE,
-        GPUI_HARNESS_TYPES,
-    ) {
+    if first_party_adapter_path_matches(adapter_path, &TOKIO_HARNESS)
+        || first_party_adapter_path_matches(adapter_path, &GPUI_HARNESS)
+    {
         let root = &root.ident;
         Some(quote! { ::#root })
     } else {
@@ -75,14 +84,9 @@ fn first_party_adapter_api_path(adapter_path: &syn::Path) -> Option<TokenStream2
     }
 }
 
-fn first_party_adapter_path_matches(
-    adapter_path: &syn::Path,
-    package_name: &str,
-    default_crate_name: &str,
-    adapter_type_names: &[&str],
-) -> bool {
-    path_last_ident_matches(adapter_path, adapter_type_names)
-        && path_root_matches_crate(adapter_path, package_name, default_crate_name)
+fn first_party_adapter_path_matches(adapter_path: &syn::Path, spec: &CrateSpec) -> bool {
+    path_last_ident_matches(adapter_path, spec.adapter_type_names)
+        && path_root_matches_crate(adapter_path, spec)
 }
 
 fn path_last_ident_matches(path: &syn::Path, expected: &[&str]) -> bool {
@@ -91,14 +95,14 @@ fn path_last_ident_matches(path: &syn::Path, expected: &[&str]) -> bool {
         .is_some_and(|segment| expected.iter().any(|name| segment.ident == name))
 }
 
-fn path_root_matches_crate(path: &syn::Path, package_name: &str, default_crate_name: &str) -> bool {
+fn path_root_matches_crate(path: &syn::Path, spec: &CrateSpec) -> bool {
     let Some(root) = path.segments.first() else {
         return false;
     };
-    if root.ident == default_crate_name {
+    if root.ident == spec.default_crate_name {
         return true;
     }
-    let Some(crate_path) = try_resolve_crate_path(package_name, default_crate_name) else {
+    let Some(crate_path) = try_resolve_crate_path(spec) else {
         return false;
     };
     let Ok(crate_path) = syn::parse2::<syn::Path>(crate_path) else {
@@ -110,77 +114,74 @@ fn path_root_matches_crate(path: &syn::Path, package_name: &str, default_crate_n
         .is_some_and(|crate_root| crate_root.ident == root.ident)
 }
 
-fn resolve_crate_path(crate_name_str: &str, default_ident: &str) -> TokenStream2 {
-    match crate_name(crate_name_str) {
-        Ok(found) => found_crate_path(found, default_ident),
-        Err(err) => handle_missing_crate(crate_name_str, &err),
+fn resolve_crate_path(spec: &CrateSpec) -> TokenStream2 {
+    match crate_name(spec.package_name) {
+        Ok(found) => found_crate_path(found, spec),
+        Err(err) => handle_missing_crate(spec, &err),
     }
 }
 
-fn found_crate_path(found: FoundCrate, default_ident: &str) -> TokenStream2 {
+fn found_crate_path(found: FoundCrate, spec: &CrateSpec) -> TokenStream2 {
     let ident = match found {
-        FoundCrate::Itself => Ident::new(default_ident, Span::call_site()),
+        FoundCrate::Itself => Ident::new(spec.default_crate_name, Span::call_site()),
         FoundCrate::Name(name) => Ident::new(&name, Span::call_site()),
     };
     quote! { ::#ident }
 }
 
 #[cfg(test)]
-fn handle_missing_crate(crate_name_str: &str, _: &proc_macro_crate::Error) -> TokenStream2 {
+fn handle_missing_crate(spec: &CrateSpec, _: &proc_macro_crate::Error) -> TokenStream2 {
     // Tests compile the macros crate in isolation without dependency crates, so
     // fall back to the default package name.
-    let ident = Ident::new(&crate_name_str.replace('-', "_"), Span::call_site());
+    let ident = Ident::new(spec.default_crate_name, Span::call_site());
     quote! { ::#ident }
 }
 
 #[cfg(not(test))]
-fn handle_missing_crate(crate_name_str: &str, err: &proc_macro_crate::Error) -> TokenStream2 {
-    panic!("{crate_name_str} crate not found: {err}");
+fn handle_missing_crate(spec: &CrateSpec, err: &proc_macro_crate::Error) -> TokenStream2 {
+    let crate_name = spec.package_name;
+    panic!("{crate_name} crate not found: {err}");
 }
 
 #[cfg(test)]
 mod tests {
-    use super::handle_missing_crate;
+    use super::{
+        handle_missing_crate, GPUI_HARNESS, RSTEST_BDD, RSTEST_BDD_HARNESS, TOKIO_HARNESS,
+    };
     use proc_macro_crate::Error;
     use std::path::PathBuf;
 
+    fn not_found_error(crate_name: &str) -> Error {
+        Error::CrateNotFound {
+            crate_name: crate_name.to_string(),
+            path: PathBuf::new(),
+        }
+    }
+
     #[test]
     fn returns_fallback_path_for_runtime_crate() {
-        let error = Error::CrateNotFound {
-            crate_name: "rstest-bdd".to_string(),
-            path: PathBuf::new(),
-        };
-        let tokens = handle_missing_crate("rstest-bdd", &error);
+        let tokens = handle_missing_crate(&RSTEST_BDD, &not_found_error("rstest-bdd"));
         assert_eq!(tokens.to_string(), ":: rstest_bdd");
     }
 
     #[test]
     fn returns_fallback_path_for_harness_crate() {
-        let error = Error::CrateNotFound {
-            crate_name: "rstest-bdd-harness".to_string(),
-            path: PathBuf::new(),
-        };
-        let tokens = handle_missing_crate("rstest-bdd-harness", &error);
+        let tokens =
+            handle_missing_crate(&RSTEST_BDD_HARNESS, &not_found_error("rstest-bdd-harness"));
         assert_eq!(tokens.to_string(), ":: rstest_bdd_harness");
     }
 
     #[test]
     fn returns_fallback_path_for_harness_tokio_crate() {
-        let error = Error::CrateNotFound {
-            crate_name: "rstest-bdd-harness-tokio".to_string(),
-            path: PathBuf::new(),
-        };
-        let tokens = handle_missing_crate("rstest-bdd-harness-tokio", &error);
+        let tokens =
+            handle_missing_crate(&TOKIO_HARNESS, &not_found_error("rstest-bdd-harness-tokio"));
         assert_eq!(tokens.to_string(), ":: rstest_bdd_harness_tokio");
     }
 
     #[test]
     fn returns_fallback_path_for_harness_gpui_crate() {
-        let error = Error::CrateNotFound {
-            crate_name: "rstest-bdd-harness-gpui".to_string(),
-            path: PathBuf::new(),
-        };
-        let tokens = handle_missing_crate("rstest-bdd-harness-gpui", &error);
+        let tokens =
+            handle_missing_crate(&GPUI_HARNESS, &not_found_error("rstest-bdd-harness-gpui"));
         assert_eq!(tokens.to_string(), ":: rstest_bdd_harness_gpui");
     }
 

--- a/crates/rstest-bdd-macros/src/codegen/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/mod.rs
@@ -6,6 +6,7 @@
 use proc_macro_crate::{FoundCrate, crate_name};
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::quote;
+use rstest_bdd_policy::TestAttributeHint;
 
 struct CrateSpec {
     package_name: &'static str,
@@ -76,6 +77,18 @@ pub(crate) fn rstest_bdd_harness_tokio_path() -> TokenStream2 {
 /// `rstest-bdd-harness` path.
 pub(crate) fn rstest_bdd_harness_api_path_for(adapter_path: &syn::Path) -> TokenStream2 {
     first_party_adapter_api_path(adapter_path).unwrap_or_else(rstest_bdd_harness_path)
+}
+
+pub(crate) fn first_party_adapter_attribute_hint(
+    adapter_path: &syn::Path,
+) -> Option<TestAttributeHint> {
+    if first_party_adapter_path_matches(adapter_path, &TOKIO_HARNESS) {
+        Some(TestAttributeHint::RstestWithTokioCurrentThread)
+    } else if first_party_adapter_path_matches(adapter_path, &GPUI_HARNESS) {
+        Some(TestAttributeHint::RstestWithGpuiTest)
+    } else {
+        None
+    }
 }
 
 fn first_party_adapter_api_path(adapter_path: &syn::Path) -> Option<TokenStream2> {
@@ -256,7 +269,7 @@ mod tests {
     }
 
     #[test]
-    fn renamed_root_with_known_type_falls_back_to_base_harness() {
+    fn renamed_root_with_known_type_uses_test_only_base_harness_fallback() {
         // Simulates: tok = { package = "rstest-bdd-harness-tokio" }
         // #[scenario(harness = tok::TokioHarness)]
         // In a test build try_resolve_crate_path returns None, so no root match.

--- a/crates/rstest-bdd-macros/src/codegen/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/mod.rs
@@ -10,6 +10,13 @@ use quote::quote;
 pub(crate) mod scenario;
 pub(crate) mod wrapper;
 
+const TOKIO_HARNESS_PACKAGE: &str = "rstest-bdd-harness-tokio";
+const TOKIO_HARNESS_CRATE: &str = "rstest_bdd_harness_tokio";
+const TOKIO_HARNESS_TYPES: &[&str] = &["TokioHarness", "TokioAttributePolicy"];
+const GPUI_HARNESS_PACKAGE: &str = "rstest-bdd-harness-gpui";
+const GPUI_HARNESS_CRATE: &str = "rstest_bdd_harness_gpui";
+const GPUI_HARNESS_TYPES: &[&str] = &["GpuiHarness", "GpuiAttributePolicy"];
+
 /// Return a token stream pointing to the `rstest_bdd` crate or its renamed form.
 pub(crate) fn rstest_bdd_path() -> TokenStream2 {
     resolve_crate_path("rstest-bdd", "rstest_bdd")
@@ -19,6 +26,17 @@ pub(crate) fn rstest_bdd_path() -> TokenStream2 {
 /// renamed form.
 pub(crate) fn rstest_bdd_harness_path() -> TokenStream2 {
     resolve_crate_path("rstest-bdd-harness", "rstest_bdd_harness")
+}
+
+/// Try to return a token stream pointing to the requested crate or renamed
+/// dependency without panicking when the consumer does not depend on it.
+pub(crate) fn try_resolve_crate_path(
+    crate_name_str: &str,
+    default_ident: &str,
+) -> Option<TokenStream2> {
+    crate_name(crate_name_str)
+        .ok()
+        .map(|found| found_crate_path(found, default_ident))
 }
 
 /// Return a token stream pointing to the `rstest_bdd_harness_tokio` crate or
@@ -31,17 +49,80 @@ pub(crate) fn rstest_bdd_harness_tokio_path() -> TokenStream2 {
     resolve_crate_path("rstest-bdd-harness-tokio", "rstest_bdd_harness_tokio")
 }
 
+/// Return the crate root that provides base harness API for the given harness
+/// or attribute-policy path.
+pub(crate) fn rstest_bdd_harness_api_path_for(adapter_path: &syn::Path) -> TokenStream2 {
+    first_party_adapter_api_path(adapter_path).unwrap_or_else(rstest_bdd_harness_path)
+}
+
+fn first_party_adapter_api_path(adapter_path: &syn::Path) -> Option<TokenStream2> {
+    let root = adapter_path.segments.first()?;
+    if first_party_adapter_path_matches(
+        adapter_path,
+        TOKIO_HARNESS_PACKAGE,
+        TOKIO_HARNESS_CRATE,
+        TOKIO_HARNESS_TYPES,
+    ) || first_party_adapter_path_matches(
+        adapter_path,
+        GPUI_HARNESS_PACKAGE,
+        GPUI_HARNESS_CRATE,
+        GPUI_HARNESS_TYPES,
+    ) {
+        let root = &root.ident;
+        Some(quote! { ::#root })
+    } else {
+        None
+    }
+}
+
+fn first_party_adapter_path_matches(
+    adapter_path: &syn::Path,
+    package_name: &str,
+    default_crate_name: &str,
+    adapter_type_names: &[&str],
+) -> bool {
+    path_last_ident_matches(adapter_path, adapter_type_names)
+        && path_root_matches_crate(adapter_path, package_name, default_crate_name)
+}
+
+fn path_last_ident_matches(path: &syn::Path, expected: &[&str]) -> bool {
+    path.segments
+        .last()
+        .is_some_and(|segment| expected.iter().any(|name| segment.ident == name))
+}
+
+fn path_root_matches_crate(path: &syn::Path, package_name: &str, default_crate_name: &str) -> bool {
+    let Some(root) = path.segments.first() else {
+        return false;
+    };
+    if root.ident == default_crate_name {
+        return true;
+    }
+    let Some(crate_path) = try_resolve_crate_path(package_name, default_crate_name) else {
+        return false;
+    };
+    let Ok(crate_path) = syn::parse2::<syn::Path>(crate_path) else {
+        return false;
+    };
+    crate_path
+        .segments
+        .first()
+        .is_some_and(|crate_root| crate_root.ident == root.ident)
+}
+
 fn resolve_crate_path(crate_name_str: &str, default_ident: &str) -> TokenStream2 {
     match crate_name(crate_name_str) {
-        Ok(found) => {
-            let ident = match found {
-                FoundCrate::Itself => Ident::new(default_ident, Span::call_site()),
-                FoundCrate::Name(name) => Ident::new(&name, Span::call_site()),
-            };
-            quote! { ::#ident }
-        }
+        Ok(found) => found_crate_path(found, default_ident),
         Err(err) => handle_missing_crate(crate_name_str, &err),
     }
+}
+
+fn found_crate_path(found: FoundCrate, default_ident: &str) -> TokenStream2 {
+    let ident = match found {
+        FoundCrate::Itself => Ident::new(default_ident, Span::call_site()),
+        FoundCrate::Name(name) => Ident::new(&name, Span::call_site()),
+    };
+    quote! { ::#ident }
 }
 
 #[cfg(test)]
@@ -91,5 +172,36 @@ mod tests {
         };
         let tokens = handle_missing_crate("rstest-bdd-harness-tokio", &error);
         assert_eq!(tokens.to_string(), ":: rstest_bdd_harness_tokio");
+    }
+
+    #[test]
+    fn returns_fallback_path_for_harness_gpui_crate() {
+        let error = Error::CrateNotFound {
+            crate_name: "rstest-bdd-harness-gpui".to_string(),
+            path: PathBuf::new(),
+        };
+        let tokens = handle_missing_crate("rstest-bdd-harness-gpui", &error);
+        assert_eq!(tokens.to_string(), ":: rstest_bdd_harness_gpui");
+    }
+
+    #[test]
+    fn first_party_harness_api_path_uses_adapter_crate() {
+        let harness_path = syn::parse_quote!(rstest_bdd_harness_tokio::TokioHarness);
+        let tokens = super::rstest_bdd_harness_api_path_for(&harness_path);
+        assert_eq!(tokens.to_string(), ":: rstest_bdd_harness_tokio");
+    }
+
+    #[test]
+    fn first_party_attribute_api_path_uses_adapter_crate() {
+        let policy_path = syn::parse_quote!(rstest_bdd_harness_gpui::GpuiAttributePolicy);
+        let tokens = super::rstest_bdd_harness_api_path_for(&policy_path);
+        assert_eq!(tokens.to_string(), ":: rstest_bdd_harness_gpui");
+    }
+
+    #[test]
+    fn custom_harness_api_path_uses_base_harness_crate() {
+        let harness_path = syn::parse_quote!(my_harness::Harness);
+        let tokens = super::rstest_bdd_harness_api_path_for(&harness_path);
+        assert_eq!(tokens.to_string(), ":: rstest_bdd_harness");
     }
 }

--- a/crates/rstest-bdd-macros/src/codegen/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/mod.rs
@@ -4,6 +4,8 @@
 //! does not depend on the runtime crate at compile-time.
 
 use proc_macro_crate::{FoundCrate, crate_name};
+#[cfg(not(test))]
+use proc_macro_error::emit_warning;
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::quote;
 use rstest_bdd_policy::TestAttributeHint;
@@ -76,7 +78,10 @@ pub(crate) fn rstest_bdd_harness_tokio_path() -> TokenStream2 {
 /// macro-expansion time (including test builds) fall back to the base
 /// `rstest-bdd-harness` path.
 pub(crate) fn rstest_bdd_harness_api_path_for(adapter_path: &syn::Path) -> TokenStream2 {
-    first_party_adapter_api_path(adapter_path).unwrap_or_else(rstest_bdd_harness_path)
+    first_party_adapter_api_path(adapter_path).unwrap_or_else(|| {
+        emit_first_party_adapter_fallback_warning(adapter_path);
+        rstest_bdd_harness_path()
+    })
 }
 
 pub(crate) fn first_party_adapter_attribute_hint(
@@ -101,6 +106,36 @@ fn first_party_adapter_spec(adapter_path: &syn::Path) -> Option<&'static CrateSp
         .into_iter()
         .find(|spec| first_party_adapter_path_matches(adapter_path, spec))
 }
+
+#[cfg(not(test))]
+fn emit_first_party_adapter_fallback_warning(adapter_path: &syn::Path) {
+    let Some(spec) = [&TOKIO_HARNESS, &GPUI_HARNESS]
+        .into_iter()
+        .find(|spec| path_last_ident_matches(adapter_path, spec.adapter_type_names))
+    else {
+        return;
+    };
+    let span = adapter_path
+        .segments
+        .last()
+        .map_or_else(Span::call_site, |segment| segment.ident.span());
+    let package_name = spec.package_name;
+    let default_crate_name = spec.default_crate_name;
+    emit_warning!(
+        span,
+        concat!(
+            "rstest-bdd could not identify this harness or attribute-policy path as a first-party adapter; ",
+            "falling back to `rstest-bdd-harness` for base harness API types. ",
+            "Use the canonical crate-root path, ensure `{}` is directly resolvable as `{}`, ",
+            "or add `rstest-bdd-harness` as a direct dev-dependency."
+        ),
+        package_name,
+        default_crate_name
+    );
+}
+
+#[cfg(test)]
+fn emit_first_party_adapter_fallback_warning(_: &syn::Path) {}
 
 fn first_party_adapter_api_root(adapter_path: &syn::Path, spec: &CrateSpec) -> TokenStream2 {
     if path_root_matches_crate(adapter_path, spec) {

--- a/crates/rstest-bdd-macros/src/codegen/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/mod.rs
@@ -68,6 +68,12 @@ pub(crate) fn rstest_bdd_harness_tokio_path() -> TokenStream2 {
 
 /// Return the crate root that provides base harness API for the given harness
 /// or attribute-policy path.
+///
+/// Adapter detection relies on the crate-root identifier in `adapter_path`
+/// matching either the default snake-case crate name or a resolved renamed
+/// dependency. Renamed dependencies that cannot be resolved at
+/// macro-expansion time (including test builds) fall back to the base
+/// `rstest-bdd-harness` path.
 pub(crate) fn rstest_bdd_harness_api_path_for(adapter_path: &syn::Path) -> TokenStream2 {
     first_party_adapter_api_path(adapter_path).unwrap_or_else(rstest_bdd_harness_path)
 }
@@ -180,29 +186,17 @@ mod tests {
     }
 
     #[rstest]
-    #[case::runtime(&RSTEST_BDD, "rstest-bdd", ":: rstest_bdd")]
-    #[case::harness(
-        &RSTEST_BDD_HARNESS,
-        "rstest-bdd-harness",
-        ":: rstest_bdd_harness"
-    )]
-    #[case::tokio(
-        &TOKIO_HARNESS,
-        "rstest-bdd-harness-tokio",
-        ":: rstest_bdd_harness_tokio"
-    )]
-    #[case::gpui(
-        &GPUI_HARNESS,
-        "rstest-bdd-harness-gpui",
-        ":: rstest_bdd_harness_gpui"
-    )]
-    fn returns_fallback_path_for_known_crates(
-        #[case] crate_spec: &super::CrateSpec,
-        #[case] not_found_name: &str,
-        #[case] expected_string: &str,
+    #[case(&RSTEST_BDD, "rstest-bdd", ":: rstest_bdd")]
+    #[case(&RSTEST_BDD_HARNESS, "rstest-bdd-harness", ":: rstest_bdd_harness")]
+    #[case(&TOKIO_HARNESS, "rstest-bdd-harness-tokio", ":: rstest_bdd_harness_tokio")]
+    #[case(&GPUI_HARNESS, "rstest-bdd-harness-gpui", ":: rstest_bdd_harness_gpui")]
+    fn returns_fallback_path(
+        #[case] spec: &super::CrateSpec,
+        #[case] pkg: &str,
+        #[case] expected: &str,
     ) {
-        let tokens = handle_missing_crate(crate_spec, &not_found_error(not_found_name));
-        assert_eq!(tokens.to_string(), expected_string);
+        let tokens = handle_missing_crate(spec, &not_found_error(pkg));
+        assert_eq!(tokens.to_string(), expected);
     }
 
     #[rstest]
@@ -230,6 +224,26 @@ mod tests {
     #[test]
     fn matching_type_name_under_unknown_root_uses_base_harness_crate() {
         let harness_path = syn::parse_quote!(my_harness::TokioHarness);
+        let tokens = super::rstest_bdd_harness_api_path_for(&harness_path);
+        assert_eq!(tokens.to_string(), ":: rstest_bdd_harness");
+    }
+
+    #[test]
+    fn aliased_import_falls_back_to_base_harness() {
+        // Simulates: use rstest_bdd_harness_tokio::TokioHarness as TH;
+        // #[scenario(harness = my_mod::TH)] - type alias not in known names.
+        let harness_path = syn::parse_quote!(rstest_bdd_harness_tokio::SomeAlias);
+        let tokens = super::rstest_bdd_harness_api_path_for(&harness_path);
+        // The type name is not in TOKIO_HARNESS.adapter_type_names, so fall back.
+        assert_eq!(tokens.to_string(), ":: rstest_bdd_harness");
+    }
+
+    #[test]
+    fn renamed_root_with_known_type_falls_back_to_base_harness() {
+        // Simulates: tok = { package = "rstest-bdd-harness-tokio" }
+        // #[scenario(harness = tok::TokioHarness)]
+        // In a test build try_resolve_crate_path returns None, so no root match.
+        let harness_path = syn::parse_quote!(tok::TokioHarness);
         let tokens = super::rstest_bdd_harness_api_path_for(&harness_path);
         assert_eq!(tokens.to_string(), ":: rstest_bdd_harness");
     }

--- a/crates/rstest-bdd-macros/src/codegen/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/mod.rs
@@ -149,6 +149,7 @@ mod tests {
         GPUI_HARNESS, RSTEST_BDD, RSTEST_BDD_HARNESS, TOKIO_HARNESS, handle_missing_crate,
     };
     use proc_macro_crate::Error;
+    use rstest::rstest;
     use std::path::PathBuf;
 
     fn not_found_error(crate_name: &str) -> Error {
@@ -158,31 +159,30 @@ mod tests {
         }
     }
 
-    #[test]
-    fn returns_fallback_path_for_runtime_crate() {
-        let tokens = handle_missing_crate(&RSTEST_BDD, &not_found_error("rstest-bdd"));
-        assert_eq!(tokens.to_string(), ":: rstest_bdd");
-    }
-
-    #[test]
-    fn returns_fallback_path_for_harness_crate() {
-        let tokens =
-            handle_missing_crate(&RSTEST_BDD_HARNESS, &not_found_error("rstest-bdd-harness"));
-        assert_eq!(tokens.to_string(), ":: rstest_bdd_harness");
-    }
-
-    #[test]
-    fn returns_fallback_path_for_harness_tokio_crate() {
-        let tokens =
-            handle_missing_crate(&TOKIO_HARNESS, &not_found_error("rstest-bdd-harness-tokio"));
-        assert_eq!(tokens.to_string(), ":: rstest_bdd_harness_tokio");
-    }
-
-    #[test]
-    fn returns_fallback_path_for_harness_gpui_crate() {
-        let tokens =
-            handle_missing_crate(&GPUI_HARNESS, &not_found_error("rstest-bdd-harness-gpui"));
-        assert_eq!(tokens.to_string(), ":: rstest_bdd_harness_gpui");
+    #[rstest]
+    #[case::runtime(&RSTEST_BDD, "rstest-bdd", ":: rstest_bdd")]
+    #[case::harness(
+        &RSTEST_BDD_HARNESS,
+        "rstest-bdd-harness",
+        ":: rstest_bdd_harness"
+    )]
+    #[case::tokio(
+        &TOKIO_HARNESS,
+        "rstest-bdd-harness-tokio",
+        ":: rstest_bdd_harness_tokio"
+    )]
+    #[case::gpui(
+        &GPUI_HARNESS,
+        "rstest-bdd-harness-gpui",
+        ":: rstest_bdd_harness_gpui"
+    )]
+    fn returns_fallback_path_for_known_crates(
+        #[case] crate_spec: &super::CrateSpec,
+        #[case] not_found_name: &str,
+        #[case] expected_string: &str,
+    ) {
+        let tokens = handle_missing_crate(crate_spec, &not_found_error(not_found_name));
+        assert_eq!(tokens.to_string(), expected_string);
     }
 
     #[test]

--- a/crates/rstest-bdd-macros/src/codegen/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/mod.rs
@@ -73,20 +73,35 @@ pub(crate) fn rstest_bdd_harness_api_path_for(adapter_path: &syn::Path) -> Token
 }
 
 fn first_party_adapter_api_path(adapter_path: &syn::Path) -> Option<TokenStream2> {
-    let root = adapter_path.segments.first()?;
-    if first_party_adapter_path_matches(adapter_path, &TOKIO_HARNESS)
-        || first_party_adapter_path_matches(adapter_path, &GPUI_HARNESS)
-    {
-        let root = &root.ident;
-        Some(quote! { ::#root })
+    first_party_adapter_spec(adapter_path)
+        .map(|spec| first_party_adapter_api_root(adapter_path, spec))
+}
+
+fn first_party_adapter_spec(adapter_path: &syn::Path) -> Option<&'static CrateSpec> {
+    [&TOKIO_HARNESS, &GPUI_HARNESS]
+        .into_iter()
+        .find(|spec| first_party_adapter_path_matches(adapter_path, spec))
+}
+
+fn first_party_adapter_api_root(adapter_path: &syn::Path, spec: &CrateSpec) -> TokenStream2 {
+    if path_root_matches_crate(adapter_path, spec) {
+        let Some(root) = adapter_path.segments.first().map(|segment| &segment.ident) else {
+            return resolve_crate_path(spec);
+        };
+        quote! { ::#root }
     } else {
-        None
+        resolve_crate_path(spec)
     }
 }
 
 fn first_party_adapter_path_matches(adapter_path: &syn::Path, spec: &CrateSpec) -> bool {
     path_last_ident_matches(adapter_path, spec.adapter_type_names)
-        && path_root_matches_crate(adapter_path, spec)
+        && (path_root_matches_crate(adapter_path, spec)
+            || is_imported_adapter_type_path(adapter_path))
+}
+
+fn is_imported_adapter_type_path(path: &syn::Path) -> bool {
+    path.segments.len() == 1
 }
 
 fn path_last_ident_matches(path: &syn::Path, expected: &[&str]) -> bool {
@@ -159,6 +174,11 @@ mod tests {
         }
     }
 
+    #[expect(clippy::expect_used, reason = "test path literals should parse")]
+    fn parse_path(path: &str) -> syn::Path {
+        syn::parse_str(path).expect("parse path")
+    }
+
     #[rstest]
     #[case::runtime(&RSTEST_BDD, "rstest-bdd", ":: rstest_bdd")]
     #[case::harness(
@@ -185,18 +205,33 @@ mod tests {
         assert_eq!(tokens.to_string(), expected_string);
     }
 
-    #[test]
-    fn first_party_harness_api_path_uses_adapter_crate() {
-        let harness_path = syn::parse_quote!(rstest_bdd_harness_tokio::TokioHarness);
-        let tokens = super::rstest_bdd_harness_api_path_for(&harness_path);
-        assert_eq!(tokens.to_string(), ":: rstest_bdd_harness_tokio");
+    #[rstest]
+    #[case::tokio_harness_canonical(
+        "rstest_bdd_harness_tokio::TokioHarness",
+        ":: rstest_bdd_harness_tokio"
+    )]
+    #[case::tokio_harness_imported("TokioHarness", ":: rstest_bdd_harness_tokio")]
+    #[case::tokio_policy_imported("TokioAttributePolicy", ":: rstest_bdd_harness_tokio")]
+    #[case::gpui_harness_imported("GpuiHarness", ":: rstest_bdd_harness_gpui")]
+    #[case::gpui_policy_canonical(
+        "rstest_bdd_harness_gpui::GpuiAttributePolicy",
+        ":: rstest_bdd_harness_gpui"
+    )]
+    #[case::gpui_policy_imported("GpuiAttributePolicy", ":: rstest_bdd_harness_gpui")]
+    fn first_party_adapter_api_path_uses_adapter_crate(
+        #[case] adapter_path: &str,
+        #[case] expected: &str,
+    ) {
+        let adapter_path = parse_path(adapter_path);
+        let tokens = super::rstest_bdd_harness_api_path_for(&adapter_path);
+        assert_eq!(tokens.to_string(), expected);
     }
 
     #[test]
-    fn first_party_attribute_api_path_uses_adapter_crate() {
-        let policy_path = syn::parse_quote!(rstest_bdd_harness_gpui::GpuiAttributePolicy);
-        let tokens = super::rstest_bdd_harness_api_path_for(&policy_path);
-        assert_eq!(tokens.to_string(), ":: rstest_bdd_harness_gpui");
+    fn matching_type_name_under_unknown_root_uses_base_harness_crate() {
+        let harness_path = syn::parse_quote!(my_harness::TokioHarness);
+        let tokens = super::rstest_bdd_harness_api_path_for(&harness_path);
+        assert_eq!(tokens.to_string(), ":: rstest_bdd_harness");
     }
 
     #[test]

--- a/crates/rstest-bdd-macros/src/codegen/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/mod.rs
@@ -170,6 +170,7 @@ mod tests {
         GPUI_HARNESS, RSTEST_BDD, RSTEST_BDD_HARNESS, TOKIO_HARNESS, handle_missing_crate,
     };
     use proc_macro_crate::Error;
+    use proptest::prelude::*;
     use rstest::rstest;
     use std::path::PathBuf;
 
@@ -183,6 +184,25 @@ mod tests {
     #[expect(clippy::expect_used, reason = "test path literals should parse")]
     fn parse_path(path: &str) -> syn::Path {
         syn::parse_str(path).expect("parse path")
+    }
+
+    fn adapter_spec(is_tokio: bool) -> &'static super::CrateSpec {
+        if is_tokio {
+            &TOKIO_HARNESS
+        } else {
+            &GPUI_HARNESS
+        }
+    }
+
+    fn known_adapter_type(spec: &super::CrateSpec, use_policy_type: bool) -> &'static str {
+        let [harness_type, policy_type] = spec.adapter_type_names else {
+            panic!("first-party adapter specs have harness and policy type names");
+        };
+        if use_policy_type {
+            policy_type
+        } else {
+            harness_type
+        }
     }
 
     #[rstest]
@@ -253,5 +273,42 @@ mod tests {
         let harness_path = syn::parse_quote!(my_harness::Harness);
         let tokens = super::rstest_bdd_harness_api_path_for(&harness_path);
         assert_eq!(tokens.to_string(), ":: rstest_bdd_harness");
+    }
+
+    proptest! {
+        #[test]
+        fn path_root_matches_crate_depends_on_resolved_root(
+            is_tokio in any::<bool>(),
+            suffix in any::<u16>(),
+            use_policy_type in any::<bool>(),
+        ) {
+            let spec = adapter_spec(is_tokio);
+            let known_type = known_adapter_type(spec, use_policy_type);
+            let matching_path = parse_path(&format!("{}::{known_type}", spec.default_crate_name));
+            let renamed_path = parse_path(&format!("renamed_{suffix}::{known_type}"));
+
+            prop_assert!(super::path_root_matches_crate(&matching_path, spec));
+            prop_assert!(!super::path_root_matches_crate(&renamed_path, spec));
+        }
+
+        #[test]
+        fn first_party_adapter_path_matches_requires_known_type_and_valid_root(
+            is_tokio in any::<bool>(),
+            suffix in any::<u16>(),
+            use_policy_type in any::<bool>(),
+        ) {
+            let spec = adapter_spec(is_tokio);
+            let known_type = known_adapter_type(spec, use_policy_type);
+            let unknown_type = format!("Alias{suffix}");
+            let imported_path = parse_path(known_type);
+            let canonical_path = parse_path(&format!("{}::{known_type}", spec.default_crate_name));
+            let renamed_path = parse_path(&format!("renamed_{suffix}::{known_type}"));
+            let aliased_path = parse_path(&format!("{}::{unknown_type}", spec.default_crate_name));
+
+            prop_assert!(super::first_party_adapter_path_matches(&imported_path, spec));
+            prop_assert!(super::first_party_adapter_path_matches(&canonical_path, spec));
+            prop_assert!(!super::first_party_adapter_path_matches(&renamed_path, spec));
+            prop_assert!(!super::first_party_adapter_path_matches(&aliased_path, spec));
+        }
     }
 }

--- a/crates/rstest-bdd-macros/src/codegen/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/mod.rs
@@ -103,11 +103,11 @@ fn first_party_adapter_api_root(adapter_path: &syn::Path, spec: &CrateSpec) -> T
 fn first_party_adapter_path_matches(adapter_path: &syn::Path, spec: &CrateSpec) -> bool {
     path_last_ident_matches(adapter_path, spec.adapter_type_names)
         && (path_root_matches_crate(adapter_path, spec)
-            || is_imported_adapter_type_path(adapter_path))
+            || is_imported_adapter_type_path(adapter_path, spec))
 }
 
-fn is_imported_adapter_type_path(path: &syn::Path) -> bool {
-    path.segments.len() == 1
+fn is_imported_adapter_type_path(path: &syn::Path, spec: &CrateSpec) -> bool {
+    path.segments.len() == 1 && try_resolve_crate_path(spec).is_some()
 }
 
 fn path_last_ident_matches(path: &syn::Path, expected: &[&str]) -> bool {
@@ -224,18 +224,15 @@ mod tests {
         "rstest_bdd_harness_tokio::TokioHarness",
         ":: rstest_bdd_harness_tokio"
     )]
-    #[case::tokio_harness_imported("TokioHarness", ":: rstest_bdd_harness_tokio")]
-    #[case::tokio_policy_imported("TokioAttributePolicy", ":: rstest_bdd_harness_tokio")]
-    #[case::gpui_harness_imported("GpuiHarness", ":: rstest_bdd_harness_gpui")]
+    #[case::tokio_harness_imported("TokioHarness", ":: rstest_bdd_harness")]
+    #[case::tokio_policy_imported("TokioAttributePolicy", ":: rstest_bdd_harness")]
+    #[case::gpui_harness_imported("GpuiHarness", ":: rstest_bdd_harness")]
     #[case::gpui_policy_canonical(
         "rstest_bdd_harness_gpui::GpuiAttributePolicy",
         ":: rstest_bdd_harness_gpui"
     )]
-    #[case::gpui_policy_imported("GpuiAttributePolicy", ":: rstest_bdd_harness_gpui")]
-    fn first_party_adapter_api_path_uses_adapter_crate(
-        #[case] adapter_path: &str,
-        #[case] expected: &str,
-    ) {
+    #[case::gpui_policy_imported("GpuiAttributePolicy", ":: rstest_bdd_harness")]
+    fn adapter_api_path_uses_expected_crate(#[case] adapter_path: &str, #[case] expected: &str) {
         let adapter_path = parse_path(adapter_path);
         let tokens = super::rstest_bdd_harness_api_path_for(&adapter_path);
         assert_eq!(tokens.to_string(), expected);
@@ -305,7 +302,7 @@ mod tests {
             let renamed_path = parse_path(&format!("renamed_{suffix}::{known_type}"));
             let aliased_path = parse_path(&format!("{}::{unknown_type}", spec.default_crate_name));
 
-            prop_assert!(super::first_party_adapter_path_matches(&imported_path, spec));
+            prop_assert!(!super::first_party_adapter_path_matches(&imported_path, spec));
             prop_assert!(super::first_party_adapter_path_matches(&canonical_path, spec));
             prop_assert!(!super::first_party_adapter_path_matches(&renamed_path, spec));
             prop_assert!(!super::first_party_adapter_path_matches(&aliased_path, spec));

--- a/crates/rstest-bdd-macros/src/codegen/scenario.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario.rs
@@ -100,9 +100,8 @@ fn generate_trait_assertions(
         return TokenStream2::new();
     }
 
-    let harness_crate = crate::codegen::rstest_bdd_harness_path();
-
     let harness_assertion = harness.map(|harness_path| {
+        let harness_crate = crate::codegen::rstest_bdd_harness_api_path_for(harness_path);
         quote! {
             const _: () = {
                 fn __assert_harness<T: #harness_crate::HarnessAdapter + Default>() {}
@@ -111,6 +110,7 @@ fn generate_trait_assertions(
         }
     });
     let attributes_assertion = attributes.map(|policy_path| {
+        let harness_crate = crate::codegen::rstest_bdd_harness_api_path_for(policy_path);
         quote! {
             const _: () = {
                 fn __assert_attr_policy<T: #harness_crate::AttributePolicy>() {}

--- a/crates/rstest-bdd-macros/src/codegen/scenario.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario.rs
@@ -1,4 +1,24 @@
 //! Code generation for scenario tests.
+//!
+//! This module coordinates the full code-generation pipeline for a single
+//! BDD scenario or scenario outline. The pipeline is partitioned across
+//! five focused sub-modules:
+//!
+//! - [`domain`] — domain types shared across the pipeline (`ScenarioConfig`,
+//!   `ScenarioReturnKind`).
+//! - [`helpers`] — step-processing utilities and case-attribute generators.
+//! - [`metadata`] — strongly-typed wrappers for feature-path and
+//!   scenario-name values used in generated code.
+//! - [`runtime`] — token generation for the async runtime wrapper and the
+//!   harness-orchestrated `ScenarioRunRequest`.
+//! - [`test_attrs`] — ADR-008 attribute-policy resolution, translating
+//!   harness and runtime-mode hints into the correct set of test attributes
+//!   (`#[rstest::rstest]`, `#[tokio::test]`, `#[gpui::test]`).
+//!
+//! Public entry points are [`generate_scenario`] and
+//! [`generate_scenario_outline`], which delegate to the internal helpers
+//! after resolving compile-time trait assertions via
+//! [`crate::codegen::rstest_bdd_harness_api_path_for`].
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;

--- a/crates/rstest-bdd-macros/src/codegen/scenario/runtime/harness.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/runtime/harness.rs
@@ -115,7 +115,7 @@ pub(super) fn assemble_test_tokens_with_harness(
     harness_path: &syn::Path,
 ) -> TokenStream2 {
     let path = crate::codegen::rstest_bdd_path();
-    let harness_crate = crate::codegen::rstest_bdd_harness_path();
+    let harness_crate = crate::codegen::rstest_bdd_harness_api_path_for(harness_path);
     let harness_context_ty = quote! {
         <#harness_path as #harness_crate::HarnessAdapter>::Context
     };

--- a/crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs
@@ -6,6 +6,8 @@ use rstest_bdd_policy::{
     resolve_test_attribute_hint_for_harness_path, resolve_test_attribute_hint_for_policy_path,
 };
 
+use crate::codegen::first_party_adapter_attribute_hint;
+
 use super::{RuntimeMode, TestAttributeHint};
 
 /// Returns `true` when `attr` is exactly `<crate_name>::<fn_name>`.
@@ -59,12 +61,12 @@ impl ResolvedAttributePolicy {
 
 fn resolve_attribute_hint_from_policy_path(path: &syn::Path) -> Option<TestAttributeHint> {
     resolve_attribute_hint_from_path(path, resolve_test_attribute_hint_for_policy_path)
-        .or_else(|| resolve_imported_policy_hint(path))
+        .or_else(|| first_party_adapter_attribute_hint(path))
 }
 
 fn resolve_attribute_hint_from_harness_path(path: &syn::Path) -> Option<TestAttributeHint> {
     resolve_attribute_hint_from_path(path, resolve_test_attribute_hint_for_harness_path)
-        .or_else(|| resolve_imported_harness_hint(path))
+        .or_else(|| first_party_adapter_attribute_hint(path))
 }
 
 fn resolve_attribute_hint_from_path(
@@ -78,37 +80,6 @@ fn resolve_attribute_hint_from_path(
         .collect();
     let segment_refs: Vec<_> = segment_names.iter().map(String::as_str).collect();
     resolver(&segment_refs)
-}
-
-fn resolve_imported_hint(
-    path: &syn::Path,
-    tokio_name: &str,
-    gpui_name: &str,
-) -> Option<TestAttributeHint> {
-    let ident = single_segment_ident(path)?;
-    if ident == tokio_name {
-        Some(TestAttributeHint::RstestWithTokioCurrentThread)
-    } else if ident == gpui_name {
-        Some(TestAttributeHint::RstestWithGpuiTest)
-    } else {
-        None
-    }
-}
-
-fn resolve_imported_policy_hint(path: &syn::Path) -> Option<TestAttributeHint> {
-    resolve_imported_hint(path, "TokioAttributePolicy", "GpuiAttributePolicy")
-}
-
-fn resolve_imported_harness_hint(path: &syn::Path) -> Option<TestAttributeHint> {
-    resolve_imported_hint(path, "TokioHarness", "GpuiHarness")
-}
-
-fn single_segment_ident(path: &syn::Path) -> Option<&proc_macro2::Ident> {
-    if path.segments.len() == 1 {
-        path.segments.first().map(|segment| &segment.ident)
-    } else {
-        None
-    }
 }
 
 /// Policy-resolution inputs bundled for ADR-008 precedence.

--- a/crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs
@@ -59,10 +59,12 @@ impl ResolvedAttributePolicy {
 
 fn resolve_attribute_hint_from_policy_path(path: &syn::Path) -> Option<TestAttributeHint> {
     resolve_attribute_hint_from_path(path, resolve_test_attribute_hint_for_policy_path)
+        .or_else(|| resolve_imported_policy_hint(path))
 }
 
 fn resolve_attribute_hint_from_harness_path(path: &syn::Path) -> Option<TestAttributeHint> {
     resolve_attribute_hint_from_path(path, resolve_test_attribute_hint_for_harness_path)
+        .or_else(|| resolve_imported_harness_hint(path))
 }
 
 fn resolve_attribute_hint_from_path(
@@ -76,6 +78,36 @@ fn resolve_attribute_hint_from_path(
         .collect();
     let segment_refs: Vec<_> = segment_names.iter().map(String::as_str).collect();
     resolver(&segment_refs)
+}
+
+fn resolve_imported_policy_hint(path: &syn::Path) -> Option<TestAttributeHint> {
+    let ident = single_segment_ident(path)?;
+    if ident == "TokioAttributePolicy" {
+        Some(TestAttributeHint::RstestWithTokioCurrentThread)
+    } else if ident == "GpuiAttributePolicy" {
+        Some(TestAttributeHint::RstestWithGpuiTest)
+    } else {
+        None
+    }
+}
+
+fn resolve_imported_harness_hint(path: &syn::Path) -> Option<TestAttributeHint> {
+    let ident = single_segment_ident(path)?;
+    if ident == "TokioHarness" {
+        Some(TestAttributeHint::RstestWithTokioCurrentThread)
+    } else if ident == "GpuiHarness" {
+        Some(TestAttributeHint::RstestWithGpuiTest)
+    } else {
+        None
+    }
+}
+
+fn single_segment_ident(path: &syn::Path) -> Option<&proc_macro2::Ident> {
+    if path.segments.len() == 1 {
+        path.segments.first().map(|segment| &segment.ident)
+    } else {
+        None
+    }
 }
 
 /// Policy-resolution inputs bundled for ADR-008 precedence.

--- a/crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs
@@ -1,4 +1,20 @@
 //! Test-attribute policy resolution for generated scenario tests.
+//!
+//! This module implements the ADR-008 precedence chain that selects which
+//! framework test attributes are emitted alongside `#[rstest::rstest]` for
+//! each generated test function:
+//!
+//! 1. An explicit `attributes = …` path supplied to the `#[scenario]` or
+//!    `#[scenarios]` macro takes highest precedence.
+//! 2. A `harness = …` path is consulted next; first-party adapter types
+//!    (`TokioHarness`, `GpuiHarness`) are recognised via
+//!    [`crate::codegen::first_party_adapter_attribute_hint`].
+//! 3. The `RuntimeMode` derived from `runtime = …` or the macro's defaults
+//!    provides the final fallback.
+//!
+//! The public surface is [`generate_test_attrs`] and [`TestAttrPolicy`].
+//! Existing user attributes (`#[tokio::test]`, `#[gpui::test]`) are
+//! detected so that generated output does not duplicate them.
 
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;

--- a/crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs
@@ -80,26 +80,27 @@ fn resolve_attribute_hint_from_path(
     resolver(&segment_refs)
 }
 
-fn resolve_imported_policy_hint(path: &syn::Path) -> Option<TestAttributeHint> {
+fn resolve_imported_hint(
+    path: &syn::Path,
+    tokio_name: &str,
+    gpui_name: &str,
+) -> Option<TestAttributeHint> {
     let ident = single_segment_ident(path)?;
-    if ident == "TokioAttributePolicy" {
+    if ident == tokio_name {
         Some(TestAttributeHint::RstestWithTokioCurrentThread)
-    } else if ident == "GpuiAttributePolicy" {
+    } else if ident == gpui_name {
         Some(TestAttributeHint::RstestWithGpuiTest)
     } else {
         None
     }
 }
 
+fn resolve_imported_policy_hint(path: &syn::Path) -> Option<TestAttributeHint> {
+    resolve_imported_hint(path, "TokioAttributePolicy", "GpuiAttributePolicy")
+}
+
 fn resolve_imported_harness_hint(path: &syn::Path) -> Option<TestAttributeHint> {
-    let ident = single_segment_ident(path)?;
-    if ident == "TokioHarness" {
-        Some(TestAttributeHint::RstestWithTokioCurrentThread)
-    } else if ident == "GpuiHarness" {
-        Some(TestAttributeHint::RstestWithGpuiTest)
-    } else {
-        None
-    }
+    resolve_imported_hint(path, "TokioHarness", "GpuiHarness")
 }
 
 fn single_segment_ident(path: &syn::Path) -> Option<&proc_macro2::Ident> {

--- a/crates/rstest-bdd-macros/src/codegen/scenario/tests.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/tests.rs
@@ -72,10 +72,6 @@ fn detects_allow_skipped_tag(#[case] tags: Vec<String>, #[case] expected: bool) 
     assert_eq!(scenario_allows_skip(&tags), expected);
 }
 
-// -----------------------------------------------------------------------------
-// Tests for generate_test_attrs: has_tokio_test detection and attribute generation
-// -----------------------------------------------------------------------------
-
 #[expect(clippy::expect_used, reason = "test helper with descriptive failures")]
 fn parse_attr(s: &str) -> syn::Attribute {
     syn::parse_str::<syn::DeriveInput>(&format!("{s} struct S;"))
@@ -103,8 +99,6 @@ fn has_tokio_test_detection(#[case] attr_str: &str, #[case] expected_tokio: bool
     let attr = parse_attr(attr_str);
     let attrs = vec![attr];
 
-    // When runtime is TokioCurrentThread and tokio::test is already present,
-    // we should NOT emit another tokio::test attribute.
     let tokens = generate_test_attrs(
         &attrs,
         &TestAttrPolicy {
@@ -117,13 +111,11 @@ fn has_tokio_test_detection(#[case] attr_str: &str, #[case] expected_tokio: bool
     let has_tokio_in_output = tokens_contain(&tokens, "tokio :: test");
 
     if expected_tokio {
-        // tokio::test detected, so output should NOT include tokio::test
         assert!(
             !has_tokio_in_output,
             "expected no tokio::test in output when user already has one: {attr_str}"
         );
     } else {
-        // tokio::test NOT detected, so output SHOULD include tokio::test
         assert!(
             has_tokio_in_output,
             "expected tokio::test in output when user does not have one: {attr_str}"
@@ -154,7 +146,6 @@ fn generate_test_attrs_output(
     );
     let output = tokens.to_string();
 
-    // All outputs should contain rstest::rstest
     assert!(
         output.contains("rstest :: rstest"),
         "expected rstest::rstest in output: {output}"
@@ -166,7 +157,6 @@ fn generate_test_attrs_output(
         "tokio::test presence mismatch for runtime={runtime:?}, attrs={attr_strs:?}"
     );
 
-    // When tokio::test is emitted, it should specify current_thread flavor
     if expect_tokio_test {
         assert!(
             output.contains("current_thread"),
@@ -174,10 +164,6 @@ fn generate_test_attrs_output(
         );
     }
 }
-
-// -----------------------------------------------------------------------------
-// Tests for generate_test_attrs with attributes policy parameter
-// -----------------------------------------------------------------------------
 
 #[expect(clippy::expect_used, reason = "test helper with descriptive failures")]
 fn parse_path(s: &str) -> syn::Path {
@@ -292,19 +278,12 @@ fn generate_test_attrs_dedupes_tokio_policy_and_user_attribute() {
     );
 }
 
-// -----------------------------------------------------------------------------
-// Tests for generate_trait_assertions
-// -----------------------------------------------------------------------------
-
-// Discriminates which single-param variant to pass, avoiding two near-identical helpers.
 #[derive(Clone, Copy)]
 enum ParamKind {
     Harness,
     Attributes,
 }
 
-// Consolidates the repeated assert-contains / assert-not-contains pattern so
-// individual trait-assertion tests stay compact.
 fn assert_single_trait_assertion(
     param_kind: ParamKind,
     path_str: &str,
@@ -332,6 +311,27 @@ fn assert_single_trait_assertion(
         !output.contains(excluded_trait),
         "should NOT contain {excluded_trait}: {output}"
     );
+}
+
+#[rustfmt::skip]
+fn assert_trait_assertion_crate_path(param_kind: ParamKind, path_str: &str, expected_trait: &str, expected_crate_path: &str) {
+    let path = parse_path(path_str);
+    let (harness, attributes) = match param_kind { ParamKind::Harness => (Some(&path), None), ParamKind::Attributes => (None, Some(&path)) };
+    let tokens = generate_trait_assertions(harness, attributes);
+    let output = tokens.to_string();
+    assert!(output.contains(expected_trait), "should contain trait `{expected_trait}`: {output}");
+    assert!(output.contains(expected_crate_path), "should resolve through `{expected_crate_path}`: {output}");
+}
+
+#[rustfmt::skip]
+#[rstest::rstest]
+#[case::tokio_harness_uses_tokio_crate(ParamKind::Harness, "rstest_bdd_harness_tokio::TokioHarness", "HarnessAdapter", "rstest_bdd_harness_tokio")]
+#[case::tokio_policy_uses_tokio_crate(ParamKind::Attributes, "rstest_bdd_harness_tokio::TokioAttributePolicy", "AttributePolicy", "rstest_bdd_harness_tokio")]
+#[case::gpui_policy_uses_gpui_crate(ParamKind::Attributes, "rstest_bdd_harness_gpui::GpuiAttributePolicy", "AttributePolicy", "rstest_bdd_harness_gpui")]
+#[case::custom_harness_uses_base_harness_crate(ParamKind::Harness, "my_crate::MyHarness", "HarnessAdapter", "rstest_bdd_harness")]
+#[case::custom_policy_uses_base_harness_crate(ParamKind::Attributes, "my_crate::MyPolicy", "AttributePolicy", "rstest_bdd_harness")]
+fn trait_assertions_resolve_correct_crate_path(#[case] kind: ParamKind, #[case] path_str: &str, #[case] expected_trait: &str, #[case] expected_crate_path: &str) {
+    assert_trait_assertion_crate_path(kind, path_str, expected_trait, expected_crate_path);
 }
 
 #[rstest::rstest]

--- a/crates/rstest-bdd-macros/src/codegen/scenario/tests.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/tests.rs
@@ -6,6 +6,7 @@ use crate::parsing::feature::ParsedStep;
 mod gpui_policy;
 mod harness_defaults;
 mod runtime_split;
+mod trait_assertions;
 
 #[expect(clippy::expect_used, reason = "test helper with descriptive failures")]
 fn kw(ts: &TokenStream2) -> crate::StepKeyword {
@@ -275,126 +276,5 @@ fn generate_test_attrs_dedupes_tokio_policy_and_user_attribute() {
     assert_eq!(
         tokio_count, 1,
         "expected exactly one tokio::test when both user attribute and policy are present, got {tokio_count}: {output}"
-    );
-}
-
-#[derive(Clone, Copy)]
-enum ParamKind {
-    Harness,
-    Attributes,
-}
-
-fn assert_single_trait_assertion(
-    param_kind: ParamKind,
-    path_str: &str,
-    expected_trait: &str,
-    excluded_trait: &str,
-) {
-    let path = parse_path(path_str);
-    let (harness, attributes) = match param_kind {
-        ParamKind::Harness => (Some(&path), None),
-        ParamKind::Attributes => (None, Some(&path)),
-    };
-    let tokens = generate_trait_assertions(harness, attributes);
-    let output = tokens.to_string();
-
-    assert!(
-        output.contains(expected_trait),
-        "should contain {expected_trait} trait bound: {output}"
-    );
-    let spaced_path = path_str.replace("::", " :: ");
-    assert!(
-        output.contains(&spaced_path),
-        "should contain type path `{spaced_path}`: {output}"
-    );
-    assert!(
-        !output.contains(excluded_trait),
-        "should NOT contain {excluded_trait}: {output}"
-    );
-}
-
-#[rustfmt::skip]
-fn assert_trait_assertion_crate_path(param_kind: ParamKind, path_str: &str, expected_trait: &str, expected_crate_path: &str) {
-    let path = parse_path(path_str);
-    let (harness, attributes) = match param_kind { ParamKind::Harness => (Some(&path), None), ParamKind::Attributes => (None, Some(&path)) };
-    let tokens = generate_trait_assertions(harness, attributes);
-    let output = tokens.to_string();
-    assert!(output.contains(expected_trait), "should contain trait `{expected_trait}`: {output}");
-    assert!(output.contains(expected_crate_path), "should resolve through `{expected_crate_path}`: {output}");
-}
-
-#[rustfmt::skip]
-#[rstest::rstest]
-#[case::tokio_harness_uses_tokio_crate(ParamKind::Harness, "rstest_bdd_harness_tokio::TokioHarness", "HarnessAdapter", "rstest_bdd_harness_tokio")]
-#[case::tokio_policy_uses_tokio_crate(ParamKind::Attributes, "rstest_bdd_harness_tokio::TokioAttributePolicy", "AttributePolicy", "rstest_bdd_harness_tokio")]
-#[case::gpui_policy_uses_gpui_crate(ParamKind::Attributes, "rstest_bdd_harness_gpui::GpuiAttributePolicy", "AttributePolicy", "rstest_bdd_harness_gpui")]
-#[case::custom_harness_uses_base_harness_crate(ParamKind::Harness, "my_crate::MyHarness", "HarnessAdapter", "rstest_bdd_harness")]
-#[case::custom_policy_uses_base_harness_crate(ParamKind::Attributes, "my_crate::MyPolicy", "AttributePolicy", "rstest_bdd_harness")]
-fn trait_assertions_resolve_correct_crate_path(#[case] kind: ParamKind, #[case] path_str: &str, #[case] expected_trait: &str, #[case] expected_crate_path: &str) {
-    assert_trait_assertion_crate_path(kind, path_str, expected_trait, expected_crate_path);
-}
-
-#[rstest::rstest]
-#[case::harness(ParamKind::Harness, "my::Harness", "HarnessAdapter", "AttributePolicy")]
-#[case::attributes(
-    ParamKind::Attributes,
-    "my::Policy",
-    "AttributePolicy",
-    "HarnessAdapter"
-)]
-fn trait_assertions_single_param(
-    #[case] kind: ParamKind,
-    #[case] path_str: &str,
-    #[case] expected_trait: &str,
-    #[case] excluded_trait: &str,
-) {
-    assert_single_trait_assertion(kind, path_str, expected_trait, excluded_trait);
-}
-
-#[test]
-fn trait_assertions_with_both() {
-    let harness_path = parse_path("my::Harness");
-    let policy_path = parse_path("my::Policy");
-    let tokens = generate_trait_assertions(Some(&harness_path), Some(&policy_path));
-    let output = tokens.to_string();
-
-    assert!(
-        output.contains("HarnessAdapter"),
-        "should contain HarnessAdapter: {output}"
-    );
-    assert!(
-        output.contains("AttributePolicy"),
-        "should contain AttributePolicy: {output}"
-    );
-}
-
-#[test]
-fn trait_assertions_with_neither() {
-    let tokens = generate_trait_assertions(None, None);
-    let output = tokens.to_string();
-
-    assert!(
-        !output.contains("HarnessAdapter"),
-        "should NOT contain HarnessAdapter: {output}"
-    );
-    assert!(
-        !output.contains("AttributePolicy"),
-        "should NOT contain AttributePolicy: {output}"
-    );
-}
-
-#[test]
-fn trait_assertions_harness_includes_default_bound() {
-    let harness_path = parse_path("my::Harness");
-    let tokens = generate_trait_assertions(Some(&harness_path), None);
-    let output = tokens.to_string();
-
-    assert!(
-        output.contains("HarnessAdapter"),
-        "should contain HarnessAdapter: {output}"
-    );
-    assert!(
-        output.contains("Default"),
-        "should contain Default bound for harness delegation: {output}"
     );
 }

--- a/crates/rstest-bdd-macros/src/codegen/scenario/tests.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/tests.rs
@@ -198,7 +198,7 @@ fn parse_path(s: &str) -> syn::Path {
     Some(parse_path("::rstest_bdd_harness_tokio::TokioAttributePolicy")),
     true
 )]
-#[case::with_imported_tokio_policy_emits_tokio(Some(parse_path("TokioAttributePolicy")), true)]
+#[case::unresolved_tokio_policy(Some(parse_path("TokioAttributePolicy")), false)]
 #[case::with_unknown_prefix_tokio_name_skips_tokio(
     Some(parse_path("my::TokioAttributePolicy")),
     false

--- a/crates/rstest-bdd-macros/src/codegen/scenario/tests.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/tests.rs
@@ -198,7 +198,7 @@ fn parse_path(s: &str) -> syn::Path {
     Some(parse_path("::rstest_bdd_harness_tokio::TokioAttributePolicy")),
     true
 )]
-#[case::with_single_segment_tokio_name_skips_tokio(Some(parse_path("TokioAttributePolicy")), false)]
+#[case::with_imported_tokio_policy_emits_tokio(Some(parse_path("TokioAttributePolicy")), true)]
 #[case::with_unknown_prefix_tokio_name_skips_tokio(
     Some(parse_path("my::TokioAttributePolicy")),
     false

--- a/crates/rstest-bdd-macros/src/codegen/scenario/tests/gpui_policy.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/tests/gpui_policy.rs
@@ -3,14 +3,19 @@
 use super::{RuntimeMode, TestAttrPolicy, generate_test_attrs, parse_path};
 
 #[rstest::rstest]
-#[case::with_gpui_policy_emits_gpui(Some(parse_path(
-    "rstest_bdd_harness_gpui::GpuiAttributePolicy"
-)))]
-#[case::with_absolute_gpui_policy_path_emits_gpui(Some(parse_path(
-    "::rstest_bdd_harness_gpui::GpuiAttributePolicy"
-)))]
-#[case::with_imported_gpui_policy_emits_gpui(Some(parse_path("GpuiAttributePolicy")))]
-fn generate_test_attrs_respects_gpui_policy_paths(#[case] policy_path: Option<syn::Path>) {
+#[case::with_gpui_policy_emits_gpui(
+    Some(parse_path("rstest_bdd_harness_gpui::GpuiAttributePolicy")),
+    true
+)]
+#[case::with_absolute_gpui_policy_path_emits_gpui(
+    Some(parse_path("::rstest_bdd_harness_gpui::GpuiAttributePolicy")),
+    true
+)]
+#[case::with_unresolved_gpui_policy_name_skips_gpui(Some(parse_path("GpuiAttributePolicy")), false)]
+fn generate_test_attrs_respects_gpui_policy_paths(
+    #[case] policy_path: Option<syn::Path>,
+    #[case] expect_gpui_test: bool,
+) {
     let policy = policy_path.as_ref();
     let tokens = generate_test_attrs(
         &[],
@@ -28,8 +33,8 @@ fn generate_test_attrs_respects_gpui_policy_paths(#[case] policy_path: Option<sy
         "should contain rstest::rstest: {output}"
     );
     assert!(
-        output.contains("gpui :: test"),
-        "should contain gpui::test when GPUI policy is selected: {output}"
+        output.contains("gpui :: test") == expect_gpui_test,
+        "gpui::test presence mismatch for policy={policy_path:?}: {output}"
     );
     assert!(
         !output.contains("tokio :: test"),

--- a/crates/rstest-bdd-macros/src/codegen/scenario/tests/gpui_policy.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/tests/gpui_policy.rs
@@ -9,6 +9,7 @@ use super::{RuntimeMode, TestAttrPolicy, generate_test_attrs, parse_path};
 #[case::with_absolute_gpui_policy_path_emits_gpui(Some(parse_path(
     "::rstest_bdd_harness_gpui::GpuiAttributePolicy"
 )))]
+#[case::with_imported_gpui_policy_emits_gpui(Some(parse_path("GpuiAttributePolicy")))]
 fn generate_test_attrs_respects_gpui_policy_paths(#[case] policy_path: Option<syn::Path>) {
     let policy = policy_path.as_ref();
     let tokens = generate_test_attrs(

--- a/crates/rstest-bdd-macros/src/codegen/scenario/tests/harness_defaults.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/tests/harness_defaults.rs
@@ -15,11 +15,11 @@ fn parse_path(s: &str) -> syn::Path {
     true,
     false
 )]
-#[case::imported_tokio_harness_beats_sync_runtime(
+#[case::unresolved_tokio_harness_name_keeps_sync_runtime(
     RuntimeMode::Sync,
     Some(parse_path("TokioHarness")),
     None,
-    true,
+    false,
     false
 )]
 #[case::gpui_harness_beats_tokio_runtime(
@@ -29,12 +29,12 @@ fn parse_path(s: &str) -> syn::Path {
     false,
     true
 )]
-#[case::imported_gpui_harness_beats_tokio_runtime(
+#[case::unresolved_gpui_harness_name_keeps_tokio_runtime(
     RuntimeMode::TokioCurrentThread,
     Some(parse_path("GpuiHarness")),
     None,
-    false,
-    true
+    true,
+    false
 )]
 #[case::std_harness_beats_tokio_runtime(
     RuntimeMode::TokioCurrentThread,

--- a/crates/rstest-bdd-macros/src/codegen/scenario/tests/harness_defaults.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/tests/harness_defaults.rs
@@ -15,9 +15,23 @@ fn parse_path(s: &str) -> syn::Path {
     true,
     false
 )]
+#[case::imported_tokio_harness_beats_sync_runtime(
+    RuntimeMode::Sync,
+    Some(parse_path("TokioHarness")),
+    None,
+    true,
+    false
+)]
 #[case::gpui_harness_beats_tokio_runtime(
     RuntimeMode::TokioCurrentThread,
     Some(parse_path("rstest_bdd_harness_gpui::GpuiHarness")),
+    None,
+    false,
+    true
+)]
+#[case::imported_gpui_harness_beats_tokio_runtime(
+    RuntimeMode::TokioCurrentThread,
+    Some(parse_path("GpuiHarness")),
     None,
     false,
     true

--- a/crates/rstest-bdd-macros/src/codegen/scenario/tests/trait_assertions.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/tests/trait_assertions.rs
@@ -1,0 +1,206 @@
+//! Tests for generated compile-time trait assertions.
+
+use super::{generate_trait_assertions, parse_path};
+
+#[derive(Clone, Copy)]
+enum ParamKind {
+    Harness,
+    Attributes,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum TraitName {
+    HarnessAdapter,
+    AttributePolicy,
+}
+
+impl TraitName {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::HarnessAdapter => "HarnessAdapter",
+            Self::AttributePolicy => "AttributePolicy",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ExpectedCrate {
+    TokioAdapter,
+    GpuiAdapter,
+    BaseHarness,
+}
+
+impl ExpectedCrate {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::TokioAdapter => "rstest_bdd_harness_tokio",
+            Self::GpuiAdapter => "rstest_bdd_harness_gpui",
+            Self::BaseHarness => "rstest_bdd_harness",
+        }
+    }
+}
+
+fn assert_single_trait_assertion(
+    param_kind: ParamKind,
+    path: &syn::Path,
+    expected_trait: TraitName,
+    excluded_trait: TraitName,
+) {
+    let (harness, attributes) = match param_kind {
+        ParamKind::Harness => (Some(path), None),
+        ParamKind::Attributes => (None, Some(path)),
+    };
+    let tokens = generate_trait_assertions(harness, attributes);
+    let output = tokens.to_string();
+    let expected = expected_trait.as_str();
+    let excluded = excluded_trait.as_str();
+
+    assert!(
+        output.contains(expected),
+        "should contain {expected} trait bound: {output}"
+    );
+    let spaced_path = quote::quote!(#path).to_string();
+    assert!(
+        output.contains(&spaced_path),
+        "should contain type path `{spaced_path}`: {output}"
+    );
+    assert!(
+        !output.contains(excluded),
+        "should NOT contain {excluded}: {output}"
+    );
+}
+
+fn assert_trait_assertion_crate_path(
+    param_kind: ParamKind,
+    path: &syn::Path,
+    expected_trait: TraitName,
+    expected_crate: ExpectedCrate,
+) {
+    let (harness, attributes) = match param_kind {
+        ParamKind::Harness => (Some(path), None),
+        ParamKind::Attributes => (None, Some(path)),
+    };
+    let tokens = generate_trait_assertions(harness, attributes);
+    let output = tokens.to_string();
+    let expected_t = expected_trait.as_str();
+    let expected_c = expected_crate.as_str();
+
+    assert!(
+        output.contains(expected_t),
+        "should contain trait `{expected_t}`: {output}"
+    );
+    assert!(
+        output.contains(expected_c),
+        "should resolve through `{expected_c}`: {output}"
+    );
+}
+
+#[rstest::rstest]
+#[case::tokio_harness_uses_tokio_crate(
+    ParamKind::Harness,
+    parse_path("rstest_bdd_harness_tokio::TokioHarness"),
+    TraitName::HarnessAdapter,
+    ExpectedCrate::TokioAdapter
+)]
+#[case::tokio_policy_uses_tokio_crate(
+    ParamKind::Attributes,
+    parse_path("rstest_bdd_harness_tokio::TokioAttributePolicy"),
+    TraitName::AttributePolicy,
+    ExpectedCrate::TokioAdapter
+)]
+#[case::gpui_policy_uses_gpui_crate(
+    ParamKind::Attributes,
+    parse_path("rstest_bdd_harness_gpui::GpuiAttributePolicy"),
+    TraitName::AttributePolicy,
+    ExpectedCrate::GpuiAdapter
+)]
+#[case::custom_harness_uses_base_harness_crate(
+    ParamKind::Harness,
+    parse_path("my_crate::MyHarness"),
+    TraitName::HarnessAdapter,
+    ExpectedCrate::BaseHarness
+)]
+#[case::custom_policy_uses_base_harness_crate(
+    ParamKind::Attributes,
+    parse_path("my_crate::MyPolicy"),
+    TraitName::AttributePolicy,
+    ExpectedCrate::BaseHarness
+)]
+fn trait_assertions_resolve_correct_crate_path(
+    #[case] kind: ParamKind,
+    #[case] path: syn::Path,
+    #[case] expected_trait: TraitName,
+    #[case] expected_crate: ExpectedCrate,
+) {
+    assert_trait_assertion_crate_path(kind, &path, expected_trait, expected_crate);
+}
+
+#[rstest::rstest]
+#[case::harness(
+    ParamKind::Harness,
+    parse_path("my::Harness"),
+    TraitName::HarnessAdapter,
+    TraitName::AttributePolicy
+)]
+#[case::attributes(
+    ParamKind::Attributes,
+    parse_path("my::Policy"),
+    TraitName::AttributePolicy,
+    TraitName::HarnessAdapter
+)]
+fn trait_assertions_single_param(
+    #[case] kind: ParamKind,
+    #[case] path: syn::Path,
+    #[case] expected_trait: TraitName,
+    #[case] excluded_trait: TraitName,
+) {
+    assert_single_trait_assertion(kind, &path, expected_trait, excluded_trait);
+}
+
+#[test]
+fn trait_assertions_with_both() {
+    let harness_path = parse_path("my::Harness");
+    let policy_path = parse_path("my::Policy");
+    let tokens = generate_trait_assertions(Some(&harness_path), Some(&policy_path));
+    let output = tokens.to_string();
+
+    assert!(
+        output.contains("HarnessAdapter"),
+        "should contain HarnessAdapter: {output}"
+    );
+    assert!(
+        output.contains("AttributePolicy"),
+        "should contain AttributePolicy: {output}"
+    );
+}
+
+#[test]
+fn trait_assertions_with_neither() {
+    let tokens = generate_trait_assertions(None, None);
+    let output = tokens.to_string();
+
+    assert!(
+        !output.contains("HarnessAdapter"),
+        "should NOT contain HarnessAdapter: {output}"
+    );
+    assert!(
+        !output.contains("AttributePolicy"),
+        "should NOT contain AttributePolicy: {output}"
+    );
+}
+
+#[test]
+fn trait_assertions_harness_includes_default_bound() {
+    let harness_path = parse_path("my::Harness");
+    let tokens = generate_trait_assertions(Some(&harness_path), None);
+    let output = tokens.to_string();
+
+    assert!(
+        output.contains("HarnessAdapter"),
+        "should contain HarnessAdapter: {output}"
+    );
+    assert!(
+        output.contains("Default"),
+        "should contain Default bound for harness delegation: {output}"
+    );
+}

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -77,6 +77,24 @@ These tests were moved out of `rstest-bdd` in this release to decouple the core
 crate from Tokio and GPUI dev-dependencies, making it publishable to crates.io
 without carrying those dependencies.
 
+## First-party adapter dependency boundary
+
+`rstest-bdd-harness` remains the owner of `HarnessAdapter`,
+`AttributePolicy`, `ScenarioRunRequest`, and related base API types. The Tokio
+and GPUI adapter crates re-export the subset of that API used by generated
+scenario code, so downstream users of first-party adapters do not need to list
+`rstest-bdd-harness` directly.
+
+When updating macro code generation, keep this boundary intact:
+
+- canonical Tokio harness and attribute policy paths should use the
+  `rstest-bdd-harness-tokio` crate root for generated base API references;
+- canonical GPUI harness and attribute policy paths should use the
+  `rstest-bdd-harness-gpui` crate root for generated base API references;
+- custom harnesses and custom attribute policies should continue to use the
+  direct `rstest-bdd-harness` crate path and therefore require that dependency
+  in the consuming crate.
+
 ## Fallback binary build in integration tests
 
 `crates/cargo-bdd/tests/cli.rs` and `examples/todo-cli/tests/cli.rs` use a

--- a/docs/execplans/10-1-1-first-party-adapters-compile-without-direct-base-harness-dependency.md
+++ b/docs/execplans/10-1-1-first-party-adapters-compile-without-direct-base-harness-dependency.md
@@ -5,9 +5,9 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
-Implementation must not begin until this plan is explicitly approved.
+Implementation began after explicit user approval on 2026-05-08.
 
 ## Purpose / big picture
 
@@ -342,13 +342,34 @@ Acceptance is met when all of the following are true:
 - [x] 2026-05-08: Used Wyvern reconnaissance agents to inspect roadmap/design
   acceptance criteria, documentation signposts, test surfaces, and risks.
 - [x] 2026-05-08: Drafted this pre-implementation ExecPlan.
-- [ ] Await explicit approval before implementation.
-- [ ] Establish failing adapter-only dependency proof.
-- [ ] Implement the approved dependency-boundary change.
-- [ ] Update migration, user, design, and internal docs as required.
+- [x] 2026-05-08: Received explicit approval to proceed with implementation.
+- [x] 2026-05-08: Removed the direct base harness dev-dependency from the
+  Tokio and GPUI example manifests to establish example-level adapter-only
+  proof.
+- [x] 2026-05-08: Confirmed the pre-fix Tokio proof fails with
+  `rstest-bdd-harness crate not found` when running
+  `cargo check -p tokio-reminders --tests`.
+- [x] 2026-05-08: Implemented adapter-root code generation for canonical
+  Tokio and GPUI first-party harness and attribute policy paths, with adapter
+  crates re-exporting the base API used by generated tests.
+- [x] 2026-05-08: Confirmed `cargo check -p tokio-reminders --tests` and
+  `cargo check -p gpui-counter --tests` pass without direct base harness
+  entries in the example manifests.
+- [x] 2026-05-08: Updated the migration guide, users guide, design document,
+  and developers guide with the first-party adapter dependency boundary.
 - [ ] Run focused validation and full gates.
-- [ ] Mark roadmap item 10.1.1 done after validation.
-- [ ] Commit, push with upstream tracking, and open the required draft PR.
+- [x] 2026-05-08: Ran focused validation:
+  `cargo check -p tokio-reminders --tests`,
+  `cargo check -p gpui-counter --tests`,
+  `cargo test -p rstest-bdd-macros`,
+  `cargo test -p tokio-reminders`,
+  `cargo test -p gpui-counter`, and the GPUI macro compile test.
+- [x] 2026-05-08: Ran full gates successfully:
+  `make check-fmt`, `make lint`, `make test`, `make markdownlint`, and
+  `make nixie`.
+- [x] 2026-05-08: Marked roadmap item 10.1.1 done after validation.
+- [x] 2026-05-08: Prepared the implementation for commit after final diff
+  review.
 
 ## Surprises & Discoveries
 
@@ -369,6 +390,22 @@ Acceptance is met when all of the following are true:
 - `docs/v0-6-0-migration-guide.md` explains first-party harness adoption but
   does not yet contain the explicit plain BDD, Tokio, GPUI, and custom harness
   dependency matrix required by roadmap item 10.1.1.
+- `leta` could not start `rust-analyzer` for this workspace during the
+  implementation pass, reporting that the language server connection closed.
+  The implementation therefore used targeted `rg` and file inspection while
+  retaining the same symbol-focused search scope.
+- Removing `rstest-bdd-harness` from `examples/tokio-reminders/Cargo.toml`
+  reproduced the exact downstream failure: the scenario macro panicked while
+  resolving the base harness crate even though the example depends on
+  `rstest-bdd-harness-tokio`.
+- The trait assertion code was a second direct base-harness resolution point,
+  independent of runtime harness delegation. Both the harness assertion and the
+  attribute-policy assertion must resolve through the adapter crate for
+  canonical first-party paths.
+- The GPUI trybuild staging path exposed an existing helper edge case:
+  `copy_dir_tree` could not canonicalize nested missing destination parents.
+  The fix teaches overlap detection to canonicalize the nearest existing
+  ancestor and reconstruct the missing suffix before copying.
 
 ## Decision Log
 
@@ -387,9 +424,42 @@ Acceptance is met when all of the following are true:
   downstream failure mode and prevent regression. Date/Author: 2026-05-08 /
   ExecPlan draft.
 
+- Decision: move the plan to `IN PROGRESS` and begin with the adapter-only
+  proof milestone. Rationale: the user explicitly instructed implementation of
+  this approved plan and repeated that the ExecPlan must be kept current.
+  Date/Author: 2026-05-08 / Implementation pass.
+
+- Decision: use workspace examples as the primary adapter-only compile proof,
+  with existing trybuild fixtures as supporting macro coverage. Rationale:
+  trybuild cases inside the adapter crates inherit test-crate dev-dependencies,
+  while the example manifests are downstream-style crates whose direct
+  dependency lists can intentionally omit `rstest-bdd-harness`. Date/Author:
+  2026-05-08 / Implementation pass.
+
+- Decision: re-export the generated-code base API from the first-party adapter
+  crates and make macro codegen target the adapter crate root for canonical
+  first-party harness and attribute-policy paths. Rationale: this preserves the
+  existing public trait contracts and custom harness behaviour while removing
+  the direct base-harness dependency from first-party adapter consumers.
+  Date/Author: 2026-05-08 / Implementation pass.
+
+- Decision: include the `copy_dir_tree` nested-destination fix in this change.
+  Rationale: the required GPUI compile proof depends on staging a feature tree
+  under a nested trybuild directory, and the helper's existing overlap guard
+  failed before the actual adapter-only compile proof could run.
+  Date/Author: 2026-05-08 / Implementation pass.
+
 ## Outcomes & Retrospective
 
-No implementation has started. The intended outcome, after approval, is a gated
-implementation that lets first-party adapter users omit direct
-`rstest-bdd-harness` dependencies while preserving custom harness support and
-public trait contracts.
+Implementation is complete and validated. First-party Tokio and GPUI adapter
+users can omit a direct `rstest-bdd-harness` dependency when selecting the
+canonical adapter harnesses or attribute policies. Custom harnesses and direct
+base API imports still use `rstest-bdd-harness` explicitly. The implementation
+also fixed a `copy_dir_tree` staging edge case that blocked the GPUI
+adapter-only compile proof. Validation logs are available under
+`/tmp/check-fmt-rstest-bdd-10-1-1-first-party-adapters-compile-without-direct-base-harness-dependency-impl.out`,
+`/tmp/lint-rstest-bdd-10-1-1-first-party-adapters-compile-without-direct-base-harness-dependency-impl.out`,
+`/tmp/test-rstest-bdd-10-1-1-first-party-adapters-compile-without-direct-base-harness-dependency-impl.out`,
+`/tmp/markdownlint-rstest-bdd-10-1-1-first-party-adapters-compile-without-direct-base-harness-dependency-impl.out`,
+and
+`/tmp/nixie-rstest-bdd-10-1-1-first-party-adapters-compile-without-direct-base-harness-dependency-impl.out`.

--- a/docs/execplans/10-1-1-first-party-adapters-compile-without-direct-base-harness-dependency.md
+++ b/docs/execplans/10-1-1-first-party-adapters-compile-without-direct-base-harness-dependency.md
@@ -1,0 +1,395 @@
+# First-party adapters compile without direct base harness dependency
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+Implementation must not begin until this plan is explicitly approved.
+
+## Purpose / big picture
+
+Roadmap item 10.1.1 removes avoidable harness adoption friction for v0.6.0 beta
+feedback. After this work, a downstream project that uses a first-party adapter
+should list only `rstest-bdd`, `rstest-bdd-macros`, and the selected adapter
+crate in `Cargo.toml`. The downstream project should not also need to list
+`rstest-bdd-harness` unless it implements a custom harness or directly uses
+base harness API types such as `HarnessAdapter`, `ScenarioRunRequest`, or
+`StdHarness`.
+
+The visible success condition is a plain dependency matrix in
+`docs/v0-6-0-migration-guide.md` covering plain BDD, Tokio, GPUI, and custom
+harnesses, plus compile tests or example manifests proving that Tokio and GPUI
+first-party adapter scenarios compile without a direct `rstest-bdd-harness`
+dependency in the consuming crate.
+
+This plan is planning-only until approved. It prepares the implementation path,
+the validation strategy, and the documentation updates needed to mark roadmap
+item 10.1.1 done.
+
+## Constraints
+
+- Do not change public trait contracts. `HarnessAdapter`, `AttributePolicy`,
+  `ScenarioRunner`, `ScenarioRunRequest`, and existing macro arguments must
+  remain source-compatible.
+- Keep the scope to roadmap item 10.1.1. Do not implement 10.1.2 missing
+  fixture diagnostics or 10.1.3 GPUI stateful regression coverage in this
+  branch.
+- Preserve ADR-005's crate boundary: Tokio and GPUI remain outside the default
+  `rstest-bdd` dependency graph.
+- Preserve ADR-007 harness context injection. Steps still request harness
+  context with `#[from(rstest_bdd_harness_context)]`.
+- Preserve ADR-008 precedence: explicit `attributes = ...` beats harness-led
+  first-party defaults, which beat deprecated runtime compatibility aliases,
+  which beat fallback attributes.
+- Preserve ADR-009 implicit fixture-name normalization. Adapter dependency
+  simplification must not alter fixture naming or `#[from(...)]` resolution.
+- Do not add new external crates. If validation needs helper code, prefer
+  existing test harnesses and existing workspace crates.
+- Do not use property tests or model checking unless the implementation
+  introduces a new invariant over a range of inputs, states, orderings, or
+  transitions. The expected change is dependency and code-generation plumbing,
+  so compile tests and behavioural tests are the primary validation.
+- Keep every Rust source file at or below 400 lines. If a touched file would
+  exceed that limit, split the implementation before continuing.
+- Documentation must use en-GB Oxford spelling and wrap Markdown paragraphs at
+  80 columns.
+- Run gates sequentially, not in parallel. Use `tee` for long-running gates so
+  the complete output remains available under `/tmp`.
+- After approval and implementation, commit the functional change only after
+  gates pass, then perform any necessary refactor as a separate gated commit.
+
+## Tolerances (exception triggers)
+
+- Scope: if implementation requires more than 18 files or more than 900 net
+  lines, stop and ask for approval before widening the change.
+- Public API: if any public signature in `rstest-bdd-harness`,
+  `rstest-bdd-harness-tokio`, `rstest-bdd-harness-gpui`, `rstest-bdd-macros`,
+  or `rstest-bdd` must change, stop and present options.
+- Dependencies: if a new external dependency is needed, stop and explain why
+  existing workspace tooling cannot cover the proof.
+- Code generation: if custom harness users would lose support for direct
+  `rstest-bdd-harness` API paths, stop and present a compatibility plan.
+- Test iterations: if the same gate fails three times after attempted fixes,
+  stop and summarize the remaining failure with the relevant `/tmp` log path.
+- GPUI: if GPUI compile or behavioural tests fail for platform setup reasons
+  rather than this change, stop and record the environment-specific blocker
+  before weakening the test.
+- Ambiguity: if "adapter-only dependency" can only be satisfied by choosing
+  between re-exporting base harness API from adapters and changing generated
+  macro paths, stop and ask for direction if both options remain viable after
+  reconnaissance.
+
+## Risks
+
+- Risk: generated scenario code currently calls
+  `crate::codegen::rstest_bdd_harness_path()` and emits paths such as
+  `rstest_bdd_harness::ScenarioRunRequest` and
+  `rstest_bdd_harness::HarnessAdapter`. Severity: high. Likelihood: high.
+  Mitigation: first add failing adapter-only compile fixtures so the current
+  friction is reproduced, then adjust the generated path strategy or adapter
+  re-exports without changing trait contracts.
+
+- Risk: adapter crates currently depend on `rstest-bdd-harness` internally but
+  do not re-export the base harness types. Severity: medium. Likelihood: high.
+  Mitigation: evaluate narrow re-exports from `rstest-bdd-harness-tokio` and
+  `rstest-bdd-harness-gpui` only if generated code can target the selected
+  first-party adapter crate path cleanly.
+
+- Risk: dependency proof can be incomplete if trybuild fixtures still inherit
+  the adapter crate's dev-dependencies, including `rstest-bdd-harness`.
+  Severity: medium. Likelihood: medium. Mitigation: make the proof explicit:
+  either use a staged standalone fixture manifest, or use examples whose
+  manifests intentionally omit direct base harness dev-dependencies and are
+  exercised by the workspace gates.
+
+- Risk: GPUI tests are feature-gated with `native-gpui-tests` and may expose
+  platform assumptions. Severity: medium. Likelihood: medium. Mitigation:
+  retain existing feature gating, keep adapter-only compile proof minimal, and
+  rely on `make test` plus `make lint` before commit.
+
+- Risk: documentation may imply that custom harness users no longer need
+  `rstest-bdd-harness`. Severity: medium. Likelihood: medium. Mitigation: make
+  the migration matrix explicit that custom harness implementation and direct
+  base API use still require `rstest-bdd-harness`.
+
+## Skills and documentation signposts
+
+Use these skills during implementation:
+
+- `leta`: inspect symbols, references, and file structure before code changes.
+- `rust-router`: route Rust-specific concerns before modifying Rust code.
+- `arch-crate-design`: check crate-boundary, feature, and public API choices.
+- `execplans`: keep this plan current as work proceeds.
+- `commit-message`: write the gated commit message through a file, not `-m`.
+- `pr-creation`: create the required draft PR after the plan branch is pushed.
+
+Use these repository documents as source material:
+
+- `docs/roadmap.md`, item 10.1.1, for the acceptance criteria and final
+  roadmap status update.
+- `docs/rstest-bdd-design.md`, especially sections 2.7.5 and 2.7.6.3, for
+  first-party adapter roles and v0.6.0-beta2 quick-win scope.
+- `docs/adr-005-harness-adapter-crates-for-framework-specific-test-integration.md`
+  for adapter crate boundaries.
+- `docs/adr-007-harness-context-injection.md` for context handoff rules.
+- `docs/adr-008-harness-led-attribute-policy-defaults.md` for attribute
+  default precedence.
+- `docs/adr-009-consistent-implicit-fixture-name-normalization.md` for fixture
+  name stability.
+- `docs/v0-6-0-migration-guide.md` for the required dependency matrix.
+- `docs/users-guide.md` for user-facing harness adapter behaviour.
+- `docs/developers-guide.md` for internal crate-boundary guidance.
+- `docs/rust-testing-with-rstest-fixtures.md`,
+  `docs/rust-doctest-dry-guide.md`, `docs/gherkin-syntax.md`, and
+  `docs/complexity-antipatterns-and-refactoring-strategies.md` for test,
+  documentation, Gherkin, and refactoring conventions.
+
+## Repository orientation
+
+The workspace root is `Cargo.toml`. First-party harness crates live under:
+
+- `crates/rstest-bdd-harness`
+- `crates/rstest-bdd-harness-tokio`
+- `crates/rstest-bdd-harness-gpui`
+
+The procedural macro crate is `crates/rstest-bdd-macros`. The main generated
+harness delegation path is currently in
+`crates/rstest-bdd-macros/src/codegen/scenario/runtime/harness.rs`. It builds
+metadata, a `ScenarioRunner`, a `ScenarioRunRequest`, and calls
+`HarnessAdapter::run`.
+
+Tokio adapter compile tests live in
+`crates/rstest-bdd-harness-tokio/tests/macro_compile.rs` with fixtures in
+`crates/rstest-bdd-harness-tokio/tests/fixtures_macros`. GPUI adapter compile
+tests live in `crates/rstest-bdd-harness-gpui/tests/macro_compile.rs` with
+fixtures in `crates/rstest-bdd-harness-gpui/tests/fixtures_macros`.
+
+The example manifests currently act as useful downstream-style proof points:
+`examples/tokio-reminders/Cargo.toml` and `examples/gpui-counter/Cargo.toml`.
+Both should be checked during implementation because they currently list
+`rstest-bdd-harness` directly as a dev-dependency even though they use a
+first-party adapter.
+
+## Implementation plan
+
+### Milestone 1: establish the failing proof
+
+Create the smallest adapter-only compile proof before changing code. The proof
+must show that a consumer can select a first-party adapter without directly
+declaring `rstest-bdd-harness`.
+
+For Tokio, add or adapt a compile fixture that depends on `rstest-bdd`,
+`rstest-bdd-macros`, and `rstest-bdd-harness-tokio`, plus Tokio runtime
+dependencies, but does not list `rstest-bdd-harness`. The fixture should use a
+canonical harness path such as:
+
+```rust,no_run
+#[scenario(
+    path = "basic.feature",
+    harness = rstest_bdd_harness_tokio::TokioHarness,
+)]
+fn scenario_uses_tokio_harness() {}
+```
+
+For GPUI, add the corresponding adapter-only proof for:
+
+```rust,no_run
+#[scenario(
+    path = "basic.feature",
+    harness = rstest_bdd_harness_gpui::GpuiHarness,
+)]
+fn scenario_uses_gpui_harness() {}
+```
+
+If trybuild cannot express a manifest that excludes inherited dev-dependencies,
+document that limitation in `Surprises & Discoveries` and use the example
+manifests as the primary dependency proof instead.
+
+Expected baseline: before implementation, the new proof should fail because
+generated code still requires a visible `rstest_bdd_harness` crate path.
+
+### Milestone 2: choose the narrow dependency mechanism
+
+Use `leta` to inspect references to `rstest_bdd_harness_path`,
+`HarnessAdapter`, `ScenarioRunRequest`, `ScenarioRunner`, and first-party
+adapter paths. Decide whether the narrowest compatible mechanism is:
+
+- to make first-party adapters re-export the base harness API needed by
+  generated code and teach codegen to use the selected first-party adapter
+  crate path for known first-party harnesses; or
+- to alter generated code so downstream consumers only need the adapter path
+  while custom harness users continue to use `rstest-bdd-harness` directly.
+
+The decision must preserve renamed dependency support through
+`proc_macro_crate`, custom harness compatibility, and ADR-008 default attribute
+resolution. Record the final choice in `Decision Log` before coding past the
+prototype.
+
+### Milestone 3: implement the code-generation and adapter boundary change
+
+Modify only the files needed by the chosen mechanism. Likely touch points are:
+
+- `crates/rstest-bdd-macros/src/codegen/mod.rs`
+- `crates/rstest-bdd-macros/src/codegen/scenario/runtime/harness.rs`
+- focused macro codegen tests under
+  `crates/rstest-bdd-macros/src/codegen/scenario/tests.rs` or
+  `crates/rstest-bdd-macros/src/codegen/scenario/tests/`
+- adapter crate roots if narrow re-exports are chosen:
+  `crates/rstest-bdd-harness-tokio/src/lib.rs` and
+  `crates/rstest-bdd-harness-gpui/src/lib.rs`
+
+Keep custom harness output unchanged unless the selected mechanism requires a
+small compatible abstraction. The generated code must still compile for
+third-party or custom harnesses that depend on `rstest-bdd-harness` directly.
+
+### Milestone 4: update examples and dependency documentation
+
+Remove direct `rstest-bdd-harness` dev-dependencies from first-party adapter
+example manifests where they are not otherwise using the base harness API:
+
+- `examples/tokio-reminders/Cargo.toml`
+- `examples/gpui-counter/Cargo.toml`
+
+Update `docs/v0-6-0-migration-guide.md` with a dependency matrix that states:
+
+- plain BDD needs `rstest-bdd`, `rstest-bdd-macros`, and `rstest`;
+- Tokio first-party harness tests need `rstest-bdd-harness-tokio`, not a
+  direct `rstest-bdd-harness` entry, unless base API types are used directly;
+- GPUI first-party harness tests need `rstest-bdd-harness-gpui`, not a direct
+  `rstest-bdd-harness` entry, unless base API types are used directly;
+- custom harness authors and direct base harness API users need
+  `rstest-bdd-harness`.
+
+Audit `docs/users-guide.md` for wording that still implies all adapter users
+must add `rstest-bdd-harness`. Update only behaviour-visible text. Update
+`docs/rstest-bdd-design.md` section 2.7.6.3 or nearby implementation notes to
+record the dependency-boundary decision if code changes alter how generated
+paths are selected. Update `docs/developers-guide.md` only if internal
+component ownership or crate-boundary guidance changes.
+
+### Milestone 5: behavioural and compile validation
+
+Run focused tests first, then full gates. Use `tee` for logs:
+
+```bash
+make check-fmt 2>&1 | tee /tmp/check-fmt-rstest-bdd-10-1-1-first-party-adapters-compile-without-direct-base-harness-dependency.out
+make lint 2>&1 | tee /tmp/lint-rstest-bdd-10-1-1-first-party-adapters-compile-without-direct-base-harness-dependency.out
+make test 2>&1 | tee /tmp/test-rstest-bdd-10-1-1-first-party-adapters-compile-without-direct-base-harness-dependency.out
+```
+
+Because this branch changes Markdown docs, also run:
+
+```bash
+make markdownlint 2>&1 | tee /tmp/markdownlint-rstest-bdd-10-1-1-first-party-adapters-compile-without-direct-base-harness-dependency.out
+make nixie 2>&1 | tee /tmp/nixie-rstest-bdd-10-1-1-first-party-adapters-compile-without-direct-base-harness-dependency.out
+```
+
+If Markdown formatting is required, run `make fmt` before re-running the format
+and Markdown gates. Do not run format, lint, and tests in parallel.
+
+Expected result: all required gates exit with status 0. The new adapter-only
+proof should fail before the implementation and pass after it.
+
+### Milestone 6: roadmap, commit, push, and PR
+
+After gates pass, mark item 10.1.1 done in `docs/roadmap.md`. Re-run the
+relevant documentation gate if the roadmap edit happens after the previous
+Markdown validation.
+
+Commit using the `commit-message` skill and a file passed to `git commit -F`.
+Do not use `git commit -m`.
+
+Push branch
+`10-1-1-first-party-adapters-compile-without-direct-base-harness-dependency`
+with upstream tracking against
+`origin/10-1-1-first-party-adapters-compile-without-direct-base-harness-dependency`.
+
+Create a draft PR using the `pr-creation` skill. The title must include
+`(10.1.1)`, and the PR summary must mention this ExecPlan:
+`docs/execplans/10-1-1-first-party-adapters-compile-without-direct-base-harness-dependency.md`.
+
+## Validation checklist
+
+Acceptance is met when all of the following are true:
+
+- `docs/v0-6-0-migration-guide.md` contains the plain BDD, Tokio, GPUI, and
+  custom harness dependency matrix.
+- At least one automated compile proof or example-level manifest proof shows
+  Tokio first-party adapter scenarios compile without a direct
+  `rstest-bdd-harness` dependency in the consuming crate.
+- At least one automated compile proof or example-level manifest proof shows
+  GPUI first-party adapter scenarios compile without a direct
+  `rstest-bdd-harness` dependency in the consuming crate.
+- Custom harness examples or docs still state that implementing custom
+  adapters requires `rstest-bdd-harness`.
+- Existing harness-led attribute defaults continue to work for Tokio and GPUI.
+- Existing custom harness tests still pass.
+- `make check-fmt`, `make lint`, `make test`, `make markdownlint`, and
+  `make nixie` pass.
+- `docs/roadmap.md` marks 10.1.1 done only after implementation validation.
+
+## Progress
+
+- [x] 2026-05-08: Read repository instructions, loaded `leta`, `execplans`,
+  `rust-router`, `arch-crate-design`, `commit-message`, and `pr-creation`
+  guidance.
+- [x] 2026-05-08: Renamed the local branch from
+  `chore/adapter-dependency-plan` to
+  `10-1-1-first-party-adapters-compile-without-direct-base-harness-dependency`.
+- [x] 2026-05-08: Used Wyvern reconnaissance agents to inspect roadmap/design
+  acceptance criteria, documentation signposts, test surfaces, and risks.
+- [x] 2026-05-08: Drafted this pre-implementation ExecPlan.
+- [ ] Await explicit approval before implementation.
+- [ ] Establish failing adapter-only dependency proof.
+- [ ] Implement the approved dependency-boundary change.
+- [ ] Update migration, user, design, and internal docs as required.
+- [ ] Run focused validation and full gates.
+- [ ] Mark roadmap item 10.1.1 done after validation.
+- [ ] Commit, push with upstream tracking, and open the required draft PR.
+
+## Surprises & Discoveries
+
+- The macro codegen path in
+  `crates/rstest-bdd-macros/src/codegen/scenario/runtime/harness.rs` currently
+  emits direct `rstest_bdd_harness` paths for `HarnessAdapter`,
+  `ScenarioMetadata`, `ScenarioRunner`, and `ScenarioRunRequest`.
+- `examples/tokio-reminders/Cargo.toml` and
+  `examples/gpui-counter/Cargo.toml` currently include direct
+  `rstest-bdd-harness` dev-dependencies, so they are useful proof points for
+  the requested friction reduction.
+- Existing adapter compile tests import
+  `rstest_bdd_harness::trybuild_staging`, so the current adapter crate test
+  harness itself uses base harness helpers even when individual downstream
+  fixture files are intended to prove adapter-only consumer dependencies.
+  Implementation must distinguish test harness internals from consumer
+  manifests.
+- `docs/v0-6-0-migration-guide.md` explains first-party harness adoption but
+  does not yet contain the explicit plain BDD, Tokio, GPUI, and custom harness
+  dependency matrix required by roadmap item 10.1.1.
+
+## Decision Log
+
+- Decision: treat this as a dependency-boundary and validation task, not a
+  trait redesign. Rationale: roadmap item 10.1.1 and design section 2.7.6.3
+  explicitly call for small, non-breaking v0.6.0-beta2 quick wins without
+  changing public contracts. Date/Author: 2026-05-08 / ExecPlan draft.
+
+- Decision: require explicit approval before implementation. Rationale: the
+  user requested a plan and stated that it must be approved before being
+  implemented. Date/Author: 2026-05-08 / ExecPlan draft.
+
+- Decision: make automated compile proof the preferred acceptance evidence,
+  with example manifest proof as supporting evidence. Rationale: the roadmap
+  allows "fixture-generation tests or docs", but compile tests catch the exact
+  downstream failure mode and prevent regression. Date/Author: 2026-05-08 /
+  ExecPlan draft.
+
+## Outcomes & Retrospective
+
+No implementation has started. The intended outcome, after approval, is a gated
+implementation that lets first-party adapter users omit direct
+`rstest-bdd-harness` dependencies while preserving custom harness support and
+public trait contracts.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -690,7 +690,7 @@ changing the public trait contracts.
 
 ### 10.1. Remove avoidable harness adoption friction
 
-- [ ] 10.1.1. Users of first-party adapters can depend only on the adapter
+- [x] 10.1.1. Users of first-party adapters can depend only on the adapter
   crate in `Cargo.toml`; `rstest-bdd-harness` is required only for custom
   harness implementations or explicit use of the base harness API. Finish line:
   `docs/v0-6-0-migration-guide.md` contains the plain BDD, Tokio, GPUI, and

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1694,7 +1694,9 @@ Attribute resolution follows the ADR-008 precedence order:
 3. deprecated `runtime = "tokio-current-thread"` compatibility alias
 4. existing runtime-mode or synchronous fallback
 
-The canonical first-party harness mappings also live in `rstest-bdd-policy`:
+The first-party harness mappings also live in `rstest-bdd-policy` and the
+macro layer recognizes both canonical crate-root paths and imported
+single-segment adapter type names:
 
 - `rstest_bdd_harness::StdHarness` -> rstest-only
 - `rstest_bdd_harness_tokio::TokioHarness` -> Tokio current-thread

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1982,6 +1982,15 @@ The release strategy is therefore split by compatibility risk:
   entity/window handles and resets world state, and migration-guide coverage
   for feature-gated downstream tests such as `cargo test --all-features`.
 
+  The first dependency-matrix quick win keeps the public harness traits in
+  `rstest-bdd-harness`, but lets first-party adapter users depend only on the
+  selected adapter crate. `rstest-bdd-harness-tokio` and
+  `rstest-bdd-harness-gpui` re-export the base API used by generated tests, and
+  the macro targets that adapter crate root when it can prove that the selected
+  harness or attribute policy is the canonical Tokio or GPUI first-party type.
+  Custom harnesses and explicit base API imports still require a direct
+  `rstest-bdd-harness` dependency.
+
 ##### 2.7.6.4 v0.6.1 early-life support helpers
 
 - **v0.6.1 early-life support:** add semver-compatible helper APIs. Candidate

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1702,6 +1702,13 @@ single-segment adapter type names:
 - `rstest_bdd_harness_tokio::TokioHarness` -> Tokio current-thread
 - `rstest_bdd_harness_gpui::GpuiHarness` -> GPUI test
 
+Imported single-segment recognition only applies to unaliased adapter type
+names. Renamed or aliased imports, such as
+`use rstest_bdd_harness_tokio::TokioHarness as MyHarness`, are not recognized
+by the macro; callers must use the full canonical crate-root path used in
+`rstest-bdd-policy`, add an explicit `rstest-bdd-harness` dependency, or expose
+the adapter under its original name for the macro to resolve it.
+
 Unknown harness paths still fall back to runtime compatibility behaviour
 because procedural macros do not evaluate arbitrary third-party
 `AttributePolicy::test_attributes()` implementations during expansion.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -871,10 +871,10 @@ It is available as a dev-dependency:
 rstest-bdd-harness-tokio = "0.6.0-beta1"
 ```
 
-When using `TokioHarness` through this first-party adapter crate, adding
-`rstest-bdd-harness` separately is unnecessary. Include the base harness crate
-only when implementing a custom harness or directly importing base API types
-such as `HarnessAdapter` or `ScenarioRunRequest`.
+A direct `rstest-bdd-harness` dependency is not required when using
+`TokioHarness` through this first-party adapter crate. Add the base harness
+crate directly only when implementing a custom harness or importing base API
+types such as `HarnessAdapter` or `ScenarioRunRequest`.
 
 `TokioHarness` can then be used directly in scenarios:
 
@@ -966,10 +966,10 @@ as a dev-dependency:
 rstest-bdd-harness-gpui = "0.6.0-beta1"
 ```
 
-When using `GpuiHarness` through this first-party adapter crate, adding
-`rstest-bdd-harness` separately is unnecessary. Include the base harness crate
-only when implementing a custom harness or directly importing base API types
-such as `HarnessAdapter` or `ScenarioRunRequest`.
+A direct `rstest-bdd-harness` dependency is not required when using
+`GpuiHarness` through this first-party adapter crate. Add the base harness
+crate directly only when implementing a custom harness or importing base API
+types such as `HarnessAdapter` or `ScenarioRunRequest`.
 
 `GpuiHarness` can then be used directly in scenarios:
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -868,10 +868,10 @@ It is available as a dev-dependency:
 rstest-bdd-harness-tokio = "0.6.0-beta1"
 ```
 
-You do not need to add `rstest-bdd-harness` separately when using
-`TokioHarness` through this first-party adapter crate. Add the base harness
-crate only when implementing a custom harness or directly importing base API
-types such as `HarnessAdapter` or `ScenarioRunRequest`.
+When using `TokioHarness` through this first-party adapter crate, adding
+`rstest-bdd-harness` separately is unnecessary. Include the base harness crate
+only when implementing a custom harness or directly importing base API types
+such as `HarnessAdapter` or `ScenarioRunRequest`.
 
 `TokioHarness` can then be used directly in scenarios:
 
@@ -963,10 +963,10 @@ as a dev-dependency:
 rstest-bdd-harness-gpui = "0.6.0-beta1"
 ```
 
-You do not need to add `rstest-bdd-harness` separately when using `GpuiHarness`
-through this first-party adapter crate. Add the base harness crate only when
-implementing a custom harness or directly importing base API types such as
-`HarnessAdapter` or `ScenarioRunRequest`.
+When using `GpuiHarness` through this first-party adapter crate, adding
+`rstest-bdd-harness` separately is unnecessary. Include the base harness crate
+only when implementing a custom harness or directly importing base API types
+such as `HarnessAdapter` or `ScenarioRunRequest`.
 
 `GpuiHarness` can then be used directly in scenarios:
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -775,19 +775,22 @@ delegation, preserving backward compatibility.
 When `attributes` is specified, the macro resolves policy-backed test
 attributes. Currently this resolution is path-based:
 
-- the canonical `rstest_bdd_harness_tokio::TokioAttributePolicy` path emits
-  Tokio current-thread test attributes for async scenario signatures,
-- the canonical `rstest_bdd_harness_gpui::GpuiAttributePolicy` path emits
-  `#[gpui::test]` for synchronous and async scenario signatures, and
+- `rstest_bdd_harness_tokio::TokioAttributePolicy`, or an imported
+  `TokioAttributePolicy`, emits Tokio current-thread test attributes for async
+  scenario signatures,
+- `rstest_bdd_harness_gpui::GpuiAttributePolicy`, or an imported
+  `GpuiAttributePolicy`, emits `#[gpui::test]` for synchronous and async
+  scenario signatures, and
 - default and unknown policy paths emit `#[rstest::rstest]` only.
 
 When `attributes` is omitted, known first-party harnesses infer matching
 default attribute policies:
 
 - `rstest_bdd_harness::StdHarness` resolves to rstest-only emission,
-- `rstest_bdd_harness_tokio::TokioHarness` resolves to the Tokio
-  current-thread policy, and
-- `rstest_bdd_harness_gpui::GpuiHarness` resolves to the GPUI test policy.
+- `rstest_bdd_harness_tokio::TokioHarness`, or an imported `TokioHarness`,
+  resolves to the Tokio current-thread policy, and
+- `rstest_bdd_harness_gpui::GpuiHarness`, or an imported `GpuiHarness`,
+  resolves to the GPUI test policy.
 
 If the harness path is not one of those known first-party paths, the macro
 falls back to the existing `RuntimeMode` compatibility behaviour. This keeps

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -783,6 +783,13 @@ attributes. Currently this resolution is path-based:
   scenario signatures, and
 - default and unknown policy paths emit `#[rstest::rstest]` only.
 
+Imported single-segment recognition only applies to unaliased first-party names.
+If the adapter crates are renamed or aliased, or the policy types are
+re-exported under different identifiers, use the canonical crate-root path
+(`rstest_bdd_harness_tokio::TokioAttributePolicy` or
+`rstest_bdd_harness_gpui::GpuiAttributePolicy`) or add a direct
+`rstest-bdd-harness` dependency to get the same attribute recognition.
+
 When `attributes` is omitted, known first-party harnesses infer matching
 default attribute policies:
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -868,6 +868,11 @@ It is available as a dev-dependency:
 rstest-bdd-harness-tokio = "0.6.0-beta1"
 ```
 
+You do not need to add `rstest-bdd-harness` separately when using
+`TokioHarness` through this first-party adapter crate. Add the base harness
+crate only when implementing a custom harness or directly importing base API
+types such as `HarnessAdapter` or `ScenarioRunRequest`.
+
 `TokioHarness` can then be used directly in scenarios:
 
 ```rust,no_run
@@ -957,6 +962,11 @@ as a dev-dependency:
 [dev-dependencies]
 rstest-bdd-harness-gpui = "0.6.0-beta1"
 ```
+
+You do not need to add `rstest-bdd-harness` separately when using `GpuiHarness`
+through this first-party adapter crate. Add the base harness crate only when
+implementing a custom harness or directly importing base API types such as
+`HarnessAdapter` or `ScenarioRunRequest`.
 
 `GpuiHarness` can then be used directly in scenarios:
 

--- a/docs/v0-6-0-migration-guide.md
+++ b/docs/v0-6-0-migration-guide.md
@@ -140,6 +140,33 @@ harness types used through the macros must implement both `HarnessAdapter` and
   macros trait-check user-provided policy types, but path-based code generation
   only recognizes canonical first-party policy paths today.
 
+### Harness dependency matrix
+
+Downstream `Cargo.toml` files should list the smallest crate set that matches
+the harness surface they use:
+
+- **Plain BDD scenarios:** add `rstest`, `rstest-bdd`, and
+  `rstest-bdd-macros`. Add `rstest-bdd-harness` directly only when test code
+  imports base harness API types.
+- **Tokio first-party harness:** add `rstest`, `rstest-bdd`,
+  `rstest-bdd-macros`, `rstest-bdd-harness-tokio`, and `tokio`. Add
+  `rstest-bdd-harness` directly only when implementing a custom harness or
+  importing base API types.
+- **GPUI first-party harness:** add `rstest`, `rstest-bdd`,
+  `rstest-bdd-macros`, `rstest-bdd-harness-gpui`, and `gpui`. Add
+  `rstest-bdd-harness` directly only when implementing a custom harness or
+  importing base API types.
+- **Custom harness implementation:** add `rstest`, `rstest-bdd`,
+  `rstest-bdd-macros`, and `rstest-bdd-harness`. Custom harnesses implement
+  `HarnessAdapter` and usually use `ScenarioRunRequest`.
+
+First-party adapter crates re-export the base harness API used by generated
+tests, so selecting `rstest_bdd_harness_tokio::TokioHarness` or
+`rstest_bdd_harness_gpui::GpuiHarness` does not require a separate direct
+`rstest-bdd-harness` entry in the consuming crate. The
+`examples/tokio-reminders` and `examples/gpui-counter` manifests intentionally
+omit that direct dependency and compile as workspace proof points.
+
 ### Workspace dependency migration for contributors
 
 Workspace contributors should not restore the old root `[patch.crates-io]`

--- a/docs/v0-6-0-migration-guide.md
+++ b/docs/v0-6-0-migration-guide.md
@@ -138,7 +138,8 @@ harness types used through the macros must implement both `HarnessAdapter` and
   platform libraries required by upstream GPUI.
 - Third-party attribute policies still need explicit user documentation. The
   macros trait-check user-provided policy types, but path-based code generation
-  only recognizes canonical first-party policy paths today.
+  only recognizes first-party policy paths and imported first-party policy type
+  names today.
 
 ### Harness dependency matrix
 
@@ -167,13 +168,16 @@ tests, so selecting `rstest_bdd_harness_tokio::TokioHarness` or
 `examples/tokio-reminders` and `examples/gpui-counter` manifests intentionally
 omit that direct dependency and compile as workspace proof points.
 
-Adapter-only manifests require macro arguments to use canonical first-party
-crate-root paths, such as `rstest_bdd_harness::StdHarness`,
+Adapter-only manifests work when macro arguments use first-party crate-root
+paths, such as `rstest_bdd_harness::StdHarness`,
 `rstest_bdd_harness_tokio::TokioHarness`, or
-`rstest_bdd_harness_gpui::GpuiHarness`. Imported aliases and local type aliases
-for those harness types are not recognized as first-party paths. When the macro
-call uses an alias, uses a local type alias, or omits `attributes = ...` while
-the harness argument is not canonical, generated code falls back to
+`rstest_bdd_harness_gpui::GpuiHarness`. They also work when the adapter type is
+imported directly and the macro argument is the single-segment first-party type
+name, such as `TokioHarness`, `TokioAttributePolicy`, `GpuiHarness`, or
+`GpuiAttributePolicy`. Local type aliases and matching type names under other
+module roots are not recognized as first-party paths. When the macro call uses
+one of those non-recognized forms, or omits `attributes = ...` while the harness
+argument is not recognized as first-party, generated code falls back to
 `rstest-bdd-harness` and therefore requires a direct base harness dependency.
 
 ### Workspace dependency migration for contributors

--- a/docs/v0-6-0-migration-guide.md
+++ b/docs/v0-6-0-migration-guide.md
@@ -168,6 +168,16 @@ tests, so selecting `rstest_bdd_harness_tokio::TokioHarness` or
 `examples/tokio-reminders` and `examples/gpui-counter` manifests intentionally
 omit that direct dependency and compile as workspace proof points.
 
+> **Canonical-path requirement:** the macro detects first-party adapters
+> by matching the crate-root identifier in the supplied path against the
+> known adapter crate names. When the Tokio or GPUI adapter crate is
+> renamed in `Cargo.toml` (for example `tok = { package =
+> "rstest-bdd-harness-tokio", … }`) or the harness type is re-exported
+> under a different module path, the macro cannot identify it as a
+> first-party adapter and falls back to resolving base API types through
+> `rstest-bdd-harness`. In those cases add `rstest-bdd-harness` as a
+> direct dev-dependency.
+
 Adapter-only manifests work when macro arguments use first-party crate-root
 paths, such as `rstest_bdd_harness::StdHarness`,
 `rstest_bdd_harness_tokio::TokioHarness`, or

--- a/docs/v0-6-0-migration-guide.md
+++ b/docs/v0-6-0-migration-guide.md
@@ -175,7 +175,7 @@ omit that direct dependency and compile as workspace proof points.
 > "rstest-bdd-harness-tokio", … }`) or the harness type is re-exported
 > under a different module path, the macro cannot identify it as a
 > first-party adapter and falls back to resolving base API types through
-> `rstest-bdd-harness`. In those cases add `rstest-bdd-harness` as a
+> `rstest-bdd-harness`. In those cases, add `rstest-bdd-harness` as a
 > direct dev-dependency.
 
 Adapter-only manifests work when macro arguments use first-party crate-root

--- a/docs/v0-6-0-migration-guide.md
+++ b/docs/v0-6-0-migration-guide.md
@@ -167,6 +167,15 @@ tests, so selecting `rstest_bdd_harness_tokio::TokioHarness` or
 `examples/tokio-reminders` and `examples/gpui-counter` manifests intentionally
 omit that direct dependency and compile as workspace proof points.
 
+Adapter-only manifests require macro arguments to use canonical first-party
+crate-root paths, such as `rstest_bdd_harness::StdHarness`,
+`rstest_bdd_harness_tokio::TokioHarness`, or
+`rstest_bdd_harness_gpui::GpuiHarness`. Imported aliases and local type aliases
+for those harness types are not recognized as first-party paths. When the macro
+call uses an alias, uses a local type alias, or omits `attributes = ...` while
+the harness argument is not canonical, generated code falls back to
+`rstest-bdd-harness` and therefore requires a direct base harness dependency.
+
 ### Workspace dependency migration for contributors
 
 Workspace contributors should not restore the old root `[patch.crates-io]`

--- a/examples/gpui-counter/Cargo.toml
+++ b/examples/gpui-counter/Cargo.toml
@@ -11,6 +11,5 @@ rust-version.workspace = true
 gpui.workspace = true
 rstest = { workspace = true }
 rstest-bdd.workspace = true
-rstest-bdd-harness.workspace = true
 rstest-bdd-harness-gpui.workspace = true
 rstest-bdd-macros.workspace = true

--- a/examples/tokio-reminders/Cargo.toml
+++ b/examples/tokio-reminders/Cargo.toml
@@ -12,6 +12,5 @@ tokio.workspace = true
 [dev-dependencies]
 rstest.workspace = true
 rstest-bdd.workspace = true
-rstest-bdd-harness.workspace = true
 rstest-bdd-harness-tokio.workspace = true
 rstest-bdd-macros.workspace = true

--- a/scripts/publish_check_gpui_manifest.py
+++ b/scripts/publish_check_gpui_manifest.py
@@ -225,10 +225,10 @@ def _validator_test_source() -> str:
     """Return the smoke test source for the validator crate."""
     return """//! Smoke tests for the packaged GPUI harness artifact.
 
-use rstest_bdd_harness::{
-    HarnessAdapter, ScenarioMetadata, ScenarioRunRequest, ScenarioRunner,
+use rstest_bdd_harness_gpui::{
+    GpuiHarness, HarnessAdapter, ScenarioMetadata, ScenarioRunRequest,
+    ScenarioRunner,
 };
-use rstest_bdd_harness_gpui::GpuiHarness;
 
 #[test]
 fn packaged_gpui_harness_runs_against_upstream_gpui() {


### PR DESCRIPTION
## Summary

This branch implements roadmap task (10.1.1) by allowing first-party Tokio and GPUI adapter users to depend on the selected adapter crate without also listing `rstest-bdd-harness` directly. Custom harness authors and callers that import base harness API types still depend on `rstest-bdd-harness` explicitly.

Roadmap task: (10.1.1)
Execplan: [docs/execplans/10-1-1-first-party-adapters-compile-without-direct-base-harness-dependency.md](https://github.com/leynos/rstest-bdd/blob/971301bc291c79d7a02d7dffeb1fe4c1fed21aee/docs/execplans/10-1-1-first-party-adapters-compile-without-direct-base-harness-dependency.md)

## Review walkthrough

- Start with [crates/rstest-bdd-macros/src/codegen/mod.rs](https://github.com/leynos/rstest-bdd/blob/971301bc291c79d7a02d7dffeb1fe4c1fed21aee/crates/rstest-bdd-macros/src/codegen/mod.rs) and [crates/rstest-bdd-macros/src/codegen/scenario.rs](https://github.com/leynos/rstest-bdd/blob/971301bc291c79d7a02d7dffeb1fe4c1fed21aee/crates/rstest-bdd-macros/src/codegen/scenario.rs) to see how generated harness and attribute-policy assertions now resolve base API paths through canonical first-party adapter crate roots.
- Then review [crates/rstest-bdd-harness-tokio/src/lib.rs](https://github.com/leynos/rstest-bdd/blob/971301bc291c79d7a02d7dffeb1fe4c1fed21aee/crates/rstest-bdd-harness-tokio/src/lib.rs) and [crates/rstest-bdd-harness-gpui/src/lib.rs](https://github.com/leynos/rstest-bdd/blob/971301bc291c79d7a02d7dffeb1fe4c1fed21aee/crates/rstest-bdd-harness-gpui/src/lib.rs) for the adapter re-exports that generated code uses.
- Check [examples/tokio-reminders/Cargo.toml](https://github.com/leynos/rstest-bdd/blob/971301bc291c79d7a02d7dffeb1fe4c1fed21aee/examples/tokio-reminders/Cargo.toml) and [examples/gpui-counter/Cargo.toml](https://github.com/leynos/rstest-bdd/blob/971301bc291c79d7a02d7dffeb1fe4c1fed21aee/examples/gpui-counter/Cargo.toml) for the downstream-style adapter-only manifest proof.
- Finish with [docs/v0-6-0-migration-guide.md](https://github.com/leynos/rstest-bdd/blob/971301bc291c79d7a02d7dffeb1fe4c1fed21aee/docs/v0-6-0-migration-guide.md), [docs/users-guide.md](https://github.com/leynos/rstest-bdd/blob/971301bc291c79d7a02d7dffeb1fe4c1fed21aee/docs/users-guide.md), and [docs/rstest-bdd-design.md](https://github.com/leynos/rstest-bdd/blob/971301bc291c79d7a02d7dffeb1fe4c1fed21aee/docs/rstest-bdd-design.md) for the documented dependency matrix and design decision.

## Validation

- `cargo check -p tokio-reminders --tests`: passed after reproducing the pre-fix missing `rstest-bdd-harness` failure.
- `cargo check -p gpui-counter --tests`: passed.
- `cargo test -p rstest-bdd-macros`: passed.
- `cargo test -p tokio-reminders`: passed.
- `cargo test -p gpui-counter`: passed.
- `cargo test -p rstest-bdd-harness-gpui --features native-gpui-tests --test macro_compile -- --nocapture`: passed.
- `make check-fmt`: passed.
- `make lint`: passed.
- `make test`: passed, including 1389 nextest tests and 62 Python publish-check tests.
- `make markdownlint`: passed.
- `make nixie`: passed.

## Notes

The GPUI adapter-only compile proof exposed a `copy_dir_tree` staging edge case for nested missing destination parents. This branch fixes that helper with a focused regression test so the GPUI trybuild fixtures can stage their feature tree before compile validation.
