### PR TITLE
Deduplicate diagnostic publishing prologue/epilogue behind a canonical helper (#510)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,6 +1658,7 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "gherkin",
+ "insta",
  "lsp-types",
  "proc-macro2",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,6 +2199,7 @@ version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",

--- a/crates/rstest-bdd-server/Cargo.toml
+++ b/crates/rstest-bdd-server/Cargo.toml
@@ -44,6 +44,7 @@ rstest-bdd-patterns.workspace = true
 tempfile = { workspace = true, optional = true }
 
 [dev-dependencies]
+insta = { workspace = true, features = ["filters"] }
 proptest.workspace = true
 rstest.workspace = true
 rstest-bdd-server = { path = ".", features = ["test-support"] }

--- a/crates/rstest-bdd-server/Cargo.toml
+++ b/crates/rstest-bdd-server/Cargo.toml
@@ -49,3 +49,6 @@ proptest.workspace = true
 rstest.workspace = true
 rstest-bdd-server = { path = ".", features = ["test-support"] }
 tempfile.workspace = true
+# `io-util` supplies `duplex`/`empty`/`AsyncReadExt` for the in-process
+# transport-backed diagnostic-publishing test.
+tokio = { workspace = true, features = ["io-util"] }

--- a/crates/rstest-bdd-server/src/handlers/diagnostics/publish.rs
+++ b/crates/rstest-bdd-server/src/handlers/diagnostics/publish.rs
@@ -149,6 +149,7 @@ pub fn publish_rust_diagnostics(state: &ServerState, rust_path: &Path) {
 
 #[cfg(test)]
 mod tests {
+    //! Snapshot and property tests for diagnostic publication payloads.
 
     use lsp_types::{DiagnosticSeverity, Position, Range};
     use proptest::prelude::*;
@@ -180,8 +181,9 @@ mod tests {
     /// that is what the `PublishDiagnosticsParams` debug output contains.
     fn snapshot_settings(dir: &Path) -> insta::Settings {
         let mut settings = insta::Settings::clone_current();
-        #[expect(clippy::expect_used, reason = "temp dirs are absolute paths")]
-        let dir_url = Url::from_file_path(dir).expect("temp dir converts to URL");
+        let Ok(dir_url) = Url::from_file_path(dir) else {
+            panic!("temp dir should convert to a URL: {}", dir.display());
+        };
         settings.add_filter(&regex::escape(dir_url.path()), "[TMP]");
         settings
     }

--- a/crates/rstest-bdd-server/src/handlers/diagnostics/publish.rs
+++ b/crates/rstest-bdd-server/src/handlers/diagnostics/publish.rs
@@ -1,12 +1,16 @@
 //! Diagnostic publishing via LSP.
 //!
 //! This module handles publishing diagnostics to the LSP client via
-//! `textDocument/publishDiagnostics` notifications.
+//! `textDocument/publishDiagnostics` notifications. All publishing flows
+//! through the canonical [`publish_with`] boundary: one place owns the
+//! client/URI guards, parameter construction, notification, and error
+//! logging. The per-file-kind functions only differ in the diagnostics they
+//! compute.
 
 use std::path::Path;
 
 use async_lsp::lsp_types::notification;
-use lsp_types::{PublishDiagnosticsParams, Url};
+use lsp_types::{Diagnostic, PublishDiagnosticsParams, Url};
 use tracing::{debug, warn};
 
 use crate::server::ServerState;
@@ -15,6 +19,82 @@ use super::compute::{compute_unimplemented_step_diagnostics, compute_unused_step
 use super::placeholder::compute_signature_mismatch_diagnostics;
 use super::scenario_outline::compute_scenario_outline_column_diagnostics;
 use super::table_docstring::compute_table_docstring_mismatch_diagnostics;
+
+/// Compute all diagnostics for a feature file, or `None` when the file has
+/// no feature index (in which case nothing is published, preserving any
+/// previously published diagnostics).
+fn compute_feature_file_diagnostics(
+    state: &ServerState,
+    feature_path: &Path,
+) -> Option<Vec<Diagnostic>> {
+    let Some(feature_index) = state.feature_index(feature_path) else {
+        debug!(path = %feature_path.display(), "no feature index for diagnostics");
+        return None;
+    };
+    let mut diagnostics = compute_unimplemented_step_diagnostics(state, feature_index);
+    diagnostics.extend(compute_table_docstring_mismatch_diagnostics(
+        state,
+        feature_index,
+    ));
+    diagnostics.extend(compute_scenario_outline_column_diagnostics(feature_index));
+    Some(diagnostics)
+}
+
+/// Compute all diagnostics for a Rust step definition file.
+///
+/// An empty vector is still published so stale diagnostics are cleared.
+fn compute_rust_file_diagnostics(state: &ServerState, rust_path: &Path) -> Vec<Diagnostic> {
+    let mut diagnostics = compute_unused_step_diagnostics(state, rust_path);
+    diagnostics.extend(compute_signature_mismatch_diagnostics(state, rust_path));
+    diagnostics
+}
+
+/// Build the publish parameters for `path` from a computation, without
+/// performing any I/O towards the client.
+///
+/// Returns `None` (publishing is skipped) when `compute` declines to produce
+/// diagnostics or when `path` cannot be converted to a URI. An empty
+/// diagnostics vector still yields parameters, because publishing an empty
+/// array clears previously published diagnostics.
+///
+/// Separated from [`publish_with`] so tests can pin the published payload
+/// without a client socket.
+fn prepare_publish(
+    state: &ServerState,
+    path: &Path,
+    compute: impl FnOnce(&ServerState, &Path) -> Option<Vec<Diagnostic>>,
+) -> Option<PublishDiagnosticsParams> {
+    let diagnostics = compute(state, path)?;
+    let Ok(uri) = Url::from_file_path(path) else {
+        warn!(path = %path.display(), "cannot convert path to URI");
+        return None;
+    };
+    Some(PublishDiagnosticsParams::new(uri, diagnostics, None))
+}
+
+/// Canonical publish boundary: guard the client socket, build parameters via
+/// [`prepare_publish`], send the notification, and log failures.
+///
+/// All diagnostic publishing must flow through this helper so the guards,
+/// parameter construction, and error logging exist exactly once; see the
+/// developers' guide for ownership and permitted call-sites.
+fn publish_with(
+    state: &ServerState,
+    path: &Path,
+    failure_message: &'static str,
+    compute: impl FnOnce(&ServerState, &Path) -> Option<Vec<Diagnostic>>,
+) {
+    let Some(client) = state.client() else {
+        debug!("no client socket available for publishing diagnostics");
+        return;
+    };
+    let Some(params) = prepare_publish(state, path, compute) else {
+        return;
+    };
+    if let Err(err) = client.notify::<notification::PublishDiagnostics>(params) {
+        warn!(error = %err, "{}", failure_message);
+    }
+}
 
 /// Publish diagnostics for a single feature file.
 ///
@@ -26,32 +106,12 @@ use super::table_docstring::compute_table_docstring_mismatch_diagnostics;
 /// Publishes them via the client socket. Publishes an empty array if no issues
 /// are found, clearing any previous diagnostics.
 pub fn publish_feature_diagnostics(state: &ServerState, feature_path: &Path) {
-    let Some(client) = state.client() else {
-        debug!("no client socket available for publishing diagnostics");
-        return;
-    };
-
-    let Some(feature_index) = state.feature_index(feature_path) else {
-        debug!(path = %feature_path.display(), "no feature index for diagnostics");
-        return;
-    };
-
-    let Ok(uri) = Url::from_file_path(feature_path) else {
-        warn!(path = %feature_path.display(), "cannot convert path to URI");
-        return;
-    };
-
-    let mut diagnostics = compute_unimplemented_step_diagnostics(state, feature_index);
-    diagnostics.extend(compute_table_docstring_mismatch_diagnostics(
+    publish_with(
         state,
-        feature_index,
-    ));
-    diagnostics.extend(compute_scenario_outline_column_diagnostics(feature_index));
-
-    let params = PublishDiagnosticsParams::new(uri, diagnostics, None);
-    if let Err(err) = client.notify::<notification::PublishDiagnostics>(params) {
-        warn!(error = %err, "failed to publish feature diagnostics");
-    }
+        feature_path,
+        "failed to publish feature diagnostics",
+        compute_feature_file_diagnostics,
+    );
 }
 
 /// Publish diagnostics for all feature files.
@@ -79,21 +139,128 @@ pub fn publish_all_feature_diagnostics(state: &ServerState) {
 /// Publishes them via the client socket. Publishes an empty array if no issues
 /// are found, clearing any previous diagnostics.
 pub fn publish_rust_diagnostics(state: &ServerState, rust_path: &Path) {
-    let Some(client) = state.client() else {
-        debug!("no client socket available for publishing diagnostics");
-        return;
-    };
+    publish_with(
+        state,
+        rust_path,
+        "failed to publish rust diagnostics",
+        |state, path| Some(compute_rust_file_diagnostics(state, path)),
+    );
+}
 
-    let Ok(uri) = Url::from_file_path(rust_path) else {
-        warn!(path = %rust_path.display(), "cannot convert path to URI");
-        return;
-    };
+#[cfg(test)]
+mod tests {
 
-    let mut diagnostics = compute_unused_step_diagnostics(state, rust_path);
-    diagnostics.extend(compute_signature_mismatch_diagnostics(state, rust_path));
+    use lsp_types::{DiagnosticSeverity, Position, Range};
+    use proptest::prelude::*;
 
-    let params = PublishDiagnosticsParams::new(uri, diagnostics, None);
-    if let Err(err) = client.notify::<notification::PublishDiagnostics>(params) {
-        warn!(error = %err, "failed to publish rust diagnostics");
+    use crate::config::ServerConfig;
+    use crate::test_support::ScenarioBuilder;
+
+    use super::*;
+
+    const FEATURE_SOURCE: &str = concat!(
+        "Feature: demo\n",
+        "  Scenario: example\n",
+        "    Given an implemented step\n",
+        "    When an unimplemented step\n",
+    );
+
+    const RUST_SOURCE: &str = concat!(
+        "use rstest_bdd_macros::{given, when};\n\n",
+        "#[given(\"an implemented step\")]\n",
+        "fn implemented(count: u32) {}\n\n",
+        "#[when(\"an unused step\")]\n",
+        "fn unused() {}\n",
+    );
+
+    /// Snapshot settings that normalize the temp-dir portion of file URIs.
+    ///
+    /// The filter matches the URL-rendered form of the directory (for
+    /// example `/C:/Users/...` on Windows rather than `C:\Users\...`), as
+    /// that is what the `PublishDiagnosticsParams` debug output contains.
+    fn snapshot_settings(dir: &Path) -> insta::Settings {
+        let mut settings = insta::Settings::clone_current();
+        #[expect(clippy::expect_used, reason = "temp dirs are absolute paths")]
+        let dir_url = Url::from_file_path(dir).expect("temp dir converts to URL");
+        settings.add_filter(&regex::escape(dir_url.path()), "[TMP]");
+        settings
+    }
+
+    #[test]
+    fn feature_publish_payload_is_pinned() {
+        let scenario = ScenarioBuilder::new().with_single_file_pair(FEATURE_SOURCE, RUST_SOURCE);
+        let params = prepare_publish(
+            &scenario.state,
+            &scenario.feature_path,
+            compute_feature_file_diagnostics,
+        );
+        #[expect(clippy::expect_used, reason = "feature index exists for staged file")]
+        let params = params.expect("feature file publishes diagnostics");
+        snapshot_settings(scenario.dir.path()).bind(|| {
+            insta::assert_debug_snapshot!("feature_publish_params", params);
+        });
+    }
+
+    #[test]
+    fn rust_publish_payload_is_pinned() {
+        let scenario = ScenarioBuilder::new().with_single_file_pair(FEATURE_SOURCE, RUST_SOURCE);
+        let params = prepare_publish(&scenario.state, &scenario.rust_path, |state, path| {
+            Some(compute_rust_file_diagnostics(state, path))
+        });
+        #[expect(clippy::expect_used, reason = "rust files always publish")]
+        let params = params.expect("rust file publishes diagnostics");
+        snapshot_settings(scenario.dir.path()).bind(|| {
+            insta::assert_debug_snapshot!("rust_publish_params", params);
+        });
+    }
+
+    #[test]
+    fn missing_feature_index_skips_publishing() {
+        let state = crate::server::ServerState::new(ServerConfig::default());
+        let params = prepare_publish(
+            &state,
+            Path::new("/no/such/file.feature"),
+            compute_feature_file_diagnostics,
+        );
+        assert!(
+            params.is_none(),
+            "missing feature index must skip publishing"
+        );
+    }
+
+    /// Strategy producing an arbitrary diagnostic vector (including empty).
+    fn diagnostics_strategy() -> impl Strategy<Value = Vec<Diagnostic>> {
+        proptest::collection::vec(
+            ("[a-zA-Z ]{1,30}", 0u32..500, 0u32..120).prop_map(|(message, line, col)| Diagnostic {
+                range: Range::new(Position::new(line, col), Position::new(line, col + 1)),
+                severity: Some(DiagnosticSeverity::WARNING),
+                message,
+                ..Diagnostic::default()
+            }),
+            0..8,
+        )
+    }
+
+    proptest! {
+        /// Publishing invariants: any computed vector (including empty) is
+        /// published verbatim — same count, same order, same URI target.
+        #[test]
+        fn publish_params_preserve_computed_diagnostics(
+            diagnostics in diagnostics_strategy(),
+        ) {
+            let state = crate::server::ServerState::new(ServerConfig::default());
+            // `Url::from_file_path` requires a platform-absolute path, so a
+            // hard-coded `/tmp/...` literal would fail on Windows.
+            let path = std::env::temp_dir().join("publish-invariants.rs");
+            let expected = diagnostics.clone();
+            let params = prepare_publish(&state, &path, move |_, _| Some(diagnostics));
+            let params = params.ok_or_else(|| {
+                TestCaseError::fail("valid path must produce publish params")
+            })?;
+            prop_assert_eq!(&params.diagnostics, &expected);
+            #[expect(clippy::expect_used, reason = "fixed absolute path converts")]
+            let expected_uri = Url::from_file_path(&path).expect("uri");
+            prop_assert_eq!(params.uri, expected_uri);
+        }
     }
 }

--- a/crates/rstest-bdd-server/src/handlers/diagnostics/publish.rs
+++ b/crates/rstest-bdd-server/src/handlers/diagnostics/publish.rs
@@ -230,6 +230,66 @@ mod tests {
         );
     }
 
+    /// Client-backed proof that `publish_feature_diagnostics` skips the whole
+    /// boundary — reaching `ClientSocket::notify` for nothing — when the
+    /// feature has no index, without a mock that bypasses `notify`.
+    ///
+    /// A real `async_lsp` main loop supplies the `ClientSocket`; its outgoing
+    /// traffic is captured off an in-memory transport. A `window/logMessage`
+    /// sentinel proves the transport records real notifications and bounds the
+    /// receive window: had the skip wrongly published, its
+    /// `textDocument/publishDiagnostics` would precede the sentinel in the
+    /// capture.
+    #[tokio::test]
+    async fn missing_feature_index_emits_no_notification_through_client() {
+        use async_lsp::MainLoop;
+        use async_lsp::lsp_types::notification::LogMessage;
+        use async_lsp::router::Router;
+        use lsp_types::{LogMessageParams, MessageType};
+        use tokio::io::AsyncReadExt;
+        use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+        let (mainloop, client) = MainLoop::new_server(|_client| Router::new(()));
+
+        let mut state = crate::server::ServerState::new(ServerConfig::default());
+        state.set_client(client.clone());
+
+        // No feature index for this path, so `publish_with` must return before
+        // ever calling `client.notify`.
+        publish_feature_diagnostics(&state, Path::new("/no/such/absolute/file.feature"));
+
+        if let Err(err) = client.notify::<LogMessage>(LogMessageParams {
+            typ: MessageType::LOG,
+            message: "sentinel".to_owned(),
+        }) {
+            panic!("sentinel notify failed: {err}");
+        }
+
+        // Drive the loop with EOF input and capture serialized output. The loop
+        // terminates with an error on input EOF; that is the expected exit, and
+        // it flushes any queued outgoing message first. `state`/`client` stay
+        // alive across the await so the loop's outgoing channel stays open.
+        let (writer, mut reader) = tokio::io::duplex(64 * 1024);
+        let input = tokio::io::empty().compat();
+        let _ = mainloop.run_buffered(input, writer.compat_write()).await;
+
+        let mut captured = Vec::new();
+        assert!(
+            reader.read_to_end(&mut captured).await.is_ok(),
+            "failed to read captured transport output"
+        );
+        let text = String::from_utf8(captured).unwrap_or_else(|_| String::from("<invalid utf-8>"));
+
+        assert!(
+            text.contains("window/logMessage"),
+            "the transport must capture the sentinel notification: {text}"
+        );
+        assert!(
+            !text.contains("textDocument/publishDiagnostics"),
+            "no publishDiagnostics may be emitted for an absent feature index: {text}"
+        );
+    }
+
     /// Strategy producing an arbitrary diagnostic vector (including empty).
     fn diagnostics_strategy() -> impl Strategy<Value = Vec<Diagnostic>> {
         proptest::collection::vec(

--- a/crates/rstest-bdd-server/src/handlers/diagnostics/publish.rs
+++ b/crates/rstest-bdd-server/src/handlers/diagnostics/publish.rs
@@ -198,31 +198,61 @@ mod tests {
         ScenarioBuilder::new().with_single_file_pair(FEATURE_SOURCE, RUST_SOURCE)
     }
 
-    #[rstest]
-    fn feature_publish_payload_is_pinned(publish_scenario: SingleFilePairScenario) {
-        let params = prepare_publish(
-            &publish_scenario.state,
-            &publish_scenario.feature_path,
-            compute_feature_file_diagnostics,
-        );
-        #[expect(clippy::expect_used, reason = "feature index exists for staged file")]
-        let params = params.expect("feature file publishes diagnostics");
-        snapshot_settings(publish_scenario.dir.path()).bind(|| {
-            insta::assert_debug_snapshot!("feature_publish_params", params);
-        });
+    /// Selects which staged file a payload case publishes.
+    type SelectPath = fn(&SingleFilePairScenario) -> &Path;
+    /// Diagnostic computation under test, in `prepare_publish`'s shape.
+    type ComputeDiagnostics = fn(&ServerState, &Path) -> Option<Vec<Diagnostic>>;
+
+    fn feature_file(scenario: &SingleFilePairScenario) -> &Path {
+        &scenario.feature_path
     }
 
+    fn rust_file(scenario: &SingleFilePairScenario) -> &Path {
+        &scenario.rust_path
+    }
+
+    /// Rust files always publish, so lift the computation into `Option`.
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "matches the ComputeDiagnostics contract, where None skips publishing"
+    )]
+    fn compute_rust_file_diagnostics_opt(
+        state: &ServerState,
+        path: &Path,
+    ) -> Option<Vec<Diagnostic>> {
+        Some(compute_rust_file_diagnostics(state, path))
+    }
+
+    /// Pin the published payload for each file kind.
+    ///
+    /// The cases share the staged workspace and the snapshot plumbing; they
+    /// differ only in the file they target and the diagnostics they compute.
     #[rstest]
-    fn rust_publish_payload_is_pinned(publish_scenario: SingleFilePairScenario) {
+    #[case::feature(
+        feature_file as SelectPath,
+        compute_feature_file_diagnostics as ComputeDiagnostics,
+        "feature_publish_params"
+    )]
+    #[case::rust(
+        rust_file as SelectPath,
+        compute_rust_file_diagnostics_opt as ComputeDiagnostics,
+        "rust_publish_params"
+    )]
+    fn publish_payload_is_pinned(
+        publish_scenario: SingleFilePairScenario,
+        #[case] select_path: SelectPath,
+        #[case] compute: ComputeDiagnostics,
+        #[case] snapshot: &str,
+    ) {
         let params = prepare_publish(
             &publish_scenario.state,
-            &publish_scenario.rust_path,
-            |state, path| Some(compute_rust_file_diagnostics(state, path)),
+            select_path(&publish_scenario),
+            compute,
         );
-        #[expect(clippy::expect_used, reason = "rust files always publish")]
-        let params = params.expect("rust file publishes diagnostics");
+        #[expect(clippy::expect_used, reason = "staged files publish diagnostics")]
+        let params = params.expect("staged file publishes diagnostics");
         snapshot_settings(publish_scenario.dir.path()).bind(|| {
-            insta::assert_debug_snapshot!("rust_publish_params", params);
+            insta::assert_debug_snapshot!(snapshot, params);
         });
     }
 

--- a/crates/rstest-bdd-server/src/handlers/diagnostics/publish.rs
+++ b/crates/rstest-bdd-server/src/handlers/diagnostics/publish.rs
@@ -153,9 +153,10 @@ mod tests {
 
     use lsp_types::{DiagnosticSeverity, Position, Range};
     use proptest::prelude::*;
+    use rstest::{fixture, rstest};
 
     use crate::config::ServerConfig;
-    use crate::test_support::ScenarioBuilder;
+    use crate::test_support::{ScenarioBuilder, SingleFilePairScenario};
 
     use super::*;
 
@@ -188,30 +189,39 @@ mod tests {
         settings
     }
 
-    #[test]
-    fn feature_publish_payload_is_pinned() {
-        let scenario = ScenarioBuilder::new().with_single_file_pair(FEATURE_SOURCE, RUST_SOURCE);
+    /// A staged feature/Rust file pair whose indices are already populated.
+    ///
+    /// Both payload snapshots publish from the same workspace; only the file
+    /// they target and the diagnostics they compute differ.
+    #[fixture]
+    fn publish_scenario() -> SingleFilePairScenario {
+        ScenarioBuilder::new().with_single_file_pair(FEATURE_SOURCE, RUST_SOURCE)
+    }
+
+    #[rstest]
+    fn feature_publish_payload_is_pinned(publish_scenario: SingleFilePairScenario) {
         let params = prepare_publish(
-            &scenario.state,
-            &scenario.feature_path,
+            &publish_scenario.state,
+            &publish_scenario.feature_path,
             compute_feature_file_diagnostics,
         );
         #[expect(clippy::expect_used, reason = "feature index exists for staged file")]
         let params = params.expect("feature file publishes diagnostics");
-        snapshot_settings(scenario.dir.path()).bind(|| {
+        snapshot_settings(publish_scenario.dir.path()).bind(|| {
             insta::assert_debug_snapshot!("feature_publish_params", params);
         });
     }
 
-    #[test]
-    fn rust_publish_payload_is_pinned() {
-        let scenario = ScenarioBuilder::new().with_single_file_pair(FEATURE_SOURCE, RUST_SOURCE);
-        let params = prepare_publish(&scenario.state, &scenario.rust_path, |state, path| {
-            Some(compute_rust_file_diagnostics(state, path))
-        });
+    #[rstest]
+    fn rust_publish_payload_is_pinned(publish_scenario: SingleFilePairScenario) {
+        let params = prepare_publish(
+            &publish_scenario.state,
+            &publish_scenario.rust_path,
+            |state, path| Some(compute_rust_file_diagnostics(state, path)),
+        );
         #[expect(clippy::expect_used, reason = "rust files always publish")]
         let params = params.expect("rust file publishes diagnostics");
-        snapshot_settings(scenario.dir.path()).bind(|| {
+        snapshot_settings(publish_scenario.dir.path()).bind(|| {
             insta::assert_debug_snapshot!("rust_publish_params", params);
         });
     }

--- a/crates/rstest-bdd-server/src/handlers/diagnostics/publish.rs
+++ b/crates/rstest-bdd-server/src/handlers/diagnostics/publish.rs
@@ -9,8 +9,7 @@
 
 use std::path::Path;
 
-use async_lsp::lsp_types::notification;
-use lsp_types::{Diagnostic, PublishDiagnosticsParams, Url};
+use async_lsp::lsp_types::{Diagnostic, PublishDiagnosticsParams, Url, notification};
 use tracing::{debug, warn};
 
 use crate::server::ServerState;
@@ -47,6 +46,22 @@ fn compute_rust_file_diagnostics(state: &ServerState, rust_path: &Path) -> Vec<D
     let mut diagnostics = compute_unused_step_diagnostics(state, rust_path);
     diagnostics.extend(compute_signature_mismatch_diagnostics(state, rust_path));
     diagnostics
+}
+
+/// Lift [`compute_rust_file_diagnostics`] into the shape `publish_with`
+/// expects.
+///
+/// Rust files always publish — an empty vector clears stale diagnostics — so
+/// this never yields `None`.
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "matches the compute contract, where None skips publishing entirely"
+)]
+fn compute_rust_file_diagnostics_opt(
+    state: &ServerState,
+    rust_path: &Path,
+) -> Option<Vec<Diagnostic>> {
+    Some(compute_rust_file_diagnostics(state, rust_path))
 }
 
 /// Build the publish parameters for `path` from a computation, without
@@ -143,7 +158,7 @@ pub fn publish_rust_diagnostics(state: &ServerState, rust_path: &Path) {
         state,
         rust_path,
         "failed to publish rust diagnostics",
-        |state, path| Some(compute_rust_file_diagnostics(state, path)),
+        compute_rust_file_diagnostics_opt,
     );
 }
 
@@ -209,18 +224,6 @@ mod tests {
 
     fn rust_file(scenario: &SingleFilePairScenario) -> &Path {
         &scenario.rust_path
-    }
-
-    /// Rust files always publish, so lift the computation into `Option`.
-    #[expect(
-        clippy::unnecessary_wraps,
-        reason = "matches the ComputeDiagnostics contract, where None skips publishing"
-    )]
-    fn compute_rust_file_diagnostics_opt(
-        state: &ServerState,
-        path: &Path,
-    ) -> Option<Vec<Diagnostic>> {
-        Some(compute_rust_file_diagnostics(state, path))
     }
 
     /// Pin the published payload for each file kind.

--- a/crates/rstest-bdd-server/src/handlers/diagnostics/snapshots/rstest_bdd_server__handlers__diagnostics__publish__tests__feature_publish_params.snap
+++ b/crates/rstest-bdd-server/src/handlers/diagnostics/snapshots/rstest_bdd_server__handlers__diagnostics__publish__tests__feature_publish_params.snap
@@ -1,0 +1,48 @@
+---
+source: crates/rstest-bdd-server/src/handlers/diagnostics/publish.rs
+expression: params
+---
+PublishDiagnosticsParams {
+    uri: Url {
+        scheme: "file",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: None,
+        port: None,
+        path: "[TMP]/test.feature",
+        query: None,
+        fragment: None,
+    },
+    diagnostics: [
+        Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 3,
+                    character: 4,
+                },
+                end: Position {
+                    line: 3,
+                    character: 30,
+                },
+            },
+            severity: Some(
+                Warning,
+            ),
+            code: Some(
+                String(
+                    "unimplemented-step",
+                ),
+            ),
+            code_description: None,
+            source: Some(
+                "rstest-bdd",
+            ),
+            message: "No Rust implementation found for When  step: \"an unimplemented step\"",
+            related_information: None,
+            tags: None,
+            data: None,
+        },
+    ],
+    version: None,
+}

--- a/crates/rstest-bdd-server/src/handlers/diagnostics/snapshots/rstest_bdd_server__handlers__diagnostics__publish__tests__rust_publish_params.snap
+++ b/crates/rstest-bdd-server/src/handlers/diagnostics/snapshots/rstest_bdd_server__handlers__diagnostics__publish__tests__rust_publish_params.snap
@@ -1,0 +1,48 @@
+---
+source: crates/rstest-bdd-server/src/handlers/diagnostics/publish.rs
+expression: params
+---
+PublishDiagnosticsParams {
+    uri: Url {
+        scheme: "file",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: None,
+        port: None,
+        path: "[TMP]/steps.rs",
+        query: None,
+        fragment: None,
+    },
+    diagnostics: [
+        Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 5,
+                    character: 0,
+                },
+                end: Position {
+                    line: 5,
+                    character: 25,
+                },
+            },
+            severity: Some(
+                Warning,
+            ),
+            code: Some(
+                String(
+                    "unused-step-definition",
+                ),
+            ),
+            code_description: None,
+            source: Some(
+                "rstest-bdd",
+            ),
+            message: "Step definition is not used by any feature file: #[when(\"an unused step\")]",
+            related_information: None,
+            tags: None,
+            data: None,
+        },
+    ],
+    version: None,
+}

