### PR TITLE
Extend first-party policy hint resolution (9.7.1)

### DIFF
--- a/crates/rstest-bdd-harness/src/trybuild_staging/mod.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/mod.rs
@@ -83,19 +83,42 @@ pub(super) fn copy_entry(entry: &fs::DirEntry, destination: &Path) -> io::Result
 fn canonical_destination_for_overlap(destination: &Path) -> io::Result<PathBuf> {
     match fs::canonicalize(destination) {
         Ok(path) => Ok(path),
-        Err(err) if err.kind() == io::ErrorKind::NotFound => canonical_missing_path(destination),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            canonical_missing_destination(destination)
+        }
         Err(err) => Err(err),
     }
 }
 
-fn canonical_missing_path(path: &Path) -> io::Result<PathBuf> {
-    let Some(name) = path.file_name() else {
-        return fs::canonicalize(std::env::current_dir()?);
-    };
-    let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) else {
-        return Ok(fs::canonicalize(std::env::current_dir()?)?.join(name));
-    };
-    Ok(canonical_destination_for_overlap(parent)?.join(name))
+fn canonical_missing_destination(destination: &Path) -> io::Result<PathBuf> {
+    let mut missing_components = Vec::new();
+    let mut current = destination;
+
+    loop {
+        match fs::canonicalize(current) {
+            Ok(mut path) => {
+                for component in missing_components.iter().rev() {
+                    path.push(component);
+                }
+                return Ok(path);
+            }
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                if let Some(name) = current.file_name() {
+                    missing_components.push(name.to_os_string());
+                }
+                if let Some(parent) = current.parent().filter(|path| !path.as_os_str().is_empty()) {
+                    current = parent;
+                } else {
+                    let mut path = fs::canonicalize(std::env::current_dir()?)?;
+                    for component in missing_components.iter().rev() {
+                        path.push(component);
+                    }
+                    return Ok(path);
+                }
+            }
+            Err(err) => return Err(err),
+        }
+    }
 }
 
 fn paths_overlap(a: &Path, b: &Path) -> bool {

--- a/crates/rstest-bdd-harness/src/trybuild_staging/mod.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/mod.rs
@@ -100,16 +100,14 @@ fn append_missing_components(mut base: PathBuf, missing: &[std::ffi::OsString]) 
 fn canonical_missing_destination(destination: &Path) -> io::Result<PathBuf> {
     let mut missing_components: Vec<std::ffi::OsString> = Vec::new();
 
-    for ancestor in destination.ancestors() {
-        if ancestor.as_os_str().is_empty() {
-            break;
-        }
+    for ancestor in destination
+        .ancestors()
+        .take_while(|p| !p.as_os_str().is_empty())
+    {
         match fs::canonicalize(ancestor) {
             Ok(base) => return Ok(append_missing_components(base, &missing_components)),
             Err(err) if err.kind() == io::ErrorKind::NotFound => {
-                if let Some(name) = ancestor.file_name() {
-                    missing_components.push(name.to_os_string());
-                }
+                missing_components.extend(ancestor.file_name().map(std::ffi::OsStr::to_os_string));
             }
             Err(err) => return Err(err),
         }

--- a/crates/rstest-bdd-harness/src/trybuild_staging/mod.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/mod.rs
@@ -90,47 +90,39 @@ fn canonical_destination_for_overlap(destination: &Path) -> io::Result<PathBuf> 
     }
 }
 
-fn append_missing_components(mut base: PathBuf, missing: &[std::ffi::OsString]) -> PathBuf {
-    for component in missing.iter().rev() {
-        if component == std::ffi::OsStr::new("..") {
-            base.pop();
-        } else {
-            base.push(component);
+fn apply_missing_tail(mut base: PathBuf, tail: &Path) -> PathBuf {
+    for component in tail.components() {
+        match component {
+            std::path::Component::ParentDir => {
+                base.pop();
+            }
+            std::path::Component::Normal(name) => base.push(name),
+            _ => {}
         }
     }
     base
 }
 
-fn missing_component_for(ancestor: &Path) -> Option<std::ffi::OsString> {
-    ancestor
-        .components()
-        .next_back()
-        .and_then(|component| match component {
-            std::path::Component::Normal(name) => Some(name.to_os_string()),
-            std::path::Component::ParentDir => Some(std::ffi::OsString::from("..")),
-            _ => None,
-        })
-}
-
 fn canonical_missing_destination(destination: &Path) -> io::Result<PathBuf> {
-    let mut missing_components: Vec<std::ffi::OsString> = Vec::new();
-
     for ancestor in destination
         .ancestors()
         .take_while(|p| !p.as_os_str().is_empty())
     {
         match fs::canonicalize(ancestor) {
-            Ok(base) => return Ok(append_missing_components(base, &missing_components)),
-            Err(err) if err.kind() == io::ErrorKind::NotFound => {
-                missing_components.extend(missing_component_for(ancestor));
+            Ok(base) => {
+                let tail = destination
+                    .strip_prefix(ancestor)
+                    .unwrap_or_else(|_| Path::new(""));
+                return Ok(apply_missing_tail(base, tail));
             }
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
             Err(err) => return Err(err),
         }
     }
 
     // No existing ancestor found; resolve against the current working directory.
     let base = fs::canonicalize(std::env::current_dir()?)?;
-    Ok(append_missing_components(base, &missing_components))
+    Ok(apply_missing_tail(base, destination))
 }
 
 fn paths_overlap(a: &Path, b: &Path) -> bool {

--- a/crates/rstest-bdd-harness/src/trybuild_staging/mod.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/mod.rs
@@ -92,9 +92,24 @@ fn canonical_destination_for_overlap(destination: &Path) -> io::Result<PathBuf> 
 
 fn append_missing_components(mut base: PathBuf, missing: &[std::ffi::OsString]) -> PathBuf {
     for component in missing.iter().rev() {
-        base.push(component);
+        if component == std::ffi::OsStr::new("..") {
+            base.pop();
+        } else {
+            base.push(component);
+        }
     }
     base
+}
+
+fn missing_component_for(ancestor: &Path) -> Option<std::ffi::OsString> {
+    ancestor
+        .components()
+        .next_back()
+        .and_then(|component| match component {
+            std::path::Component::Normal(name) => Some(name.to_os_string()),
+            std::path::Component::ParentDir => Some(std::ffi::OsString::from("..")),
+            _ => None,
+        })
 }
 
 fn canonical_missing_destination(destination: &Path) -> io::Result<PathBuf> {
@@ -107,7 +122,7 @@ fn canonical_missing_destination(destination: &Path) -> io::Result<PathBuf> {
         match fs::canonicalize(ancestor) {
             Ok(base) => return Ok(append_missing_components(base, &missing_components)),
             Err(err) if err.kind() == io::ErrorKind::NotFound => {
-                missing_components.extend(ancestor.file_name().map(std::ffi::OsStr::to_os_string));
+                missing_components.extend(missing_component_for(ancestor));
             }
             Err(err) => return Err(err),
         }

--- a/crates/rstest-bdd-harness/src/trybuild_staging/mod.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/mod.rs
@@ -90,35 +90,34 @@ fn canonical_destination_for_overlap(destination: &Path) -> io::Result<PathBuf> 
     }
 }
 
-fn canonical_missing_destination(destination: &Path) -> io::Result<PathBuf> {
-    let mut missing_components = Vec::new();
-    let mut current = destination;
+fn append_missing_components(mut base: PathBuf, missing: &[std::ffi::OsString]) -> PathBuf {
+    for component in missing.iter().rev() {
+        base.push(component);
+    }
+    base
+}
 
-    loop {
-        match fs::canonicalize(current) {
-            Ok(mut path) => {
-                for component in missing_components.iter().rev() {
-                    path.push(component);
-                }
-                return Ok(path);
-            }
+fn canonical_missing_destination(destination: &Path) -> io::Result<PathBuf> {
+    let mut missing_components: Vec<std::ffi::OsString> = Vec::new();
+
+    for ancestor in destination.ancestors() {
+        if ancestor.as_os_str().is_empty() {
+            break;
+        }
+        match fs::canonicalize(ancestor) {
+            Ok(base) => return Ok(append_missing_components(base, &missing_components)),
             Err(err) if err.kind() == io::ErrorKind::NotFound => {
-                if let Some(name) = current.file_name() {
+                if let Some(name) = ancestor.file_name() {
                     missing_components.push(name.to_os_string());
-                }
-                if let Some(parent) = current.parent().filter(|path| !path.as_os_str().is_empty()) {
-                    current = parent;
-                } else {
-                    let mut path = fs::canonicalize(std::env::current_dir()?)?;
-                    for component in missing_components.iter().rev() {
-                        path.push(component);
-                    }
-                    return Ok(path);
                 }
             }
             Err(err) => return Err(err),
         }
     }
+
+    // No existing ancestor found; resolve against the current working directory.
+    let base = fs::canonicalize(std::env::current_dir()?)?;
+    Ok(append_missing_components(base, &missing_components))
 }
 
 fn paths_overlap(a: &Path, b: &Path) -> bool {

--- a/crates/rstest-bdd-harness/src/trybuild_staging/prop_tests.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/prop_tests.rs
@@ -7,7 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use proptest::prelude::*;
 
-use super::copy_dir_tree;
+use super::{canonical_missing_destination, copy_dir_tree, paths_overlap};
 
 #[expect(
     clippy::expect_used,
@@ -83,7 +83,118 @@ fn build_nested_source_with_symlink(
     (src, dst)
 }
 
+fn path_with_missing_parent_dirs(
+    root: &Path,
+    existing_depth: usize,
+    missing_depth: usize,
+) -> PathBuf {
+    let mut path = root.to_path_buf();
+    for index in 0..existing_depth {
+        path = path.join(format!("existing_{index}"));
+    }
+    for index in 0..missing_depth {
+        path = path.join(format!("missing_{index}"));
+    }
+    path.join("dst")
+}
+
+fn path_resolving_back_to_source(root: &Path, source_name: &str, missing_depth: usize) -> PathBuf {
+    let mut path = root.to_path_buf();
+    for index in 0..missing_depth {
+        path = path.join(format!("missing_{index}"));
+    }
+    for _ in 0..missing_depth {
+        path = path.join("..");
+    }
+    path.join(source_name)
+}
+
 proptest! {
+    /// Missing destination parent chains canonicalize to the same path as the
+    /// nearest existing ancestor plus the generated missing tail.
+    #[test]
+    fn missing_destination_parent_chains_resolve_from_existing_ancestor(
+        existing_depth in 0usize..5,
+        missing_depth in 1usize..6,
+    ) {
+        let root = unique_root("missing_parent_chain");
+        let _ = fs::remove_dir_all(&root);
+        let destination = path_with_missing_parent_dirs(&root, existing_depth, missing_depth);
+        let mut existing = root.clone();
+        for index in 0..existing_depth {
+            existing = existing.join(format!("existing_{index}"));
+        }
+        #[expect(
+            clippy::expect_used,
+            reason = "property-test temp-dir setup and canonicalization after explicit setup"
+        )]
+        {
+            fs::create_dir_all(&existing).expect("create existing ancestor");
+            let mut expected = fs::canonicalize(&existing).expect("canonicalize ancestor");
+            for index in 0..missing_depth {
+                expected = expected.join(format!("missing_{index}"));
+            }
+            expected = expected.join("dst");
+            let actual = canonical_missing_destination(&destination);
+            let _ = fs::remove_dir_all(&root);
+            prop_assert_eq!(actual.expect("canonical missing destination"), expected);
+        }
+    }
+
+    /// A destination with arbitrary missing components followed by matching
+    /// parent-directory components still resolves back to the source tree.
+    #[test]
+    fn missing_tail_parent_dirs_resolve_to_overlapping_source(
+        missing_depth in 1usize..6,
+    ) {
+        let root = unique_root("missing_tail_parent_dirs");
+        let _ = fs::remove_dir_all(&root);
+        let src = root.join("src");
+        let destination = path_resolving_back_to_source(&root, "src", missing_depth);
+        #[expect(
+            clippy::expect_used,
+            reason = "property-test temp-dir setup and canonicalization after explicit setup"
+        )]
+        {
+            fs::create_dir_all(&src).expect("create src");
+            let canonical_src = fs::canonicalize(&src).expect("canonicalize src");
+            let canonical_dst = canonical_missing_destination(&destination)
+                .expect("canonical missing destination");
+            prop_assert!(paths_overlap(&canonical_src, &canonical_dst));
+            prop_assert!(!root.join("missing_0").exists());
+        }
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// `copy_dir_tree` rejects overlap destinations that only become apparent
+    /// after resolving arbitrary missing components and `..` components.
+    #[test]
+    fn copy_dir_tree_rejects_generated_missing_tail_overlaps(
+        missing_depth in 1usize..6,
+    ) {
+        let root = unique_root("copy_dir_missing_tail_overlap");
+        let _ = fs::remove_dir_all(&root);
+        let src = root.join("src");
+        let dst = path_resolving_back_to_source(&root, "src", missing_depth);
+        #[expect(
+            clippy::expect_used,
+            reason = "property-test temp-dir setup and err-kind extraction after explicit guards"
+        )]
+        {
+            fs::create_dir_all(&src).expect("create src");
+            fs::write(src.join("f.txt"), b"x").expect("write f.txt");
+            let result = copy_dir_tree(&src, &dst);
+            prop_assert!(!root.join("missing_0").exists());
+            prop_assert_eq!(
+                result
+                    .expect_err("expected overlap rejection")
+                    .kind(),
+                std::io::ErrorKind::InvalidInput,
+            );
+        }
+        let _ = fs::remove_dir_all(&root);
+    }
+
     /// A symlink at the top level of the source tree is always rejected,
     /// regardless of how many regular files accompany it.
     #[test]

--- a/crates/rstest-bdd-harness/src/trybuild_staging/prop_tests.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/prop_tests.rs
@@ -1,4 +1,8 @@
-//! Property tests for symlink rejection in [`super::copy_dir_tree`].
+//! Property tests for [`super::copy_dir_tree`] staging invariants.
+//!
+//! These cover symlink rejection as well as verification that missing
+//! destination paths are canonicalized and destination overlaps are detected
+//! before a copy can create or remove the wrong tree.
 
 use std::fs;
 use std::os::unix::fs::symlink;

--- a/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
@@ -146,6 +146,7 @@ fn copy_dir_tree_replaces_existing_file_destination(replace_file_dest_staging: R
     assert!(dst.join("f.txt").exists());
 }
 
+#[test]
 fn copy_dir_tree_creates_missing_destination_parent_chain() {
     #[expect(
         clippy::expect_used,
@@ -167,7 +168,13 @@ fn copy_dir_tree_creates_missing_destination_parent_chain() {
     }
 }
 
-fn copy_dir_tree_rejects_destination_inside_missing_parent_chain() {
+struct MissingTailOverlapStaging {
+    root: TempDir,
+    src: PathBuf,
+}
+
+#[fixture]
+fn missing_tail_overlap_staging() -> MissingTailOverlapStaging {
     #[expect(
         clippy::expect_used,
         reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
@@ -176,17 +183,49 @@ fn copy_dir_tree_rejects_destination_inside_missing_parent_chain() {
         let (root, src, _) = make_src_dst_scaffold();
         fs::create_dir_all(&src).expect("create src");
         fs::write(src.join("f.txt"), b"x").expect("write f.txt");
-        // dst is a non-existent subtree of src - must be rejected as overlapping.
-        let dst = src.join("missing").join("child");
-        let err = copy_dir_tree(&src, &dst).expect_err("overlap inside missing parent chain");
+        MissingTailOverlapStaging { root, src }
+    }
+}
+
+enum MissingTailOverlapDestination {
+    InsideMissingParentChain,
+    ResolvedThroughMissingParentDir,
+}
+
+impl MissingTailOverlapDestination {
+    fn path(&self, root: &std::path::Path, src: &std::path::Path) -> PathBuf {
+        match self {
+            Self::InsideMissingParentChain => src.join("missing").join("child"),
+            Self::ResolvedThroughMissingParentDir => root.join("missing").join("..").join("src"),
+        }
+    }
+}
+
+#[rstest]
+#[case::inside_missing_parent_chain(MissingTailOverlapDestination::InsideMissingParentChain)]
+#[case::resolved_through_missing_parent_dir(
+    MissingTailOverlapDestination::ResolvedThroughMissingParentDir
+)]
+fn copy_dir_tree_rejects_missing_tail_overlap_destinations(
+    missing_tail_overlap_staging: MissingTailOverlapStaging,
+    #[case] destination: MissingTailOverlapDestination,
+) {
+    #[expect(
+        clippy::expect_used,
+        reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
+    )]
+    {
+        let MissingTailOverlapStaging { root, src } = missing_tail_overlap_staging;
+        let dst = destination.path(root.path(), &src);
+        let err = copy_dir_tree(&src, &dst).expect_err("missing-tail destination overlaps source");
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
         assert!(
             err.to_string().contains("refusing overlapping"),
             "unexpected error message: {err}"
         );
-        drop(root);
     }
 }
+
 struct SymlinkInSourceStaging {
     _root: TempDir,
     src: PathBuf,
@@ -319,27 +358,7 @@ fn copy_dir_tree_rejects_identical_source_and_destination() {
     }
 }
 
-fn copy_dir_tree_rejects_destination_resolved_through_missing_parent_dir() {
-    #[expect(
-        clippy::expect_used,
-        reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
-    )]
-    {
-        let (root, src, _dst) = make_src_dst_scaffold();
-        fs::create_dir_all(&src).expect("src");
-        fs::write(src.join("f.txt"), b"x").expect("write");
-        // Destination resolves through a missing intermediate segment back to src.
-        let dst = root.path().join("missing").join("..").join("src");
-
-        let err = copy_dir_tree(&src, &dst).expect_err("resolved destination is source");
-
-        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
-        assert!(
-            err.to_string().contains("refusing overlapping"),
-            "unexpected error message: {err}"
-        );
-    }
-}
+#[test]
 fn copy_dir_tree_rejects_destination_inside_source() {
     #[expect(
         clippy::expect_used,

--- a/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
@@ -146,7 +146,26 @@ fn copy_dir_tree_replaces_existing_file_destination(replace_file_dest_staging: R
     assert!(dst.join("f.txt").exists());
 }
 
-#[cfg(unix)]
+fn copy_dir_tree_creates_missing_destination_parent_chain() {
+    #[expect(
+        clippy::expect_used,
+        reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
+    )]
+    {
+        let root = TempDir::new().expect("tempdir");
+        let src = root.path().join("src");
+        let dst = root.path().join("missing").join("parents").join("dst");
+        fs::create_dir_all(&src).expect("create src");
+        fs::write(src.join("f.txt"), b"hello").expect("write f.txt");
+
+        copy_dir_tree(&src, &dst).expect("copy_dir_tree");
+
+        assert_eq!(
+            fs::read(dst.join("f.txt")).expect("read dst file"),
+            b"hello"
+        );
+    }
+}
 struct SymlinkInSourceStaging {
     _root: TempDir,
     src: PathBuf,

--- a/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
@@ -152,8 +152,8 @@ fn copy_dir_tree_creates_missing_destination_parent_chain() {
         reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
     )]
     {
-        let (root, src, dst) = make_src_dst_scaffold();
-        let dst = dst.join("missing").join("parents").join("dst");
+        let (root, src, _) = make_src_dst_scaffold();
+        let dst = root.path().join("missing").join("parents").join("dst");
         std::fs::create_dir_all(&src).expect("create src");
         std::fs::write(src.join("f.txt"), b"hello").expect("write f.txt");
 
@@ -174,18 +174,18 @@ fn copy_dir_tree_rejects_destination_inside_missing_parent_chain() {
         reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
     )]
     {
-        let root = TempDir::new().expect("tempdir");
-        let src = root.path().join("src");
+        let (root, src, _) = make_src_dst_scaffold();
         fs::create_dir_all(&src).expect("create src");
         fs::write(src.join("f.txt"), b"x").expect("write f.txt");
         // dst is a non-existent subtree of src - must be rejected as overlapping.
-        let dst = src.join("missing").join("nested_dst");
+        let dst = src.join("missing").join("child");
         let err = copy_dir_tree(&src, &dst).expect_err("overlap inside missing parent chain");
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
         assert!(
             err.to_string().contains("refusing overlapping"),
             "unexpected error message: {err}"
         );
+        drop(root);
     }
 }
 struct SymlinkInSourceStaging {

--- a/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
@@ -152,10 +152,10 @@ fn copy_dir_tree_creates_missing_destination_parent_chain() {
         reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
     )]
     {
-        let (root, src, _) = make_src_dst_scaffold();
-        let dst = root.path().join("missing").join("parents").join("dst");
-        std::fs::create_dir_all(&src).expect("create src");
-        std::fs::write(src.join("f.txt"), b"hello").expect("write f.txt");
+        let (root, src, dst) = make_src_dst_scaffold();
+        let dst = dst.join("missing").join("parents");
+        fs::create_dir_all(&src).expect("create src");
+        fs::write(src.join("f.txt"), b"hello").expect("write f.txt");
 
         copy_dir_tree(&src, &dst).expect("copy_dir_tree");
 
@@ -163,7 +163,6 @@ fn copy_dir_tree_creates_missing_destination_parent_chain() {
             fs::read(dst.join("f.txt")).expect("read dst file"),
             b"hello"
         );
-        // root must remain in scope to keep the tempdir alive.
         drop(root);
     }
 }
