### PR TITLE
Update harness-led defaults documentation (9.7.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
  "rstest-bdd-harness",
  "serde",
  "serde_json",
- "serial_test",
+ "serial_test 2.0.0",
  "tempfile",
 ]
 
@@ -1548,7 +1548,7 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
- "serial_test",
+ "serial_test 2.0.0",
  "the-newtype",
  "thiserror 1.0.69",
  "tokio",
@@ -1584,7 +1584,7 @@ dependencies = [
  "rstest-bdd",
  "rstest-bdd-harness",
  "rstest-bdd-macros",
- "serial_test",
+ "serial_test 2.0.0",
  "trybuild",
 ]
 
@@ -1599,6 +1599,7 @@ dependencies = [
  "rstest-bdd",
  "rstest-bdd-harness",
  "rstest-bdd-macros",
+ "serial_test 3.4.0",
  "tokio",
  "trybuild",
 ]
@@ -1624,7 +1625,7 @@ dependencies = [
  "rstest-bdd-harness",
  "rstest-bdd-patterns",
  "rstest-bdd-policy",
- "serial_test",
+ "serial_test 2.0.0",
  "syn 2.0.106",
  "tempfile",
  "thiserror 1.0.69",
@@ -1787,10 +1788,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "self_cell"
@@ -1881,7 +1897,22 @@ dependencies = [
  "lazy_static",
  "log",
  "parking_lot",
- "serial_test_derive",
+ "serial_test_derive 2.0.0",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive 3.4.0",
 ]
 
 [[package]]
@@ -1889,6 +1920,17 @@ name = "serial_test_derive"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/rstest-bdd-harness-gpui/Cargo.toml
+++ b/crates/rstest-bdd-harness-gpui/Cargo.toml
@@ -42,19 +42,3 @@ trybuild.workspace = true
 name = "macro_compile"
 path = "tests/macro_compile.rs"
 required-features = ["native-gpui-tests"]
-[[test]]
-name = "macro_compile"
-path = "tests/macro_compile.rs"
-required-features = ["native-gpui-tests"]
-[[test]]
-name = "macro_compile"
-path = "tests/macro_compile.rs"
-required-features = ["native-gpui-tests"]
-[[test]]
-name = "macro_compile"
-path = "tests/macro_compile.rs"
-required-features = ["native-gpui-tests"]
-[[test]]
-name = "macro_compile"
-path = "tests/macro_compile.rs"
-required-features = ["native-gpui-tests"]

--- a/crates/rstest-bdd-harness-gpui/tests/fixtures_macros/scenario_harness_gpui_default.expanded.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/fixtures_macros/scenario_harness_gpui_default.expanded.rs
@@ -1,0 +1,13 @@
+//! Expanded output for `scenario` with the GPUI harness-led default policy.
+
+#[rstest::rstest]
+fn with_gpui_harness_default_attributes() {
+    let __rstest_bdd_harness = <rstest_bdd_harness_gpui::GpuiHarness as Default>::default();
+    <rstest_bdd_harness_gpui::GpuiHarness as rstest_bdd_harness::HarnessAdapter>::run(
+        &__rstest_bdd_harness,
+        __rstest_bdd_request,
+    )
+    .unwrap_or_else(|err| {
+        panic!("harness failed to initialise scenario: {err}")
+    })
+}

--- a/crates/rstest-bdd-harness-gpui/tests/fixtures_macros/scenarios_harness_gpui_default.expanded.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/fixtures_macros/scenarios_harness_gpui_default.expanded.rs
@@ -1,0 +1,13 @@
+//! Expanded output for `scenarios!` with the GPUI harness-led default policy.
+
+#[rstest::rstest]
+fn basic_discovers_a_gpui_scenario() {
+    let __rstest_bdd_harness = <rstest_bdd_harness_gpui::GpuiHarness as Default>::default();
+    <rstest_bdd_harness_gpui::GpuiHarness as rstest_bdd_harness::HarnessAdapter>::run(
+        &__rstest_bdd_harness,
+        __rstest_bdd_request,
+    )
+    .unwrap_or_else(|err| {
+        panic!("harness failed to initialise scenario: {err}")
+    })
+}

--- a/crates/rstest-bdd-harness-gpui/tests/macro_compile.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/macro_compile.rs
@@ -12,6 +12,7 @@ use rstest_bdd_harness::macrotest_support::{
     trybuild_crate_root,
 };
 use rstest_bdd_harness::trybuild_staging::{copy_dir_tree, copy_file};
+use serial_test::serial;
 
 fn crate_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -22,6 +23,7 @@ fn fixture_path(relative: &str) -> PathBuf {
 }
 
 #[test]
+#[serial]
 fn gpui_macro_fixtures_compile() -> Result<(), Box<dyn std::error::Error>> {
     stage_trybuild_support_files()?;
     let tests = trybuild::TestCases::new();

--- a/crates/rstest-bdd-harness-gpui/tests/macro_compile.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/macro_compile.rs
@@ -30,22 +30,26 @@ fn gpui_macro_fixtures_compile() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn gpui_override_macro_expansions_match_snapshots() {
+fn gpui_macro_expansions_match_snapshots() {
     if !macrotest_snapshot_refresh_is_enabled() {
         return;
     }
-    macrotest::expand_without_refresh(
+    for fixture in [
+        "tests/fixtures_macros/scenario_harness_gpui_default.rs",
         "tests/fixtures_macros/scenario_harness_gpui_override_default.rs",
-    );
-    macrotest::expand_without_refresh(
+        "tests/fixtures_macros/scenarios_harness_gpui_default.rs",
         "tests/fixtures_macros/scenarios_harness_gpui_override_default.rs",
-    );
+    ] {
+        macrotest::expand_without_refresh(fixture);
+    }
 }
 
 #[test]
-fn gpui_override_snapshots_encode_attribute_boundaries() {
+fn gpui_snapshots_encode_attribute_boundaries() {
     for path in [
+        "tests/fixtures_macros/scenario_harness_gpui_default.expanded.rs",
         "tests/fixtures_macros/scenario_harness_gpui_override_default.expanded.rs",
+        "tests/fixtures_macros/scenarios_harness_gpui_default.expanded.rs",
         "tests/fixtures_macros/scenarios_harness_gpui_override_default.expanded.rs",
     ] {
         assert_snapshot_contains(path, &["#[rstest::rstest]", "HarnessAdapter>::run"]);

--- a/crates/rstest-bdd-harness-gpui/tests/macro_compile.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/macro_compile.rs
@@ -6,9 +6,20 @@
 
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 
+use rstest_bdd_harness::macrotest_support::{
+    assert_snapshot_contains, assert_snapshot_omits, snapshot_refresh_is_enabled,
+    trybuild_crate_root,
+};
 use rstest_bdd_harness::trybuild_staging::{copy_dir_tree, copy_file};
+
+fn crate_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn fixture_path(relative: &str) -> PathBuf {
+    crate_root().join(relative)
+}
 
 #[test]
 fn gpui_macro_fixtures_compile() -> Result<(), Box<dyn std::error::Error>> {
@@ -31,7 +42,7 @@ fn gpui_macro_fixtures_compile() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn gpui_macro_expansions_match_snapshots() {
-    if !macrotest_snapshot_refresh_is_enabled() {
+    if !snapshot_refresh_is_enabled() {
         return;
     }
     for fixture in [
@@ -46,54 +57,21 @@ fn gpui_macro_expansions_match_snapshots() {
 
 #[test]
 fn gpui_snapshots_encode_attribute_boundaries() {
-    for path in [
+    for relative in [
         "tests/fixtures_macros/scenario_harness_gpui_default.expanded.rs",
         "tests/fixtures_macros/scenario_harness_gpui_override_default.expanded.rs",
         "tests/fixtures_macros/scenarios_harness_gpui_default.expanded.rs",
         "tests/fixtures_macros/scenarios_harness_gpui_override_default.expanded.rs",
     ] {
-        assert_snapshot_contains(path, &["#[rstest::rstest]", "HarnessAdapter>::run"]);
-        assert_snapshot_omits(path, "gpui::test");
+        let path = fixture_path(relative);
+        assert_snapshot_contains(&path, &["#[rstest::rstest]", "HarnessAdapter>::run"]);
+        assert_snapshot_omits(&path, "gpui::test");
     }
-}
-
-fn macrotest_snapshot_refresh_is_enabled() -> bool {
-    std::env::var_os("RSTEST_BDD_RUN_MACROTEST").is_some() && cargo_expand_is_available()
-}
-
-fn cargo_expand_is_available() -> bool {
-    Command::new("cargo")
-        .args(["expand", "--version"])
-        .output()
-        .is_ok_and(|output| output.status.success())
-}
-
-fn assert_snapshot_contains(path: &str, needles: &[&str]) {
-    let contents = read_snapshot(path);
-    for needle in needles {
-        assert!(
-            contents.contains(needle),
-            "expected {path} to contain {needle:?}"
-        );
-    }
-}
-
-fn assert_snapshot_omits(path: &str, needle: &str) {
-    let contents = read_snapshot(path);
-    assert!(
-        !contents.contains(needle),
-        "expected {path} to omit {needle:?}"
-    );
-}
-
-fn read_snapshot(path: &str) -> String {
-    fs::read_to_string(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(path))
-        .unwrap_or_else(|err| panic!("failed to read snapshot {path}: {err}"))
 }
 
 fn stage_trybuild_support_files() -> Result<(), Box<dyn std::error::Error>> {
-    let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let trybuild_root = trybuild_crate_root()?;
+    let crate_root = crate_root();
+    let trybuild_root = gpui_trybuild_crate_root()?;
     copy_file(
         &crate_root.join("tests/fixtures_macros/basic.feature"),
         &trybuild_root.join("basic.feature"),
@@ -106,13 +84,6 @@ fn stage_trybuild_support_files() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn trybuild_crate_root() -> Result<PathBuf, Box<dyn std::error::Error>> {
-    let metadata = cargo_metadata::MetadataCommand::new()
-        .manifest_path(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"))
-        .no_deps()
-        .exec()?;
-    Ok(metadata
-        .target_directory
-        .into_std_path_buf()
-        .join("tests/trybuild/rstest-bdd-harness-gpui"))
+fn gpui_trybuild_crate_root() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    trybuild_crate_root(&crate_root().join("Cargo.toml"), "rstest-bdd-harness-gpui")
 }

--- a/crates/rstest-bdd-harness-gpui/tests/scenario_macros.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/scenario_macros.rs
@@ -143,6 +143,14 @@ fn gpui_test_context_is_valid(#[from(rstest_bdd_harness_context)] context: &gpui
     assert_gpui_context_uses_upstream_test_api(context);
 }
 
+/// Runtime integration coverage for the harness-led-default policy in
+/// ADR-008: the macro is invoked with `harness = GpuiHarness` and no
+/// `attributes = ...`, so the macro infers `GpuiAttributePolicy` and the
+/// emitted `#[gpui::test]` is filtered (the function is sync, the GPUI
+/// runtime is supplied by the harness rather than the attribute). Reaching
+/// `TestAppContext` and `executor()` from steps proves the harness honoured
+/// the inferred contract at runtime. Pairs with the macro-output snapshot
+/// at `tests/macro_compile.rs::gpui_snapshots_encode_attribute_boundaries`.
 #[scenario(
     path = "tests/features/gpui_harness.feature",
     name = "GPUI harness injects TestAppContext",
@@ -197,6 +205,12 @@ scenarios!(
     attributes = rstest_bdd_harness_gpui::GpuiAttributePolicy,
 );
 
+// Runtime integration coverage for the `scenarios!` form of the
+// harness-led-default policy: no `attributes = ...` is supplied, so the macro
+// infers `GpuiAttributePolicy` from the first-party `GpuiHarness` path.
+// Scenario steps observe `TestAppContext`, which only `GpuiHarness` can
+// inject; the generated tests therefore exercise the inferred contract end
+// to end.
 scenarios!(
     "tests/features/gpui_harness_default_scenarios",
     harness = rstest_bdd_harness_gpui::GpuiHarness,

--- a/crates/rstest-bdd-harness-tokio/Cargo.toml
+++ b/crates/rstest-bdd-harness-tokio/Cargo.toml
@@ -32,9 +32,3 @@ tokio = { version = "1", features = ["macros", "rt", "time", "sync"] }
 [[test]]
 name = "macro_compile"
 path = "tests/macro_compile.rs"
-[[test]]
-name = "macro_compile"
-path = "tests/macro_compile.rs"
-[[test]]
-name = "macro_compile"
-path = "tests/macro_compile.rs"

--- a/crates/rstest-bdd-harness-tokio/Cargo.toml
+++ b/crates/rstest-bdd-harness-tokio/Cargo.toml
@@ -26,6 +26,7 @@ rstest-bdd-macros.workspace = true
 cargo_metadata.workspace = true
 macrotest.workspace = true
 prettyplease.workspace = true
+serial_test = "3"
 trybuild.workspace = true
 tokio = { version = "1", features = ["macros", "rt", "time", "sync"] }
 

--- a/crates/rstest-bdd-harness-tokio/tests/fixtures_macros/scenario_harness_tokio_default.expanded.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/fixtures_macros/scenario_harness_tokio_default.expanded.rs
@@ -1,0 +1,13 @@
+//! Expanded output for `scenario` with the Tokio harness-led default policy.
+
+#[rstest::rstest]
+fn with_tokio_harness_default_attributes() {
+    let __rstest_bdd_harness = <rstest_bdd_harness_tokio::TokioHarness as Default>::default();
+    <rstest_bdd_harness_tokio::TokioHarness as rstest_bdd_harness::HarnessAdapter>::run(
+        &__rstest_bdd_harness,
+        __rstest_bdd_request,
+    )
+    .unwrap_or_else(|err| {
+        panic!("harness failed to initialise scenario: {err}")
+    })
+}

--- a/crates/rstest-bdd-harness-tokio/tests/fixtures_macros/scenarios_harness_tokio_default.expanded.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/fixtures_macros/scenarios_harness_tokio_default.expanded.rs
@@ -1,0 +1,13 @@
+//! Expanded output for `scenarios!` with the Tokio harness-led default policy.
+
+#[rstest::rstest]
+fn tokio_scenarios_macro_uses_harness_led_defaults() {
+    let __rstest_bdd_harness = <rstest_bdd_harness_tokio::TokioHarness as Default>::default();
+    <rstest_bdd_harness_tokio::TokioHarness as rstest_bdd_harness::HarnessAdapter>::run(
+        &__rstest_bdd_harness,
+        __rstest_bdd_request,
+    )
+    .unwrap_or_else(|err| {
+        panic!("harness failed to initialise scenario: {err}")
+    })
+}

--- a/crates/rstest-bdd-harness-tokio/tests/macro_compile.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/macro_compile.rs
@@ -35,26 +35,28 @@ fn tokio_macro_fixtures_compile() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn tokio_override_macro_expansions_match_snapshots() {
+fn tokio_macro_expansions_match_snapshots() {
     if !macrotest_snapshot_refresh_is_enabled() {
         return;
     }
+    macrotest::expand_without_refresh("tests/fixtures_macros/scenario_harness_tokio_default.rs");
     macrotest::expand_without_refresh(
         "tests/fixtures_macros/scenario_harness_tokio_override_default.rs",
     );
+    macrotest::expand_without_refresh("tests/fixtures_macros/scenarios_harness_tokio_default.rs");
     macrotest::expand_without_refresh("tests/fixtures_macros/scenarios_attributes_tokio.rs");
 }
 
 #[test]
-fn tokio_override_snapshots_encode_attribute_boundaries() {
-    assert_snapshot_contains(
+fn tokio_snapshots_encode_attribute_boundaries() {
+    for path in [
+        "tests/fixtures_macros/scenario_harness_tokio_default.expanded.rs",
         "tests/fixtures_macros/scenario_harness_tokio_override_default.expanded.rs",
-        &["#[rstest::rstest]", "HarnessAdapter>::run"],
-    );
-    assert_snapshot_omits(
-        "tests/fixtures_macros/scenario_harness_tokio_override_default.expanded.rs",
-        "tokio::test",
-    );
+        "tests/fixtures_macros/scenarios_harness_tokio_default.expanded.rs",
+    ] {
+        assert_snapshot_contains(path, &["#[rstest::rstest]", "HarnessAdapter>::run"]);
+        assert_snapshot_omits(path, "tokio::test");
+    }
     assert_snapshot_contains(
         "tests/fixtures_macros/scenarios_attributes_tokio.expanded.rs",
         &["#[tokio::test", "async fn"],

--- a/crates/rstest-bdd-harness-tokio/tests/macro_compile.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/macro_compile.rs
@@ -10,6 +10,7 @@ use rstest_bdd_harness::macrotest_support::{
     trybuild_crate_root,
 };
 use rstest_bdd_harness::trybuild_staging::copy_file;
+use serial_test::serial;
 
 fn crate_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -20,6 +21,7 @@ fn fixture_path(relative: &str) -> PathBuf {
 }
 
 #[test]
+#[serial]
 fn tokio_macro_fixtures_compile() -> Result<(), Box<dyn std::error::Error>> {
     stage_trybuild_support_files()?;
     let tests = trybuild::TestCases::new();

--- a/crates/rstest-bdd-harness-tokio/tests/macro_compile.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/macro_compile.rs
@@ -3,11 +3,21 @@
 //! These tests live with the Tokio harness crate so the core `rstest-bdd`
 //! package can be published without resolving Tokio harness dev-dependencies.
 
-use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 
+use rstest_bdd_harness::macrotest_support::{
+    assert_snapshot_contains, assert_snapshot_omits, snapshot_refresh_is_enabled,
+    trybuild_crate_root,
+};
 use rstest_bdd_harness::trybuild_staging::copy_file;
+
+fn crate_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn fixture_path(relative: &str) -> PathBuf {
+    crate_root().join(relative)
+}
 
 #[test]
 fn tokio_macro_fixtures_compile() -> Result<(), Box<dyn std::error::Error>> {
@@ -36,87 +46,50 @@ fn tokio_macro_fixtures_compile() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn tokio_macro_expansions_match_snapshots() {
-    if !macrotest_snapshot_refresh_is_enabled() {
+    if !snapshot_refresh_is_enabled() {
         return;
     }
-    macrotest::expand_without_refresh("tests/fixtures_macros/scenario_harness_tokio_default.rs");
-    macrotest::expand_without_refresh(
+    for fixture in [
+        "tests/fixtures_macros/scenario_harness_tokio_default.rs",
         "tests/fixtures_macros/scenario_harness_tokio_override_default.rs",
-    );
-    macrotest::expand_without_refresh("tests/fixtures_macros/scenarios_harness_tokio_default.rs");
-    macrotest::expand_without_refresh("tests/fixtures_macros/scenarios_attributes_tokio.rs");
+        "tests/fixtures_macros/scenarios_harness_tokio_default.rs",
+        "tests/fixtures_macros/scenarios_attributes_tokio.rs",
+    ] {
+        macrotest::expand_without_refresh(fixture);
+    }
 }
 
 #[test]
 fn tokio_snapshots_encode_attribute_boundaries() {
-    for path in [
+    for relative in [
         "tests/fixtures_macros/scenario_harness_tokio_default.expanded.rs",
         "tests/fixtures_macros/scenario_harness_tokio_override_default.expanded.rs",
         "tests/fixtures_macros/scenarios_harness_tokio_default.expanded.rs",
     ] {
-        assert_snapshot_contains(path, &["#[rstest::rstest]", "HarnessAdapter>::run"]);
-        assert_snapshot_omits(path, "tokio::test");
+        let path = fixture_path(relative);
+        assert_snapshot_contains(&path, &["#[rstest::rstest]", "HarnessAdapter>::run"]);
+        assert_snapshot_omits(&path, "tokio::test");
     }
     assert_snapshot_contains(
-        "tests/fixtures_macros/scenarios_attributes_tokio.expanded.rs",
+        &fixture_path("tests/fixtures_macros/scenarios_attributes_tokio.expanded.rs"),
         &["#[tokio::test", "async fn"],
     );
 }
 
-fn macrotest_snapshot_refresh_is_enabled() -> bool {
-    std::env::var_os("RSTEST_BDD_RUN_MACROTEST").is_some() && cargo_expand_is_available()
-}
-
-fn cargo_expand_is_available() -> bool {
-    Command::new("cargo")
-        .args(["expand", "--version"])
-        .output()
-        .is_ok_and(|output| output.status.success())
-}
-
-fn assert_snapshot_contains(path: &str, needles: &[&str]) {
-    let contents = read_snapshot(path);
-    for needle in needles {
-        assert!(
-            contents.contains(needle),
-            "expected {path} to contain {needle:?}"
-        );
-    }
-}
-
-fn assert_snapshot_omits(path: &str, needle: &str) {
-    let contents = read_snapshot(path);
-    assert!(
-        !contents.contains(needle),
-        "expected {path} to omit {needle:?}"
-    );
-}
-
-fn read_snapshot(path: &str) -> String {
-    fs::read_to_string(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(path))
-        .unwrap_or_else(|err| panic!("failed to read snapshot {path}: {err}"))
-}
-
 fn stage_trybuild_support_files() -> Result<(), Box<dyn std::error::Error>> {
-    let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let crate_root = crate_root();
+    let trybuild_root = tokio_trybuild_crate_root()?;
     copy_file(
         &crate_root.join("tests/fixtures_macros/basic.feature"),
-        &trybuild_crate_root()?.join("basic.feature"),
+        &trybuild_root.join("basic.feature"),
     )?;
     copy_file(
         &crate_root.join("tests/fixtures_macros/scenarios_harness_tokio_default.feature"),
-        &trybuild_crate_root()?.join("scenarios_harness_tokio_default.feature"),
+        &trybuild_root.join("scenarios_harness_tokio_default.feature"),
     )?;
     Ok(())
 }
 
-fn trybuild_crate_root() -> Result<PathBuf, Box<dyn std::error::Error>> {
-    let metadata = cargo_metadata::MetadataCommand::new()
-        .manifest_path(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"))
-        .no_deps()
-        .exec()?;
-    Ok(metadata
-        .target_directory
-        .into_std_path_buf()
-        .join("tests/trybuild/rstest-bdd-harness-tokio"))
+fn tokio_trybuild_crate_root() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    trybuild_crate_root(&crate_root().join("Cargo.toml"), "rstest-bdd-harness-tokio")
 }

--- a/crates/rstest-bdd-harness-tokio/tests/scenario_macros.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/scenario_macros.rs
@@ -69,6 +69,17 @@ fn tokio_runtime_remains_available() {
 }
 
 /// Tests `#[scenario]` with `harness = TokioHarness` only.
+///
+/// This is one of the runtime integration coverage points for the
+/// harness-led-default attribute-policy inference defined in ADR-008: the
+/// macro is called with `harness = TokioHarness` and no `attributes = ...`,
+/// so the macro infers `TokioAttributePolicy` and emits the Tokio test
+/// attributes (with `#[tokio::test]` filtered for sync signatures). The
+/// scenario steps reach into `tokio::runtime::Handle::current()` and
+/// `spawn_local`, which would panic if the harness had not stood up a
+/// current-thread Tokio runtime + `LocalSet`. See
+/// `tests/macro_compile.rs::tokio_snapshots_encode_attribute_boundaries`
+/// for the corresponding macro-output snapshot coverage.
 #[scenario(
     path = "tests/features/tokio_harness.feature",
     name = "Tokio runtime is active during step execution",
@@ -124,6 +135,12 @@ async fn async_steps_completed(#[from(rstest_bdd_harness_context)] ctx: &TokioTe
 }
 
 /// Tests that `async fn` step definitions work with `TokioHarness`.
+///
+/// Pairs with [`scenario_runs_inside_tokio_runtime`] as runtime integration
+/// coverage for the harness-led-default policy: the macro is invoked with
+/// `harness = TokioHarness` and no `attributes = ...`, async step bodies
+/// reach for `Handle::current()` and `spawn_local`, and the steps run only
+/// because `TokioHarness` supplied the inferred runtime contract.
 #[scenario(
     path = "tests/features/tokio_harness.feature",
     name = "Async step definitions execute under TokioHarness",
@@ -131,6 +148,11 @@ async fn async_steps_completed(#[from(rstest_bdd_harness_context)] ctx: &TokioTe
 )]
 fn scenario_async_steps_under_tokio_harness() {}
 
+// Runtime integration coverage for the `scenarios!` form of the
+// harness-led-default policy: no `attributes = ...` is supplied, so the macro
+// infers `TokioAttributePolicy` from the first-party `TokioHarness` path. The
+// generated tests run only when `TokioHarness` makes a current-thread runtime
+// available to each step body.
 scenarios!(
     "tests/features/tokio_harness_scenarios",
     harness = rstest_bdd_harness_tokio::TokioHarness,

--- a/crates/rstest-bdd-harness/src/lib.rs
+++ b/crates/rstest-bdd-harness/src/lib.rs
@@ -7,6 +7,8 @@ mod adapter;
 #[doc(hidden)]
 pub mod binary_test_support;
 mod error;
+#[doc(hidden)]
+pub mod macrotest_support;
 mod policy;
 mod runner;
 mod std_harness;

--- a/crates/rstest-bdd-harness/src/macrotest_support.rs
+++ b/crates/rstest-bdd-harness/src/macrotest_support.rs
@@ -36,13 +36,17 @@ fn cargo_expand_is_available() -> bool {
 }
 
 /// Reads a snapshot file at `path`, panicking with file context on failure.
-#[must_use]
-pub fn read_snapshot(path: &Path) -> String {
+fn read_snapshot(path: &Path) -> String {
     fs::read_to_string(path)
         .unwrap_or_else(|err| panic!("failed to read snapshot {}: {err}", path.display()))
 }
 
 /// Asserts that every needle appears at least once in the snapshot at `path`.
+///
+/// # Panics
+///
+/// Panics if `path` cannot be read (I/O error), or if any needle is absent
+/// from the snapshot contents.
 pub fn assert_snapshot_contains(path: &Path, needles: &[&str]) {
     let contents = read_snapshot(path);
     for needle in needles {
@@ -55,6 +59,11 @@ pub fn assert_snapshot_contains(path: &Path, needles: &[&str]) {
 }
 
 /// Asserts that `needle` does not appear anywhere in the snapshot at `path`.
+///
+/// # Panics
+///
+/// Panics if `path` cannot be read (I/O error), or if `needle` is found in
+/// the snapshot contents.
 pub fn assert_snapshot_omits(path: &Path, needle: &str) {
     let contents = read_snapshot(path);
     assert!(

--- a/crates/rstest-bdd-harness/src/macrotest_support.rs
+++ b/crates/rstest-bdd-harness/src/macrotest_support.rs
@@ -1,0 +1,86 @@
+//! Shared helpers for harness crates that run `macrotest` against snapshot
+//! fixtures.
+//!
+//! These utilities back the `macro_compile` integration suites in the Tokio
+//! and GPUI harness crates so both can resolve `cargo expand`, decide whether
+//! macrotest refresh is enabled, and perform substring assertions over
+//! `.expanded.rs` snapshot files without re-implementing identical code in
+//! each crate. The module is exposed as a hidden API for those harness tests
+//! only and is not part of the supported public surface.
+//!
+//! Snapshot paths are passed as absolute paths because each caller's
+//! `CARGO_MANIFEST_DIR` resolves at compile time inside the caller crate;
+//! sharing the helpers via this module avoids that per-crate coupling.
+
+use std::error::Error;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Returns `true` when the macrotest refresh workflow is enabled.
+///
+/// The workflow requires the `RSTEST_BDD_RUN_MACROTEST` environment variable
+/// to be set and the `cargo expand` subcommand to be available. Both
+/// conditions must hold for `macrotest::expand_without_refresh` to produce a
+/// useful comparison against the checked-in `.expanded.rs` files.
+#[must_use]
+pub fn snapshot_refresh_is_enabled() -> bool {
+    std::env::var_os("RSTEST_BDD_RUN_MACROTEST").is_some() && cargo_expand_is_available()
+}
+
+fn cargo_expand_is_available() -> bool {
+    Command::new("cargo")
+        .args(["expand", "--version"])
+        .output()
+        .is_ok_and(|output| output.status.success())
+}
+
+/// Reads a snapshot file at `path`, panicking with file context on failure.
+#[must_use]
+pub fn read_snapshot(path: &Path) -> String {
+    fs::read_to_string(path)
+        .unwrap_or_else(|err| panic!("failed to read snapshot {}: {err}", path.display()))
+}
+
+/// Asserts that every needle appears at least once in the snapshot at `path`.
+pub fn assert_snapshot_contains(path: &Path, needles: &[&str]) {
+    let contents = read_snapshot(path);
+    for needle in needles {
+        assert!(
+            contents.contains(needle),
+            "expected {} to contain {needle:?}",
+            path.display(),
+        );
+    }
+}
+
+/// Asserts that `needle` does not appear anywhere in the snapshot at `path`.
+pub fn assert_snapshot_omits(path: &Path, needle: &str) {
+    let contents = read_snapshot(path);
+    assert!(
+        !contents.contains(needle),
+        "expected {} to omit {needle:?}",
+        path.display(),
+    );
+}
+
+/// Computes the trybuild scratch directory for the crate whose manifest lives
+/// at `manifest_path`.
+///
+/// The returned path joins the workspace `target` directory with
+/// `tests/trybuild/<target_subdir>`, matching the layout trybuild uses for
+/// per-crate scratch space.
+pub fn trybuild_crate_root(
+    manifest_path: &Path,
+    target_subdir: &str,
+) -> Result<PathBuf, Box<dyn Error>> {
+    let metadata = cargo_metadata::MetadataCommand::new()
+        .manifest_path(manifest_path)
+        .no_deps()
+        .exec()?;
+    Ok(metadata
+        .target_directory
+        .into_std_path_buf()
+        .join("tests/trybuild")
+        .join(target_subdir))
+}

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -47,6 +47,45 @@ parent-directory components such as `missing/../dst` must therefore preserve
 their logical meaning, so a destination that resolves back to the source tree
 is rejected even when part of the destination path is not yet present.
 
+## Macro expansion snapshot helpers (`macrotest_support`)
+
+The `rstest-bdd-harness` crate exposes a `#[doc(hidden)]` module
+`macrotest_support` that provides shared helpers for the `macro_compile`
+integration suites in the Tokio and GPUI harness crates. Both suites run
+`macrotest` against committed `.expanded.rs` snapshots and need a common way
+to gate snapshot refresh, perform substring assertions over snapshot contents,
+and resolve per-crate trybuild scratch directories. The module is not part
+of the supported public surface of `rstest-bdd-harness`.
+
+### Snapshot refresh gating
+
+`snapshot_refresh_is_enabled()` returns `true` only when the
+`RSTEST_BDD_RUN_MACROTEST` environment variable is set and the
+`cargo expand` subcommand is available on `PATH`. It gates
+`macrotest::expand_without_refresh` calls so snapshot comparisons are
+skipped in ordinary CI and local development, and only exercised during
+deliberate snapshot-refresh workflows.
+
+### Snapshot substring assertions
+
+- `assert_snapshot_contains(path, needles)` — asserts that each needle
+  substring appears at least once in the snapshot file at `path`. Panics on
+  I/O failure or when any needle is absent from the snapshot contents.
+- `assert_snapshot_omits(path, needle)` — asserts that `needle` does not
+  appear anywhere in the snapshot file at `path`. Panics on I/O failure or
+  when the needle is found in the snapshot contents.
+
+Both functions read the full snapshot into memory and use substring matching,
+so they are intended for small, human-readable `.expanded.rs` snapshots.
+
+### Trybuild crate root resolution
+
+`trybuild_crate_root(manifest_path, target_subdir)` resolves the per-crate
+trybuild scratch directory by querying `cargo metadata` for the workspace
+`target` directory and appending `tests/trybuild/<target_subdir>`. It returns
+`Result<PathBuf, Box<dyn Error>>` and is consumed by `stage_trybuild_support_files`
+in each harness crate's `macro_compile.rs` test.
+
 ## nextest on Windows: trybuild deadlock
 
 nextest wraps test binaries in Windows Job Objects. Child `cargo` processes

--- a/docs/execplans/9-7-4-update-guides-design-docs-and-examples.md
+++ b/docs/execplans/9-7-4-update-guides-design-docs-and-examples.md
@@ -211,6 +211,13 @@ repository gates.
       `4539cd8`.
 - [x] (2026-05-26T00:00:00+02:00) Pushed the completed implementation to
       `origin/9-7-4-update-guides-design-docs-and-examples`.
+- [x] (2026-05-29T00:00:00Z) Added harness-led-default macro expansion
+      snapshots for `scenario_harness_tokio_default`,
+      `scenarios_harness_tokio_default`, `scenario_harness_gpui_default`, and
+      `scenarios_harness_gpui_default`. Each snapshot encodes the expected
+      `#[rstest::rstest]` plus `HarnessAdapter::run` pattern, and the
+      `macro_compile.rs` assertion suites cover all four. All repository gates
+      pass after the addition.
 
 ## Surprises & discoveries
 
@@ -318,6 +325,15 @@ repository gates.
   default, and focused example tests prove that the delivered harness-led
   defaults cover these examples. Date/Author: 2026-05-26T00:00:00+02:00 /
   Codex.
+- Decision: Author the four harness-led-default expansion snapshots in the
+  pruned style of the existing override-default and Tokio attributes snapshots,
+  rather than capturing the full macro expansion. Rationale: `cargo expand`
+  is not available in this sandbox, the existing snapshots follow the same
+  hand-curated convention, and the `*_snapshots_encode_attribute_boundaries`
+  tests assert against discriminating substrings rather than literal token
+  equality. The opt-in `macrotest::expand_without_refresh` runner can refresh
+  the snapshots when `RSTEST_BDD_RUN_MACROTEST=1` and `cargo-expand` is
+  installed. Date/Author: 2026-05-29T00:00:00Z / Codex.
 
 ## Outcomes & retrospective
 

--- a/docs/execplans/9-7-4-update-guides-design-docs-and-examples.md
+++ b/docs/execplans/9-7-4-update-guides-design-docs-and-examples.md
@@ -218,6 +218,13 @@ repository gates.
       `#[rstest::rstest]` plus `HarnessAdapter::run` pattern, and the
       `macro_compile.rs` assertion suites cover all four. All repository gates
       pass after the addition.
+- [x] (2026-05-29T00:00:00Z) Addressed reviewer follow-ups: extracted the
+      duplicated `macro_compile.rs` snapshot helpers into a shared
+      `rstest_bdd_harness::macrotest_support` hidden module, and added doc
+      comments to the existing `harness = TokioHarness` / `harness =
+      GpuiHarness` runtime integration tests in each crate's
+      `scenario_macros.rs` so their role as harness-led-default execution
+      coverage is unambiguous.
 
 ## Surprises & discoveries
 

--- a/docs/execplans/9-7-4-update-guides-design-docs-and-examples.md
+++ b/docs/execplans/9-7-4-update-guides-design-docs-and-examples.md
@@ -1,11 +1,10 @@
 # Update harness-led defaults documentation and examples
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+ `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 This plan covers roadmap item 9.7.4 only. It must be approved before
 implementation begins. While
@@ -16,13 +15,12 @@ authorizes it.
 ## Purpose / big picture
 
 Roadmap item 9.7.4 updates the user-facing documentation and first-party
-example prose after roadmap items 9.7.1, 9.7.2, and 9.7.3 delivered
-harness-led attribute-policy defaults. The user-visible behaviour is that
-first-party Tokio and Graphical Processing User Interface (GPUI) integrations
-can be configured with `harness = ...` alone. When the harness path is one of
-the recognized first-party paths, the macro infers the matching first-party
-attribute policy unless the caller supplies an explicit `attributes = ...`
-override.
+example prose after roadmap items 9.7.1, 9.7.2, and 9.7.3 delivered harness-led
+attribute-policy defaults. The user-visible behaviour is that first-party Tokio
+and Graphical Processing User Interface (GPUI) integrations can be configured
+with `harness = ...` alone. When the harness path is one of the recognized
+first-party paths, the macro infers the matching first-party attribute policy
+unless the caller supplies an explicit `attributes = ...` override.
 
 After this work is implemented, a reader can start in `docs/users-guide.md`,
 `docs/rstest-bdd-design.md`, `docs/v0-6-0-migration-guide.md`, or the
@@ -42,7 +40,8 @@ repository gates.
 
 ## Constraints
 
-- Do not implement this plan until the maintainer explicitly approves it.
+- The maintainer approved implementation on 2026-05-26 by asking Codex to
+  proceed with the planned functionality.
 - Treat implementation as contingent while ADR-008 remains `Proposed`, unless
   the maintainer explicitly authorizes contingent implementation.
 - Keep scope to roadmap item 9.7.4. Do not redesign the harness adapter layer,
@@ -55,10 +54,9 @@ repository gates.
   4. existing runtime-mode or synchronous fallback
 - Preserve support for `attributes`-only configuration.
 - Preserve the third-party caveat: arbitrary user-defined
-  `AttributePolicy::test_attributes()` implementations are not evaluated
-  during procedural macro expansion, so unknown third-party harnesses must
-  document explicit `attributes = ...` use where custom test attributes are
-  required.
+  `AttributePolicy::test_attributes()` implementations are not evaluated during
+  procedural macro expansion, so unknown third-party harnesses must document
+  explicit `attributes = ...` use where custom test attributes are required.
 - Preserve ADR-005 crate boundaries. Tokio and GPUI dependencies must remain
   in opt-in adapter crates, not in `rstest-bdd`, `rstest-bdd-macros`, or
   `rstest-bdd-harness`.
@@ -76,8 +74,7 @@ repository gates.
   sequentially before each CodeRabbit review and before committing the
   completed implementation.
 - Use `coderabbit review --agent` after each major implementation milestone.
-  CodeRabbit concerns must be addressed or explicitly recorded before moving
-  on.
+  CodeRabbit concerns must be addressed or explicitly recorded before moving on.
 - Commit focused changes after their gates pass. Use the commit-message skill
   and `git commit -F`, not `git commit -m`.
 - Do not mark roadmap item 9.7.4 done until the documentation/example update
@@ -92,8 +89,8 @@ repository gates.
 ## Tolerances (exception triggers)
 
 - Scope: if implementation requires more than 10 files changed or more than
-  700 net lines, stop and confirm whether the work has expanded beyond
-  roadmap item 9.7.4.
+  700 net lines, stop and confirm whether the work has expanded beyond roadmap
+  item 9.7.4.
 - Code scope: if any Rust source change is needed beyond removing redundant
   first-party `attributes = ...` arguments from example tests, stop and update
   this plan before proceeding.
@@ -112,16 +109,16 @@ repository gates.
   design decision rather than a mechanical documentation fix, record it in
   `Decision Log` and ask for direction.
 - Ambiguity: if `docs/users-guide.md`, `docs/rstest-bdd-design.md`,
-  `docs/v0-6-0-migration-guide.md`, ADR-008, and the implementation disagree
-  on first-party inference or third-party caveats, stop and present the
+  `docs/v0-6-0-migration-guide.md`, ADR-008, and the implementation disagree on
+  first-party inference or third-party caveats, stop and present the
   interpretations.
 
 ## Risks
 
 - Risk: documentation could overstate ADR-008 while the ADR remains
   `Proposed`. Severity: high. Likelihood: medium. Mitigation: keep the plan
-  contingent until approval and, during implementation, either wait for
-  ADR-008 acceptance or record explicit maintainer authorization.
+  contingent until approval and, during implementation, either wait for ADR-008
+  acceptance or record explicit maintainer authorization.
 - Risk: examples could imply all harnesses infer attribute policies.
   Severity: high. Likelihood: medium. Mitigation: keep first-party wording
   narrow and repeat that third-party harnesses need explicit policy guidance
@@ -142,8 +139,8 @@ repository gates.
   gates before review.
 - Risk: CodeRabbit review can take 7 to 30 or more minutes according to the
   current CodeRabbit CLI documentation. Severity: low. Likelihood: medium.
-  Mitigation: run reviews as explicit milestones and wait for completion
-  rather than treating a long-running review as a failure.
+  Mitigation: run reviews as explicit milestones and wait for completion rather
+  than treating a long-running review as a failure.
 - Risk: property tests, Kani, or Verus could be requested by the generic task
   template but are not justified by a prose-only update. Severity: low.
   Likelihood: low. Mitigation: record that no new invariant, state machine, or
@@ -188,112 +185,161 @@ repository gates.
 - [x] (2026-05-24T16:36:48Z) Committed the draft ExecPlan for review.
 - [x] (2026-05-24T16:36:48Z) Pushed the branch and opened draft pull request
       <https://github.com/leynos/rstest-bdd/pull/497> for plan review.
-- [ ] Await explicit maintainer approval before implementation begins.
+- [x] (2026-05-26T00:00:00+02:00) Received explicit maintainer approval to
+      proceed with implementation from this ExecPlan.
+- [x] (2026-05-26T00:00:00+02:00) Re-read the plan, current branch state, and
+      audited documentation/example occurrences of harness and attribute
+      policy guidance.
+- [x] (2026-05-26T00:00:00+02:00) Updated first-party Tokio and GPUI examples
+      to demonstrate harness-only defaults.
+- [x] (2026-05-26T00:00:00+02:00) Updated the user guide, migration guide, and
+      design document to lead with harness-only first-party configuration.
+- [x] (2026-05-26T00:00:00+02:00) Ran focused example tests for
+      `tokio-reminders` and `gpui-counter`; both passed.
+- [x] (2026-05-26T00:00:00+02:00) Ran `make markdownlint`; it now passes.
+- [x] (2026-05-26T00:00:00+02:00) Validated with `make nixie`,
+      `make check-fmt`, `make lint`, `make typecheck`, and `make test`.
+- [x] (2026-05-26T00:00:00+02:00) Ran `coderabbit review --agent` after the
+      documentation/example milestone; it reported zero findings.
+- [x] (2026-05-26T00:00:00+02:00) Marked roadmap item 9.7.4 done after
+      validation and CodeRabbit review.
+- [x] (2026-05-26T00:00:00+02:00) Re-ran final gates after the roadmap and
+      ExecPlan status updates.
+- [x] (2026-05-26T00:00:00+02:00) Ran final `coderabbit review --agent`; it
+      reported zero findings.
+- [x] (2026-05-26T00:00:00+02:00) Committed the completed implementation as
+      `4539cd8`.
+- [ ] Push the completed implementation.
 
 ## Surprises & discoveries
 
 - Observation: roadmap items 9.7.1, 9.7.2, and 9.7.3 are already marked
-  delivered while ADR-008 remains `Proposed`.
-  Evidence: `docs/roadmap.md` records the items as delivered under maintainer
-  authorization; `docs/adr-008-harness-led-attribute-policy-defaults.md` still
-  says `Status: Proposed`.
-  Impact: this plan keeps implementation contingent and avoids marking 9.7.4
-  done during plan drafting.
+  delivered while ADR-008 remains `Proposed`. Evidence: `docs/roadmap.md`
+  records the items as delivered under maintainer authorization;
+  `docs/adr-008-harness-led-attribute-policy-defaults.md` still says
+  `Status: Proposed`. Impact: this plan keeps implementation contingent and
+  avoids marking 9.7.4 done during plan drafting.
 - Observation: `docs/users-guide.md` already recommends harness-led defaults
   in one section but still carries forward-looking 9.7.4 notes and several
   paired or override examples that can be mistaken for canonical first-party
-  usage.
-  Evidence: the guide contains a note that 9.7.4 will revise examples, plus
-  repeated `GpuiHarness` examples paired with
-  `DefaultAttributePolicy`.
+  usage. Evidence: the guide contains a note that 9.7.4 will revise examples,
+  plus repeated `GpuiHarness` examples paired with `DefaultAttributePolicy`.
   Impact: implementation should audit the whole guide rather than only editing
   the first matching snippet.
 - Observation: the first-party example READMEs currently describe binding
-  scenarios with both `harness = ...` and `attributes = ...`.
-  Evidence: `examples/tokio-reminders/README.md` and
-  `examples/gpui-counter/README.md` both teach paired arguments.
-  Impact: first-party example prose is definitely in scope, and example test
-  source may also need to drop redundant `attributes = ...` arguments so the
-  prose and working examples match.
+  scenarios with both `harness = ...` and `attributes = ...`. Evidence:
+  `examples/tokio-reminders/README.md` and `examples/gpui-counter/README.md`
+  both teach paired arguments. Impact: first-party example prose is definitely
+  in scope, and example test source may also need to drop redundant
+  `attributes = ...` arguments so the prose and working examples match.
 - Observation: Firecrawl found the current CodeRabbit CLI documentation
-  describes `--agent` as structured JSON output for agent integrations and
-  says reviews can take 7 to 30 or more minutes depending on scope.
-  Evidence: Firecrawl search result for <https://docs.coderabbit.ai/cli>.
-  Impact: the plan treats CodeRabbit review as a long-running milestone that
-  must complete before moving on.
+  describes `--agent` as structured JSON output for agent integrations and says
+  reviews can take 7 to 30 or more minutes depending on scope. Evidence:
+  Firecrawl search result for <https://docs.coderabbit.ai/cli>. Impact: the
+  plan treats CodeRabbit review as a long-running milestone that must complete
+  before moving on.
 - Observation: the full `make markdownlint` gate currently fails before this
-  task changes any implementation docs.
-  Evidence: `/tmp/markdownlint-9-7-4-update-guides-design-docs-and-examples.out`
-  reports 93 errors in `docs/users-guide.md`; the focused lint command for
-  this ExecPlan reports zero errors.
-  Impact: this planning branch records the blocker honestly and does not
-  attempt the unapproved user-guide cleanup as part of the pre-implementation
-  plan.
+  task changes any implementation docs. Evidence:
+  `/tmp/markdownlint-9-7-4-update-guides-design-docs-and-examples.out` reports
+  93 errors in `docs/users-guide.md`; the focused lint command for this
+  ExecPlan reports zero errors. Impact: this planning branch records the
+  blocker honestly and does not attempt the unapproved user-guide cleanup as
+  part of the pre-implementation plan.
 - Observation: Cargo metadata initially failed because both first-party
-  harness manifests declared duplicate `macro_compile` test targets.
-  Evidence: `make check-fmt` failed first on
-  `crates/rstest-bdd-harness-gpui/Cargo.toml`, then on
-  `crates/rstest-bdd-harness-tokio/Cargo.toml`, with "found duplicate test
-  name macro_compile".
-  Impact: the plan branch includes a separate gate-unblocking manifest cleanup
-  so `make check-fmt`, `make lint`, `make typecheck`, and `make test` can run.
+  harness manifests declared duplicate `macro_compile` test targets. Evidence:
+  `make check-fmt` failed first on `crates/rstest-bdd-harness-gpui/Cargo.toml`,
+  then on `crates/rstest-bdd-harness-tokio/Cargo.toml`, with "found duplicate
+  test name macro_compile". Impact: the plan branch includes a separate
+  gate-unblocking manifest cleanup so `make check-fmt`, `make lint`,
+  `make typecheck`, and `make test` can run.
+- Observation: implementation approval arrived while ADR-008 still says
+  `Status: Proposed`. Evidence: the maintainer asked Codex on 2026-05-26 to
+  proceed with this ExecPlan;
+  `docs/adr-008-harness-led-attribute-policy-defaults.md` still has proposed
+  status. Impact: proceed under explicit maintainer authorization and record
+  that the canonical documentation change is still tied to ADR-008's staged
+  rollout.
+- Observation: `docs/users-guide.md` contains duplicated GPUI override snippets
+  inside the Tokio harness section and a forward-looking 9.7.4 note. Evidence:
+  the audit found repeated `my_gpui_scenario_with_explicit_override` examples
+  around the harness overview, Tokio section, and GPUI section. Impact: clean
+  up the duplicated snippets as part of the user-guide update so the guide
+  presents one normal first-party path and one explicit override pattern.
+- Observation: `make fmt` ran Rust formatting and Markdown fixers, but the
+  Markdown linting phase initially failed on repository-wide line-length
+  reports after the fixers completed. Evidence:
+  `/tmp/fmt-9-7-4-update-guides-design-docs-and-examples.out` contains the
+  failed `markdownlint --fix` output; unrelated formatter churn was restored
+  before continuing. Impact: keep only task-owned files in the worktree and use
+  `make markdownlint` plus the Rust formatting check as the authoritative
+  gates for the final branch state.
 
 ## Decision log
 
 - Decision: Keep this branch as a pre-implementation planning branch and do
-  not mark roadmap item 9.7.4 done.
-  Rationale: the user explicitly requested an ExecPlan and stated that the
-  plan must be approved before implementation.
+  not mark roadmap item 9.7.4 done. Rationale: the user explicitly requested an
+  ExecPlan and stated that the plan must be approved before implementation.
   Date/Author: 2026-05-24T16:36:48Z / Codex.
 - Decision: Treat example test-source edits as allowed only when needed to
-  keep first-party examples truthful and compiling.
-  Rationale: roadmap item 9.7.4 says examples should no longer require both
-  parameters by default. In this repository, the first-party examples include
-  both prose and Rust test files, so the implementation may need a small source
-  edit to make the examples lead with harness-only defaults.
-  Date/Author: 2026-05-24T16:36:48Z / Codex.
+  keep first-party examples truthful and compiling. Rationale: roadmap item
+  9.7.4 says examples should no longer require both parameters by default. In
+  this repository, the first-party examples include both prose and Rust test
+  files, so the implementation may need a small source edit to make the
+  examples lead with harness-only defaults. Date/Author: 2026-05-24T16:36:48Z /
+  Codex.
 - Decision: Do not plan property tests, Kani, or Verus for the default
-  implementation path.
-  Rationale: the requested work updates documentation and examples for already
-  delivered behaviour. It introduces no new resolver invariant, state
-  transition, unsafe code, or contractual business rule requiring proof.
-  Date/Author: 2026-05-24T16:36:48Z / Codex.
+  implementation path. Rationale: the requested work updates documentation and
+  examples for already delivered behaviour. It introduces no new resolver
+  invariant, state transition, unsafe code, or contractual business rule
+  requiring proof. Date/Author: 2026-05-24T16:36:48Z / Codex.
 - Decision: Use the exact pull request title task marker requested by the
   user, `(7.7.4)`, for the draft plan pull request even though the roadmap item
-  is 9.7.4.
-  Rationale: the pull request instruction is explicit and separate from the
-  roadmap numbering in the plan body.
-  Date/Author: 2026-05-24T16:36:48Z / Codex.
+  is 9.7.4. Rationale: the pull request instruction is explicit and separate
+  from the roadmap numbering in the plan body. Date/Author:
+  2026-05-24T16:36:48Z / Codex.
 - Decision: Fix duplicate first-party harness `macro_compile` test target
-  declarations in this planning branch.
-  Rationale: the duplicates prevented Cargo metadata from loading, which made
-  the repository gates impossible to run. The fix is a minimal manifest
-  cleanup and does not implement roadmap item 9.7.4.
-  Date/Author: 2026-05-24T16:36:48Z / Codex.
+  declarations in this planning branch. Rationale: the duplicates prevented
+  Cargo metadata from loading, which made the repository gates impossible to
+  run. The fix is a minimal manifest cleanup and does not implement roadmap
+  item 9.7.4. Date/Author: 2026-05-24T16:36:48Z / Codex.
 - Decision: Do not fix `docs/users-guide.md` Markdown lint failures in this
-  pre-implementation planning branch.
-  Rationale: those failures are outside the new ExecPlan and overlap the
-  documentation implementation area that must wait for plan approval.
-  Date/Author: 2026-05-24T16:36:48Z / Codex.
+  pre-implementation planning branch. Rationale: those failures are outside the
+  new ExecPlan and overlap the documentation implementation area that must wait
+  for plan approval. Date/Author: 2026-05-24T16:36:48Z / Codex.
+- Decision: Treat the user's 2026-05-26 "proceed with implementation" request
+  as the required approval gate for the plan and for contingent ADR-008
+  documentation work. Rationale: the request explicitly names this ExecPlan and
+  asks for implementation of the planned functionality. Date/Author:
+  2026-05-26T00:00:00+02:00 / Codex.
+- Decision: Remove redundant first-party `attributes = ...` arguments from the
+  Tokio reminders and GPUI counter scenario tests. Rationale: the roadmap item
+  requires first-party examples to no longer require both parameters by
+  default, and focused example tests prove that the delivered harness-led
+  defaults cover these examples. Date/Author: 2026-05-26T00:00:00+02:00 /
+  Codex.
 
 ## Outcomes & retrospective
 
-The pre-implementation draft now captures the approval gate, ADR-008
-contingency, documentation scope, example scope, validation strategy,
-CodeRabbit review loop, and pull request requirements. Implementation remains
-blocked until a maintainer explicitly approves this plan.
+The implementation aligns the user guide, design document, migration guide, and
+first-party example crates with harness-led defaults for recognized Tokio and
+GPUI harnesses. The examples now demonstrate `harness = ...` alone as the
+normal first-party path, while the guide and migration prose retain
+`attributes = ...` as an override, attributes-only, and third-party caveat
+surface. Focused Tokio and GPUI example tests passed, full deterministic gates
+passed twice, and both implementation CodeRabbit reviews reported zero
+findings. Roadmap item 9.7.4 is marked done.
 
 ## Context and orientation
 
 The harness adapter architecture comes from ADR-005 and is documented in
 `docs/adr-005-harness-adapter-crates-for-framework-specific-test-integration.md`.
-It keeps framework-specific runtime integration out of the core runtime and
-macro crates. The shared `rstest-bdd-harness` crate defines
-`HarnessAdapter`, `ScenarioRunRequest`, `ScenarioRunner`, `AttributePolicy`,
-and `DefaultAttributePolicy`.
+ It keeps framework-specific runtime integration out of the core runtime and
+macro crates. The shared `rstest-bdd-harness` crate defines `HarnessAdapter`,
+`ScenarioRunRequest`, `ScenarioRunner`, `AttributePolicy`, and
+`DefaultAttributePolicy`.
 
-ADR-008 proposes the harness-led default rule for first-party integrations.
-The rule keeps `HarnessAdapter` and `AttributePolicy` separate, but it makes
+ADR-008 proposes the harness-led default rule for first-party integrations. The
+rule keeps `HarnessAdapter` and `AttributePolicy` separate, but it makes
 `harness = ...` the lead user decision for known first-party harnesses. If the
 caller writes `harness = rstest_bdd_harness_tokio::TokioHarness` and omits
 `attributes = ...`, the macro infers the Tokio first-party attribute policy.
@@ -322,8 +368,7 @@ Important repository files:
   `examples/gpui-counter/README.md` are first-party example prose.
 - `examples/tokio-reminders/tests/reminders.rs` and
   `examples/gpui-counter/tests/counter.rs` are compiling first-party example
-  tests that may need to drop redundant explicit first-party attribute
-  policies.
+  tests that may need to drop redundant explicit first-party attribute policies.
 
 Relevant background documents to signpost during implementation:
 
@@ -340,39 +385,39 @@ Relevant background documents to signpost during implementation:
 ## Plan of work
 
 Stage A is the approval and readiness checkpoint. Confirm whether ADR-008 has
-been accepted. If it remains `Proposed`, record maintainer authorization
-before implementing documentation that presents harness-led defaults as
-canonical. Re-read `docs/roadmap.md` item 9.7.4, ADR-008, the 9.7.1 to 9.7.3
-execplans, and the current guide/design/migration/example surfaces. Do not
-edit files in this stage except for keeping this ExecPlan current.
+been accepted. If it remains `Proposed`, record maintainer authorization before
+implementing documentation that presents harness-led defaults as canonical.
+Re-read `docs/roadmap.md` item 9.7.4, ADR-008, the 9.7.1 to 9.7.3 execplans,
+and the current guide/design/migration/example surfaces. Do not edit files in
+this stage except for keeping this ExecPlan current.
 
 Stage B audits all documentation and example occurrences. Search for
 `harness =`, `attributes =`, `TokioHarness`, `TokioAttributePolicy`,
-`GpuiHarness`, `GpuiAttributePolicy`, `runtime = "tokio-current-thread"`,
-and `9.7.4` across `docs/`, `README.md`, `crates/*/README.md`, and
-`examples/`. Classify each occurrence as one of four cases: canonical
-first-party harness-only guidance, explicit override guidance,
-attributes-only guidance, or third-party caveat. The audit is complete when
-there are no unclassified paired first-party examples.
+`GpuiHarness`, `GpuiAttributePolicy`, `runtime = "tokio-current-thread"`, and
+`9.7.4` across `docs/`, `README.md`, `crates/*/README.md`, and `examples/`.
+Classify each occurrence as one of four cases: canonical first-party
+harness-only guidance, explicit override guidance, attributes-only guidance, or
+third-party caveat. The audit is complete when there are no unclassified paired
+first-party examples.
 
 Stage C updates the user guide and migration guide. In `docs/users-guide.md`,
-make harness-only first-party snippets the normal Tokio and GPUI examples,
-so the public guidance leads with the same default path. Remove stale
-forward-looking notes about 9.7.4, keep one explicit
-`attributes = ...` override example, and preserve the third-party limitation
-near custom harness guidance. In `docs/v0-6-0-migration-guide.md`, make the
-stage 9.7's impact explicit: first-party `StdHarness`, `TokioHarness`, and
-`GpuiHarness` infer matching defaults when named by recognized paths; explicit
-`attributes = ...` remains the override; renamed, aliased, re-exported, or
-third-party paths still need caveat-aware guidance.
+make harness-only first-party snippets the normal Tokio and GPUI examples, so
+the public guidance leads with the same default path. Remove stale
+forward-looking notes about 9.7.4, keep one explicit `attributes = ...`
+override example, and preserve the third-party limitation near custom harness
+guidance. In `docs/v0-6-0-migration-guide.md`, make the stage 9.7's impact
+explicit: first-party `StdHarness`, `TokioHarness`, and `GpuiHarness` infer
+matching defaults when named by recognized paths; explicit `attributes = ...`
+remains the override; renamed, aliased, re-exported, or third-party paths still
+need caveat-aware guidance.
 
 Stage D updates the design document. In `docs/rstest-bdd-design.md`, align the
 architecture summary and first-party plugin target sections with harness-led
 defaults as the recommended first-party user path. Keep internal details about
 path-based recognition, `TestAttrPolicy`, `resolve_attribute_policy`, and the
-ADR-008 precedence order. If the implementation work requires a substantive
-new design decision, update ADR-008 or create a new ADR before changing the
-design document; otherwise, cite ADR-008 as the governing decision.
+ADR-008 precedence order. If the implementation work requires a substantive new
+design decision, update ADR-008 or create a new ADR before changing the design
+document; otherwise, cite ADR-008 as the governing decision.
 
 Stage E updates first-party examples. In `examples/tokio-reminders/README.md`
 and `examples/gpui-counter/README.md`, replace prose that says examples bind
@@ -525,16 +570,16 @@ Wyvern reconnaissance identified these high-signal planning facts:
 - 9.7.1, 9.7.2, and 9.7.3 are already delivered, so implementation should not
   change resolver behaviour unless documentation exposes a real mismatch.
 - `docs/users-guide.md`, `docs/rstest-bdd-design.md`,
-  `docs/v0-6-0-migration-guide.md`, `examples/tokio-reminders/README.md`,
-  and `examples/gpui-counter/README.md` are the main documentation surfaces.
+  `docs/v0-6-0-migration-guide.md`, `examples/tokio-reminders/README.md`, and
+  `examples/gpui-counter/README.md` are the main documentation surfaces.
 - Example Rust files may need a narrow edit because they still pair first-party
   harnesses with explicit first-party attribute policies.
 
 Firecrawl resolved external tooling assumptions:
 
 - CodeRabbit CLI documentation at <https://docs.coderabbit.ai/cli> describes
-  `--agent` as structured output for agent integrations and recommends
-  letting reviews run in the background when they take several minutes.
+  `--agent` as structured output for agent integrations and recommends letting
+  reviews run in the background when they take several minutes.
 - CodeRabbit's Markdown tooling page identifies `markdownlint-cli2` as the
   Markdown linter, matching the repository `Makefile` target.
 

--- a/docs/execplans/9-7-4-update-guides-design-docs-and-examples.md
+++ b/docs/execplans/9-7-4-update-guides-design-docs-and-examples.md
@@ -449,7 +449,7 @@ the requested title marker `(7.7.4)`, and include the Lody session link in a
 Run commands from the repository root:
 
 ```bash
-cd /home/leynos/.lody/repos/github---leynos---rstest-bdd/worktrees/cf6a7d98-d416-4269-a866-1b7f701d1f2d
+cd "$(git rev-parse --show-toplevel)"
 ```
 
 During implementation, begin with status and audit commands:

--- a/docs/execplans/9-7-4-update-guides-design-docs-and-examples.md
+++ b/docs/execplans/9-7-4-update-guides-design-docs-and-examples.md
@@ -1,0 +1,586 @@
+# Update harness-led defaults documentation and examples
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+This plan covers roadmap item 9.7.4 only. It must be approved before
+implementation begins. While
+`docs/adr-008-harness-led-attribute-policy-defaults.md` remains in `Proposed`
+status, implementation remains contingent unless a maintainer explicitly
+authorizes it.
+
+## Purpose / big picture
+
+Roadmap item 9.7.4 updates the user-facing documentation and first-party
+example prose after roadmap items 9.7.1, 9.7.2, and 9.7.3 delivered
+harness-led attribute-policy defaults. The user-visible behaviour is that
+first-party Tokio and Graphical Processing User Interface (GPUI) integrations
+can be configured with `harness = ...` alone. When the harness path is one of
+the recognized first-party paths, the macro infers the matching first-party
+attribute policy unless the caller supplies an explicit `attributes = ...`
+override.
+
+After this work is implemented, a reader can start in `docs/users-guide.md`,
+`docs/rstest-bdd-design.md`, `docs/v0-6-0-migration-guide.md`, or the
+first-party example crates and see the same recommendation: use harness-only
+configuration for first-party Tokio and GPUI scenarios by default; use
+`attributes = ...` only for explicit overrides, attributes-only use, or
+third-party caveats. The finish line is observable when the examples no longer
+teach paired `harness = ...` and `attributes = ...` arguments as the normal
+first-party path, the third-party limitation remains explicit, and the
+repository quality gates pass.
+
+This task is documentation-led, but it may touch example test source if prose
+and snippets would otherwise disagree with compiling first-party examples. If
+example source changes are necessary, they must be treated as implementation
+changes and validated with the affected example tests as well as the full
+repository gates.
+
+## Constraints
+
+- Do not implement this plan until the maintainer explicitly approves it.
+- Treat implementation as contingent while ADR-008 remains `Proposed`, unless
+  the maintainer explicitly authorizes contingent implementation.
+- Keep scope to roadmap item 9.7.4. Do not redesign the harness adapter layer,
+  attribute policy resolver, macro argument syntax, or first-party adapter
+  crates.
+- Preserve the ADR-008 precedence order:
+  1. explicit `attributes = ...`
+  2. known first-party `harness = ...` mapping
+  3. deprecated `runtime = "tokio-current-thread"` compatibility alias
+  4. existing runtime-mode or synchronous fallback
+- Preserve support for `attributes`-only configuration.
+- Preserve the third-party caveat: arbitrary user-defined
+  `AttributePolicy::test_attributes()` implementations are not evaluated
+  during procedural macro expansion, so unknown third-party harnesses must
+  document explicit `attributes = ...` use where custom test attributes are
+  required.
+- Preserve ADR-005 crate boundaries. Tokio and GPUI dependencies must remain
+  in opt-in adapter crates, not in `rstest-bdd`, `rstest-bdd-macros`, or
+  `rstest-bdd-harness`.
+- Update `docs/v0-6-0-migration-guide.md` for every stage 9.7 change that
+  affects library consumers, usage, or newly available functionality.
+- Keep documentation in en-GB Oxford spelling and follow
+  `docs/documentation-style-guide.md`.
+- Use `make fmt` after documentation changes unless it would touch unrelated
+  files. If unrelated formatter churn appears, stop, record the finding in
+  `Decision Log`, and validate changed Markdown with focused linting before
+  continuing.
+- Validate Markdown with `make markdownlint`; validate diagrams with
+  `make nixie` if any Mermaid diagram is changed.
+- Run `make check-fmt`, `make lint`, `make typecheck`, and `make test`
+  sequentially before each CodeRabbit review and before committing the
+  completed implementation.
+- Use `coderabbit review --agent` after each major implementation milestone.
+  CodeRabbit concerns must be addressed or explicitly recorded before moving
+  on.
+- Commit focused changes after their gates pass. Use the commit-message skill
+  and `git commit -F`, not `git commit -m`.
+- Do not mark roadmap item 9.7.4 done until the documentation/example update
+  has been implemented, validated, reviewed, and committed. This draft plan
+  does not authorize that roadmap status change.
+- Use relevant skills during implementation: `execplans` for this living plan,
+  `leta` for code navigation, `rust-router` plus `arch-crate-design` for crate
+  boundary checks, `en-gb-oxendict-style` for prose, `firecrawl-mcp` for
+  external tooling checks, `commit-message` for commits, and `pr-creation` for
+  pull request metadata.
+
+## Tolerances (exception triggers)
+
+- Scope: if implementation requires more than 10 files changed or more than
+  700 net lines, stop and confirm whether the work has expanded beyond
+  roadmap item 9.7.4.
+- Code scope: if any Rust source change is needed beyond removing redundant
+  first-party `attributes = ...` arguments from example tests, stop and update
+  this plan before proceeding.
+- Interface: if any public trait, macro argument, crate feature, or documented
+  public API signature must change, stop and escalate.
+- Dependencies: if a new external dependency is required, stop and escalate.
+- Governance: if ADR-008 is still `Proposed` at implementation time, stop
+  before changing canonical guidance unless maintainer authorization is
+  recorded in `Decision Log`.
+- Validation: if `make check-fmt`, `make lint`, `make typecheck`, or
+  `make test` fails for an unrelated reason, capture the log path and stop
+  before marking roadmap 9.7.4 done.
+- Iterations: if the same gate fails three consecutive fix attempts, stop and
+  escalate with the log path, current hypothesis, and options.
+- CodeRabbit: if `coderabbit review --agent` reports a concern requiring a
+  design decision rather than a mechanical documentation fix, record it in
+  `Decision Log` and ask for direction.
+- Ambiguity: if `docs/users-guide.md`, `docs/rstest-bdd-design.md`,
+  `docs/v0-6-0-migration-guide.md`, ADR-008, and the implementation disagree
+  on first-party inference or third-party caveats, stop and present the
+  interpretations.
+
+## Risks
+
+- Risk: documentation could overstate ADR-008 while the ADR remains
+  `Proposed`. Severity: high. Likelihood: medium. Mitigation: keep the plan
+  contingent until approval and, during implementation, either wait for
+  ADR-008 acceptance or record explicit maintainer authorization.
+- Risk: examples could imply all harnesses infer attribute policies.
+  Severity: high. Likelihood: medium. Mitigation: keep first-party wording
+  narrow and repeat that third-party harnesses need explicit policy guidance
+  when custom attributes are required.
+- Risk: removing `attributes = ...` from example source could hide explicit
+  override coverage. Severity: medium. Likelihood: medium. Mitigation: keep at
+  least one clear override example in the user guide and rely on existing
+  roadmap 9.7.3 tests for explicit override behaviour.
+- Risk: `docs/users-guide.md` already contains duplicated or misplaced harness
+  snippets, so a narrow edit could leave contradictory examples behind.
+  Severity: medium. Likelihood: high. Mitigation: audit all `harness =`,
+  `attributes =`, `TokioHarness`, and `GpuiHarness` occurrences in the guide,
+  design document, migration guide, first-party example READMEs, and example
+  tests.
+- Risk: documentation-only changes may still break Markdown formatting or
+  Mermaid validation. Severity: low. Likelihood: medium. Mitigation: run
+  `make markdownlint`, `make nixie` when diagrams change, and full repository
+  gates before review.
+- Risk: CodeRabbit review can take 7 to 30 or more minutes according to the
+  current CodeRabbit CLI documentation. Severity: low. Likelihood: medium.
+  Mitigation: run reviews as explicit milestones and wait for completion
+  rather than treating a long-running review as a failure.
+- Risk: property tests, Kani, or Verus could be requested by the generic task
+  template but are not justified by a prose-only update. Severity: low.
+  Likelihood: low. Mitigation: record that no new invariant, state machine, or
+  proof obligation is introduced unless implementation unexpectedly changes
+  resolver code.
+
+## Progress
+
+- [x] (2026-05-24T16:36:48Z) Loaded `leta`, `rust-router`, `execplans`,
+      `firecrawl-mcp`, `commit-message`, and `pr-creation` guidance.
+- [x] (2026-05-24T16:36:48Z) Created a Leta workspace for this checkout with
+      `leta workspace add`.
+- [x] (2026-05-24T16:36:48Z) Confirmed the starting branch was not `main` and
+      renamed it to `9-7-4-update-guides-design-docs-and-examples`.
+- [x] (2026-05-24T16:36:48Z) Created context pack `pk_c63lbw6a` for the
+      Wyvern-assisted planning activity.
+- [x] (2026-05-24T16:36:48Z) Used a Wyvern agent team for read-only planning
+      reconnaissance over the roadmap, ADR-008, user guide, design document,
+      migration guide, and first-party examples.
+- [x] (2026-05-24T16:36:48Z) Used Firecrawl to verify external tooling
+      assumptions for CodeRabbit CLI `--agent` mode and Markdown linting.
+- [x] (2026-05-24T16:36:48Z) Drafted this pre-implementation ExecPlan.
+- [x] (2026-05-24T16:36:48Z) Validated this ExecPlan directly with
+      `markdownlint-cli2 docs/execplans/9-7-4-update-guides-design-docs-and-examples.md`.
+- [x] (2026-05-24T16:36:48Z) Ran `make markdownlint`; it failed on
+      pre-existing `docs/users-guide.md` lint errors not introduced by this
+      plan.
+- [x] (2026-05-24T16:36:48Z) Removed duplicate `macro_compile` test target
+      entries from the Tokio and GPUI harness manifests, so Cargo metadata can
+      load.
+- [x] (2026-05-24T16:36:48Z) Validated the draft-plan branch with
+      `make check-fmt`, `make lint`, `make typecheck`, and `make test`.
+- [x] (2026-05-24T16:36:48Z) Ran `coderabbit review --agent`; it reported
+      five trivial prose findings in this ExecPlan.
+- [x] (2026-05-24T16:36:48Z) Addressed CodeRabbit's prose findings, reran
+      `make check-fmt`, `make lint`, `make typecheck`, and `make test`, and
+      reran `coderabbit review --agent`.
+- [x] (2026-05-24T16:36:48Z) Confirmed the follow-up CodeRabbit review
+      completed with zero findings.
+- [x] (2026-05-24T16:36:48Z) Committed the duplicate `macro_compile` manifest
+      cleanup as `5de9886`.
+- [x] (2026-05-24T16:36:48Z) Committed the draft ExecPlan for review.
+- [ ] Push the branch and open a draft pull request for plan review.
+- [ ] Await explicit maintainer approval before implementation begins.
+
+## Surprises & discoveries
+
+- Observation: roadmap items 9.7.1, 9.7.2, and 9.7.3 are already marked
+  delivered while ADR-008 remains `Proposed`.
+  Evidence: `docs/roadmap.md` records the items as delivered under maintainer
+  authorization; `docs/adr-008-harness-led-attribute-policy-defaults.md` still
+  says `Status: Proposed`.
+  Impact: this plan keeps implementation contingent and avoids marking 9.7.4
+  done during plan drafting.
+- Observation: `docs/users-guide.md` already recommends harness-led defaults
+  in one section but still carries forward-looking 9.7.4 notes and several
+  paired or override examples that can be mistaken for canonical first-party
+  usage.
+  Evidence: the guide contains a note that 9.7.4 will revise examples, plus
+  repeated `GpuiHarness` examples paired with
+  `DefaultAttributePolicy`.
+  Impact: implementation should audit the whole guide rather than only editing
+  the first matching snippet.
+- Observation: the first-party example READMEs currently describe binding
+  scenarios with both `harness = ...` and `attributes = ...`.
+  Evidence: `examples/tokio-reminders/README.md` and
+  `examples/gpui-counter/README.md` both teach paired arguments.
+  Impact: first-party example prose is definitely in scope, and example test
+  source may also need to drop redundant `attributes = ...` arguments so the
+  prose and working examples match.
+- Observation: Firecrawl found the current CodeRabbit CLI documentation
+  describes `--agent` as structured JSON output for agent integrations and
+  says reviews can take 7 to 30 or more minutes depending on scope.
+  Evidence: Firecrawl search result for <https://docs.coderabbit.ai/cli>.
+  Impact: the plan treats CodeRabbit review as a long-running milestone that
+  must complete before moving on.
+- Observation: the full `make markdownlint` gate currently fails before this
+  task changes any implementation docs.
+  Evidence: `/tmp/markdownlint-9-7-4-update-guides-design-docs-and-examples.out`
+  reports 93 errors in `docs/users-guide.md`; the focused lint command for
+  this ExecPlan reports zero errors.
+  Impact: this planning branch records the blocker honestly and does not
+  attempt the unapproved user-guide cleanup as part of the pre-implementation
+  plan.
+- Observation: Cargo metadata initially failed because both first-party
+  harness manifests declared duplicate `macro_compile` test targets.
+  Evidence: `make check-fmt` failed first on
+  `crates/rstest-bdd-harness-gpui/Cargo.toml`, then on
+  `crates/rstest-bdd-harness-tokio/Cargo.toml`, with "found duplicate test
+  name macro_compile".
+  Impact: the plan branch includes a separate gate-unblocking manifest cleanup
+  so `make check-fmt`, `make lint`, `make typecheck`, and `make test` can run.
+
+## Decision log
+
+- Decision: Keep this branch as a pre-implementation planning branch and do
+  not mark roadmap item 9.7.4 done.
+  Rationale: the user explicitly requested an ExecPlan and stated that the
+  plan must be approved before implementation.
+  Date/Author: 2026-05-24T16:36:48Z / Codex.
+- Decision: Treat example test-source edits as allowed only when needed to
+  keep first-party examples truthful and compiling.
+  Rationale: roadmap item 9.7.4 says examples should no longer require both
+  parameters by default. In this repository, the first-party examples include
+  both prose and Rust test files, so the implementation may need a small source
+  edit to make the examples lead with harness-only defaults.
+  Date/Author: 2026-05-24T16:36:48Z / Codex.
+- Decision: Do not plan property tests, Kani, or Verus for the default
+  implementation path.
+  Rationale: the requested work updates documentation and examples for already
+  delivered behaviour. It introduces no new resolver invariant, state
+  transition, unsafe code, or contractual business rule requiring proof.
+  Date/Author: 2026-05-24T16:36:48Z / Codex.
+- Decision: Use the exact pull request title task marker requested by the
+  user, `(7.7.4)`, for the draft plan pull request even though the roadmap item
+  is 9.7.4.
+  Rationale: the pull request instruction is explicit and separate from the
+  roadmap numbering in the plan body.
+  Date/Author: 2026-05-24T16:36:48Z / Codex.
+- Decision: Fix duplicate first-party harness `macro_compile` test target
+  declarations in this planning branch.
+  Rationale: the duplicates prevented Cargo metadata from loading, which made
+  the repository gates impossible to run. The fix is a minimal manifest
+  cleanup and does not implement roadmap item 9.7.4.
+  Date/Author: 2026-05-24T16:36:48Z / Codex.
+- Decision: Do not fix `docs/users-guide.md` Markdown lint failures in this
+  pre-implementation planning branch.
+  Rationale: those failures are outside the new ExecPlan and overlap the
+  documentation implementation area that must wait for plan approval.
+  Date/Author: 2026-05-24T16:36:48Z / Codex.
+
+## Outcomes & retrospective
+
+The pre-implementation draft now captures the approval gate, ADR-008
+contingency, documentation scope, example scope, validation strategy,
+CodeRabbit review loop, and pull request requirements. Implementation remains
+blocked until a maintainer explicitly approves this plan.
+
+## Context and orientation
+
+The harness adapter architecture comes from ADR-005 and is documented in
+`docs/adr-005-harness-adapter-crates-for-framework-specific-test-integration.md`.
+It keeps framework-specific runtime integration out of the core runtime and
+macro crates. The shared `rstest-bdd-harness` crate defines
+`HarnessAdapter`, `ScenarioRunRequest`, `ScenarioRunner`, `AttributePolicy`,
+and `DefaultAttributePolicy`.
+
+ADR-008 proposes the harness-led default rule for first-party integrations.
+The rule keeps `HarnessAdapter` and `AttributePolicy` separate, but it makes
+`harness = ...` the lead user decision for known first-party harnesses. If the
+caller writes `harness = rstest_bdd_harness_tokio::TokioHarness` and omits
+`attributes = ...`, the macro infers the Tokio first-party attribute policy.
+The same model applies to `rstest_bdd_harness_gpui::GpuiHarness`. An explicit
+`attributes = ...` argument always overrides the inferred default.
+
+Roadmap items 9.7.1, 9.7.2, and 9.7.3 have already delivered resolver,
+code-generation, unit, trybuild, and behavioural coverage for the rule. This
+plan updates the documentation and first-party examples so the public guidance
+matches that delivered behaviour once ADR-008 is accepted or explicitly
+authorized for contingent documentation.
+
+Important repository files:
+
+- `docs/roadmap.md` contains item 9.7.4 and must be marked done only after
+  implementation, validation, and review complete.
+- `docs/adr-008-harness-led-attribute-policy-defaults.md` defines the
+  proposed precedence and caveats.
+- `docs/users-guide.md` is the main user-facing guide and currently contains
+  mixed harness-led and explicit-pair examples.
+- `docs/rstest-bdd-design.md` records the architecture, code-generation
+  model, and first-party plugin targets.
+- `docs/v0-6-0-migration-guide.md` is the upgrade guide for consumer-visible
+  stage-9.7 behaviour.
+- `examples/tokio-reminders/README.md` and
+  `examples/gpui-counter/README.md` are first-party example prose.
+- `examples/tokio-reminders/tests/reminders.rs` and
+  `examples/gpui-counter/tests/counter.rs` are compiling first-party example
+  tests that may need to drop redundant explicit first-party attribute
+  policies.
+
+Relevant background documents to signpost during implementation:
+
+- `docs/rstest-bdd-language-server-design.md` for language-server scope
+  boundaries.
+- `docs/rust-testing-with-rstest-fixtures.md` for fixture guidance.
+- `docs/rust-doctest-dry-guide.md` for snippet maintenance discipline.
+- `docs/complexity-antipatterns-and-refactoring-strategies.md` for avoiding
+  broad rewrites.
+- `docs/gherkin-syntax.md` for Gherkin terminology.
+- `docs/documentation-style-guide.md` for Markdown, ADR, and en-GB Oxford
+  style.
+
+## Plan of work
+
+Stage A is the approval and readiness checkpoint. Confirm whether ADR-008 has
+been accepted. If it remains `Proposed`, record maintainer authorization
+before implementing documentation that presents harness-led defaults as
+canonical. Re-read `docs/roadmap.md` item 9.7.4, ADR-008, the 9.7.1 to 9.7.3
+execplans, and the current guide/design/migration/example surfaces. Do not
+edit files in this stage except for keeping this ExecPlan current.
+
+Stage B audits all documentation and example occurrences. Search for
+`harness =`, `attributes =`, `TokioHarness`, `TokioAttributePolicy`,
+`GpuiHarness`, `GpuiAttributePolicy`, `runtime = "tokio-current-thread"`,
+and `9.7.4` across `docs/`, `README.md`, `crates/*/README.md`, and
+`examples/`. Classify each occurrence as one of four cases: canonical
+first-party harness-only guidance, explicit override guidance,
+attributes-only guidance, or third-party caveat. The audit is complete when
+there are no unclassified paired first-party examples.
+
+Stage C updates the user guide and migration guide. In `docs/users-guide.md`,
+make harness-only first-party snippets the normal Tokio and GPUI examples,
+so the public guidance leads with the same default path. Remove stale
+forward-looking notes about 9.7.4, keep one explicit
+`attributes = ...` override example, and preserve the third-party limitation
+near custom harness guidance. In `docs/v0-6-0-migration-guide.md`, make the
+stage 9.7's impact explicit: first-party `StdHarness`, `TokioHarness`, and
+`GpuiHarness` infer matching defaults when named by recognized paths; explicit
+`attributes = ...` remains the override; renamed, aliased, re-exported, or
+third-party paths still need caveat-aware guidance.
+
+Stage D updates the design document. In `docs/rstest-bdd-design.md`, align the
+architecture summary and first-party plugin target sections with harness-led
+defaults as the recommended first-party user path. Keep internal details about
+path-based recognition, `TestAttrPolicy`, `resolve_attribute_policy`, and the
+ADR-008 precedence order. If the implementation work requires a substantive
+new design decision, update ADR-008 or create a new ADR before changing the
+design document; otherwise, cite ADR-008 as the governing decision.
+
+Stage E updates first-party examples. In `examples/tokio-reminders/README.md`
+and `examples/gpui-counter/README.md`, replace prose that says examples bind
+scenarios with both harness and attribute policy by default. If the Rust test
+files still show redundant `attributes = ...` on their primary first-party
+scenarios, remove those arguments so the example code demonstrates the
+harness-only default. Keep or add prose explaining that explicit
+`attributes = ...` remains available for overrides, not for the normal
+first-party path.
+
+Stage F performs validation and review. Run the focused example tests if any
+example source changed, then run the full repository gates sequentially with
+`tee` logs in `/tmp`. Run `coderabbit review --agent` after the documentation
+milestone and again after any CodeRabbit-driven fixes. When validation and
+review are clean, update this plan's `Progress`, `Surprises & discoveries`,
+`Decision log`, and `Outcomes & retrospective`, then mark roadmap item 9.7.4
+done in `docs/roadmap.md`.
+
+Stage G commits, pushes, and opens the implementation pull request. Use
+file-based commit messages. Push the branch to
+`origin/9-7-4-update-guides-design-docs-and-examples`. The pre-implementation
+plan pull request should be draft, mention this ExecPlan in the summary, use
+the requested title marker `(7.7.4)`, and include the Lody session link in a
+`## References` section.
+
+## Concrete steps
+
+Run commands from the repository root:
+
+```bash
+cd /home/leynos/.lody/repos/github---leynos---rstest-bdd/worktrees/cf6a7d98-d416-4269-a866-1b7f701d1f2d
+```
+
+During implementation, begin with status and audit commands:
+
+```bash
+git branch --show-current
+git status --short
+rg -n \
+  "harness =|attributes =|TokioHarness|TokioAttributePolicy|GpuiHarness" \
+  docs README.md crates examples -g '*.md' -g '*.rs'
+rg -n \
+  "GpuiAttributePolicy|runtime = \"tokio-current-thread\"|9\\.7\\.4" \
+  docs README.md crates examples -g '*.md' -g '*.rs'
+```
+
+Expected transcript shape:
+
+```plaintext
+9-7-4-update-guides-design-docs-and-examples
+```
+
+Use these focused tests if example source changes:
+
+```bash
+SLUG=9-7-4-update-guides-design-docs-and-examples
+set -o pipefail; cargo test -p tokio-reminders 2>&1 | tee /tmp/test-tokio-reminders-$SLUG.out
+set -o pipefail; cargo test -p gpui-counter 2>&1 | tee /tmp/test-gpui-counter-$SLUG.out
+```
+
+Run repository gates sequentially before each CodeRabbit review and final
+commit:
+
+```bash
+set -o pipefail; make markdownlint 2>&1 | tee /tmp/markdownlint-9-7-4-update-guides-design-docs-and-examples.out
+set -o pipefail; make nixie 2>&1 | tee /tmp/nixie-9-7-4-update-guides-design-docs-and-examples.out
+set -o pipefail; make check-fmt 2>&1 | tee /tmp/check-fmt-9-7-4-update-guides-design-docs-and-examples.out
+set -o pipefail; make lint 2>&1 | tee /tmp/lint-9-7-4-update-guides-design-docs-and-examples.out
+set -o pipefail; make typecheck 2>&1 | tee /tmp/typecheck-9-7-4-update-guides-design-docs-and-examples.out
+set -o pipefail; make test 2>&1 | tee /tmp/test-9-7-4-update-guides-design-docs-and-examples.out
+```
+
+Run CodeRabbit after gates:
+
+```bash
+set -o pipefail; coderabbit review --agent 2>&1 | tee /tmp/coderabbit-9-7-4-update-guides-design-docs-and-examples.out
+```
+
+Use file-based commits:
+
+```bash
+git diff --check
+git status --short
+git add <changed files>
+COMMIT_MSG_DIR=$(mktemp -d)
+cat > "$COMMIT_MSG_DIR/COMMIT_MSG.md" << 'ENDOFMSG'
+Update harness-led defaults guidance
+
+Align the guide, design document, migration guide, and first-party examples
+with the ADR-008 harness-led default configuration model.
+ENDOFMSG
+git commit -F "$COMMIT_MSG_DIR/COMMIT_MSG.md"
+rm -rf "$COMMIT_MSG_DIR"
+```
+
+## Validation and acceptance
+
+Acceptance for the approved implementation:
+
+- `docs/users-guide.md` recommends first-party harness-only configuration for
+  Tokio and GPUI as the normal path.
+- `docs/rstest-bdd-design.md` records the same recommendation while preserving
+  the internal path-based resolver and precedence details.
+- `docs/v0-6-0-migration-guide.md` reflects the consumer-visible stage-9.7
+  behaviour, including first-party inference and explicit override guidance.
+- `examples/tokio-reminders` and `examples/gpui-counter` no longer teach that
+  both `harness = ...` and first-party `attributes = ...` are required by
+  default.
+- `attributes = ...` remains documented as an override pattern and
+  attributes-only escape hatch.
+- Third-party harness caveats remain explicit.
+- If example Rust source changes, `cargo test -p tokio-reminders` and
+  `cargo test -p gpui-counter` pass.
+- `make markdownlint`, `make nixie` when relevant, `make check-fmt`,
+  `make lint`, `make typecheck`, and `make test` pass.
+- `coderabbit review --agent` reports no unresolved concerns requiring code or
+  documentation changes.
+- `docs/roadmap.md` marks item 9.7.4 done only after the approved
+  implementation, validation, and review are complete.
+
+Quality method:
+
+- Use `rg` for Markdown/prose audit of harness and attribute examples.
+- Use focused example tests for changed example source.
+- Use full Makefile gates for repository health.
+- Use CodeRabbit CLI agent mode as a reviewer after deterministic gates pass.
+
+## Idempotence and recovery
+
+The audit and validation commands are safe to repeat. Documentation edits
+should be small and reviewable; if a stage produces confusing churn, inspect
+`git diff`, revert only the edits from the current stage, and re-apply a
+smaller patch. Do not revert unrelated work in the tree.
+
+If `make fmt` changes unrelated Markdown, stop before staging those files.
+Record the formatter behaviour in `Surprises & discoveries`, restore unrelated
+formatter churn, and use focused `markdownlint` plus the full repository gates
+to validate the intended files.
+
+If CodeRabbit reports findings, update the relevant documentation or this plan
+and rerun deterministic gates before invoking CodeRabbit again. If a finding
+contradicts ADR-008, record the conflict and ask for maintainer direction.
+
+## Artifacts and notes
+
+Wyvern reconnaissance identified these high-signal planning facts:
+
+- ADR-008 is still `Proposed`, so 9.7.4 is contingent until acceptance or
+  explicit maintainer authorization.
+- 9.7.1, 9.7.2, and 9.7.3 are already delivered, so implementation should not
+  change resolver behaviour unless documentation exposes a real mismatch.
+- `docs/users-guide.md`, `docs/rstest-bdd-design.md`,
+  `docs/v0-6-0-migration-guide.md`, `examples/tokio-reminders/README.md`,
+  and `examples/gpui-counter/README.md` are the main documentation surfaces.
+- Example Rust files may need a narrow edit because they still pair first-party
+  harnesses with explicit first-party attribute policies.
+
+Firecrawl resolved external tooling assumptions:
+
+- CodeRabbit CLI documentation at <https://docs.coderabbit.ai/cli> describes
+  `--agent` as structured output for agent integrations and recommends
+  letting reviews run in the background when they take several minutes.
+- CodeRabbit's Markdown tooling page identifies `markdownlint-cli2` as the
+  Markdown linter, matching the repository `Makefile` target.
+
+Current Lody session:
+
+```plaintext
+https://lody.ai/leynos/sessions/cf6a7d98-d416-4269-a866-1b7f701d1f2d
+```
+
+## Interfaces and dependencies
+
+No new Rust API, crate dependency, feature flag, protocol, or data format is
+planned. The implementation should document and demonstrate the existing
+interfaces:
+
+```rust,no_run
+#[scenario(
+    path = "tests/features/reminders.feature",
+    name = "Scheduling a reminder queues it for later delivery",
+    harness = rstest_bdd_harness_tokio::TokioHarness,
+)]
+fn queues_a_scheduled_reminder(#[from(service)] _: ReminderService) {}
+```
+
+```rust,no_run
+#[scenario(
+    path = "tests/features/counter.feature",
+    name = "Increment a counter and observe GPUI context",
+    harness = rstest_bdd_harness_gpui::GpuiHarness,
+)]
+fn increment_and_observe_gpui_context(#[from(app)] _: CounterApp) {}
+```
+
+Explicit override examples should remain available:
+
+```rust,no_run
+#[scenario(
+    path = "tests/features/my_ui.feature",
+    harness = rstest_bdd_harness_gpui::GpuiHarness,
+    attributes = rstest_bdd_harness::DefaultAttributePolicy,
+)]
+fn my_gpui_scenario_with_explicit_override() {}
+```
+
+## Revision note
+
+Initial draft created on 2026-05-24. It captures the plan approval gate,
+ADR-008 contingency, Wyvern reconnaissance, Firecrawl tooling check, expected
+documentation surfaces, validation commands, CodeRabbit review points, and the
+pull request requirements for the pre-implementation plan branch.

--- a/docs/execplans/9-7-4-update-guides-design-docs-and-examples.md
+++ b/docs/execplans/9-7-4-update-guides-design-docs-and-examples.md
@@ -186,7 +186,8 @@ repository gates.
 - [x] (2026-05-24T16:36:48Z) Committed the duplicate `macro_compile` manifest
       cleanup as `5de9886`.
 - [x] (2026-05-24T16:36:48Z) Committed the draft ExecPlan for review.
-- [ ] Push the branch and open a draft pull request for plan review.
+- [x] (2026-05-24T16:36:48Z) Pushed the branch and opened draft pull request
+      <https://github.com/leynos/rstest-bdd/pull/497> for plan review.
 - [ ] Await explicit maintainer approval before implementation begins.
 
 ## Surprises & discoveries

--- a/docs/execplans/9-7-4-update-guides-design-docs-and-examples.md
+++ b/docs/execplans/9-7-4-update-guides-design-docs-and-examples.md
@@ -209,7 +209,8 @@ repository gates.
       reported zero findings.
 - [x] (2026-05-26T00:00:00+02:00) Committed the completed implementation as
       `4539cd8`.
-- [ ] Push the completed implementation.
+- [x] (2026-05-26T00:00:00+02:00) Pushed the completed implementation to
+      `origin/9-7-4-update-guides-design-docs-and-examples`.
 
 ## Surprises & discoveries
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -687,14 +687,17 @@ implementation commitments.
   2026-05-21 with unit coverage for precedence and unknown-path negatives,
   trybuild fixtures for first-party override and attributes-only expansion,
   and behavioural Tokio and GPUI scenario coverage. (Buzzy Bee)
-- [ ] 9.7.4. Update the user guide, design document, and first-party example
+- [x] 9.7.4. Update the user guide, design document, and first-party example
   prose to lead with harness-only configuration once the default-inference
   behaviour lands. Retain `attributes = ...` as an override pattern and keep
   the current third-party caveats explicit. Finish line: `docs/users-guide.md`
   and `docs/rstest-bdd-design.md` recommend harness-led defaults for the
   first-party integrations, examples no longer require both parameters by
   default, and `make markdownlint` passes. Prerequisite: 9.7.3. Design Doc:
-  `docs/adr-008-harness-led-attribute-policy-defaults.md`. (Dinolump)
+  `docs/adr-008-harness-led-attribute-policy-defaults.md`. Delivered
+  2026-05-26 with harness-only Tokio and GPUI example code, updated guide,
+  design, and migration prose, focused example tests, full repository gates,
+  and CodeRabbit review. (Dinolump)
 
 ## 10. First-cut beta feedback: v0.6.0-beta2 quick wins
 

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -29,11 +29,11 @@ coexist within the same project, use the same fixture model for dependency
 injection, and are executed by the standard `cargo test` command. This approach
 eliminates the need for a separate test runner, reducing continuous integration
 (CI) and continuous delivery (CD) configuration complexity and lowering the
-barrier to adoption for teams already invested in the Rust testing
-ecosystem.[^3]
+barrier to adoption for teams already invested in the Rust testing ecosystem.[
+^3]
 
-The design is heavily modelled on `pytest-bdd`, a successful plugin for
-Python's `pytest` framework.[^4]
+The design is heavily modelled on `pytest-bdd`, a successful plugin for Python's
+ `pytest` framework.[^4]
 
 `pytest-bdd`'s success stems from its ability to leverage the full power of its
 host framework—including fixtures, parameterisation, and a vast plugin
@@ -365,16 +365,16 @@ classDiagram
 
   The implementation uses `convert_case` to provide familiar serde-style rename
   rules (`lowercase`, `PascalCase`, `kebab-case`, and screaming variants).
-  Field attributes support header overrides (`column`), tolerant booleans
-  (`truthy`), whitespace normalization (`trim`), optional cells (`optional` on
+  Field attributes support header overrides (`column`), tolerant booleans (
+  `truthy`), whitespace normalization (`trim`), optional cells (`optional` on
   `Option<T>`), and defaults (`default` or `default = path`). Absent a custom
   parser, the derive falls back to `FromStr` with error types constrained to
   `std::error::Error`. Custom parsers are functions of the form
   `fn(&str) -> Result<T, E>` where `E: Error + Send + Sync + 'static`. The
   generated code matches `DataTableError::MissingColumn` and
   `DataTableError::MissingCell` to drive optional and default behaviour while
-  propagating all other failures unchanged. The `truthy` attribute is limited
-  to `bool` fields to maintain clear semantics.
+  propagating all other failures unchanged. The `truthy` attribute is limited to
+   `bool` fields to maintain clear semantics.
 
   Trybuild fixtures lock down these invariants. Dedicated compile-fail cases
   assert that `#[datatable(optional)]` only applies to `Option<T>` fields,
@@ -588,14 +588,13 @@ macro has a distinct role in the compile-time orchestration of the BDD tests.
   combined with `#[from]`, and a missing table triggers a runtime error.
 
 - Doc strings: A multi-line text block immediately following a step is
-  exposed to the step function through an optional `docstring` parameter of
-  type `String`. The runner passes the raw block to the wrapper as
-  `Option<&str>`, and the wrapper clones it into an owned `String` before
-  calling the step function. As with data tables, the parameter must use this
-  exact name and concrete type for detection. The wrapper fails at runtime if
-  the docstring is absent. A data table must precede any docstring parameter,
-  and feature files may delimit the block using either triple double-quotes or
-  triple backticks.
+  exposed to the step function through an optional `docstring` parameter of type
+   `String`. The runner passes the raw block to the wrapper as `Option<&str>`,
+  and the wrapper clones it into an owned `String` before calling the step
+  function. As with data tables, the parameter must use this exact name and
+  concrete type for detection. The wrapper fails at runtime if the docstring is
+  absent. A data table must precede any docstring parameter, and feature files
+  may delimit the block using either triple double-quotes or triple backticks.
 
 Macro attribute expansion relies on `rstest-bdd-macros::MacroPattern` to
 compile and cache regular expressions during macro execution. The helper
@@ -655,8 +654,8 @@ with the project's core goals:
    completely bypass
 
    `rstest` and `cargo test`, violating the primary design goal of seamless
-   integration. It would effectively be a reimplementation of `cucumber-rs`,
-   not `rstest-bdd`.
+   integration. It would effectively be a reimplementation of `cucumber-rs`, not
+    `rstest-bdd`.
 2. `build.rs` **Code Generation:** A build script (`build.rs`) could be used to
    parse all `.rs` files in the `tests` directory before the main compilation.
    It could find all the step-definition attributes and generate a single,
@@ -1113,9 +1112,9 @@ fn test_sample_scenario(my_fixture: MyFixture) { /\* final assertion \*/ }
 3. It traverses the AST to find the `Scenario` with the name "Sample Scenario".
 4. During compilation, the macro validates that each Gherkin step has a
    matching definition recorded by the step macros and emits `compile_error!`
-   when one is missing. At runtime, the generated test still performs lookup
-   via `inventory::iter::<Step>()` to resolve the concrete function and to
-   perform placeholder matching and argument extraction.
+   when one is missing. At runtime, the generated test still performs lookup via
+    `inventory::iter::<Step>()` to resolve the concrete function and to perform
+   placeholder matching and argument extraction.
 5. Using the `quote!` macro [^16], it generates a completely new Rust function.
    This generated function replaces the original
 
@@ -1288,9 +1287,9 @@ fail-fast behaviour prevents silent runtime issues.
 
 #### 2.5.4 Tokio current-thread mode
 
-The initial implementation targets Tokio current-thread mode
-(`#[tokio::test(flavor = "current_thread")]`). This mode aligns with the
-existing `RefCell`-backed fixture model:
+The initial implementation targets Tokio current-thread mode (
+`#[tokio::test(flavor = "current_thread")]`). This mode aligns with the existing
+ `RefCell`-backed fixture model:
 
 - Step futures may be `!Send` because they execute on a single thread.
 - Steps can hold `RefMut` guards or `&mut T` borrows across `.await` points.
@@ -1488,7 +1487,9 @@ The core crate defines:
 The `#[scenario]` and `scenarios!` macros accept `harness = path::ToHarness`,
 defaulting to `StdHarness` when omitted. The generated test body delegates to
 the chosen harness adapter, which controls runtime setup, teardown, and any
-framework-specific fixture injection.
+framework-specific fixture injection. For recognized first-party harness paths,
+the macro also infers the matching default attribute policy when
+`attributes = ...` is omitted.
 
 Phase 9.1 implements the core crate with the following interfaces:
 
@@ -1694,9 +1695,9 @@ Attribute resolution follows the ADR-008 precedence order:
 3. deprecated `runtime = "tokio-current-thread"` compatibility alias
 4. existing runtime-mode or synchronous fallback
 
-The first-party harness mappings also live in `rstest-bdd-policy` and the
-macro layer recognizes both canonical crate-root paths and imported
-single-segment adapter type names:
+The first-party harness mappings also live in `rstest-bdd-policy` and the macro
+layer recognizes both canonical crate-root paths and imported single-segment
+adapter type names:
 
 - `rstest_bdd_harness::StdHarness` -> rstest-only
 - `rstest_bdd_harness_tokio::TokioHarness` -> Tokio current-thread
@@ -1762,8 +1763,8 @@ Second, when `attributes` is `None`, a known first-party harness path is
 resolved via `resolve_test_attribute_hint_for_harness_path` in
 `rstest-bdd-policy`. Third, if no explicit path or known harness mapping is
 present, the deprecated `runtime = "tokio-current-thread"` alias still reaches
-Tokio behaviour through `RuntimeMode::test_attribute_hint()` when the runtime
-is `TokioCurrentThread`. Fourth, all remaining cases fall back to the sync or
+Tokio behaviour through `RuntimeMode::test_attribute_hint()` when the runtime is
+ `TokioCurrentThread`. Fourth, all remaining cases fall back to the sync or
 generic-async baseline, which emits `#[rstest::rstest]` only. This preserves
 ADR-008's "explicit policy beats harness default beats compatibility alias
 beats fallback" ordering while still producing `TokenStream2` output from one
@@ -1818,12 +1819,11 @@ The harness-side lookup that makes the second precedence level work lives in
 `crates/rstest-bdd-policy/src/lib.rs` as
 `resolve_test_attribute_hint_for_harness_path`. It accepts a `&[&str]` of path
 segments and returns `Option<TestAttributeHint>`, with the canonical mappings
-held in the `KNOWN_HARNESS_HINTS` table: `STD_HARNESS_PATH`
-(`["rstest_bdd_harness", "StdHarness"]`) maps to
-`TestAttributeHint::RstestOnly`, `TOKIO_HARNESS_PATH`
-(`["rstest_bdd_harness_tokio", "TokioHarness"]`) maps to
-`TestAttributeHint::RstestWithTokioCurrentThread`, and `GPUI_HARNESS_PATH`
-(`["rstest_bdd_harness_gpui", "GpuiHarness"]`) maps to
+held in the `KNOWN_HARNESS_HINTS` table: `STD_HARNESS_PATH` (
+`["rstest_bdd_harness", "StdHarness"]`) maps to `TestAttributeHint::RstestOnly`,
+ `TOKIO_HARNESS_PATH` (`["rstest_bdd_harness_tokio", "TokioHarness"]`) maps to
+`TestAttributeHint::RstestWithTokioCurrentThread`, and `GPUI_HARNESS_PATH` (
+`["rstest_bdd_harness_gpui", "GpuiHarness"]`) maps to
 `TestAttributeHint::RstestWithGpuiTest`. Unknown third-party paths return
 `None`, causing `resolve_attribute_policy` to continue down to the runtime
 fallback. The helper is annotated `#[must_use]` because discarding a `Some`
@@ -1846,23 +1846,24 @@ The first official adapters and policies are:
   available inside step functions. `TokioAttributePolicy` implements
   `AttributePolicy` and emits `#[rstest::rstest]` followed by
   `#[tokio::test(flavor = "current_thread")]`. The crate depends only on
-  `rstest-bdd-harness` (workspace) and `tokio` (version "1", features =
-  ["rt"]), keeping the dependency footprint minimal per ADR-005.
-  Immediate-ready async step *definitions* (`async fn` steps) do work inside
-  `TokioHarness`, but the generated sync wrapper only polls them once when a
-  harness-provided Tokio runtime is already active. If such a step yields
-  `Pending`, execution fails with an informative runtime error rather than
-  silently blocking. Users should therefore reserve harness-driven async steps
-  for one-poll operations and prefer synchronous steps plus external async
-  validation when a scenario needs multi-poll coordination. `TokioHarness::run`
-  currently performs one `tokio::task::yield_now()` tick after
-  `request.run(())` returns; this advances simple queued local tasks but does
-  not guarantee full `LocalSet` drain for multi-poll futures such as
-  timer-driven work. The user-facing demonstration crate under
-  `examples/tokio-reminders` models a local reminder queue whose BDD suite
-  exercises `TokioHarness` with harness-led default attributes end-to-end,
-  while the crate's unit tests cover the explicit `flush().await` coordination
-  pattern.
+  `rstest-bdd-harness` (workspace) and `tokio` (version "1", features = ["
+  rt"]), keeping the dependency footprint minimal per ADR-005. Immediate-ready
+  async step *definitions* (`async fn` steps) do work inside `TokioHarness`,
+  but the generated sync wrapper only polls them once when a harness-provided
+  Tokio runtime is already active. If such a step yields `Pending`, execution
+  fails with an informative runtime error rather than silently blocking. Users
+  should therefore reserve harness-driven async steps for one-poll operations
+  and prefer synchronous steps plus external async validation when a scenario
+  needs multi-poll coordination. `TokioHarness::run` currently performs one
+  `tokio::task::yield_now()` tick after `request.run(())` returns; this
+  advances simple queued local tasks but does not guarantee full `LocalSet`
+  drain for multi-poll futures such as timer-driven work. The user-facing
+  demonstration crate under `examples/tokio-reminders` models a local reminder
+  queue whose BDD suite exercises `TokioHarness` with harness-led default
+  attributes end-to-end, while the crate's unit tests cover the explicit
+  `flush().await` coordination pattern. User-facing examples should therefore
+  lead with `harness = rstest_bdd_harness_tokio::TokioHarness` alone and reserve
+   `attributes = ...` for explicit overrides or attributes-only cases.
 - `rstest-bdd-harness-gpui` (implemented, phase 9.4): provides `GpuiHarness`
   and `GpuiAttributePolicy`. `GpuiHarness` implements `HarnessAdapter` by
   running each `ScenarioRunRequest` inside `gpui::run_test`, building a
@@ -1876,10 +1877,10 @@ The first official adapters and policies are:
   Publish-check automation synthesizes a standalone package artifact for
   `rstest-bdd-harness-gpui` and compiles a generated validator crate against
   upstream `gpui`; GPUI behavioural and integration tests remain feature-gated
-  behind `native-gpui-tests` as an explicit opt-in suite. A
-  user-facing demonstration crate under `examples/gpui-counter` models a simple
-  counter application whose BDD suite exercises `GpuiHarness` with harness-led
-  default attributes end-to-end, with step definitions that access injected
+  behind `native-gpui-tests` as an explicit opt-in suite. A user-facing
+  demonstration crate under `examples/gpui-counter` models a simple counter
+  application whose BDD suite exercises `GpuiHarness` with harness-led default
+  attributes end-to-end, with step definitions that access injected
   `TestAppContext` through `rstest_bdd_harness_context`. Focused `rstest-bdd`
   integration coverage also verifies canonical GPUI policy resolution for
   `scenarios!`, canonical and absolute first-party GPUI policy paths for
@@ -1899,8 +1900,8 @@ Validation for the delivered model is intentionally split across layers:
   harness-runner contracts;
 - behavioural and integration tests in `rstest-bdd` verify custom harness
   delegation, `rstest_bdd_harness_context` injection, Tokio runtime
-  compatibility, GPUI integration, GPUI attribute-policy resolution through
-  both `#[scenario]` and `scenarios!`, and the deprecated runtime alias path.
+  compatibility, GPUI integration, GPUI attribute-policy resolution through both
+   `#[scenario]` and `scenarios!`, and the deprecated runtime alias path.
 
 #### 2.7.6 First-cut beta feedback and adoption implications
 
@@ -2079,8 +2080,8 @@ incrementally.
   `rstest-bdd-macros` (the proc-macro implementation).
 
 - Implement the `inventory`-based step registry. Define the `Step` struct and
-  the `#[given]`, `#[when]`, and `#[then]` macros to populate the registry
-  using `inventory::submit!`.
+  the `#[given]`, `#[when]`, and `#[then]` macros to populate the registry using
+   `inventory::submit!`.
 
 - Implement a basic `#[scenario]` macro. This includes compile-time Gherkin
   file parsing and a lookup map built at runtime from the step registry.
@@ -2207,8 +2208,8 @@ skip details in diagnostic tooling and IDE integrations.
 - 2025-12-10: Diagnostic tooling now records scenario line numbers and tag
   sets alongside skip reasons, and tracks bypassed step definitions when
   execution halts early. `cargo bdd skipped` and `cargo bdd steps --skipped`
-  surface this data (with JSON fields `feature`, `scenario`, `line`, `tags`,
-  and `reason`) to support IDE integrations and CLI consumers.
+  surface this data (with JSON fields `feature`, `scenario`, `line`, `tags`, and
+   `reason`) to support IDE integrations and CLI consumers.
 - 2025-12-12: Bypassed-step recording is gated at codegen time with
   `cfg(feature = "diagnostics")` to keep non-diagnostic builds linkable. The
   runtime reuses the scenario tag vector for reporting to avoid repeated
@@ -2334,16 +2335,16 @@ between their BDD acceptance tests and their other unit/integration tests.
 
 The following table summarizes the key differences:
 
-| Feature          | rstest-bdd (Proposed)                                                                                                                             | cucumber                                                                          |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Test Runner      | Standard cargo test (via rstest expansion)                                                                                                        | Custom runner invoked from a main function (World::run(…)) [^19]                  |
-| State Management | rstest fixtures; dependency injection model [^1]                                                                                                  | Mandatory World struct; a central state object per scenario [^11]                 |
-| Step Discovery   | Automatic via compile-time registration (inventory) and runtime matching                                                                          | Explicit collection in the test runner setup (World::cucumber().steps(…)) [^20]   |
-| Parameterisation | Gherkin Scenario Outline maps to rstest's #[case] parameterisation [^21]                                                                          | Handled internally by the cucumber runner                                         |
-| Async Support    | Tokio current-thread mode (planned); multi-thread and other runtimes as future work (see §2.5 and [ADR-001](adr-001-async-fixtures-and-test.md))  | Built-in; requires specifying an async runtime [^11]                              |
-| Ecosystem        | Seamless integration with rstest and cargo features                                                                                               | Self-contained framework; can use any Rust library within steps                   |
-| Ergonomics       | pytest-bdd-like; explicit #[scenario] binding links test code to features [^6]                                                                    | cucumber-jvm/js-like; feature-driven, with a central test runner                  |
-| Core Philosophy  | BDD as an extension of the existing rstest framework                                                                                              | A native Rust implementation of the Cucumber framework standard                   |
+| Feature          | rstest-bdd (Proposed)                                                                                                                            | cucumber                                                                        |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
+| Test Runner      | Standard cargo test (via rstest expansion)                                                                                                       | Custom runner invoked from a main function (World::run(…)) [^19]                |
+| State Management | rstest fixtures; dependency injection model [^1]                                                                                                 | Mandatory World struct; a central state object per scenario [^11]               |
+| Step Discovery   | Automatic via compile-time registration (inventory) and runtime matching                                                                         | Explicit collection in the test runner setup (World::cucumber().steps(…)) [^20] |
+| Parameterisation | Gherkin Scenario Outline maps to rstest's #[case] parameterisation [^21]                                                                         | Handled internally by the cucumber runner                                       |
+| Async Support    | Tokio current-thread mode (planned); multi-thread and other runtimes as future work (see §2.5 and [ADR-001](adr-001-async-fixtures-and-test.md)) | Built-in; requires specifying an async runtime [^11]                            |
+| Ecosystem        | Seamless integration with rstest and cargo features                                                                                              | Self-contained framework; can use any Rust library within steps                 |
+| Ergonomics       | pytest-bdd-like; explicit #[scenario] binding links test code to features [^6]                                                                   | cucumber-jvm/js-like; feature-driven, with a central test runner                |
+| Core Philosophy  | BDD as an extension of the existing rstest framework                                                                                             | A native Rust implementation of the Cucumber framework standard                 |
 
 ### 3.5 Potential extensions
 
@@ -2912,8 +2913,10 @@ Delivered behaviour:
   path. Tokio and GPUI integrations therefore stay in opt-in crates while the
   core macros remain dependency-light.
 - `runtime = "tokio-current-thread"` remains supported as deprecated
-  compatibility syntax for `scenarios!`, but explicit `harness = ...` and
-  `attributes = ...` configuration is the canonical user-facing model.
+  compatibility syntax for `scenarios!`, but explicit harness-led configuration
+  is the canonical user-facing model. First-party Tokio and GPUI scenarios
+  should lead with `harness = ...` alone. Explicit `attributes = ...` remains
+  the override and third-party escape hatch.
 
 The [v0.6.0 migration guide](v0-6-0-migration-guide.md) is the canonical
 user-facing upgrade path for these delivered changes. It translates the
@@ -3041,8 +3044,8 @@ These macros keep test code succinct while still surfacing detailed diagnostics.
   `I18nAssets`, so the Fluent loader can discover translations. Missing keys or
   unsupported locales fall back to English.
 - **Refactor diagnostic messages:** Keep proc‑macro diagnostics stable and in
-  English for deterministic builds. Localize user‑facing runtime messages in
-  the `rstest-bdd` crate using `FluentLanguageLoader` and `i18n-embed`'s locale
+  English for deterministic builds. Localize user‑facing runtime messages in the
+   `rstest-bdd` crate using `FluentLanguageLoader` and `i18n-embed`'s locale
   requesters. Avoid compile‑time locale switches in macros.
 
 #### Implemented localization harness

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1190,7 +1190,7 @@ that a step or scenario stopped executing. Use
 `rstest_bdd::assert_step_skipped!` to unwrap a `StepExecution::Skipped`
 outcome, optionally constraining its message, and
 `rstest_bdd::assert_scenario_skipped!` to inspect
-[`ScenarioStatus`](https://docs.rs/rstest-bdd/latest/rstest_bdd/reporting/enum.ScenarioStatus.html) records. Both macros accept
+[`ScenarioStatus`][scenario-status] records. Both macros accept
  `message_absent = true` to assert that no message was provided and substring
 matching to confirm that a message contains the expected reason.
 
@@ -2308,3 +2308,5 @@ running any remaining test code. While advanced Gherkin constructs and
 parameterization remain on the horizon, this foundation allows teams to
 integrate acceptance criteria into their Rust test suites and to engage all
 three amigos in the specification process.
+
+[scenario-status]: https://docs.rs/rstest-bdd/latest/rstest_bdd/reporting/enum.ScenarioStatus.html

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1190,7 +1190,7 @@ that a step or scenario stopped executing. Use
 `rstest_bdd::assert_step_skipped!` to unwrap a `StepExecution::Skipped`
 outcome, optionally constraining its message, and
 `rstest_bdd::assert_scenario_skipped!` to inspect
-[`ScenarioStatus`](crate::reporting::ScenarioStatus) records. Both macros accept
+[`ScenarioStatus`](https://docs.rs/rstest-bdd/latest/rstest_bdd/reporting/enum.ScenarioStatus.html) records. Both macros accept
  `message_absent = true` to assert that no message was provided and substring
 matching to confirm that a message contains the expected reason.
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -32,8 +32,8 @@ edition.
 development via `rust-toolchain.toml` so contributors get consistent `rustfmt`
 and `clippy` behaviour.
 
-Step definitions may be synchronous functions (`fn`) or asynchronous functions
-(`async fn`). The framework no longer depends on the `async-trait` crate to
+Step definitions may be synchronous functions (`fn`) or asynchronous functions (
+`async fn`). The framework no longer depends on the `async-trait` crate to
 express async methods in traits. Projects that previously relied on
 `#[async_trait]` in helper traits should replace those methods with ordinary
 functions, and use async steps or async fixtures where appropriate. Step
@@ -735,25 +735,6 @@ include the leading `@`. When the filter is combined with `index` or `name`,
 the macro emits a compile error if the selected scenario does not satisfy the
 expression.
 
-```rust,no_run
-# use rstest_bdd_macros::scenario;
-#[scenario(
-    path = "tests/features/my_ui.feature",
-    harness = rstest_bdd_harness_gpui::GpuiHarness,
-    attributes = rstest_bdd_harness::DefaultAttributePolicy,
-)]
-fn my_gpui_scenario_with_explicit_override() {}
-```
-
-This contract is enforced by focused integration coverage in
-`crates/rstest-bdd-harness-gpui/tests/macro_compile.rs`,
-`crates/rstest-bdd-harness-gpui/tests/scenario_macros.rs`, and
-`crates/rstest-bdd-harness-gpui/tests/stateful_window.rs`. Those suites verify
-GPUI attribute-policy resolution for `#[scenario]` and `scenarios!`,
-deduplication when a `#[scenario]` test already carries an explicit
-`#[gpui::test]`, and stateful window scenarios that carry durable handles
-across steps.
-
 ### Harness adapter and attribute policy
 
 The `harness` and `attributes` parameters accept Rust type paths pointing to
@@ -771,10 +752,6 @@ Use them in this order of preference:
   selecting an attribute policy without harness delegation.
 - Treat `runtime = "tokio-current-thread"` as legacy compatibility syntax for
   `scenarios!`, not as the canonical configuration surface.
-
-> **Note:** Roadmap item 9.7.4 will revise the surrounding examples to lead
-> with harness-only configuration. Until then, the examples below show the
-> tested override and attributes-only forms explicitly.
 
 When `harness` is specified, the generated test body delegates scenario
 execution through the harness adapter. The macro wraps the runtime portion of
@@ -806,10 +783,10 @@ attributes. Currently this resolution is path-based:
   scenario signatures, and
 - default and unknown policy paths emit `#[rstest::rstest]` only.
 
-Imported single-segment recognition only applies to unaliased first-party names.
-If the adapter crates are renamed or aliased, or the policy types are
-re-exported under different identifiers, use the canonical crate-root path
-(`rstest_bdd_harness_tokio::TokioAttributePolicy` or
+Imported single-segment recognition only applies to unaliased first-party
+names. If the adapter crates are renamed or aliased, or the policy types are
+re-exported under different identifiers, use the canonical crate-root path (
+`rstest_bdd_harness_tokio::TokioAttributePolicy` or
 `rstest_bdd_harness_gpui::GpuiAttributePolicy`) or add a direct
 `rstest-bdd-harness` dependency to get the same attribute recognition.
 
@@ -838,14 +815,28 @@ In simple terms, attribute selection works like this:
    `runtime = "tokio-current-thread"` compatibility alias when no explicit
    attributes or harness were selected.
 4. Otherwise, if the `#[scenario]` function is `async fn`, the macro emits
-   `#[rstest::rstest]` and `#[tokio::test(flavor = "current_thread")]`
-   (unless the user already supplies a `#[tokio::test]` attribute, in which
-   case deduplication suppresses the second copy).
+   `#[rstest::rstest]` and `#[tokio::test(flavor = "current_thread")]` (unless
+   the user already supplies a `#[tokio::test]` attribute, in which case
+   deduplication suppresses the second copy).
 5. If none of those apply, the macro emits the normal synchronous
    `#[rstest::rstest]` attribute set.
 
 The macro still removes duplicate framework attributes. For example, if user
 code already has `#[gpui::test]`, the GPUI policy does not emit a second copy.
+
+First-party GPUI configuration normally needs only the harness:
+
+```rust,no_run
+# use rstest_bdd_macros::scenario;
+#[scenario(
+    path = "tests/features/my_ui.feature",
+    harness = rstest_bdd_harness_gpui::GpuiHarness,
+)]
+fn my_gpui_scenario() {}
+```
+
+Use `attributes = ...` only when the scenario intentionally overrides the
+inferred first-party policy:
 
 ```rust,no_run
 # use rstest_bdd_macros::scenario;
@@ -857,29 +848,20 @@ code already has `#[gpui::test]`, the GPUI policy does not emit a second copy.
 fn my_gpui_scenario_with_explicit_override() {}
 ```
 
-This contract is enforced by focused integration coverage in
+Focused integration coverage in
 `crates/rstest-bdd-harness-gpui/tests/macro_compile.rs`,
 `crates/rstest-bdd-harness-gpui/tests/scenario_macros.rs`, and
-`crates/rstest-bdd-harness-gpui/tests/stateful_window.rs`. Those suites verify
-GPUI attribute-policy resolution for `#[scenario]` and `scenarios!`,
-deduplication when a `#[scenario]` test already carries an explicit
-`#[gpui::test]`, and stateful window scenarios that carry durable handles
-across steps.
-
-# use rstest_bdd_macros::scenarios;
-scenarios!(
-    "tests/features/auto",
-    harness = rstest_bdd_harness::StdHarness,
-);
-```
+`crates/rstest-bdd-harness-gpui/tests/stateful_window.rs` verifies GPUI
+attribute-policy resolution for `#[scenario]` and `scenarios!`, deduplication
+when a `#[scenario]` test already carries an explicit `#[gpui::test]`, and
+stateful window scenarios that carry durable handles across steps.
 
 #### Third-party harness adapter cookbook
 
-A separate harness crate is appropriate when a framework needs setup,
-teardown, runtime ownership, or typed context that should not become a
-dependency of the core `rstest-bdd` crates. A Bevy integration, for example,
-should live in an opt-in crate such as `rstest-bdd-harness-bevy` and expose two
-public types:
+A separate harness crate is appropriate when a framework needs setup, teardown,
+runtime ownership, or typed context that should not become a dependency of the
+core `rstest-bdd` crates. A Bevy integration, for example, should live in an
+opt-in crate such as `rstest-bdd-harness-bevy` and expose two public types:
 
 - a harness adapter, such as `BevyHarness`, implementing `HarnessAdapter`; and
 - an optional attribute policy, such as `BevyAttributePolicy`, implementing
@@ -1036,7 +1018,7 @@ Feature: Bevy world
 
 The compile-checked mirror for this cookbook lives at
 `crates/rstest-bdd/tests/fixtures_macros/scenario_third_party_harness_cookbook.rs`.
-Maintainers should keep that fixture and the snippets above aligned when the
+ Maintainers should keep that fixture and the snippets above aligned when the
 third-party harness contract changes.
 
 Harness adapters must faithfully propagate the runner's return value inside
@@ -1069,80 +1051,22 @@ A direct `rstest-bdd-harness` dependency is not required when using
 crate directly only when implementing a custom harness or importing base API
 types such as `HarnessAdapter` or `ScenarioRunRequest`.
 
-`TokioHarness` can then be used directly in scenarios:
+`TokioHarness` can then be used directly in scenarios. For this first-party
+adapter, the macro infers `TokioAttributePolicy` from the canonical harness
+path when `attributes = ...` is omitted:
 
 ```rust,no_run
 # use rstest_bdd_macros::scenario;
 #[scenario(
-    path = "tests/features/my_ui.feature",
-    harness = rstest_bdd_harness_gpui::GpuiHarness,
-    attributes = rstest_bdd_harness::DefaultAttributePolicy,
+    path = "tests/features/reminders.feature",
+    name = "Scheduling a reminder queues it for later delivery",
+    harness = rstest_bdd_harness_tokio::TokioHarness,
 )]
-fn my_gpui_scenario_with_explicit_override() {}
+fn queues_a_scheduled_reminder() {}
 ```
 
-This contract is enforced by focused integration coverage in
-`crates/rstest-bdd-harness-gpui/tests/macro_compile.rs`,
-`crates/rstest-bdd-harness-gpui/tests/scenario_macros.rs`, and
-`crates/rstest-bdd-harness-gpui/tests/stateful_window.rs`. Those suites verify
-GPUI attribute-policy resolution for `#[scenario]` and `scenarios!`,
-deduplication when a `#[scenario]` test already carries an explicit
-`#[gpui::test]`, and stateful window scenarios that carry durable handles
-across steps.
-
-# use rstest_bdd_harness_tokio::TokioTestContext;
-# use rstest_bdd_macros::given;
-
-#[derive(Debug, PartialEq, Eq)]
-struct UserRow {
-    name: String,
-    email: String,
-    active: bool,
-}
-
-impl DataTableRow for UserRow {
-    const REQUIRES_HEADER: bool = true;
-
-    fn parse_row(mut row: RowSpec<'_>) -> Result<Self, DataTableError> {
-        let name = row.take_column("name")?;
-        let email = row.take_column("email")?;
-        let active = row.parse_column_with(
-            "active",
-            datatable::truthy_bool,
-        )?;
-        Ok(Self { name, email, active })
-    }
-}
-
-#[given("the following users exist:")]
-fn users_exist(#[datatable] rows: Rows<UserRow>) {
-    for row in rows {
-        assert!(row.active || row.name == "Bob");
-    }
-}
-```
-
-Projects that prefer to work with raw rows can declare the argument as
-`Vec<Vec<String>>` and handle parsing manually. Both forms can co-exist within
-the same project, allowing incremental adoption of typed tables.
-
-# use rstest_bdd_macros::scenario;
-#[scenario(
-    path = "tests/features/my_ui.feature",
-    harness = rstest_bdd_harness_gpui::GpuiHarness,
-    attributes = rstest_bdd_harness::DefaultAttributePolicy,
-)]
-fn my_gpui_scenario_with_explicit_override() {}
-```
-
-This contract is enforced by focused integration coverage in
-`crates/rstest-bdd-harness-gpui/tests/macro_compile.rs`,
-`crates/rstest-bdd-harness-gpui/tests/scenario_macros.rs`, and
-`crates/rstest-bdd-harness-gpui/tests/stateful_window.rs`. Those suites verify
-GPUI attribute-policy resolution for `#[scenario]` and `scenarios!`,
-deduplication when a `#[scenario]` test already carries an explicit
-`#[gpui::test]`, and stateful window scenarios that carry durable handles
-across steps.
+Keep explicit `attributes = ...` only for overrides, attributes-only tests, or
+unrecognized paths where the default cannot be inferred.
 
 ### Using the GPUI harness
 
@@ -1160,37 +1084,21 @@ A direct `rstest-bdd-harness` dependency is not required when using
 crate directly only when implementing a custom harness or importing base API
 types such as `HarnessAdapter` or `ScenarioRunRequest`.
 
-`GpuiHarness` can then be used directly in scenarios:
+`GpuiHarness` can then be used directly in scenarios. For this first-party
+adapter, the macro infers `GpuiAttributePolicy` from the canonical harness path
+when `attributes = ...` is omitted:
 
 ```rust,no_run
 # use rstest_bdd_macros::scenario;
 #[scenario(
-    path = "tests/features/my_ui.feature",
+    path = "tests/features/counter.feature",
+    name = "Increment a counter and observe GPUI context",
     harness = rstest_bdd_harness_gpui::GpuiHarness,
-    attributes = rstest_bdd_harness::DefaultAttributePolicy,
 )]
-fn my_gpui_scenario_with_explicit_override() {}
+fn increment_and_observe_gpui_context() {}
 ```
 
-This contract is enforced by focused integration coverage in
-`crates/rstest-bdd-harness-gpui/tests/macro_compile.rs`,
-`crates/rstest-bdd-harness-gpui/tests/scenario_macros.rs`, and
-`crates/rstest-bdd-harness-gpui/tests/stateful_window.rs`. Those suites verify
-GPUI attribute-policy resolution for `#[scenario]` and `scenarios!`,
-deduplication when a `#[scenario]` test already carries an explicit
-`#[gpui::test]`, and stateful window scenarios that carry durable handles
-across steps.
-
-# use rstest_bdd_macros::scenario;
-#[scenario(
-    path = "tests/features/my_ui.feature",
-    harness = rstest_bdd_harness_gpui::GpuiHarness,
-    attributes = rstest_bdd_harness::DefaultAttributePolicy,
-)]
-fn my_gpui_scenario_with_explicit_override() {}
-```
-
-This contract is enforced by focused integration coverage in
+Focused integration coverage in
 `crates/rstest-bdd-harness-gpui/tests/macro_compile.rs`,
 `crates/rstest-bdd-harness-gpui/tests/scenario_macros.rs`, and
 `crates/rstest-bdd-harness-gpui/tests/stateful_window.rs`. Those suites verify
@@ -1218,45 +1126,15 @@ handle:
 # }
 ```
 
-The selection function preserves the caller-supplied order, so applications can
-pass a list of preferred locales. The helper resolves to the best available
-translation and continues to fall back to English when a requested locale is
-not shipped with the crate. Procedural macro diagnostics remain in English so
-compile-time output stays deterministic regardless of the host machine’s
-language settings.
-
-[`Localizations`]: https://docs.rs/rstest-bdd/latest/rstest_bdd/localization/
-[`FluentLanguageLoader`]:
-https://docs.rs/i18n-embed/latest/i18n_embed/fluent/struct.FluentLanguageLoader.html
-
-# thread_local! {
-#     static STATE: std::cell::RefCell<Option<(
-#         gpui::Entity<CounterView>,
-#         gpui::AnyWindowHandle,
-#     )>> = std::cell::RefCell::new(None);
-# }
-```
-
-The selection function preserves the caller-supplied order, so applications can
-pass a list of preferred locales. The helper resolves to the best available
-translation and continues to fall back to English when a requested locale is
-not shipped with the crate. Procedural macro diagnostics remain in English so
-compile-time output stays deterministic regardless of the host machine’s
-language settings.
-
-[`Localizations`]: https://docs.rs/rstest-bdd/latest/rstest_bdd/localization/
-[`FluentLanguageLoader`]:
-https://docs.rs/i18n-embed/latest/i18n_embed/fluent/struct.FluentLanguageLoader.html
-
 ### Skipping scenarios
 
 Steps or hooks may call `rstest_bdd::skip!` to stop executing the remaining
 steps. The macro records a `Skipped` outcome and short-circuits the scenario so
-the generated test returns before evaluating the annotated function body.
-Invoke `skip!()` with no arguments to record a skipped outcome without a
-message. Pass an optional string to describe the reason, and use the standard
-`format!` syntax to interpolate values when needed. Set the
-`RSTEST_BDD_FAIL_ON_SKIPPED` environment variable to `1`, or call
+the generated test returns before evaluating the annotated function body. Invoke
+ `skip!()` with no arguments to record a skipped outcome without a message.
+Pass an optional string to describe the reason, and use the standard `format!`
+syntax to interpolate values when needed. Set the `RSTEST_BDD_FAIL_ON_SKIPPED`
+environment variable to `1`, or call
 `rstest_bdd::config::set_fail_on_skipped(true)`, to escalate skipped scenarios
 into test failures unless the feature or scenario carries an `@allow_skipped`
 tag. (Example-level tags are not yet evaluated.)
@@ -1312,9 +1190,9 @@ that a step or scenario stopped executing. Use
 `rstest_bdd::assert_step_skipped!` to unwrap a `StepExecution::Skipped`
 outcome, optionally constraining its message, and
 `rstest_bdd::assert_scenario_skipped!` to inspect
-[`ScenarioStatus`](crate::reporting::ScenarioStatus) records. Both macros
-accept `message_absent = true` to assert that no message was provided and
-substring matching to confirm that a message contains the expected reason.
+[`ScenarioStatus`](crate::reporting::ScenarioStatus) records. Both macros accept
+ `message_absent = true` to assert that no message was provided and substring
+matching to confirm that a message contains the expected reason.
 
 ```rust,no_run
 use rstest_bdd::{assert_scenario_skipped, assert_step_skipped, StepExecution};
@@ -1402,8 +1280,8 @@ consumed via `StepContext` rather than referenced directly in the test body.
 ## Async scenario execution
 
 Scenarios can run asynchronously under Tokio's current-thread runtime. This
-enables test code to `.await` async operations while preserving the
-`RefCell`-backed fixture model for mutable borrows across await points.
+enables test code to `.await` async operations while preserving the `RefCell`
+-backed fixture model for mutable borrows across await points.
 
 ### Using `#[scenario]` with async
 
@@ -1632,9 +1510,8 @@ fn async_wrapper_with_aliases<'ctx>(
 ### Current limitations
 
 - **Tokio current-thread mode only:** Multi-threaded Tokio mode would require
-  `Send` futures, which conflicts with the `RefCell`-backed fixture storage.
-  See [ADR-001](adr-001-async-fixtures-and-test.md) for the full design
-  rationale.
+  `Send` futures, which conflicts with the `RefCell`-backed fixture storage. See
+   [ADR-001](adr-001-async-fixtures-and-test.md) for the full design rationale.
 - **Nested runtime safeguards:** Async-only steps running in synchronous
   scenarios use a per-step runtime fallback, which refuses to run when a Tokio
   runtime is already active on the current thread.
@@ -1790,11 +1667,11 @@ Best practices for writing effective scenarios include:
   referring to `{u32}`), escape them as `{{` and `}}` rather than placing them
   inside `{name:type}`. The lexer closes the placeholder at the first `}` after
   the optional type hint; any characters between the `:type` and that first `}`
-  are ignored (for example, `{n:u32 extra}` parses as `name = n`,
-  `type = u32`). `name` must start with a letter or underscore and may contain
-  letters, digits, or underscores (`[A-Za-z_][A-Za-z0-9_]*`). Whitespace within
-  the type hint is ignored (for example, `{count: u32}` and `{count:u32}` are
-  both accepted), but whitespace is not allowed between the name and the colon.
+  are ignored (for example, `{n:u32 extra}` parses as `name = n`, `type = u32`).
+   `name` must start with a letter or underscore and may contain letters,
+  digits, or underscores (`[A-Za-z_][A-Za-z0-9_]*`). Whitespace within the type
+  hint is ignored (for example, `{count: u32}` and `{count:u32}` are both
+  accepted), but whitespace is not allowed between the name and the colon.
   Prefer the compact form `{count:u32}` in new code. When a pattern contains no
   placeholders, the step text must match exactly. Unknown type hints are
   treated as generic placeholders and capture any non-newline text using a
@@ -1976,39 +1853,6 @@ inspection of the row and column that triggered the failure:
 # }
 ```
 
-The selection function preserves the caller-supplied order, so applications can
-pass a list of preferred locales. The helper resolves to the best available
-translation and continues to fall back to English when a requested locale is
-not shipped with the crate. Procedural macro diagnostics remain in English so
-compile-time output stays deterministic regardless of the host machine’s
-language settings.
-
-[`Localizations`]: https://docs.rs/rstest-bdd/latest/rstest_bdd/localization/
-[`FluentLanguageLoader`]:
-https://docs.rs/i18n-embed/latest/i18n_embed/fluent/struct.FluentLanguageLoader.html
-
-# use rstest_bdd::datatable::{DataTableError, Rows};
-# use rstest_bdd_macros::DataTableRow;
-#
-# #[derive(Debug, PartialEq, Eq, DataTableRow)]
-# struct UserRow {
-#     name: String,
-#     #[datatable(truthy)]
-#     active: bool,
-# }
-```
-
-The selection function preserves the caller-supplied order, so applications can
-pass a list of preferred locales. The helper resolves to the best available
-translation and continues to fall back to English when a requested locale is
-not shipped with the crate. Procedural macro diagnostics remain in English so
-compile-time output stays deterministic regardless of the host machine’s
-language settings.
-
-[`Localizations`]: https://docs.rs/rstest-bdd/latest/rstest_bdd/localization/
-[`FluentLanguageLoader`]:
-https://docs.rs/i18n-embed/latest/i18n_embed/fluent/struct.FluentLanguageLoader.html
-
 ## Limitations and roadmap
 
 The `rstest‑bdd` project is evolving. Several features described in the design
@@ -2110,9 +1954,9 @@ not shipped with the crate. Procedural macro diagnostics remain in English so
 compile-time output stays deterministic regardless of the host machine’s
 language settings.
 
-[`Localizations`]: https://docs.rs/rstest-bdd/latest/rstest_bdd/localization/
+[`Localizations`]: <https://docs.rs/rstest-bdd/latest/rstest_bdd/localization/>
 [`FluentLanguageLoader`]:
-https://docs.rs/i18n-embed/latest/i18n_embed/fluent/struct.FluentLanguageLoader.html
+<https://docs.rs/i18n-embed/latest/i18n_embed/fluent/struct.FluentLanguageLoader.html>
 
 ## Diagnostic tooling
 
@@ -2178,9 +2022,8 @@ rstest_bdd::reporting::json::write_snapshot(&mut buffer)?;
 ```
 
 The companion `rstest_bdd::reporting::junit` module renders the same snapshot
-as JUnit XML. Each skipped scenario emits a `<skipped>` element with an
-optional `message` attribute so continuous integration (CI) servers surface the
-reason:
+as JUnit XML. Each skipped scenario emits a `<skipped>` element with an optional
+ `message` attribute so continuous integration (CI) servers surface the reason:
 
 ```rust,no_run
 let mut xml = String::new();

--- a/docs/v0-6-0-migration-guide.md
+++ b/docs/v0-6-0-migration-guide.md
@@ -8,8 +8,8 @@ that need a new testing practice to be useful.
 ## Breaking changes
 
 - Implicit fixture names now normalize exactly one leading underscore.
-  Parameters named `world` and `_world` both resolve to the implicit fixture
-  key `world`; `__world` resolves to `_world`. Explicit `#[from(...)]` fixture
+  Parameters named `world` and `_world` both resolve to the implicit fixture key
+   `world`; `__world` resolves to `_world`. Explicit `#[from(...)]` fixture
   names remain exact.
 - The legacy `scenarios!(..., runtime = "tokio-current-thread")` form now acts
   as a deprecated compatibility alias for
@@ -132,10 +132,14 @@ harness types used through the macros must implement both `HarnessAdapter` and
   `rstest_bdd_harness_context` fixture key.
 - Tokio integration should use the explicit
   `rstest_bdd_harness_tokio::TokioHarness` form instead of the deprecated
-  `runtime = "tokio-current-thread"` compatibility syntax.
-- GPUI integration should use the opt-in `rstest-bdd-harness-gpui` crate and,
-  when native GPUI is used outside this workspace's shim, account for the
-  platform libraries required by upstream GPUI.
+  `runtime = "tokio-current-thread"` compatibility syntax. The first-party
+  Tokio attribute policy is inferred from the canonical harness path, so new
+  examples no longer need a paired `attributes = ...` argument by default.
+- GPUI integration should use the opt-in `rstest-bdd-harness-gpui` crate and
+  the canonical `rstest_bdd_harness_gpui::GpuiHarness` path. The first-party
+  GPUI attribute policy is inferred when `attributes = ...` is omitted. When
+  native GPUI is used outside this workspace's shim, account for the platform
+  libraries required by upstream GPUI.
 - Third-party attribute policies still need explicit user documentation. The
   macros trait-check user-provided policy types, but path-based code generation
   only recognizes first-party policy paths and imported first-party policy type
@@ -186,8 +190,8 @@ imported directly and the macro argument is the single-segment first-party type
 name, such as `TokioHarness`, `TokioAttributePolicy`, `GpuiHarness`, or
 `GpuiAttributePolicy`. Local type aliases and matching type names under other
 module roots are not recognized as first-party paths. When the macro call uses
-one of those non-recognized forms, or omits `attributes = ...` while the harness
-argument is not recognized as first-party, generated code falls back to
+one of those non-recognized forms, or omits `attributes = ...` while the
+harness argument is not recognized as first-party, generated code falls back to
 `rstest-bdd-harness` and therefore requires a direct base harness dependency.
 
 ### Workspace dependency migration for contributors
@@ -234,8 +238,8 @@ fn search_works(world: Result<World, String>) -> Result<(), String> {
 
 The generated scenario unwraps `world` with `?` before inserting the inner
 `World` value into `StepContext`. Borrowed result-like fixtures are rejected:
-use `Result<T, E>` or `StepResult<T, E>` by value rather than `&Result<T, E>`
-or `&StepResult<T, E>`.
+use `Result<T, E>` or `StepResult<T, E>` by value rather than `&Result<T, E>` or
+ `&StepResult<T, E>`.
 
 ### Adopt harness context
 
@@ -312,6 +316,10 @@ runtime with a `LocalSet`. Step functions can use
 async steps that yield `Pending` are not supported in this mode. Use explicit
 `.await` coordination in the code under test, or use an async scenario with an
 external Tokio test attribute when the scenario itself must be asynchronous.
+When `attributes = ...` is omitted, the macro infers
+`rstest_bdd_harness_tokio::TokioAttributePolicy` for the canonical
+`TokioHarness` path. Keep `attributes = ...` only for overrides,
+attributes-only configuration, or non-recognized harness paths.
 
 ### Adopt GPUI harness configuration
 
@@ -336,7 +344,8 @@ fn counter_updates() {}
 When `attributes = ...` is omitted, the macro infers
 `rstest_bdd_harness_gpui::GpuiAttributePolicy` for the canonical `GpuiHarness`
 path. Steps can request the injected `gpui::TestAppContext` with
-`#[from(rstest_bdd_harness_context)]`.
+`#[from(rstest_bdd_harness_context)]`. Keep `attributes = ...` only for
+overrides, attributes-only configuration, or non-recognized harness paths.
 
 ## Migration checklist
 
@@ -353,6 +362,9 @@ path. Steps can request the injected `gpui::TestAppContext` with
   `Result<T, E>` or `StepResult<T, E>` fixtures by value.
 - [ ] Add `rstest-bdd-harness-tokio` or `rstest-bdd-harness-gpui` only to test
   targets that need those framework integrations.
+- [ ] Remove redundant paired first-party `attributes = ...` arguments from
+  Tokio and GPUI examples unless the scenario is intentionally demonstrating an
+  override.
 
 ## Common errors and fixes
 

--- a/examples/gpui-counter/README.md
+++ b/examples/gpui-counter/README.md
@@ -1,10 +1,10 @@
 # GPUI counter example
 
 This example crate demonstrates writing behaviour-driven development (BDD)
-tests that exercise the GPUI harness adapter and attribute policy from
-`rstest-bdd-harness-gpui`. The scenarios model a simple counter application
-while also observing GPUI-injected `TestAppContext` details from within step
-definitions.
+tests with the first-party GPUI harness adapter from `rstest-bdd-harness-gpui`.
+The scenarios rely on harness-led attribute-policy defaults, model a simple
+counter application, and observe GPUI-injected `TestAppContext` details from
+within step definitions.
 
 ## Running the tests
 
@@ -17,8 +17,9 @@ cargo test -p gpui-counter
 The BDD scenarios live in `tests/features/counter.feature`. Step definitions in
 `tests/counter.rs` demonstrate:
 
-- Binding scenarios with both `harness = GpuiHarness` and
-  `attributes = GpuiAttributePolicy`.
+- Binding first-party GPUI scenarios with `harness = GpuiHarness` alone.
+- Relying on the macro to infer `GpuiAttributePolicy` from the first-party
+  harness path.
 - Accessing the injected `gpui::TestAppContext` through the
   `#[from(rstest_bdd_harness_context)]` fixture key.
 - Recording harness context observations (e.g. `TestAppContext` availability)

--- a/examples/gpui-counter/tests/counter.rs
+++ b/examples/gpui-counter/tests/counter.rs
@@ -1,7 +1,7 @@
 //! BDD acceptance tests for the GPUI counter example.
 //!
-//! These tests demonstrate `GpuiHarness` and `GpuiAttributePolicy` in a
-//! user-facing example crate, with step access to injected
+//! These tests demonstrate harness-led GPUI defaults in a user-facing example
+//! crate, with step access to injected
 //! `gpui::TestAppContext` via the `rstest_bdd_harness_context` fixture key.
 
 use gpui_counter::CounterApp;
@@ -60,7 +60,6 @@ fn a_gpui_test_context_was_recorded(app: &CounterApp) {
     path = "tests/features/counter.feature",
     name = "Increment a counter and observe GPUI context",
     harness = rstest_bdd_harness_gpui::GpuiHarness,
-    attributes = rstest_bdd_harness_gpui::GpuiAttributePolicy,
 )]
 fn increment_and_observe_gpui_context(#[from(app)] _: CounterApp) {}
 
@@ -68,6 +67,5 @@ fn increment_and_observe_gpui_context(#[from(app)] _: CounterApp) {}
     path = "tests/features/counter.feature",
     name = "Multiple increments and decrements",
     harness = rstest_bdd_harness_gpui::GpuiHarness,
-    attributes = rstest_bdd_harness_gpui::GpuiAttributePolicy,
 )]
 fn multiple_increments_and_decrements(#[from(app)] _: CounterApp) {}

--- a/examples/tokio-reminders/README.md
+++ b/examples/tokio-reminders/README.md
@@ -1,10 +1,10 @@
 # Tokio reminders example
 
 This example crate demonstrates writing behaviour-driven development (BDD)
-tests that exercise `TokioHarness` and `TokioAttributePolicy` from
-`rstest-bdd-harness-tokio`. The scenarios model a small reminder service that
-queues local Tokio tasks, while the unit tests and doctest validate explicit
-`flush().await` coordination.
+tests with the first-party `TokioHarness` from `rstest-bdd-harness-tokio`. The
+scenarios rely on harness-led attribute-policy defaults, model a small reminder
+service that queues local Tokio tasks, and leave explicit `flush().await`
+coordination to the unit tests and doctest.
 
 ## Running the tests
 
@@ -17,8 +17,9 @@ cargo test -p tokio-reminders
 The BDD scenarios live in `tests/features/reminders.feature`. Step definitions
 in `tests/reminders.rs` demonstrate:
 
-- Binding scenarios with both `harness = TokioHarness` and
-  `attributes = TokioAttributePolicy`.
+- Binding first-party Tokio scenarios with `harness = TokioHarness` alone.
+- Relying on the macro to infer `TokioAttributePolicy` from the first-party
+  harness path.
 - Using immediate-ready `async fn` step definitions under `TokioHarness`.
 - Observing queued reminder state without requiring a multi-poll async step.
 

--- a/examples/tokio-reminders/tests/reminders.rs
+++ b/examples/tokio-reminders/tests/reminders.rs
@@ -59,7 +59,6 @@ async fn no_reminders_have_been_delivered_yet(service: &ReminderService) {
     path = "tests/features/reminders.feature",
     name = "Scheduling a reminder queues it for later delivery",
     harness = rstest_bdd_harness_tokio::TokioHarness,
-    attributes = rstest_bdd_harness_tokio::TokioAttributePolicy,
 )]
 fn queues_a_scheduled_reminder(#[from(service)] _: ReminderService) {}
 
@@ -67,6 +66,5 @@ fn queues_a_scheduled_reminder(#[from(service)] _: ReminderService) {}
     path = "tests/features/reminders.feature",
     name = "Scheduling multiple reminders preserves queue order",
     harness = rstest_bdd_harness_tokio::TokioHarness,
-    attributes = rstest_bdd_harness_tokio::TokioAttributePolicy,
 )]
 fn preserves_queue_order(#[from(service)] _: ReminderService) {}


### PR DESCRIPTION
## Summary

Implement roadmap item 9.7.4 by aligning the user guide, design document, migration guide, and first-party examples with ADR-008 harness-led attribute-policy defaults.

Roadmap task: 9.7.4
Execplan: [docs/execplans/9-7-4-update-guides-design-docs-and-examples.md](https://github.com/leynos/rstest-bdd/blob/9-7-4-update-guides-design-docs-and-examples/docs/execplans/9-7-4-update-guides-design-docs-and-examples.md)

## Changes

- Update `docs/users-guide.md`, `docs/rstest-bdd-design.md`, and `docs/v0-6-0-migration-guide.md` to lead with first-party `harness = ...` defaults for Tokio and GPUI.
- Keep `attributes = ...` documented as the explicit override, attributes-only configuration, and third-party caveat surface.
- Update `examples/tokio-reminders` and `examples/gpui-counter` prose and scenario tests so their normal first-party examples no longer pass redundant first-party attribute policies.
- Mark roadmap item 9.7.4 done and keep the execplan current through implementation, validation, review, commit, and push.

## Validation

- `cargo test -p tokio-reminders`: passed.
- `cargo test -p gpui-counter`: passed.
- `make markdownlint`: passed.
- `make nixie`: passed.
- `make check-fmt`: passed.
- `make lint`: passed.
- `make typecheck`: passed.
- `make test`: passed; 1,473 nextest tests passed, 7 skipped, and 62 Python publish-check tests passed.
- `coderabbit review --agent`: passed twice on the implementation branch with zero findings.

## Notes

This PR also includes the earlier gate-unblocking manifest cleanup that removed duplicate `macro_compile` test target declarations from the Tokio and GPUI harness manifests.

## References

- Lody session: https://lody.ai/leynos/sessions/cf6a7d98-d416-4269-a866-1b7f701d1f2d