--- a/crates/rstest-bdd-server/tests/smoke_lsp/clearing.rs
+++ b/crates/rstest-bdd-server/tests/smoke_lsp/clearing.rs
@@ -131,6 +131,13 @@ fn smoke_rust_diagnostics_cleared_once_step_referenced(mut server: ServerHandle)
         .expect("expected non-empty rust diagnostics for the unused step");
 
     // A feature that uses the step removes the "unused" finding.
+    //
+    // This save's own notification is deliberately not awaited before the
+    // re-save below. `didSave` is dispatched to a synchronous handler that
+    // indexes and publishes inline, and both notifications travel the same
+    // stdin stream, so the server cannot begin the re-save before this save is
+    // indexed. Awaiting here would only assert an ordering the transport
+    // already guarantees.
     let feature_path = dir.join("rust_clearing.feature");
     std::fs::write(
         &feature_path,

--- a/crates/rstest-bdd-server/tests/smoke_lsp/clearing.rs
+++ b/crates/rstest-bdd-server/tests/smoke_lsp/clearing.rs
@@ -1,0 +1,165 @@
+//! End-to-end smoke tests for empty-vector clearing of published diagnostics.
+//!
+//! Split out of `main.rs` so each smoke-test file stays within the 400-line
+//! limit. Reuses the `ServerHandle` fixture, `wire` helpers, and constants
+//! from the crate root.
+
+use rstest::rstest;
+
+use super::wire::{did_save, is_non_empty_diagnostics, shutdown_and_exit};
+use super::{MAX_RECV_MESSAGES, ServerHandle, server};
+
+/// Exercise the canonical publication boundary end-to-end through the public
+/// publishers. An unimplemented step first emits a non-empty
+/// `publishDiagnostics` notification; once the matching Rust step is added, the
+/// feature re-publishes an *empty* diagnostics array to clear the resolved
+/// diagnostic. This pins that `publish_with` actually notifies the client and
+/// that empty vectors are published (not suppressed) — behaviour the
+/// payload-only `prepare_publish` tests cannot observe.
+#[rstest]
+#[expect(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test assertions use .expect() and indexing for clear failure messages"
+)]
+fn smoke_feature_diagnostics_cleared_once_step_implemented(mut server: ServerHandle) {
+    let dir = server.workspace_root().to_path_buf();
+    let feature_path = dir.join("clearing.feature");
+    std::fs::write(
+        &feature_path,
+        concat!(
+            "Feature: clearing\n",
+            "  Scenario: pending\n",
+            "    Given a pending step\n",
+        ),
+    )
+    .expect("write feature");
+    let feature_uri = lsp_types::Url::from_file_path(&feature_path).expect("feature URI");
+    let feature_uri = feature_uri.as_str().to_owned();
+
+    // Saving the feature publishes a non-empty diagnostic for the
+    // unimplemented step through the canonical boundary.
+    did_save(&mut server.stdin, &feature_path);
+    let non_empty_uri = feature_uri.clone();
+    server
+        .receiver
+        .recv_notification_matching(
+            move |msg| {
+                is_non_empty_diagnostics(msg)
+                    && msg["params"]["uri"].as_str() == Some(non_empty_uri.as_str())
+            },
+            MAX_RECV_MESSAGES,
+        )
+        .expect("expected non-empty diagnostics for the unimplemented step");
+
+    // Implement the step in a Rust file; saving it re-publishes every feature,
+    // and the now-satisfied feature must publish an empty diagnostics array to
+    // clear the stale diagnostic.
+    let rust_path = dir.join("clearing_steps.rs");
+    std::fs::write(
+        &rust_path,
+        concat!(
+            "use rstest_bdd_macros::given;\n",
+            "\n",
+            "#[given(\"a pending step\")]\n",
+            "fn a_pending_step() {}\n",
+        ),
+    )
+    .expect("write rust steps");
+
+    did_save(&mut server.stdin, &rust_path);
+    server
+        .receiver
+        .recv_notification_matching(
+            move |msg| {
+                msg.get("method").and_then(|m| m.as_str())
+                    == Some("textDocument/publishDiagnostics")
+                    && msg["params"]["uri"].as_str() == Some(feature_uri.as_str())
+                    && msg["params"]["diagnostics"]
+                        .as_array()
+                        .is_some_and(Vec::is_empty)
+            },
+            MAX_RECV_MESSAGES,
+        )
+        .expect("expected empty diagnostics clearing the resolved feature");
+
+    shutdown_and_exit(&mut server.stdin, &server.receiver, &mut server.child, 99);
+}
+
+/// Exercise the Rust side of the canonical boundary end-to-end: a Rust step
+/// with no feature referencing it is reported as unused (non-empty
+/// `publishDiagnostics`), and once a feature uses it, re-saving the Rust file
+/// re-publishes an empty diagnostics array for the same Rust URI — proving
+/// `publish_rust_diagnostics` clears stale diagnostics with an empty vector,
+/// which the payload-only `prepare_publish` tests cannot observe.
+#[rstest]
+#[expect(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test assertions use .expect() and indexing for clear failure messages"
+)]
+fn smoke_rust_diagnostics_cleared_once_step_referenced(mut server: ServerHandle) {
+    let dir = server.workspace_root().to_path_buf();
+
+    let rust_path = dir.join("rust_clearing_steps.rs");
+    std::fs::write(
+        &rust_path,
+        concat!(
+            "use rstest_bdd_macros::given;\n",
+            "\n",
+            "#[given(\"an orphan step\")]\n",
+            "fn an_orphan_step() {}\n",
+        ),
+    )
+    .expect("write rust steps");
+    let rust_uri = lsp_types::Url::from_file_path(&rust_path).expect("rust URI");
+    let rust_uri = rust_uri.as_str().to_owned();
+
+    // Saving the Rust file with no feature referencing the step publishes a
+    // non-empty "unused step" diagnostic for the Rust URI.
+    did_save(&mut server.stdin, &rust_path);
+    let non_empty_uri = rust_uri.clone();
+    server
+        .receiver
+        .recv_notification_matching(
+            move |msg| {
+                is_non_empty_diagnostics(msg)
+                    && msg["params"]["uri"].as_str() == Some(non_empty_uri.as_str())
+            },
+            MAX_RECV_MESSAGES,
+        )
+        .expect("expected non-empty rust diagnostics for the unused step");
+
+    // A feature that uses the step removes the "unused" finding.
+    let feature_path = dir.join("rust_clearing.feature");
+    std::fs::write(
+        &feature_path,
+        concat!(
+            "Feature: clearing\n",
+            "  Scenario: uses the step\n",
+            "    Given an orphan step\n",
+        ),
+    )
+    .expect("write feature");
+    did_save(&mut server.stdin, &feature_path);
+
+    // Re-saving the Rust file re-publishes it; the step is now used, so its
+    // computed diagnostics are empty and an empty array clears the stale one.
+    did_save(&mut server.stdin, &rust_path);
+    server
+        .receiver
+        .recv_notification_matching(
+            move |msg| {
+                msg.get("method").and_then(|m| m.as_str())
+                    == Some("textDocument/publishDiagnostics")
+                    && msg["params"]["uri"].as_str() == Some(rust_uri.as_str())
+                    && msg["params"]["diagnostics"]
+                        .as_array()
+                        .is_some_and(Vec::is_empty)
+            },
+            MAX_RECV_MESSAGES,
+        )
+        .expect("expected empty rust diagnostics clearing the resolved step");
+
+    shutdown_and_exit(&mut server.stdin, &server.receiver, &mut server.child, 99);
+}