@@ -326,11 +325,11 @@ fn copy_dir_tree_rejects_destination_resolved_through_missing_parent_dir() {
         reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
     )]
     {
-        let root = TempDir::new().expect("tempdir");
-        let src = root.path().join("dst");
+        let (root, src, _dst) = make_src_dst_scaffold();
         fs::create_dir_all(&src).expect("src");
         fs::write(src.join("f.txt"), b"x").expect("write");
-        let dst = root.path().join("missing").join("..").join("dst");
+        // Destination resolves through a missing intermediate segment back to src.
+        let dst = root.path().join("missing").join("..").join("src");
 
         let err = copy_dir_tree(&src, &dst).expect_err("resolved destination is source");
 

--- a/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
@@ -223,6 +223,7 @@ fn copy_dir_tree_rejects_missing_tail_overlap_destinations(
     }
 }
 
+#[cfg(unix)]
 struct SymlinkInSourceStaging {
     _root: TempDir,
     src: PathBuf,

--- a/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
@@ -168,56 +168,21 @@ fn copy_dir_tree_creates_missing_destination_parent_chain() {
     }
 }
 
-struct MissingTailOverlapStaging {
-    root: TempDir,
-    src: PathBuf,
-}
-
-#[fixture]
-fn missing_tail_overlap_staging() -> MissingTailOverlapStaging {
+#[test]
+fn copy_dir_tree_rejects_destination_resolved_through_missing_parent_dir() {
     #[expect(
         clippy::expect_used,
         reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
     )]
     {
-        let (root, src, _) = make_src_dst_scaffold();
+        let (root, src, _dst) = make_src_dst_scaffold();
         fs::create_dir_all(&src).expect("create src");
         fs::write(src.join("f.txt"), b"x").expect("write f.txt");
-        MissingTailOverlapStaging { root, src }
-    }
-}
+        // Destination resolves through a missing intermediate segment back to src.
+        let dst = root.path().join("missing").join("..").join("src");
 
-enum MissingTailOverlapDestination {
-    InsideMissingParentChain,
-    ResolvedThroughMissingParentDir,
-}
+        let err = copy_dir_tree(&src, &dst).expect_err("resolved destination is source");
 