--- a/crates/rstest-bdd-server/tests/smoke_lsp/main.rs
+++ b/crates/rstest-bdd-server/tests/smoke_lsp/main.rs
@@ -312,3 +312,80 @@ fn smoke_diagnostics_published_for_unimplemented_step(mut server: ServerHandle) 
 
     shutdown_and_exit(&mut server.stdin, &server.receiver, &mut server.child, 99);
 }
+
+/// Exercise the canonical publication boundary end-to-end through the public
+/// publishers. An unimplemented step first emits a non-empty
+/// `publishDiagnostics` notification; once the matching Rust step is added, the
+/// feature re-publishes an *empty* diagnostics array to clear the resolved
+/// diagnostic. This pins that `publish_with` actually notifies the client and
+/// that empty vectors are published (not suppressed) — behaviour the
+/// payload-only `prepare_publish` tests cannot observe.
+#[rstest]
+#[expect(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test assertions use .expect() and indexing for clear failure messages"
+)]
+fn smoke_feature_diagnostics_cleared_once_step_implemented(mut server: ServerHandle) {
+    let dir = server.workspace_root().to_path_buf();
+    let feature_path = dir.join("clearing.feature");
+    std::fs::write(
+        &feature_path,
+        concat!(
+            "Feature: clearing\n",
+            "  Scenario: pending\n",
+            "    Given a pending step\n",
+        ),
+    )
+    .expect("write feature");
+    let feature_uri = lsp_types::Url::from_file_path(&feature_path).expect("feature URI");
+    let feature_uri = feature_uri.as_str().to_owned();
+
+    // Saving the feature publishes a non-empty diagnostic for the
+    // unimplemented step through the canonical boundary.
+    did_save(&mut server.stdin, &feature_path);
+    let non_empty_uri = feature_uri.clone();
+    server
+        .receiver
+        .recv_notification_matching(
+            move |msg| {
+                is_non_empty_diagnostics(msg)
+                    && msg["params"]["uri"].as_str() == Some(non_empty_uri.as_str())
+            },
+            MAX_RECV_MESSAGES,
+        )
+        .expect("expected non-empty diagnostics for the unimplemented step");
+
+    // Implement the step in a Rust file; saving it re-publishes every feature,
+    // and the now-satisfied feature must publish an empty diagnostics array to
+    // clear the stale diagnostic.
+    let rust_path = dir.join("clearing_steps.rs");
+    std::fs::write(
+        &rust_path,
+        concat!(
+            "use rstest_bdd_macros::given;\n",
+            "\n",
+            "#[given(\"a pending step\")]\n",
+            "fn a_pending_step() {}\n",
+        ),
+    )
+    .expect("write rust steps");
+
+    did_save(&mut server.stdin, &rust_path);
+    server
+        .receiver
+        .recv_notification_matching(
+            move |msg| {
+                msg.get("method").and_then(|m| m.as_str())
+                    == Some("textDocument/publishDiagnostics")
+                    && msg["params"]["uri"].as_str() == Some(feature_uri.as_str())
+                    && msg["params"]["diagnostics"]
+                        .as_array()
+                        .is_some_and(Vec::is_empty)
+            },
+            MAX_RECV_MESSAGES,
+        )
+        .expect("expected empty diagnostics clearing the resolved feature");
+
+    shutdown_and_exit(&mut server.stdin, &server.receiver, &mut server.child, 99);
+}

--- a/crates/rstest-bdd-server/tests/smoke_lsp/main.rs
+++ b/crates/rstest-bdd-server/tests/smoke_lsp/main.rs
@@ -6,6 +6,7 @@
 //! JSON-RPC communication, indexing pipeline, handler responses, and
 //! graceful shutdown.
 
+mod clearing;
 mod wire;
 
 use std::io::BufReader;
@@ -309,83 +310,6 @@ fn smoke_diagnostics_published_for_unimplemented_step(mut server: ServerHandle) 
         "diagnostic message should mention the unimplemented step, \
          got: {first_msg}"
     );
-
-    shutdown_and_exit(&mut server.stdin, &server.receiver, &mut server.child, 99);
-}
-
-/// Exercise the canonical publication boundary end-to-end through the public
-/// publishers. An unimplemented step first emits a non-empty
-/// `publishDiagnostics` notification; once the matching Rust step is added, the
-/// feature re-publishes an *empty* diagnostics array to clear the resolved
-/// diagnostic. This pins that `publish_with` actually notifies the client and
-/// that empty vectors are published (not suppressed) — behaviour the
-/// payload-only `prepare_publish` tests cannot observe.
-#[rstest]
-#[expect(
-    clippy::expect_used,
-    clippy::indexing_slicing,
-    reason = "test assertions use .expect() and indexing for clear failure messages"
-)]
-fn smoke_feature_diagnostics_cleared_once_step_implemented(mut server: ServerHandle) {
-    let dir = server.workspace_root().to_path_buf();
-    let feature_path = dir.join("clearing.feature");
-    std::fs::write(
-        &feature_path,
-        concat!(
-            "Feature: clearing\n",
-            "  Scenario: pending\n",
-            "    Given a pending step\n",
-        ),
-    )
-    .expect("write feature");
-    let feature_uri = lsp_types::Url::from_file_path(&feature_path).expect("feature URI");
-    let feature_uri = feature_uri.as_str().to_owned();
-
-    // Saving the feature publishes a non-empty diagnostic for the
-    // unimplemented step through the canonical boundary.
-    did_save(&mut server.stdin, &feature_path);
-    let non_empty_uri = feature_uri.clone();
-    server
-        .receiver
-        .recv_notification_matching(
-            move |msg| {
-                is_non_empty_diagnostics(msg)
-                    && msg["params"]["uri"].as_str() == Some(non_empty_uri.as_str())
-            },
-            MAX_RECV_MESSAGES,
-        )
-        .expect("expected non-empty diagnostics for the unimplemented step");
-
-    // Implement the step in a Rust file; saving it re-publishes every feature,
-    // and the now-satisfied feature must publish an empty diagnostics array to
-    // clear the stale diagnostic.
-    let rust_path = dir.join("clearing_steps.rs");
-    std::fs::write(
-        &rust_path,
-        concat!(
-            "use rstest_bdd_macros::given;\n",
-            "\n",
-            "#[given(\"a pending step\")]\n",
-            "fn a_pending_step() {}\n",
-        ),
-    )
-    .expect("write rust steps");
-
-    did_save(&mut server.stdin, &rust_path);
-    server
-        .receiver
-        .recv_notification_matching(
-            move |msg| {
-                msg.get("method").and_then(|m| m.as_str())
-                    == Some("textDocument/publishDiagnostics")
-                    && msg["params"]["uri"].as_str() == Some(feature_uri.as_str())
-                    && msg["params"]["diagnostics"]
-                        .as_array()
-                        .is_some_and(Vec::is_empty)
-            },
-            MAX_RECV_MESSAGES,
-        )
-        .expect("expected empty diagnostics clearing the resolved feature");
 
     shutdown_and_exit(&mut server.stdin, &server.receiver, &mut server.child, 99);
 }

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -912,10 +912,21 @@ The published payloads for representative feature and Rust files are pinned
 by `insta` snapshots, and the publish invariants (count preserved, empty
 vector still published) by a property test, both in
 `handlers/diagnostics/publish.rs`. The boundary itself — that `publish_with`