-impl MissingTailOverlapDestination {
-    fn path(&self, root: &std::path::Path, src: &std::path::Path) -> PathBuf {
-        match self {
-            Self::InsideMissingParentChain => src.join("missing").join("child"),
-            Self::ResolvedThroughMissingParentDir => root.join("missing").join("..").join("src"),
-        }
-    }
-}
-
-#[rstest]
-#[case::inside_missing_parent_chain(MissingTailOverlapDestination::InsideMissingParentChain)]
-#[case::resolved_through_missing_parent_dir(
-    MissingTailOverlapDestination::ResolvedThroughMissingParentDir
-)]
-fn copy_dir_tree_rejects_missing_tail_overlap_destinations(
-    missing_tail_overlap_staging: MissingTailOverlapStaging,
-    #[case] destination: MissingTailOverlapDestination,
-) {
-    #[expect(
-        clippy::expect_used,
-        reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
-    )]
-    {
-        let MissingTailOverlapStaging { root, src } = missing_tail_overlap_staging;
-        let dst = destination.path(root.path(), &src);
-        let err = copy_dir_tree(&src, &dst).expect_err("missing-tail destination overlaps source");
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
         assert!(
             err.to_string().contains("refusing overlapping"),

--- a/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
@@ -200,26 +200,25 @@ fn copy_dir_tree_rejects_missing_tail_overlap_destinations(
     overlap_check_staging: OverlapCheckStaging,
     #[case] variant: MissingTailDestination,
 ) {
-    #[expect(
-        clippy::expect_used,
-        reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
-    )]
-    {
-        let OverlapCheckStaging { root, src } = overlap_check_staging;
-        let dst = match variant {
-            MissingTailDestination::InsideSource => src.join("missing").join("child"),
-            MissingTailDestination::ResolvedBackToSource => {
-                root.path().join("missing").join("..").join("src")
-            }
-        };
-        let err = copy_dir_tree(&src, &dst).expect_err("expected overlap rejection");
-        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
-        assert!(!dst.exists(), "dst should not be created");
-        assert!(
-            err.to_string().contains("refusing overlapping"),
-            "unexpected error message: {err}"
-        );
-    }
+    let OverlapCheckStaging { root, src } = overlap_check_staging;
+    let missing = root.path().join("missing");
+    let (dst, not_created) = match variant {
+        MissingTailDestination::InsideSource => {
+            let d = src.join("missing").join("child");
+            (d.clone(), d)
+        }
+        MissingTailDestination::ResolvedBackToSource => (missing.join("..").join("src"), missing),
+    };
+    let err = match copy_dir_tree(&src, &dst) {
+        Ok(()) => panic!("expected overlap rejection"),
+        Err(err) => err,
+    };
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    assert!(!not_created.exists(), "no new path should be created");
+    assert!(
+        err.to_string().contains("refusing overlapping"),
+        "unexpected error message: {err}"
+    );
 }
 
 #[cfg(unix)]

--- a/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
@@ -189,9 +189,7 @@ fn copy_dir_tree_creates_missing_destination_parent_chain() {
 
 #[derive(Clone)]
 enum MissingTailDestination {
-    /// dst = src / "missing" / "child" - direct descendant of source through a missing segment
     InsideSource,
-    /// dst = root / "missing" / ".." / "src" - resolves via `..` back to source
     ResolvedBackToSource,
 }
 
@@ -216,6 +214,7 @@ fn copy_dir_tree_rejects_missing_tail_overlap_destinations(
         };
         let err = copy_dir_tree(&src, &dst).expect_err("expected overlap rejection");
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(!dst.exists(), "dst should not be created");
         assert!(
             err.to_string().contains("refusing overlapping"),
             "unexpected error message: {err}"

--- a/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
@@ -298,7 +298,27 @@ fn copy_dir_tree_rejects_identical_source_and_destination() {
     }
 }
 
-#[test]
+fn copy_dir_tree_rejects_destination_resolved_through_missing_parent_dir() {
+    #[expect(
+        clippy::expect_used,
+        reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
+    )]
+    {
+        let root = TempDir::new().expect("tempdir");
+        let src = root.path().join("dst");
+        fs::create_dir_all(&src).expect("src");
+        fs::write(src.join("f.txt"), b"x").expect("write");
+        let dst = root.path().join("missing").join("..").join("dst");
+
+        let err = copy_dir_tree(&src, &dst).expect_err("resolved destination is source");
+
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(
+            err.to_string().contains("refusing overlapping"),
+            "unexpected error message: {err}"
+        );
+    }
+}
 fn copy_dir_tree_rejects_destination_inside_source() {
     #[expect(
         clippy::expect_used,

--- a/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
@@ -184,26 +184,20 @@ fn copy_dir_tree_creates_missing_destination_parent_chain() {
     }
 }
 
-fn copy_dir_tree_rejects_destination_inside_missing_parent_chain(
-    overlap_check_staging: OverlapCheckStaging,
-) {
-    #[expect(
-        clippy::expect_used,
-        reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
-    )]
-    {
-        let OverlapCheckStaging { root: _root, src } = overlap_check_staging;
-        let dst = src.join("missing").join("child");
-        let err = copy_dir_tree(&src, &dst).expect_err("overlap inside missing parent chain");
-        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
-        assert!(
-            err.to_string().contains("refusing overlapping"),
-            "unexpected error message: {err}"
-        );
-    }
+#[derive(Clone)]
+enum MissingTailDestination {
+    /// dst = src / "missing" / "child" - direct descendant of source through a missing segment
+    InsideSource,
+    /// dst = root / "missing" / ".." / "src" - resolves via `..` back to source
+    ResolvedBackToSource,
 }
-fn copy_dir_tree_rejects_destination_resolved_through_missing_parent_dir(
+
+#[rstest]
+#[case::inside_source(MissingTailDestination::InsideSource)]
+#[case::resolved_back_to_source(MissingTailDestination::ResolvedBackToSource)]
+fn copy_dir_tree_rejects_missing_tail_overlap_destinations(
     overlap_check_staging: OverlapCheckStaging,
+    #[case] variant: MissingTailDestination,
 ) {
     #[expect(
         clippy::expect_used,
@@ -211,8 +205,13 @@ fn copy_dir_tree_rejects_destination_resolved_through_missing_parent_dir(
     )]
     {
         let OverlapCheckStaging { root, src } = overlap_check_staging;
-        let dst = root.path().join("missing").join("..").join("src");
-        let err = copy_dir_tree(&src, &dst).expect_err("resolved destination is source");
+        let dst = match variant {
+            MissingTailDestination::InsideSource => src.join("missing").join("child"),
+            MissingTailDestination::ResolvedBackToSource => {
+                root.path().join("missing").join("..").join("src")
+            }
+        };
+        let err = copy_dir_tree(&src, &dst).expect_err("expected overlap rejection");
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
         assert!(
             err.to_string().contains("refusing overlapping"),

--- a/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
@@ -81,7 +81,23 @@ fn make_src_dst_scaffold() -> (TempDir, PathBuf, PathBuf) {
     (root, src, dst)
 }
 
-#[fixture]
+struct OverlapCheckStaging {
+    root: TempDir,
+    src: PathBuf,
+}
+
+fn overlap_check_staging() -> OverlapCheckStaging {
+    #[expect(
+        clippy::expect_used,
+        reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
+    )]
+    {
+        let (root, src, _dst) = make_src_dst_scaffold();
+        fs::create_dir_all(&src).expect("create src");
+        fs::write(src.join("f.txt"), b"x").expect("write f.txt");
+        OverlapCheckStaging { root, src }
+    }
+}
 fn replace_dir_staging() -> ReplaceDstStaging {
     #[expect(
         clippy::expect_used,
@@ -168,21 +184,35 @@ fn copy_dir_tree_creates_missing_destination_parent_chain() {
     }
 }
 
-#[test]
-fn copy_dir_tree_rejects_destination_resolved_through_missing_parent_dir() {
+fn copy_dir_tree_rejects_destination_inside_missing_parent_chain(
+    overlap_check_staging: OverlapCheckStaging,
+) {
     #[expect(
         clippy::expect_used,
         reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
     )]
     {
-        let (root, src, _dst) = make_src_dst_scaffold();
-        fs::create_dir_all(&src).expect("create src");
-        fs::write(src.join("f.txt"), b"x").expect("write f.txt");
-        // Destination resolves through a missing intermediate segment back to src.
+        let OverlapCheckStaging { root: _root, src } = overlap_check_staging;
+        let dst = src.join("missing").join("child");
+        let err = copy_dir_tree(&src, &dst).expect_err("overlap inside missing parent chain");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(
+            err.to_string().contains("refusing overlapping"),
+            "unexpected error message: {err}"
+        );
+    }
+}
+fn copy_dir_tree_rejects_destination_resolved_through_missing_parent_dir(
+    overlap_check_staging: OverlapCheckStaging,
+) {
+    #[expect(
+        clippy::expect_used,
+        reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
+    )]
+    {
+        let OverlapCheckStaging { root, src } = overlap_check_staging;
         let dst = root.path().join("missing").join("..").join("src");
-
         let err = copy_dir_tree(&src, &dst).expect_err("resolved destination is source");
-
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
         assert!(
             err.to_string().contains("refusing overlapping"),

--- a/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
@@ -152,17 +152,39 @@ fn copy_dir_tree_creates_missing_destination_parent_chain() {
         reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
     )]
     {
-        let root = TempDir::new().expect("tempdir");
-        let src = root.path().join("src");
-        let dst = root.path().join("missing").join("parents").join("dst");
-        fs::create_dir_all(&src).expect("create src");
-        fs::write(src.join("f.txt"), b"hello").expect("write f.txt");
+        let (root, src, dst) = make_src_dst_scaffold();
+        let dst = dst.join("missing").join("parents").join("dst");
+        std::fs::create_dir_all(&src).expect("create src");
+        std::fs::write(src.join("f.txt"), b"hello").expect("write f.txt");
 
         copy_dir_tree(&src, &dst).expect("copy_dir_tree");
 
         assert_eq!(
             fs::read(dst.join("f.txt")).expect("read dst file"),
             b"hello"
+        );
+        // root must remain in scope to keep the tempdir alive.
+        drop(root);
+    }
+}
+
+fn copy_dir_tree_rejects_destination_inside_missing_parent_chain() {
+    #[expect(
+        clippy::expect_used,
+        reason = "integration-style tests panic on improbable temp-dir I/O setup failures"
+    )]
+    {
+        let root = TempDir::new().expect("tempdir");
+        let src = root.path().join("src");
+        fs::create_dir_all(&src).expect("create src");
+        fs::write(src.join("f.txt"), b"x").expect("write f.txt");
+        // dst is a non-existent subtree of src - must be rejected as overlapping.
+        let dst = src.join("missing").join("nested_dst");
+        let err = copy_dir_tree(&src, &dst).expect_err("overlap inside missing parent chain");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(
+            err.to_string().contains("refusing overlapping"),
+            "unexpected error message: {err}"
         );
     }
 }

--- a/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
@@ -86,6 +86,7 @@ struct OverlapCheckStaging {
     src: PathBuf,
 }
 
+#[fixture]
 fn overlap_check_staging() -> OverlapCheckStaging {
     #[expect(
         clippy::expect_used,
@@ -98,6 +99,8 @@ fn overlap_check_staging() -> OverlapCheckStaging {
         OverlapCheckStaging { root, src }
     }
 }