-actually emits a `publishDiagnostics` notification through the client socket,
-including an empty array to clear resolved diagnostics — is exercised
-end-to-end against a live server by the `smoke_lsp` integration suite, which
-`prepare_publish`-only tests cannot observe.
+actually reaches (or, for a skip, never reaches) `ClientSocket::notify` — is
+proven through a real client socket, which `prepare_publish`-only tests cannot
+observe:
+
+- **Missing-index skip** is a transport-backed unit test in
+  `handlers/diagnostics/publish.rs`: a real `async_lsp` main loop supplies the
+  `ClientSocket`, `publish_feature_diagnostics` is called for a path with no
+  feature index, and the captured outgoing traffic contains a sentinel
+  notification but no `publishDiagnostics` — so the absent index skips the
+  whole boundary rather than clearing prior client diagnostics.
+- **Emission and empty-vector clearing** for both feature and Rust files are
+  exercised end-to-end against a live server by the `smoke_lsp` integration
+  suite: an unimplemented/unused step yields a non-empty
+  `publishDiagnostics`, and resolving it re-publishes an empty array for the
+  same URI.
 
 ## cargo-bdd scenario output formatting
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -886,6 +886,34 @@ feature-gated regression suite in
 `crates/rstest-bdd-harness-gpui/tests/scenario_name_in_logs.rs` apply the
 attribute to every `GpuiHarness::run`-driving test.
 
+
+## Canonical diagnostic publish path
+
+All LSP diagnostic publishing in `rstest-bdd-server` flows through the
+canonical `publish_with` helper in
+`crates/rstest-bdd-server/src/handlers/diagnostics/publish.rs`. It owns the
+publish boundary exactly once: the client-socket guard, the
+path-to-URI guard, `PublishDiagnosticsParams` construction, the
+`textDocument/publishDiagnostics` notification, and failure logging.
+
+- **Ownership:** the diagnostics handler layer owns the helper; it is private
+  to the `diagnostics::publish` module.
+- **Permitted call-sites:** the public per-file-kind functions
+  (`publish_feature_diagnostics`, `publish_rust_diagnostics`, and any future
+  variant). New diagnostic publishers must delegate to `publish_with` with a
+  compute closure rather than re-implementing the guards or notify call.
+- **Composition rules:** the compute closure returns
+  `Option<Vec<Diagnostic>>` — `None` skips publishing entirely (used when a
+  feature file has no index, preserving previously published diagnostics),
+  while `Some(vec![])` still publishes so stale diagnostics are cleared.
+  `prepare_publish` separates parameter construction from the notify side
+  effect so tests can pin payloads without a client socket.
+
+The published payloads for representative feature and Rust files are pinned
+by `insta` snapshots, and the publish invariants (count preserved, empty
+vector still published) by a property test, both in
+`handlers/diagnostics/publish.rs`.
+
 ## cargo-bdd scenario output formatting
 
 `crates/cargo-bdd/src/output.rs` owns the rendering of skipped-scenario and

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -888,8 +888,8 @@ attribute to every `GpuiHarness::run`-driving test.
 
 ## Canonical diagnostic publish path
 