+
+#[fixture]
 fn replace_dir_staging() -> ReplaceDstStaging {
     #[expect(
         clippy::expect_used,

--- a/crates/rstest-bdd-policy/src/lib.rs
+++ b/crates/rstest-bdd-policy/src/lib.rs
@@ -251,7 +251,24 @@ mod tests {
     #[case(GPUI_HARNESS_PATH, Some(TestAttributeHint::RstestWithGpuiTest))]
     #[case(&["my", "Harness"], None)]
     #[case(&["TokioHarness"], None)]
+    #[case(&["my", "TokioHarness"], None)]
+    #[case(&["rstest_bdd_harness", "TokioHarness"], None)]
+    #[case(&["rstest_bdd_harness_tokio", "TokioHarness", "Extra"], None)]
     fn resolves_harness_paths(#[case] path: &[&str], #[case] expected: Option<TestAttributeHint>) {
         assert_eq!(resolve_test_attribute_hint_for_harness_path(path), expected);
+    }
+
+    #[rstest]
+    #[case(DEFAULT_ATTRIBUTE_POLICY_PATH, STD_HARNESS_PATH)]
+    #[case(TOKIO_ATTRIBUTE_POLICY_PATH, TOKIO_HARNESS_PATH)]
+    #[case(GPUI_ATTRIBUTE_POLICY_PATH, GPUI_HARNESS_PATH)]
+    fn first_party_harness_paths_match_their_attribute_policy_hints(
+        #[case] policy_path: &[&str],
+        #[case] harness_path: &[&str],
+    ) {
+        assert_eq!(
+            resolve_test_attribute_hint_for_harness_path(harness_path),
+            resolve_test_attribute_hint_for_policy_path(policy_path)
+        );
     }
 }

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -477,7 +477,7 @@ and attribute-policy types:
 | `STD_HARNESS_PATH` | `["rstest_bdd_harness", "StdHarness"]` |
 | `TOKIO_HARNESS_PATH` | `["rstest_bdd_harness_tokio", "TokioHarness"]` |
 | `GPUI_HARNESS_PATH` | `["rstest_bdd_harness_gpui", "GpuiHarness"]` |
-| `DEFAULT_ATTRIBUTE_POLICY_PATH` | `["rstest_bdd_harness", "StdAttributePolicy"]` |
+| `DEFAULT_ATTRIBUTE_POLICY_PATH` | `["rstest_bdd_harness", "DefaultAttributePolicy"]` |
 | `TOKIO_ATTRIBUTE_POLICY_PATH` | `["rstest_bdd_harness_tokio", "TokioAttributePolicy"]` |
 | `GPUI_ATTRIBUTE_POLICY_PATH` | `["rstest_bdd_harness_gpui", "GpuiAttributePolicy"]` |
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -478,7 +478,7 @@ and attribute-policy types:
 | `TOKIO_HARNESS_PATH` | `["rstest_bdd_harness_tokio", "TokioHarness"]` |
 | `GPUI_HARNESS_PATH` | `["rstest_bdd_harness_gpui", "GpuiHarness"]` |
 | `DEFAULT_ATTRIBUTE_POLICY_PATH` | `["rstest_bdd_harness", "StdAttributePolicy"]` |
-| `TOKIO_ATTRIBUTE_POLICY_PATH` | tokio attribute-policy path |
+| `TOKIO_ATTRIBUTE_POLICY_PATH` | `["rstest_bdd_harness_tokio", "TokioAttributePolicy"]` |
 | `GPUI_ATTRIBUTE_POLICY_PATH` | `["rstest_bdd_harness_gpui", "GpuiAttributePolicy"]` |
 
 Use these constants wherever a first-party path must be compared or

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -454,13 +454,13 @@ and then copies the contents of `src` into it.
 
 To prevent accidental self-copies, `copy_dir_tree` resolves the canonical
 paths of `src` and `dst` before copying and rejects any call where the
-resolved `dst` is a prefix of, or equal to, the resolved `src`. This check
-is performed even when `dst` does not yet exist: the function walks up to
-the nearest existing ancestor of `dst`, canonicalizes that ancestor, and
-re-appends the missing tail components to obtain the resolved destination.
-This means that paths such as `<src>/missing/../other` that traverse back
-into the source tree through a not-yet-existing intermediate segment are
-still detected and rejected with `io::ErrorKind::InvalidInput`.
+resolved `src` equals `dst`, `src` starts with `dst`, or `dst` starts with
+`src`. This check is performed even when `dst` does not yet exist: the
+function walks up to the nearest existing ancestor of `dst`, canonicalizes
+that ancestor, and re-appends the missing tail components to obtain the
+resolved destination. This means that paths such as `<src>/missing/../other`
+that traverse back into the source tree through a not-yet-existing intermediate
+segment are still detected and rejected with `io::ErrorKind::InvalidInput`.
 
 ### First-party policy path constants and resolver helpers
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -240,6 +240,7 @@ locations:
 - `TOKIO_HARNESS_PATH`
 - `GPUI_HARNESS_PATH`
 - `DEFAULT_ATTRIBUTE_POLICY_PATH`
+- `TOKIO_ATTRIBUTE_POLICY_PATH`
 - `GPUI_ATTRIBUTE_POLICY_PATH`
 
 Use `resolve_test_attribute_hint_for_policy_path()` when macro arguments name

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -456,7 +456,7 @@ To prevent accidental self-copies, `copy_dir_tree` resolves the canonical
 paths of `src` and `dst` before copying and rejects any call where the
 resolved `dst` is a prefix of, or equal to, the resolved `src`. This check
 is performed even when `dst` does not yet exist: the function walks up to
-the nearest existing ancestor of `dst`, canonicalises that ancestor, and
+the nearest existing ancestor of `dst`, canonicalizes that ancestor, and
 re-appends the missing tail components to obtain the resolved destination.
 This means that paths such as `<src>/missing/../other` that traverse back
 into the source tree through a not-yet-existing intermediate segment are
@@ -477,7 +477,7 @@ and attribute-policy types:
 | `STD_HARNESS_PATH` | `["rstest_bdd_harness", "StdHarness"]` |
 | `TOKIO_HARNESS_PATH` | `["rstest_bdd_harness_tokio", "TokioHarness"]` |
 | `GPUI_HARNESS_PATH` | `["rstest_bdd_harness_gpui", "GpuiHarness"]` |
-| `DEFAULT_ATTRIBUTE_POLICY_PATH` | tokio attribute-policy path (default) |
+| `DEFAULT_ATTRIBUTE_POLICY_PATH` | `["rstest_bdd_harness", "StdAttributePolicy"]` |
 | `TOKIO_ATTRIBUTE_POLICY_PATH` | tokio attribute-policy path |
 | `GPUI_ATTRIBUTE_POLICY_PATH` | `["rstest_bdd_harness_gpui", "GpuiAttributePolicy"]` |
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -487,16 +487,10 @@ canonical source of truth and may be updated in future releases.
 
 #### Resolver functions
 
-`resolve_test_attribute_hint_for_policy_path(path: &[&str]) -> Option<TestAttributeHint>`
-: Returns the hint for a known first-party attribute-policy type path.
-  Returns `None` for any path that is not an exact match for a known
-  first-party policy path. Do not use this function for harness paths.
-
-`resolve_test_attribute_hint_for_harness_path(path: &[&str]) -> Option<TestAttributeHint>`
-: Returns the hint for a known first-party harness type path, delegating
-  to the policy-path resolver for the corresponding attribute-policy type.
-  Returns `None` for any path that is not an exact match for a known
-  first-party harness path.
+| Function | Use |
+| --- | --- |
+| `resolve_test_attribute_hint_for_policy_path(path: &[&str]) -> Option<TestAttributeHint>` | Returns the hint for a known first-party attribute-policy type path. Returns `None` for any path that is not an exact match for a known first-party policy path. Do not use this function for harness paths. |
+| `resolve_test_attribute_hint_for_harness_path(path: &[&str]) -> Option<TestAttributeHint>` | Returns the hint for a known first-party harness type path, delegating to the policy-path resolver for the corresponding attribute-policy type. Returns `None` for any path that is not an exact match for a known first-party harness path. |
 
 Both functions require exact matches against first-party paths. Paths with
 wrong prefixes, extra segments, or partial matches all return `None`. Use

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -39,6 +39,14 @@ Tokio and GPUI harness crates to stage `.feature` files into the trybuild
 scratch directory before `TestCases::pass` / `compile_fail` are called. Do not
 use these helpers outside test code.
 
+`copy_dir_tree` rejects overlapping source and destination trees before it
+removes or creates the destination. The overlap check canonicalizes
+destinations whose final path does not exist yet by walking to the nearest
+existing ancestor and replaying the missing tail. Missing parent chains and
+parent-directory components such as `missing/../dst` must therefore preserve
+their logical meaning, so a destination that resolves back to the source tree
+is rejected even when part of the destination path is not yet present.
+
 ## nextest on Windows: trybuild deadlock
 
 nextest wraps test binaries in Windows Job Objects. Child `cargo` processes
@@ -223,6 +231,24 @@ Regression tests enforce this boundary:
 
 - Runtime re-export assertions.[^4]
 - Macro import assertions.[^5]
+
+Shared first-party path constants also live in `rstest-bdd-policy` so macro
+parsing, harness adapters, and documentation can agree on canonical policy
+locations:
+
+- `STD_HARNESS_PATH`
+- `TOKIO_HARNESS_PATH`
+- `GPUI_HARNESS_PATH`
+- `DEFAULT_ATTRIBUTE_POLICY_PATH`
+- `GPUI_ATTRIBUTE_POLICY_PATH`
+
+Use `resolve_test_attribute_hint_for_policy_path()` when macro arguments name
+an attribute-policy plugin path directly. Use
+`resolve_test_attribute_hint_for_harness_path()` when `attributes = ...` is
+omitted and a first-party harness path should imply its default
+`TestAttributeHint`. Both helpers deliberately require exact first-party paths;
+unknown third-party paths and paths with extra components return `None`, so
+external harnesses must still opt in with an explicit attribute policy.
 
 The architectural rationale explains this decision and its consequences.[^6]
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -443,6 +443,66 @@ Use the same pattern in hand-written tests instead of bare `.unwrap()`. This
 keeps the concrete `HarnessError` visible in the panic message when a harness
 cannot initialize its infrastructure.
 
+### Staging: `copy_dir_tree` and missing destination parent chains
+
+`trybuild_staging::copy_dir_tree(src, dst)` creates any missing parent
+directories in the `dst` path before copying, so callers do not need to
+pre-create the destination tree. For example, if `dst` is
+`tmp/a/b/c` and only `tmp` exists, `copy_dir_tree` creates `tmp/a/b/c`
+and then copies the contents of `src` into it.
+
+To prevent accidental self-copies, `copy_dir_tree` resolves the canonical
+paths of `src` and `dst` before copying and rejects any call where the
+resolved `dst` is a prefix of, or equal to, the resolved `src`. This check
+is performed even when `dst` does not yet exist: the function walks up to
+the nearest existing ancestor of `dst`, canonicalises that ancestor, and
+re-appends the missing tail components to obtain the resolved destination.
+This means that paths such as `<src>/missing/../other` that traverse back
+into the source tree through a not-yet-existing intermediate segment are
+still detected and rejected with `io::ErrorKind::InvalidInput`.
+
+### First-party policy path constants and resolver helpers
+
+The `rstest-bdd-policy` crate exposes path constants and two resolver
+functions that map a type-path to a `TestAttributeHint`.
+
+#### Path constants
+
+The following `&[&str]` constants identify the known first-party harness
+and attribute-policy types:
+
+| Constant | Path segments |
+| --- | --- |
+| `STD_HARNESS_PATH` | `["rstest_bdd_harness", "StdHarness"]` |
+| `TOKIO_HARNESS_PATH` | `["rstest_bdd_harness_tokio", "TokioHarness"]` |
+| `GPUI_HARNESS_PATH` | `["rstest_bdd_harness_gpui", "GpuiHarness"]` |
+| `DEFAULT_ATTRIBUTE_POLICY_PATH` | tokio attribute-policy path (default) |
+| `TOKIO_ATTRIBUTE_POLICY_PATH` | tokio attribute-policy path |
+| `GPUI_ATTRIBUTE_POLICY_PATH` | `["rstest_bdd_harness_gpui", "GpuiAttributePolicy"]` |
+
+Use these constants wherever a first-party path must be compared or
+matched; do not inline the string slices, as the constants are the
+canonical source of truth and may be updated in future releases.
+
+#### Resolver functions
+
+`resolve_test_attribute_hint_for_policy_path(path: &[&str]) -> Option<TestAttributeHint>`
+: Returns the hint for a known first-party attribute-policy type path.
+  Returns `None` for any path that is not an exact match for a known
+  first-party policy path. Do not use this function for harness paths.
+
+`resolve_test_attribute_hint_for_harness_path(path: &[&str]) -> Option<TestAttributeHint>`
+: Returns the hint for a known first-party harness type path, delegating
+  to the policy-path resolver for the corresponding attribute-policy type.
+  Returns `None` for any path that is not an exact match for a known
+  first-party harness path.
+
+Both functions require exact matches against first-party paths. Paths with
+wrong prefixes, extra segments, or partial matches all return `None`. Use
+`resolve_test_attribute_hint_for_harness_path` when the call site has a
+harness type path; use `resolve_test_attribute_hint_for_policy_path` when
+it has an attribute-policy type path.
+
 ### Third-party adapter crates
 
 Third-party harness crates outside this workspace implement the same

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -245,7 +245,7 @@ locations:
 
 Use `resolve_test_attribute_hint_for_policy_path()` when macro arguments name
 an attribute-policy plugin path directly. Use
-`resolve_test_attribute_hint_for_harness_path()` when `attributes = ...` is
+`resolve_test_attribute_hint_for_harness_path()` when `attributes = …` is
 omitted and a first-party harness path should imply its default
 `TestAttributeHint`. Both helpers deliberately require exact first-party paths;
 unknown third-party paths and paths with extra components return `None`, so

--- a/docs/execplans/9-7-1-first-party-policy-hint-resolution.md
+++ b/docs/execplans/9-7-1-first-party-policy-hint-resolution.md
@@ -566,6 +566,9 @@ git diff -- \
   docs/roadmap.md \
   docs/rstest-bdd-design.md \
   docs/users-guide.md \
+  docs/developers-guide.md \
+  crates/rstest-bdd-harness/src/trybuild_staging/mod.rs \
+  crates/rstest-bdd-harness/src/trybuild_staging/tests.rs \
   crates/rstest-bdd-policy/src/lib.rs \
   crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs
 ```

--- a/docs/execplans/9-7-1-first-party-policy-hint-resolution.md
+++ b/docs/execplans/9-7-1-first-party-policy-hint-resolution.md
@@ -612,8 +612,9 @@ rewrite working code. Run the focused tests and gates, update only the missing
 documentation or roadmap state, and explain the reconciliation in the Decision
 Log and final commit message.
 
-If ADR-008 remains `Proposed`, stop cleanly with this plan in `DRAFT` and do
-not mark the roadmap item done.
+If ADR-008 remains `Proposed`, stop cleanly with this plan in `DRAFT` except
+for the maintainer-authorization exception recorded above, and do not mark the
+roadmap item done.
 
 ## Artifacts and notes
 

--- a/docs/execplans/9-7-1-first-party-policy-hint-resolution.md
+++ b/docs/execplans/9-7-1-first-party-policy-hint-resolution.md
@@ -10,8 +10,8 @@ Status: COMPLETE
 This plan covers roadmap item 9.7.1 only. It must be approved before
 implementation begins, and implementation must not begin while
 `docs/adr-008-harness-led-attribute-policy-defaults.md` remains in `Proposed`
-status unless a maintainer explicitly authorizes work against the proposed
-decision.
+status unless a maintainer explicitly authorizes work against Architecture
+Decision Record (ADR) 008.
 
 ## Purpose / big picture
 
@@ -176,12 +176,19 @@ gates all agree.
 - [x] (2026-05-08T16:09:00+02:00) Ran `make lint`; it passed.
 - [x] (2026-05-08T16:13:00+02:00) Ran `make nixie`; it passed.
 - [x] (2026-05-08T16:14:00+02:00) Ran `make markdownlint`; it passed.
-- [x] (2026-05-08T16:23:00+02:00) Investigated the full-suite GPUI failure
-      and found `copy_dir_tree` could not stage files into a destination whose
-      parent chain did not yet exist.
+- [x] (2026-05-08T16:23:00+02:00) Investigated the full-suite Graphical User
+      Interface (GPUI) failure and found `copy_dir_tree` could not stage files
+      into a destination whose parent chain did not yet exist.
 - [x] (2026-05-08T16:28:00+02:00) Fixed `copy_dir_tree` overlap checking to
       canonicalize the nearest existing destination ancestor and added a
       regression test for missing destination parent chains.
+- [x] (2026-05-12T00:00:00+02:00) Addressed review feedback by simplifying
+      missing destination reconstruction to apply a relative tail with
+      `std::path::Component`, and by checking rejected overlap destinations are
+      not created.
+- [x] (2026-05-12T00:00:00+02:00) Validated the review fixes with
+      `cargo test -p rstest-bdd-harness trybuild_staging`, `make check-fmt`,
+      `make lint`, `make markdownlint`, and `make test`; all passed.
 - [x] (2026-05-08T16:30:00+02:00) Ran
       `cargo test -p rstest-bdd-harness trybuild_staging`; all 12 selected
       tests passed.
@@ -225,7 +232,7 @@ gates all agree.
   `resolve_attribute_policy` even though the functions exist and compile.
   Evidence: direct `leta show` invocations failed before source inspection.
   Impact: continue using `rg` and targeted file reads for this small Rust
-  change, while recording the LSP limitation.
+  change, while recording the Language Server Protocol (LSP) limitation.
 - Observation: the existing code already implements the shared resolver
   surface and macro precedence wiring requested by 9.7.1. Evidence:
   `crates/rstest-bdd-policy/src/lib.rs` defines

--- a/docs/execplans/9-7-1-first-party-policy-hint-resolution.md
+++ b/docs/execplans/9-7-1-first-party-policy-hint-resolution.md
@@ -189,6 +189,10 @@ gates all agree.
 - [x] (2026-05-12T00:00:00+02:00) Validated the review fixes with
       `cargo test -p rstest-bdd-harness trybuild_staging`, `make check-fmt`,
       `make lint`, `make markdownlint`, and `make test`; all passed.
+- [x] (2026-05-13T00:00:00+02:00) Added `proptest` coverage for missing-tail
+      destination canonicalization and generated overlap rejection. Validated
+      with `cargo test -p rstest-bdd-harness trybuild_staging`,
+      `make check-fmt`, `make lint`, `make markdownlint`, and `make test`.
 - [x] (2026-05-08T16:30:00+02:00) Ran
       `cargo test -p rstest-bdd-harness trybuild_staging`; all 12 selected
       tests passed.

--- a/docs/execplans/9-7-1-first-party-policy-hint-resolution.md
+++ b/docs/execplans/9-7-1-first-party-policy-hint-resolution.md
@@ -478,7 +478,7 @@ message must say that explicitly.
 Start in the repository root:
 
 ```bash
-cd /home/leynos/.lody/repos/github---leynos---rstest-bdd/worktrees/740747bd-ef6a-438d-a91e-d81f8120dbe2
+cd "$(git rev-parse --show-toplevel)"
 git branch --show-current
 ```
 

--- a/docs/execplans/9-7-1-first-party-policy-hint-resolution.md
+++ b/docs/execplans/9-7-1-first-party-policy-hint-resolution.md
@@ -1,0 +1,557 @@
+# Extend first-party policy hint resolution
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+This plan covers roadmap item 9.7.1 only. It must be approved before
+implementation begins, and implementation must not begin while
+`docs/adr-008-harness-led-attribute-policy-defaults.md` remains in `Proposed`
+status unless a maintainer explicitly authorizes work against the proposed
+decision.
+
+## Purpose / big picture
+
+Roadmap item 9.7.1 extends the shared test-attribute hint resolver so known
+first-party harness paths imply the same default test-attribute hints as their
+matching first-party attribute-policy paths. After the change, shared helper
+code can resolve these two equivalent user choices to the same
+`TestAttributeHint`:
+
+```rust,no_run
+// Attribute-policy path.
+rstest_bdd_harness_tokio::TokioAttributePolicy
+
+// Harness path.
+rstest_bdd_harness_tokio::TokioHarness
+```
+
+This matters because ADR-008 makes `harness = ...` the lead configuration for
+first-party integrations. Users should be able to select `StdHarness`,
+`TokioHarness`, or `GpuiHarness` without also repeating the matching
+`attributes = ...` value, while still preserving explicit attribute-policy
+overrides and third-party escape hatches.
+
+Success is observable when unit tests prove that the shared resolver returns
+the same hint for each first-party harness path and its matching
+attribute-policy path, unknown third-party harnesses do not infer a policy, and
+the ADR-008 precedence edge cases are covered. The roadmap item must not be
+marked done until the accepted ADR, code, tests, documentation, and repository
+gates all agree.
+
+## Constraints
+
+- Do not implement this plan before explicit approval.
+- Do not implement this plan while ADR-008 is still `Proposed` unless a
+  maintainer explicitly authorizes contingent implementation.
+- Keep the scope to roadmap item 9.7.1. Do not fold in roadmap items 9.7.2,
+  9.7.3, or 9.7.4 except where a small test is necessary to prove the shared
+  resolver contract.
+- Preserve the ADR-005 boundary: `HarnessAdapter` remains the runtime
+  delegation boundary and `AttributePolicy` remains the emitted test-attribute
+  boundary.
+- Preserve the ADR-008 precedence order:
+  1. explicit `attributes = ...`
+  2. known first-party `harness = ...` mapping
+  3. deprecated `runtime = "tokio-current-thread"` compatibility alias
+  4. existing runtime-mode or synchronous fallback
+- Keep `attributes`-only configuration valid.
+- Unknown third-party harness paths must not infer attribute-policy hints.
+- Do not add external dependencies unless the maintainer approves a separate
+  dependency decision.
+- Use `rstest` for parameterized unit tests. `rust-rspec` is not currently
+  present in this workspace; do not introduce it just for this finite lookup
+  task unless a maintainer explicitly asks for that dependency.
+- Property tests, Kani, or Verus are not required for a fixed canonical lookup
+  table. If implementation changes into a generalized parser or stateful
+  resolver with invariants over arbitrary inputs, stop and add the appropriate
+  proof or property-test strategy before continuing.
+- Keep code files under the repository's 400-line limit and keep new helpers
+  documented with examples where public.
+- Run gates sequentially. Do not run format, lint, or test commands in
+  parallel.
+
+## Tolerances
+
+- Scope: if the implementation requires more than 8 files changed or more than
+  350 net lines, stop and re-check whether the work has drifted into 9.7.2 or a
+  broader macro-codegen refactor.
+- Interface: if any public trait, macro argument, or existing public function
+  signature must change, stop and escalate before continuing.
+- Dependencies: if a new external crate is required, stop and escalate.
+- Governance: if ADR-008 remains `Proposed`, stop before code changes unless
+  explicit maintainer approval is recorded in this plan.
+- Existing-work reconciliation: if the current code already satisfies 9.7.1,
+  do not rewrite it. Verify the behaviour, update missing documentation or
+  roadmap state only after gates pass, and record the finding in the Decision
+  Log.
+- Validation: if `make check-fmt`, `make lint`, or `make test` fails for an
+  unrelated reason, capture the log path and stop before marking the roadmap
+  item done.
+- Iterations: if the same gate fails three consecutive fix attempts, stop and
+  escalate with the log path and current hypothesis.
+- Ambiguity: if docs and code disagree on canonical paths, precedence, or
+  whether 9.7.1 is already delivered, stop and present the interpretations.
+
+## Risks
+
+- Risk: the working tree already contains ADR-008-shaped helpers while
+  `docs/roadmap.md` still leaves 9.7.1 unchecked and ADR-008 remains
+  `Proposed`. Severity: high. Likelihood: high. Mitigation: start with a
+  reconciliation milestone that inspects code, tests, ADR status, and roadmap
+  state before editing implementation code.
+- Risk: implementing harness-led defaults in macro codegen would accidentally
+  consume scope from 9.7.2. Severity: medium. Likelihood: medium. Mitigation:
+  keep 9.7.1 centred on shared hint helpers and unit-level precedence proof;
+  defer broad public macro behaviour to the 9.7.2 plan unless a narrow helper
+  test is needed.
+- Risk: a single-segment path such as `TokioHarness` could be mistaken for the
+  canonical first-party path. Severity: medium. Likelihood: medium. Mitigation:
+  require exact segment matching against canonical paths.
+- Risk: unknown third-party harnesses could silently receive first-party
+  attributes, making extension behaviour surprising. Severity: high.
+  Likelihood: low. Mitigation: add explicit `rstest` cases for unknown
+  harnesses, similarly named harnesses, and wrong crate prefixes.
+- Risk: `make test` may not exercise every compile-time fixture when nextest is
+  active. Severity: medium. Likelihood: medium. Mitigation: include focused
+  crate tests for `rstest-bdd-policy` and `rstest-bdd-macros`, then run the
+  repository-wide gates required by this task.
+- Risk: documentation could overstate third-party inference. Severity: medium.
+  Likelihood: medium. Mitigation: update design and user-facing docs to state
+  that only known first-party paths infer defaults and third-party policies
+  remain explicit.
+
+## Progress
+
+- [x] (2026-05-08T11:22:32Z) Loaded and applied the `execplans`, `leta`,
+      `rust-router`, and `arch-crate-design` skills for this planning task.
+- [x] (2026-05-08T11:22:32Z) Created context-pack artefact
+      `pk_4pujtp56` for the Wyvern planning team.
+- [x] (2026-05-08T11:22:32Z) Asked Wyvern agents to inspect ADR/design
+      requirements, implementation/test touchpoints, and PR workflow
+      constraints.
+- [x] (2026-05-08T11:22:32Z) Confirmed the branch was not `main` and renamed
+      it to `9-7-1-first-party-policy-hint-resolution`.
+- [x] (2026-05-08T11:22:32Z) Reviewed `docs/roadmap.md`,
+      `docs/adr-008-harness-led-attribute-policy-defaults.md`, and
+      `docs/rstest-bdd-design.md` for the requested scope.
+- [x] (2026-05-08T11:22:32Z) Inspected current resolver and macro-codegen
+      touchpoints enough to identify existing ADR-008-shaped helpers.
+- [x] (2026-05-08T11:22:32Z) Drafted this pre-implementation ExecPlan.
+- [ ] Await explicit approval before implementation.
+- [ ] After approval and ADR acceptance, reconcile existing implementation
+      against 9.7.1 before making code edits.
+- [ ] Implement or complete missing shared resolver behaviour.
+- [ ] Add or complete unit tests for canonical mappings, unknown paths, and
+      precedence edge cases.
+- [ ] Add behavioural or compile-time coverage only where applicable to prove
+      externally observable resolver use without absorbing 9.7.2.
+- [ ] Update design, user, and component documentation where behaviour or
+      internal contracts change.
+- [ ] Run all required gates.
+- [ ] Mark roadmap item 9.7.1 done after successful validation.
+- [ ] Commit the completed implementation as a focused change.
+
+## Surprises & Discoveries
+
+- Observation: `docs/adr-008-harness-led-attribute-policy-defaults.md` is still
+  in `Proposed` status. Evidence: its `Status` section says `Proposed`. Impact:
+  this plan must remain contingent until approval and ADR acceptance.
+- Observation: roadmap prerequisites 9.3.4 and 9.4.4 are already marked done.
+  Evidence: `docs/roadmap.md` marks both items with `[x]`. Impact: the
+  remaining governance gate is ADR-008 acceptance.
+- Observation: the current worktree already contains
+  `resolve_test_attribute_hint_for_harness_path` and a `KNOWN_HARNESS_HINTS`
+  table in `crates/rstest-bdd-policy/src/lib.rs`. Evidence: targeted source
+  inspection found canonical entries for `StdHarness`, `TokioHarness`, and
+  `GpuiHarness`. Impact: implementation must begin by verifying whether 9.7.1
+  is already functionally delivered and only then decide whether code changes
+  are needed.
+- Observation: `docs/rstest-bdd-design.md` and `docs/users-guide.md` already
+  describe harness-led defaults in several places. Evidence: both documents
+  contain sections describing known first-party harness inference. Impact:
+  documentation work may be reconciliation and correction rather than
+  first-time drafting.
+- Observation: `leta workspace add` succeeded, but rust-analyzer failed to
+  start for semantic queries in this worktree. Evidence: `leta grep` returned a
+  rust-analyzer connection-closed error. Impact: this planning pass used
+  targeted `rg` and file reads after recording the tool limitation.
+
+## Decision Log
+
+- Decision: keep this ExecPlan in `DRAFT` status and explicitly gate
+  implementation on both plan approval and ADR-008 acceptance. Rationale: the
+  roadmap says 9.7 items are contingent while ADR-008 remains `Proposed`, and
+  the user reminded that the plan must be approved before implementation.
+  Date/Author: 2026-05-08 / Codex.
+- Decision: make Stage A a reconciliation inventory rather than assuming no
+  prior implementation exists. Rationale: current code and docs already contain
+  several of the names and behaviours requested by 9.7.1, while the roadmap
+  remains unchecked. Date/Author: 2026-05-08 / Codex.
+- Decision: keep canonical mappings in `rstest-bdd-policy` unless the
+  reconciliation step finds a dependency or API problem. Rationale: policy
+  hints are shared execution-policy data, and keeping the lookup outside
+  `rstest-bdd-macros` avoids reintroducing macro-local mapping tables.
+  Date/Author: 2026-05-08 / Codex.
+- Decision: do not require property testing, Kani, or Verus for the fixed
+  first-party lookup table. Rationale: the invariant is finite and better
+  covered by exhaustive parameterized `rstest` cases over the canonical and
+  negative path matrix. Date/Author: 2026-05-08 / Codex.
+
+## Outcomes & Retrospective
+
+This section is intentionally empty while the plan is in `DRAFT`. Fill it in
+after implementation or after a reconciliation-only delivery proves that the
+feature was already present and only roadmap or documentation state needed to
+be corrected.
+
+## Context and orientation
+
+The relevant workspace crates are:
+
+- `crates/rstest-bdd-policy`: shared runtime and test-attribute policy enums.
+  This is the preferred home for canonical path-to-`TestAttributeHint`
+  resolution because both runtime and macro crates can depend on it without a
+  procedural macro dependency cycle.
+- `crates/rstest-bdd-macros`: procedural macro code generation for
+  `#[scenario]` and `scenarios!`. It consumes `TestAttributeHint` to decide
+  whether to emit `#[rstest::rstest]`,
+  `#[tokio::test(flavor = "current_thread")]`, or `#[gpui::test]`.
+- `crates/rstest-bdd-harness`: first-party shared harness traits and
+  `StdHarness`.
+- `crates/rstest-bdd-harness-tokio`: first-party Tokio harness and
+  `TokioAttributePolicy`.
+- `crates/rstest-bdd-harness-gpui`: first-party GPUI harness and
+  `GpuiAttributePolicy`.
+
+The important terms are:
+
+- A harness path is the Rust type path supplied as `harness = ...`, such as
+  `rstest_bdd_harness_tokio::TokioHarness`.
+- An attribute-policy path is the Rust type path supplied as
+  `attributes = ...`, such as `rstest_bdd_harness_tokio::TokioAttributePolicy`.
+- A `TestAttributeHint` is the shared enum that describes which framework test
+  attributes the macro layer should generate.
+- A first-party path is an exact canonical path owned by this workspace. A
+  third-party path is any user or external crate path.
+
+The canonical mappings required by 9.7.1 are:
+
+- `rstest_bdd_harness::StdHarness` maps to the same hint as
+  `rstest_bdd_harness::DefaultAttributePolicy`.
+- `rstest_bdd_harness_tokio::TokioHarness` maps to the same hint as
+  `rstest_bdd_harness_tokio::TokioAttributePolicy`.
+- `rstest_bdd_harness_gpui::GpuiHarness` maps to the same hint as
+  `rstest_bdd_harness_gpui::GpuiAttributePolicy`.
+
+The relevant source and documentation entrypoints are:
+
+- `docs/roadmap.md`, section 9.7.1, for acceptance criteria and prerequisite
+  status.
+- `docs/adr-008-harness-led-attribute-policy-defaults.md`, especially the
+  decision outcome, precedence rules, migration plan, and known risks.
+- `docs/rstest-bdd-design.md`, section 2.7.3 and adjacent ADR-008 notes, for
+  component architecture and macro integration.
+- `docs/users-guide.md`, harness adapter and attribute policy sections, for
+  user-visible behaviour and third-party caveats.
+- `docs/rstest-bdd-language-server-design.md`, to confirm no language-server
+  contract changes are needed.
+- `docs/rust-testing-with-rstest-fixtures.md`,
+  `docs/rust-doctest-dry-guide.md`,
+  `docs/complexity-antipatterns-and-refactoring-strategies.md`, and
+  `docs/gherkin-syntax.md`, for testing and documentation style constraints.
+- `crates/rstest-bdd-policy/src/lib.rs`, for `RuntimeMode`,
+  `TestAttributeHint`, existing policy-path resolution, and any harness-path
+  resolution.
+- `crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs`, for
+  precedence between explicit attribute paths, harness paths, runtime aliases,
+  and fallback hints.
+- `crates/rstest-bdd-macros/src/codegen/scenario/tests.rs` and sibling test
+  modules, for unit tests around generated attributes.
+
+Relevant skills to load when implementing this plan are `leta` for code
+navigation, `rust-router` followed by `arch-crate-design` for crate-boundary
+decisions, and `rust-types-and-apis` only if a public resolver signature must
+change.
+
+## Plan of work
+
+Stage A is reconciliation and must make no functional edits. Confirm ADR-008
+status first. If the ADR is still `Proposed`, record the blocker in this plan
+and stop unless maintainer approval explicitly authorizes implementation. After
+that, compare roadmap 9.7.1 against the current implementation in
+`crates/rstest-bdd-policy/src/lib.rs` and
+`crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs`. Confirm whether
+the shared resolver already exposes policy-path and harness-path lookup
+helpers, whether the helper tests already cover unknown third-party paths, and
+whether macro-level precedence tests already exist. Record findings in
+`Surprises & Discoveries` and decide whether code changes are needed.
+
+Stage B adds or completes the shared resolver. In
+`crates/rstest-bdd-policy/src/lib.rs`, keep or add canonical path constants for
+`DEFAULT_ATTRIBUTE_POLICY_PATH`, `STD_HARNESS_PATH`,
+`TOKIO_ATTRIBUTE_POLICY_PATH`, `TOKIO_HARNESS_PATH`,
+`GPUI_ATTRIBUTE_POLICY_PATH`, and `GPUI_HARNESS_PATH`. Keep or add a
+`resolve_test_attribute_hint_for_harness_path(path_segments: &[&str]) -> Option<TestAttributeHint>`
+ helper beside `resolve_test_attribute_hint_for_policy_path`. The harness
+resolver must match only exact canonical path segments and return `None` for
+single-segment names, wrong crate prefixes, similarly named third-party types,
+and arbitrary unknown paths.
+
+Stage C adds or completes unit tests. Use `rstest` parameterized cases in
+`crates/rstest-bdd-policy/src/lib.rs` or a focused sibling test module to prove
+each first-party harness path returns the same `TestAttributeHint` as the
+matching first-party attribute-policy path. Add negative cases for
+`["TokioHarness"]`, `["my", "TokioHarness"]`, `["my", "Harness"]`, and any
+other similarly named path needed to prove exact matching. If macro-level
+precedence is not already covered, add focused tests in
+`crates/rstest-bdd-macros/src/codegen/scenario/tests/harness_defaults.rs` or
+the local equivalent to prove explicit `attributes = ...` beats known
+`harness = ...`, known harness beats runtime fallback, unknown harness falls
+back to runtime, and explicit unknown attributes intentionally resolve to the
+rstest-only fallback.
+
+Stage D adds only applicable behavioural or compile-time coverage. Because
+9.7.1 is a shared helper change, public-macro end-to-end expansion belongs
+primarily to 9.7.2 and 9.7.3. Add a behavioural, trybuild, or integration test
+in this stage only if the reconciliation step shows there is no existing test
+that exercises the helper through macro codegen. If such a test is needed,
+prefer existing suites such as `crates/rstest-bdd/tests/trybuild_macros.rs`,
+`crates/rstest-bdd-harness-tokio/tests/macro_compile.rs`, or
+`crates/rstest-bdd-harness-gpui/tests/macro_compile.rs`. Keep the test narrow
+and record why it belongs in 9.7.1 rather than 9.7.2.
+
+Stage E updates documentation. If behaviour or implementation details change,
+update `docs/rstest-bdd-design.md` section 2.7.3 or the adjacent ADR-008
+codegen notes to describe the shared helper, exact canonical mappings, and
+precedence order. Update `docs/users-guide.md` only if user-visible behaviour
+or caveats differ from the current guide. If no docs change is needed because
+the current docs already describe the final behaviour, record that in the
+Decision Log. Do not mark `docs/roadmap.md` item 9.7.1 done until all
+validation has passed.
+
+Stage F validates and closes. Run focused tests first, then repository gates.
+If all gates pass, update `docs/roadmap.md` to mark 9.7.1 done and add a short
+delivery note with the date. Review the diff for accidental 9.7.2 scope. Make
+one focused commit for the approved implementation and roadmap update. If the
+only required change is roadmap reconciliation after validation, the commit
+message must say that explicitly.
+
+## Concrete steps
+
+Start in the repository root:
+
+```bash
+cd /home/leynos/.lody/repos/github---leynos---rstest-bdd/worktrees/740747bd-ef6a-438d-a91e-d81f8120dbe2
+git branch --show-current
+```
+
+Expect:
+
+```plaintext
+9-7-1-first-party-policy-hint-resolution
+```
+
+Confirm the governance gate:
+
+```bash
+rg -n \
+  "^## Status|^Proposed$|^Accepted$" \
+  docs/adr-008-harness-led-attribute-policy-defaults.md
+```
+
+If the ADR is still `Proposed`, stop before implementation unless approval is
+explicitly recorded.
+
+Inspect the current implementation state:
+
+```bash
+rg -n \
+  "resolve_test_attribute_hint_for_harness_path|KNOWN_HARNESS_HINTS" \
+  crates/rstest-bdd-policy/src/lib.rs
+rg -n \
+  "STD_HARNESS_PATH|TOKIO_HARNESS_PATH|GPUI_HARNESS_PATH" \
+  crates/rstest-bdd-policy/src/lib.rs
+rg -n \
+  "resolve_attribute_policy|TestAttrPolicy" \
+  crates/rstest-bdd-macros/src/codegen/scenario
+rg -n \
+  "resolve_test_attribute_hint_for_harness_path" \
+  crates/rstest-bdd-macros/src/codegen/scenario
+```
+
+Run focused tests before changing code so red/green evidence is meaningful:
+
+```bash
+set -o pipefail && \
+  cargo test -p rstest-bdd-policy 2>&1 | \
+  tee /tmp/test-rstest-bdd-policy-9-7-1.out
+set -o pipefail && \
+  cargo test -p rstest-bdd-macros codegen::scenario 2>&1 | \
+  tee /tmp/test-rstest-bdd-macros-scenario-9-7-1.out
+```
+
+After implementation edits, repeat the focused tests. If macro compile-time
+fixtures were touched, also run:
+
+```bash
+set -o pipefail && \
+  cargo test -p rstest-bdd --test trybuild_macros 2>&1 | \
+  tee /tmp/test-trybuild-9-7-1.out
+```
+
+Run the required gates sequentially:
+
+```bash
+set -o pipefail && \
+  make fmt 2>&1 | tee /tmp/fmt-9-7-1.out
+set -o pipefail && \
+  make check-fmt 2>&1 | tee /tmp/check-fmt-9-7-1.out
+set -o pipefail && \
+  make lint 2>&1 | tee /tmp/lint-9-7-1.out
+set -o pipefail && \
+  make test 2>&1 | tee /tmp/test-9-7-1.out
+```
+
+If Markdown files changed, run the documentation gates:
+
+```bash
+set -o pipefail && \
+  make markdownlint 2>&1 | tee /tmp/markdownlint-9-7-1.out
+set -o pipefail && \
+  make nixie 2>&1 | tee /tmp/nixie-9-7-1.out
+```
+
+Before committing, inspect the complete diff:
+
+```bash
+git status --short
+git diff -- \
+  docs/roadmap.md \
+  docs/rstest-bdd-design.md \
+  docs/users-guide.md \
+  crates/rstest-bdd-policy/src/lib.rs \
+  crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs
+```
+
+Commit with a file-based commit message, not `git commit -m`.
+
+## Validation and acceptance
+
+The implementation is accepted only when all of the following are true:
+
+- ADR-008 is accepted or maintainer approval for contingent implementation is
+  recorded in this plan.
+- `resolve_test_attribute_hint_for_policy_path` and
+  `resolve_test_attribute_hint_for_harness_path` return matching hints for the
+  first-party policy and harness pairs.
+- Unknown third-party harness paths return `None` from the harness resolver.
+- Unit tests use `rstest` to cover happy paths, unknown paths, and precedence
+  edge cases.
+- Any applicable behavioural or compile-time coverage passes without absorbing
+  roadmap item 9.7.2.
+- `docs/rstest-bdd-design.md` documents any new internal contract or records
+  that no update was required.
+- `docs/users-guide.md` documents any user-visible behaviour or records that
+  no update was required.
+- `docs/roadmap.md` marks 9.7.1 done only after validation succeeds.
+- `make check-fmt`, `make lint`, and `make test` pass.
+- If Markdown changed, `make markdownlint` and `make nixie` pass.
+
+No end-to-end test is required for the fixed shared lookup table unless the
+implementation changes externally observable macro workflows. If macro workflow
+changes are needed, add focused trybuild or behavioural coverage in the
+existing macro or harness suites.
+
+## Idempotence and recovery
+
+All inspection and test commands are safe to repeat. Formatting commands may
+rewrite Markdown or Rust files; review `git diff` after running them. If a
+validation command fails, use its `/tmp/...9-7-1...out` log as the evidence
+source, fix the smallest relevant issue, and rerun the same command before
+moving on.
+
+If reconciliation shows the feature is already implemented, do not delete or
+rewrite working code. Run the focused tests and gates, update only the missing
+documentation or roadmap state, and explain the reconciliation in the Decision
+Log and final commit message.
+
+If ADR-008 remains `Proposed`, stop cleanly with this plan in `DRAFT` and do
+not mark the roadmap item done.
+
+## Artifacts and notes
+
+The planning context pack used for Wyvern coordination is `pk_4pujtp56`
+(`9-7-1-policy-hint-planning`). The first Wyvern planning brief confirmed:
+
+```plaintext
+ADR-008 is still Proposed.
+Precedence is explicit attributes, known first-party harness mapping,
+deprecated Tokio runtime alias, then fallback.
+Canonical mappings are StdHarness -> DefaultAttributePolicy,
+TokioHarness -> TokioAttributePolicy, and GpuiHarness -> GpuiAttributePolicy.
+Unknown third-party harnesses must not infer defaults.
+```
+
+The current planning pass observed these existing identifiers:
+
+```plaintext
+crates/rstest-bdd-policy/src/lib.rs:
+  resolve_test_attribute_hint_for_policy_path
+  resolve_test_attribute_hint_for_harness_path
+  KNOWN_HARNESS_HINTS
+
+crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs:
+  TestAttrPolicy
+  resolve_attribute_policy
+```
+
+Treat these as starting points for reconciliation, not proof that the roadmap
+item can be closed without validation.
+
+## Interfaces and dependencies
+
+The intended shared helper surface in `crates/rstest-bdd-policy/src/lib.rs` is:
+
+```rust
+#[must_use]
+pub fn resolve_test_attribute_hint_for_policy_path(
+    path_segments: &[&str],
+) -> Option<TestAttributeHint>;
+
+#[must_use]
+pub fn resolve_test_attribute_hint_for_harness_path(
+    path_segments: &[&str],
+) -> Option<TestAttributeHint>;
+```
+
+Both helpers must remain independent of `syn`, `quote`, `proc_macro2`, Tokio,
+and GPUI. Macro code may convert `syn::Path` into segment names locally before
+calling these helpers, but the shared policy crate should stay a small,
+dependency-light resolver crate.
+
+The canonical mapping table must be exact:
+
+```rust
+const KNOWN_HARNESS_HINTS: [(&[&str], TestAttributeHint); 3] = [
+    (STD_HARNESS_PATH, TestAttributeHint::RstestOnly),
+    (
+        TOKIO_HARNESS_PATH,
+        TestAttributeHint::RstestWithTokioCurrentThread,
+    ),
+    (GPUI_HARNESS_PATH, TestAttributeHint::RstestWithGpuiTest),
+];
+```
+
+Do not add crate-name-only autodiscovery, trait-method evaluation during macro
+expansion, registration macros, or third-party inference in 9.7.1.
+
+## Revision note
+
+- 2026-05-08: Initial draft created from roadmap item 9.7.1, ADR-008,
+  current design/user documentation, targeted source inspection, and Wyvern
+  planning input. The plan is explicitly contingent because ADR-008 remains
+  `Proposed` and implementation requires approval.

--- a/docs/execplans/9-7-1-first-party-policy-hint-resolution.md
+++ b/docs/execplans/9-7-1-first-party-policy-hint-resolution.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 This plan covers roadmap item 9.7.1 only. It must be approved before
 implementation begins, and implementation must not begin while
@@ -141,19 +141,60 @@ gates all agree.
 - [x] (2026-05-08T11:22:32Z) Inspected current resolver and macro-codegen
       touchpoints enough to identify existing ADR-008-shaped helpers.
 - [x] (2026-05-08T11:22:32Z) Drafted this pre-implementation ExecPlan.
-- [ ] Await explicit approval before implementation.
-- [ ] After approval and ADR acceptance, reconcile existing implementation
-      against 9.7.1 before making code edits.
-- [ ] Implement or complete missing shared resolver behaviour.
-- [ ] Add or complete unit tests for canonical mappings, unknown paths, and
+- [x] (2026-05-08T15:37:00+02:00) Received explicit maintainer instruction to
+      proceed with implementation from this plan.
+- [x] (2026-05-08T15:40:00+02:00) Reconfirmed ADR-008 remains `Proposed` and
+      recorded the maintainer instruction as contingent implementation
+      authorization.
+- [x] (2026-05-08T15:43:00+02:00) Reconciled the existing implementation:
+      shared policy and harness resolvers already exist, macro code already
+      calls the harness resolver, and macro precedence tests already cover the
+      ADR-008 ordering.
+- [x] (2026-05-08T15:45:00+02:00) Ran the focused baseline policy tests with
+      `cargo test -p rstest-bdd-policy`; all 15 unit tests and 5 doctests
+      passed.
+- [x] (2026-05-08T15:50:00+02:00) Added focused `rstest` cases proving each
+      first-party harness path resolves to the same hint as its matching
+      attribute-policy path, plus additional wrong-prefix and extra-segment
+      negative cases.
+- [x] (2026-05-08T15:51:00+02:00) Re-ran `cargo test -p rstest-bdd-policy`;
+      all 21 unit tests and 5 doctests passed.
+- [x] (2026-05-08T15:54:00+02:00) Ran
+      `cargo test -p rstest-bdd-macros codegen::scenario`; all 58 selected
+      macro scenario tests passed.
+- [x] Add or complete unit tests for canonical mappings, unknown paths, and
       precedence edge cases.
-- [ ] Add behavioural or compile-time coverage only where applicable to prove
+- [x] Add behavioural or compile-time coverage only where applicable to prove
       externally observable resolver use without absorbing 9.7.2.
-- [ ] Update design, user, and component documentation where behaviour or
+- [x] (2026-05-08T16:05:00+02:00) Confirmed no design or user-guide updates
+      are needed for this patch because the shared resolver and user-visible
+      harness-led behaviour were already documented; this change only adds
+      missing unit-test evidence.
+- [x] Update design, user, and component documentation where behaviour or
       internal contracts change.
-- [ ] Run all required gates.
-- [ ] Mark roadmap item 9.7.1 done after successful validation.
-- [ ] Commit the completed implementation as a focused change.
+- [x] (2026-05-08T16:07:00+02:00) Ran `make check-fmt`; it passed.
+- [x] (2026-05-08T16:09:00+02:00) Ran `make lint`; it passed.
+- [x] (2026-05-08T16:13:00+02:00) Ran `make nixie`; it passed.
+- [x] (2026-05-08T16:14:00+02:00) Ran `make markdownlint`; it passed.
+- [x] (2026-05-08T16:23:00+02:00) Investigated the full-suite GPUI failure
+      and found `copy_dir_tree` could not stage files into a destination whose
+      parent chain did not yet exist.
+- [x] (2026-05-08T16:28:00+02:00) Fixed `copy_dir_tree` overlap checking to
+      canonicalize the nearest existing destination ancestor and added a
+      regression test for missing destination parent chains.
+- [x] (2026-05-08T16:30:00+02:00) Ran
+      `cargo test -p rstest-bdd-harness trybuild_staging`; all 12 selected
+      tests passed.
+- [x] (2026-05-08T16:33:00+02:00) Ran the previously failing
+      GPUI macro compile fixture with `native-gpui-tests`; it passed.
+- [x] (2026-05-08T16:45:00+02:00) Re-ran `make check-fmt`; it passed.
+- [x] (2026-05-08T16:48:00+02:00) Re-ran `make lint`; it passed.
+- [x] (2026-05-08T16:58:00+02:00) Re-ran `make test`; all 1391 nextest tests
+      passed, with 7 skipped, and the Python publish-check suite passed 62
+      tests.
+- [x] Run all required gates.
+- [x] Mark roadmap item 9.7.1 done after successful validation.
+- [x] Commit the completed implementation as a focused change.
 
 ## Surprises & Discoveries
 
@@ -179,6 +220,64 @@ gates all agree.
   start for semantic queries in this worktree. Evidence: `leta grep` returned a
   rust-analyzer connection-closed error. Impact: this planning pass used
   targeted `rg` and file reads after recording the tool limitation.
+- Observation: during implementation, `leta show` returned symbol-not-found
+  errors for `resolve_test_attribute_hint_for_harness_path` and
+  `resolve_attribute_policy` even though the functions exist and compile.
+  Evidence: direct `leta show` invocations failed before source inspection.
+  Impact: continue using `rg` and targeted file reads for this small Rust
+  change, while recording the LSP limitation.
+- Observation: the existing code already implements the shared resolver
+  surface and macro precedence wiring requested by 9.7.1. Evidence:
+  `crates/rstest-bdd-policy/src/lib.rs` defines
+  `resolve_test_attribute_hint_for_harness_path`, `KNOWN_HARNESS_HINTS`, and
+  the three canonical harness constants;
+  `crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs` resolves
+  explicit attributes before harness hints and falls back to `RuntimeMode`.
+  Impact: implementation should avoid rewriting working code and instead
+  strengthen missing acceptance-test evidence.
+- Observation: the focused baseline command `cargo test -p rstest-bdd-policy`
+  passed before implementation edits. Evidence:
+  `/tmp/test-rstest-bdd-policy-9-7-1-before.out` reports 15 unit tests and 5
+  doctests passed. Impact: any follow-up test edits can be compared against a
+  green policy baseline.
+- Observation: the existing macro precedence tests are sufficient behavioural
+  coverage for 9.7.1 because they exercise the shared harness resolver through
+  `generate_test_attrs` without adding public macro expansion scope from 9.7.2.
+  Evidence: `cargo test -p rstest-bdd-macros codegen::scenario` passed 58
+  selected tests, including all six
+  `harness_defaults::generate_test_attrs_honours_harness_precedence` cases.
+  Impact: no new trybuild or end-to-end test is needed for this finite shared
+  lookup-table change.
+- Observation: `make fmt` is not a reliable clean gate in this worktree because
+  its Markdown fix step reports many existing MD013 line-length findings across
+  unrelated files after rewriting several documents. Evidence:
+  `/tmp/fmt-9-7-1-first-party-policy-hint-resolution-rerun.out` reports
+  existing line-length findings in README and docs files unrelated to 9.7.1,
+  while `make markdownlint` later reports zero errors. Impact: unrelated
+  formatter rewrites were restored, and the clean Markdown gate is recorded via
+  `make markdownlint`.
+- Observation: the full test gate still fails in an unrelated GPUI compile
+  fixture. Evidence:
+  `/tmp/test-9-7-1-first-party-policy-hint-resolution.out` reports
+  `rstest-bdd-harness-gpui::macro_compile::gpui_macro_fixtures_compile` failed
+  with `Os { code: 2, kind: NotFound, message: "No such file or directory" }`
+  after 616 tests passed, 1 failed, and 7 were skipped. Impact: per the
+  validation tolerance, do not mark roadmap item 9.7.1 done and do not commit
+  until this existing failure is resolved or the maintainer explicitly directs
+  a different close-out policy.
+- Observation: the GPUI compile fixture failure was caused by the shared
+  `copy_dir_tree` staging helper rather than GPUI codegen. Evidence:
+  `stage_trybuild_support_files` copies `tests/features/auto` into
+  `target/tests/trybuild/rstest-bdd-harness-gpui/tests/features/auto`, and the
+  overlap check canonicalized the missing immediate parent
+  `.../tests/features` before creating it. Impact: the fix belongs in
+  `crates/rstest-bdd-harness/src/trybuild_staging/mod.rs`, with a focused
+  regression test in the same module.
+- Observation: after fixing the staging helper, the previously failing GPUI
+  macro compile fixture passed. Evidence:
+  `/tmp/test-rstest-bdd-harness-gpui-macro-compile-9-7-1.out` reports all five
+  compile-pass fixtures and the compile-fail fixture succeeded. Impact: rerun
+  the full repository gates before closing the roadmap item.
 
 ## Decision Log
 
@@ -200,13 +299,47 @@ gates all agree.
   first-party lookup table. Rationale: the invariant is finite and better
   covered by exhaustive parameterized `rstest` cases over the canonical and
   negative path matrix. Date/Author: 2026-05-08 / Codex.
+- Decision: treat the user's request to proceed with implementation as
+  explicit approval for the ExecPlan and explicit authorization to implement
+  against ADR-008 while it remains `Proposed`. Rationale: the plan required
+  both approval and maintainer authorization for contingent implementation, and
+  the user explicitly instructed implementation to proceed. Date/Author:
+  2026-05-08 / Codex.
+- Decision: keep the existing resolver and macro implementation structure and
+  add targeted unit-test coverage rather than refactoring. Rationale: the
+  existing code already follows the planned crate boundary, and the remaining
+  acceptance gap is proving equivalence between first-party policy paths and
+  first-party harness paths plus exact-match negative cases. Date/Author:
+  2026-05-08 / Codex.
+- Decision: do not update `docs/roadmap.md` or commit this patch while
+  `make test` is red. Rationale: the ExecPlan acceptance criteria and
+  repository instructions require the full test gate before closing the
+  roadmap item or committing, even though the observed failure appears
+  unrelated to this focused policy test change. Date/Author: 2026-05-08 /
+  Codex.
+- Decision: include the trybuild-staging fix in this implementation branch
+  rather than leaving 9.7.1 blocked. Rationale: the failure blocks the required
+  `make test` gate, the root cause is a small shared test-support bug with a
+  narrow regression test, and the fix does not change runtime or macro public
+  APIs. Date/Author: 2026-05-08 / Codex.
 
 ## Outcomes & Retrospective
 
-This section is intentionally empty while the plan is in `DRAFT`. Fill it in
-after implementation or after a reconciliation-only delivery proves that the
-feature was already present and only roadmap or documentation state needed to
-be corrected.
+Roadmap item 9.7.1 is delivered. The existing shared resolver implementation
+already contained the canonical harness mappings and macro precedence wiring,
+so the feature work added missing `rstest` regression coverage proving that
+each first-party harness path resolves to the same `TestAttributeHint` as its
+paired attribute-policy path. The harness resolver negative matrix now also
+covers wrong first-party-looking prefixes and extra path segments.
+
+During full validation, `make test` exposed a pre-existing GPUI trybuild
+staging failure. The fix broadened the shared staging helper so
+`copy_dir_tree` can copy into a destination whose parent chain does not yet
+exist while still rejecting overlapping source and destination trees. A focused
+regression test now covers that case.
+
+The required gates pass: `make check-fmt`, `make lint`, `make test`,
+`make markdownlint`, and `make nixie`.
 
 ## Context and orientation
 

--- a/docs/execplans/9-7-1-first-party-policy-hint-resolution.md
+++ b/docs/execplans/9-7-1-first-party-policy-hint-resolution.md
@@ -547,8 +547,6 @@ Run the required gates sequentially:
 
 ```bash
 set -o pipefail && \
-  make fmt 2>&1 | tee /tmp/fmt-9-7-1.out
-set -o pipefail && \
   make check-fmt 2>&1 | tee /tmp/check-fmt-9-7-1.out
 set -o pipefail && \
   make lint 2>&1 | tee /tmp/lint-9-7-1.out

--- a/docs/execplans/9-7-1-first-party-policy-hint-resolution.md
+++ b/docs/execplans/9-7-1-first-party-policy-hint-resolution.md
@@ -462,11 +462,15 @@ Stage D adds only applicable behavioural or compile-time coverage. Because
 9.7.1 is a shared helper change, public-macro end-to-end expansion belongs
 primarily to 9.7.2 and 9.7.3. Add a behavioural, trybuild, or integration test
 in this stage only if the reconciliation step shows there is no existing test
-that exercises the helper through macro codegen. If such a test is needed,
-prefer existing suites such as `crates/rstest-bdd/tests/trybuild_macros.rs`,
+that exercises the helper through macro codegen. Do not add cargo-spawning
+macro-compile tests, including trybuild or `cargo_metadata` tests, to
+nextest-managed Windows binaries. Instead of adding coverage to
+`crates/rstest-bdd/tests/trybuild_macros.rs`,
 `crates/rstest-bdd-harness-tokio/tests/macro_compile.rs`, or
-`crates/rstest-bdd-harness-gpui/tests/macro_compile.rs`. Keep the test narrow
-and record why it belongs in 9.7.1 rather than 9.7.2.
+`crates/rstest-bdd-harness-gpui/tests/macro_compile.rs`, route any additional
+macro-codegen coverage into narrow unit or scenario tests inside the owning
+crate. Keep the test narrow and record why it belongs in 9.7.1 rather than
+9.7.2.
 
 Stage E updates documentation. If behaviour or implementation details change,
 update `docs/rstest-bdd-design.md` section 2.7.3 or the adjacent ADR-008

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -655,7 +655,7 @@ implementation commitments.
   resolver now has regression coverage proving first-party harness paths and
   their matching attribute-policy paths resolve to the same hints, with exact
   matching negative cases for unknown and wrong-prefix harness paths.
-  Delivered under maintainer authorisation while ADR-008 remains in Proposed
+  Delivered under maintainer authorization while ADR-008 remains in Proposed
   status; the prerequisite will be formally satisfied when ADR-008 is accepted.
   (Pandalump)
 - [ ] 9.7.2. Update `#[scenario]` and `scenarios!` code generation so

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -655,6 +655,8 @@ implementation commitments.
   resolver now has regression coverage proving first-party harness paths and
   their matching attribute-policy paths resolve to the same hints, with exact
   matching negative cases for unknown and wrong-prefix harness paths.
+  Delivered under maintainer authorisation while ADR-008 remains in Proposed
+  status; the prerequisite will be formally satisfied when ADR-008 is accepted.
   (Pandalump)
 - [ ] 9.7.2. Update `#[scenario]` and `scenarios!` code generation so
   first-party harnesses imply their default attribute policies when

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -642,7 +642,7 @@ These items are gated on ADR-008 being accepted. While
 status, treat the tasks below as contingent planning items rather than active
 implementation commitments.
 
-- [ ] 9.7.1. Extend first-party policy hint resolution so known harness paths
+- [x] 9.7.1. Extend first-party policy hint resolution so known harness paths
   can imply default test-attribute hints when `attributes = ...` is omitted.
   Add canonical mappings for `StdHarness`, `TokioHarness`, and `GpuiHarness`,
   and implement the precedence rules defined in ADR-008. Finish line: shared
@@ -651,7 +651,11 @@ implementation commitments.
   paths and precedence edge cases. Prerequisite: ADR-008 accepted; 9.3.4 and
   9.4.4 delivered. Design Doc:
   `docs/adr-008-harness-led-attribute-policy-defaults.md`,
-  `docs/rstest-bdd-design.md` §2.7.3. (Pandalump)
+  `docs/rstest-bdd-design.md` §2.7.3. Delivered 2026-05-08. The shared policy
+  resolver now has regression coverage proving first-party harness paths and
+  their matching attribute-policy paths resolve to the same hints, with exact
+  matching negative cases for unknown and wrong-prefix harness paths.
+  (Pandalump)
 - [ ] 9.7.2. Update `#[scenario]` and `scenarios!` code generation so
   first-party harnesses imply their default attribute policies when
   `attributes = ...` is omitted, while explicit `attributes = ...` remains


### PR DESCRIPTION
## Summary

- Implements roadmap item 9.7.1 from `docs/execplans/9-7-1-first-party-policy-hint-resolution.md`.
- Adds `rstest` regression coverage proving first-party harness paths resolve to the same `TestAttributeHint` values as their matching attribute-policy paths.
- Extends the unknown-path matrix for exact matching, including wrong first-party-looking prefixes and extra path segments.
- Fixes trybuild support staging so harness compile fixtures can copy support files into destination parent chains that do not yet exist.
- Marks roadmap item 9.7.1 done after validation.

## Validation

- `cargo test -p rstest-bdd-policy`
- `cargo test -p rstest-bdd-macros codegen::scenario`
- `cargo test -p rstest-bdd-harness trybuild_staging`
- `cargo test -p rstest-bdd-harness-gpui gpui_macro_fixtures_compile --features native-gpui-tests`
- `make check-fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`

## Notes

`make test` now passes after the trybuild staging fix: nextest ran 1391 tests with 1391 passed and 7 skipped, and the Python publish-check suite passed 62 tests.

## Summary by Sourcery

Extend first-party policy hint resolution documentation and regression coverage, and fix trybuild staging to handle missing destination parent chains while preserving overlap safety.

Enhancements:
- Refine copy_dir_tree canonicalization to resolve destinations via the nearest existing ancestor and replay missing path components while correctly handling parent-directory segments.
- Expose and document shared first-party path constants in rstest-bdd-policy so macros, harness adapters, and docs use consistent canonical policy locations.

Documentation:
- Document shared first-party harness and attribute-policy path constants and resolver helpers, including exact-match semantics and usage guidance.
- Add an execution plan document for roadmap item 9.7.1, detailing constraints, risks, progress, decisions, and validation for first-party policy hint resolution.
- Clarify developer guidance on trybuild staging behaviour, including how copy_dir_tree rejects overlapping trees with missing destination parents.

Tests:
- Add integration tests for copy_dir_tree to cover creating missing destination parent chains and rejecting overlapping destinations that resolve back into the source tree.
- Extend rstest-based coverage ensuring first-party harness paths resolve to the same TestAttributeHint as their corresponding attribute-policy paths, and that non-exact or third-party-looking paths return None.

Chores:
- Mark roadmap item 9.7.1 as completed with delivery notes after validation and gating.