-All LSP diagnostic publishing in `rstest-bdd-server` flows through the
-canonical `publish_with` helper in
+All Language Server Protocol (LSP) diagnostic publishing in `rstest-bdd-server`
+flows through the canonical `publish_with` helper in
 `crates/rstest-bdd-server/src/handlers/diagnostics/publish.rs`. It owns the
 publish boundary exactly once: the client-socket guard, the
 path-to-URI guard, `PublishDiagnosticsParams` construction, the
@@ -911,7 +911,11 @@ path-to-URI guard, `PublishDiagnosticsParams` construction, the
 The published payloads for representative feature and Rust files are pinned
 by `insta` snapshots, and the publish invariants (count preserved, empty
 vector still published) by a property test, both in
-`handlers/diagnostics/publish.rs`.
+`handlers/diagnostics/publish.rs`. The boundary itself — that `publish_with`
+actually emits a `publishDiagnostics` notification through the client socket,
+including an empty array to clear resolved diagnostics — is exercised
+end-to-end against a live server by the `smoke_lsp` integration suite, which
+`prepare_publish`-only tests cannot observe.
 
 ## cargo-bdd scenario output formatting
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -904,9 +904,9 @@ path-to-URI guard, `PublishDiagnosticsParams` construction, the
 - **Composition rules:** the compute closure returns
   `Option<Vec<Diagnostic>>` — `None` skips publishing entirely (used when a
   feature file has no index, preserving previously published diagnostics),
-  while `Some(vec![])` still publishes so stale diagnostics are cleared.
+  while `Some(vec![])` still publishes, so stale diagnostics are cleared.
   `prepare_publish` separates parameter construction from the notify side
-  effect so tests can pin payloads without a client socket.
+  effect, so tests can pin payloads without a client socket.
 
 The published payloads for representative feature and Rust files are pinned
 by `insta` snapshots, and the publish invariants (count preserved, empty

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -886,7 +886,6 @@ feature-gated regression suite in
 `crates/rstest-bdd-harness-gpui/tests/scenario_name_in_logs.rs` apply the
 attribute to every `GpuiHarness::run`-driving test.
 
-
 ## Canonical diagnostic publish path
 
 All LSP diagnostic publishing in `rstest-bdd-server` flows through the

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1266,40 +1266,6 @@ defensively re-runs the reset before storing handles and observes the
 
 ```rust,no_run
 # use rstest_bdd_macros::given;
-
-#[derive(Debug, PartialEq, Eq)]
-struct UserRow {
-    name: String,
-    email: String,
-    active: bool,
-}
-
-impl DataTableRow for UserRow {
-    const REQUIRES_HEADER: bool = true;
-
-    fn parse_row(mut row: RowSpec<'_>) -> Result<Self, DataTableError> {
-        let name = row.take_column("name")?;
-        let email = row.take_column("email")?;
-        let active = row.parse_column_with(
-            "active",
-            datatable::truthy_bool,
-        )?;
-        Ok(Self { name, email, active })
-    }
-}
-
-#[given("the following users exist:")]
-fn users_exist(#[datatable] rows: Rows<UserRow>) {
-    for row in rows {
-        assert!(row.active || row.name == "Bob");
-    }
-}
-```
-
-Projects that prefer to work with raw rows can declare the argument as
-`Vec<Vec<String>>` and handle parsing manually. Both forms can co-exist within
-the same project, allowing incremental adoption of typed tables.
-
 # fn reset_state_before_assignment() {}
 # fn with_state<R>(_: impl FnOnce(&mut ()) -> R) -> R { unimplemented!() }
 #[given("a fresh GPUI window is opened")]
@@ -2816,15 +2782,15 @@ Diagnostics are updated incrementally:
   file.
 
 When a recomputation finds nothing to report, the server publishes an empty
-diagnostic list for that file. Warnings you have just fixed therefore clear
-from the Problems panel on the next save, rather than lingering until the
-editor or the server is restarted.
+diagnostic list for that file. Resolved warnings therefore clear from the
+Problems panel on the next save, rather than lingering until the editor or the
+server is restarted.
 
-A file the server has not indexed is skipped rather than cleared. If a
-`.feature` file has not been saved since the server started, it has no index
-yet, so saving an unrelated file leaves whatever diagnostics the editor
-already shows for it untouched instead of blanking them. Save the file itself
-to index it and refresh its diagnostics.
+A file the server has not indexed is skipped rather than cleared. A `.feature`
+file that has not been saved since the server started has no index yet, so
+saving an unrelated file leaves whatever diagnostics the editor already shows
+for it untouched instead of blanking them. Saving the file itself indexes it
+and refreshes its diagnostics.
 
 Diagnostics appear in the editor's Problems panel and as inline warnings,
 similar to compiler diagnostics. They use the source `rstest-bdd` and the codes

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1266,6 +1266,40 @@ defensively re-runs the reset before storing handles and observes the
 
 ```rust,no_run
 # use rstest_bdd_macros::given;
+
+#[derive(Debug, PartialEq, Eq)]
+struct UserRow {
+    name: String,
+    email: String,
+    active: bool,
+}
+
+impl DataTableRow for UserRow {
+    const REQUIRES_HEADER: bool = true;
+
+    fn parse_row(mut row: RowSpec<'_>) -> Result<Self, DataTableError> {
+        let name = row.take_column("name")?;
+        let email = row.take_column("email")?;
+        let active = row.parse_column_with(
+            "active",
+            datatable::truthy_bool,
+        )?;
+        Ok(Self { name, email, active })
+    }
+}
+
+#[given("the following users exist:")]
+fn users_exist(#[datatable] rows: Rows<UserRow>) {
+    for row in rows {
+        assert!(row.active || row.name == "Bob");
+    }
+}
+```
+
+Projects that prefer to work with raw rows can declare the argument as
+`Vec<Vec<String>>` and handle parsing manually. Both forms can co-exist within
+the same project, allowing incremental adoption of typed tables.
+
 # fn reset_state_before_assignment() {}
 # fn with_state<R>(_: impl FnOnce(&mut ()) -> R) -> R { unimplemented!() }
 #[given("a fresh GPUI window is opened")]
@@ -2780,6 +2814,17 @@ Diagnostics are updated incrementally:
   or removed step definitions may affect which steps are implemented) and
   checks for unused definitions and placeholder count mismatches in the saved
   file.
+
+When a recomputation finds nothing to report, the server publishes an empty
+diagnostic list for that file. Warnings you have just fixed therefore clear
+from the Problems panel on the next save, rather than lingering until the
+editor or the server is restarted.
+
+A file the server has not indexed is skipped rather than cleared. If a
+`.feature` file has not been saved since the server started, it has no index
+yet, so saving an unrelated file leaves whatever diagnostics the editor
+already shows for it untouched instead of blanking them. Save the file itself
+to index it and refresh its diagnostics.
 
 Diagnostics appear in the editor's Problems panel and as inline warnings,
 similar to compiler diagnostics. They use the source `rstest-bdd` and the codes


### PR DESCRIPTION
## Summary

Closes #510

- Extract one canonical `publish_with(state, path, failure_message, compute)` helper owning the client guard, URI guard, `PublishDiagnosticsParams` construction, `client.notify`, and error logging; `publish_feature_diagnostics` and `publish_rust_diagnostics` are now thin wrappers over it.
- The feature variant's `feature_index` guard is supplied via its compute closure: `None` skips publishing entirely (preserving previous diagnostics), while `Some(vec![])` still publishes so stale diagnostics are cleared.
- `prepare_publish` separates the pure parameter construction from the notify side effect for testability without a client socket.
- Tests:
  - `insta` snapshots pin the published `PublishDiagnosticsParams` (URI + ordered diagnostics) for a representative feature file and Rust file (temp dir normalized to `[TMP]`).
  - A `proptest` suite pins the publish invariants for arbitrary diagnostic vectors: count and order preserved, empty vector still publishes, URI targets the requested path.
- Canonical publish path documented in `docs/developers-guide.md` (ownership, permitted call-sites, composition rules).

## Testing

- `make check-fmt`, `make lint`, `make typecheck`, `make test` (1490 passed), `make markdownlint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Unify LSP diagnostic publishing behind a shared helper and add tests and docs around the canonical publish path.

Enhancements:
- Introduce shared `publish_with` and `prepare_publish` helpers to centralize client/URI guarding, parameter construction, and error logging for diagnostic publishing.
- Split feature and Rust diagnostic computation into dedicated functions to clarify behavior when no feature index exists and to always clear stale Rust diagnostics.

Build:
- Add `insta` with filter support as a dev-dependency for snapshotting diagnostic publish payloads.

Documentation:
- Document the canonical diagnostic publish path, ownership, and composition rules in the developers guide.

Tests:
- Add snapshot tests pinning the published `PublishDiagnosticsParams` for representative feature and Rust files, normalizing temp directory paths.
- Add property-based tests ensuring publish parameters preserve the computed diagnostics’ count, order, emptiness semantics, and URI target.
- Add unit tests covering behavior when a feature index is missing to ensure publishing is skipped.