### PR TITLE
Collapse six registry step-lookups into one canonical mark-and-project helper (#507)

### DIFF
--- a/crates/rstest-bdd/src/registry/async_lookup.rs
+++ b/crates/rstest-bdd/src/registry/async_lookup.rs
@@ -31,8 +31,7 @@ pub fn lookup_step_async_with_mode(
     keyword: StepKeyword,
     pattern: PatternStr<'_>,
 ) -> Option<(AsyncStepFn, StepExecutionMode)> {
-    super::resolve_exact_step(keyword, pattern).map(|step| {
-        super::mark_used((step.keyword, step.pattern));
+    super::mark_and_project(super::resolve_exact_step(keyword, pattern), |step| {
         (step.run_async, step.execution_mode)
     })
 }
@@ -59,8 +58,7 @@ pub fn find_step_async_with_mode(
     keyword: StepKeyword,
     text: StepText<'_>,
 ) -> Option<(AsyncStepFn, StepExecutionMode)> {
-    super::resolve_step(keyword, text).map(|step| {
-        super::mark_used((step.keyword, step.pattern));
+    super::mark_and_project(super::resolve_step(keyword, text), |step| {
         (step.run_async, step.execution_mode)
     })
 }

--- a/crates/rstest-bdd/src/registry/mod.rs
+++ b/crates/rstest-bdd/src/registry/mod.rs
@@ -284,22 +284,34 @@ fn step_specificity(step: &Step) -> SpecificityScore {
     })
 }
 
+/// Mark a resolved step as used and apply a projection to it.
+///
+/// This is the canonical post-resolution path shared by every public lookup
+/// function: the `mark_used` call lives here exactly once, so any lookup
+/// variant that returns `Some` is guaranteed to record the step for
+/// unused-step diagnostics. New lookup variants must resolve a step and pass
+/// it through this helper rather than calling `mark_used` directly; see the
+/// developers' guide for the invariant.
+fn mark_and_project<T>(
+    step: Option<&'static Step>,
+    project: impl FnOnce(&'static Step) -> T,
+) -> Option<T> {
+    step.map(|step| {
+        mark_used((step.keyword, step.pattern));
+        project(step)
+    })
+}
+
 /// Look up a registered step by keyword and pattern.
 #[must_use]
 pub fn lookup_step(keyword: StepKeyword, pattern: PatternStr<'_>) -> Option<StepFn> {
-    resolve_exact_step(keyword, pattern).map(|step| {
-        mark_used((step.keyword, step.pattern));
-        step.run
-    })
+    mark_and_project(resolve_exact_step(keyword, pattern), |step| step.run)
 }
 
 /// Find a registered step whose pattern matches the provided text.
 #[must_use]
 pub fn find_step(keyword: StepKeyword, text: StepText<'_>) -> Option<StepFn> {
-    resolve_step(keyword, text).map(|step| {
-        mark_used((step.keyword, step.pattern));
-        step.run
-    })
+    mark_and_project(resolve_step(keyword, text), |step| step.run)
 }
 
 /// Look up a registered async step by keyword and pattern.
@@ -309,10 +321,7 @@ pub fn find_step(keyword: StepKeyword, text: StepText<'_>) -> Option<StepFn> {
 /// definitions.
 #[must_use]
 pub fn lookup_step_async(keyword: StepKeyword, pattern: PatternStr<'_>) -> Option<AsyncStepFn> {
-    resolve_exact_step(keyword, pattern).map(|step| {
-        mark_used((step.keyword, step.pattern));
-        step.run_async
-    })
+    mark_and_project(resolve_exact_step(keyword, pattern), |step| step.run_async)
 }
 
 /// Find a registered async step whose pattern matches the provided text.
@@ -322,10 +331,7 @@ pub fn lookup_step_async(keyword: StepKeyword, pattern: PatternStr<'_>) -> Optio
 /// definitions.
 #[must_use]
 pub fn find_step_async(keyword: StepKeyword, text: StepText<'_>) -> Option<AsyncStepFn> {
-    resolve_step(keyword, text).map(|step| {
-        mark_used((step.keyword, step.pattern));
-        step.run_async
-    })
+    mark_and_project(resolve_step(keyword, text), |step| step.run_async)
 }
 
 /// Find a registered step and return its full metadata.
@@ -347,9 +353,7 @@ pub fn find_step_async(keyword: StepKeyword, text: StepText<'_>) -> Option<Async
 /// ```
 #[must_use]
 pub fn find_step_with_metadata(keyword: StepKeyword, text: StepText<'_>) -> Option<&'static Step> {
-    resolve_step(keyword, text).inspect(|step| {
-        mark_used((step.keyword, step.pattern));
-    })
+    mark_and_project(resolve_step(keyword, text), |step| step)
 }
 
 /// Return registered steps that were never executed.

--- a/crates/rstest-bdd/tests/registry_mark_used_props.rs
+++ b/crates/rstest-bdd/tests/registry_mark_used_props.rs
@@ -8,6 +8,8 @@
 //! the invariant via `unused_steps`.
 
 use proptest::prelude::*;
+use std::collections::BTreeSet;
+
 use rstest_bdd::{
     StepContext, StepError, StepExecution, StepKeyword, find_step, find_step_async,
     find_step_async_with_mode, find_step_with_metadata, lookup_step, lookup_step_async,
@@ -37,6 +39,15 @@ const TARGET_PATTERNS: [&str; 3] = [
 /// Patterns for sentinel steps that are never looked up successfully; they
 /// must remain unused throughout, proving failed lookups mark nothing.
 const SENTINEL_PATTERNS: [&str; 2] = ["mark-used prop sentinel one", "mark-used prop sentinel two"];
+
+/// Patterns for every step whose usage state is asserted by this suite.
+const OBSERVED_PATTERNS: [&str; 5] = [
+    "mark-used prop target alpha",
+    "mark-used prop target beta",
+    "mark-used prop target gamma",
+    "mark-used prop sentinel one",
+    "mark-used prop sentinel two",
+];
 
 step!(
     StepKeyword::Given,
@@ -78,6 +89,36 @@ fn keyword_for(index: usize) -> StepKeyword {
     }
 }
 
+/// Keyword each sentinel pattern was registered under.
+fn sentinel_keyword_for(index: usize) -> StepKeyword {
+    match index {
+        0 => StepKeyword::Given,
+        _ => StepKeyword::When,
+    }
+}
+
+/// Return a keyword that is guaranteed to differ from the given keyword.
+fn mismatched_keyword(keyword: StepKeyword) -> StepKeyword {
+    match keyword {
+        StepKeyword::Given => StepKeyword::When,
+        StepKeyword::When => StepKeyword::Then,
+        StepKeyword::Then | StepKeyword::And | StepKeyword::But => StepKeyword::Given,
+    }
+}
+
+/// Return the observed patterns the registry currently reports as unused.
+fn unused_observed_patterns() -> BTreeSet<&'static str> {
+    unused_steps()
+        .iter()
+        .filter_map(|step| {
+            OBSERVED_PATTERNS
+                .iter()
+                .copied()
+                .find(|pattern| step.pattern.as_str() == *pattern)
+        })
+        .collect()
+}
+
 /// Return whether the registry currently reports `pattern` as unused.
 fn is_unused(pattern: &str) -> bool {
     unused_steps()
@@ -114,8 +155,20 @@ proptest! {
         let keyword = keyword_for(target);
 
         if hit {
+            let before_unused = unused_observed_patterns();
             let resolved = run_variant(variant, keyword, pattern);
             prop_assert!(resolved, "registered step must resolve");
+            let after_unused = unused_observed_patterns();
+            let newly_used = before_unused
+                .difference(&after_unused)
+                .copied()
+                .collect::<Vec<_>>();
+
+            prop_assert!(
+                newly_used.iter().all(|used_pattern| *used_pattern == *pattern),
+                "successful lookup marked unrelated steps used: {:?}",
+                newly_used
+            );
             prop_assert!(
                 !is_unused(pattern),
                 "successful lookup must mark the step used"
@@ -132,5 +185,31 @@ proptest! {
                 "failed lookups must not mark sentinel steps used"
             );
         }
+    }
+
+    /// A lookup whose text matches a registered pattern but whose keyword does
+    /// not match must behave as a miss and leave the step unused.
+    #[test]
+    fn mismatched_keyword_lookups_do_not_resolve_or_mark_used(
+        variant in 0usize..7,
+        sentinel in 0usize..SENTINEL_PATTERNS.len(),
+    ) {
+        let pattern = SENTINEL_PATTERNS
+            .get(sentinel)
+            .ok_or_else(|| TestCaseError::fail("sentinel index in range"))?;
+        let keyword = sentinel_keyword_for(sentinel);
+        let wrong_keyword = mismatched_keyword(keyword);
+
+        let resolved = run_variant(variant, wrong_keyword, pattern);
+        prop_assert!(
+            !resolved,
+            "lookup unexpectedly resolved step with mismatched keyword: {:?} vs {:?}",
+            wrong_keyword,
+            keyword
+        );
+        prop_assert!(
+            is_unused(pattern),
+            "lookup with mismatched keyword marked pattern as used: {pattern}"
+        );
     }
 }

--- a/crates/rstest-bdd/tests/registry_mark_used_props.rs
+++ b/crates/rstest-bdd/tests/registry_mark_used_props.rs
@@ -1,0 +1,136 @@
+//! Property-based tests for the registry usage-marking invariant.
+//!
+//! Every public lookup variant funnels through the canonical
+//! `mark_and_project` helper, so a lookup that returns `Some` must mark
+//! exactly the resolved step as used, and a lookup that returns `None` must
+//! mark nothing. This suite drives all six lookup variants (plus
+//! `find_step_with_metadata`) against a pool of registered steps and asserts
+//! the invariant via `unused_steps`.
+
+use proptest::prelude::*;
+use rstest_bdd::{
+    StepContext, StepError, StepExecution, StepKeyword, find_step, find_step_async,
+    find_step_async_with_mode, find_step_with_metadata, lookup_step, lookup_step_async,
+    lookup_step_async_with_mode, step, unused_steps,
+};
+
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "step handlers must return Result<StepExecution, StepError>"
+)]
+fn noop_step_wrapper(
+    _ctx: &mut StepContext<'_>,
+    _text: &str,
+    _docstring: Option<&str>,
+    _table: Option<&[&[&str]]>,
+) -> Result<StepExecution, StepError> {
+    Ok(StepExecution::from_value(None))
+}
+
+/// Patterns for steps the property may successfully look up.
+const TARGET_PATTERNS: [&str; 3] = [
+    "mark-used prop target alpha",
+    "mark-used prop target beta",
+    "mark-used prop target gamma",
+];
+
+/// Patterns for sentinel steps that are never looked up successfully; they
+/// must remain unused throughout, proving failed lookups mark nothing.
+const SENTINEL_PATTERNS: [&str; 2] = ["mark-used prop sentinel one", "mark-used prop sentinel two"];
+
+step!(
+    StepKeyword::Given,
+    "mark-used prop target alpha",
+    noop_step_wrapper,
+    &[]
+);
+step!(
+    StepKeyword::When,
+    "mark-used prop target beta",
+    noop_step_wrapper,
+    &[]
+);
+step!(
+    StepKeyword::Then,
+    "mark-used prop target gamma",
+    noop_step_wrapper,
+    &[]
+);
+step!(
+    StepKeyword::Given,
+    "mark-used prop sentinel one",
+    noop_step_wrapper,
+    &[]
+);
+step!(
+    StepKeyword::When,
+    "mark-used prop sentinel two",
+    noop_step_wrapper,
+    &[]
+);
+
+/// Keyword each target pattern was registered under.
+fn keyword_for(index: usize) -> StepKeyword {
+    match index {
+        0 => StepKeyword::Given,
+        1 => StepKeyword::When,
+        _ => StepKeyword::Then,
+    }
+}
+
+/// Return whether the registry currently reports `pattern` as unused.
+fn is_unused(pattern: &str) -> bool {
+    unused_steps()
+        .iter()
+        .any(|step| step.pattern.as_str() == pattern)
+}
+
+/// Invoke one lookup variant, returning whether it resolved a step.
+fn run_variant(variant: usize, keyword: StepKeyword, text: &str) -> bool {
+    match variant {
+        0 => lookup_step(keyword, text.into()).is_some(),
+        1 => find_step(keyword, text.into()).is_some(),
+        2 => lookup_step_async(keyword, text.into()).is_some(),
+        3 => find_step_async(keyword, text.into()).is_some(),
+        4 => lookup_step_async_with_mode(keyword, text.into()).is_some(),
+        5 => find_step_async_with_mode(keyword, text.into()).is_some(),
+        _ => find_step_with_metadata(keyword, text.into()).is_some(),
+    }
+}
+
+proptest! {
+    /// A successful lookup through any variant marks the resolved step used;
+    /// a failed lookup marks nothing (sentinels stay unused throughout).
+    #[test]
+    fn every_lookup_variant_upholds_usage_marking(
+        variant in 0usize..7,
+        target in 0usize..TARGET_PATTERNS.len(),
+        hit in any::<bool>(),
+        miss_suffix in "[a-z]{4,12}",
+    ) {
+        let pattern = TARGET_PATTERNS
+            .get(target)
+            .ok_or_else(|| TestCaseError::fail("target index in range"))?;
+        let keyword = keyword_for(target);
+
+        if hit {
+            let resolved = run_variant(variant, keyword, pattern);
+            prop_assert!(resolved, "registered step must resolve");
+            prop_assert!(
+                !is_unused(pattern),
+                "successful lookup must mark the step used"
+            );
+        } else {
+            let missing = format!("mark-used prop missing {miss_suffix}");
+            let resolved = run_variant(variant, keyword, &missing);
+            prop_assert!(!resolved, "unregistered text must not resolve");
+        }
+
+        for sentinel in SENTINEL_PATTERNS {
+            prop_assert!(
+                is_unused(sentinel),
+                "failed lookups must not mark sentinel steps used"
+            );
+        }
+    }
+}

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -723,7 +723,6 @@ feature-gated regression suite in
 `crates/rstest-bdd-harness-gpui/tests/scenario_name_in_logs.rs` apply the
 attribute to every `GpuiHarness::run`-driving test.
 
-
 ## Registry lookup usage-marking invariant
 
 Every public step-lookup function in `crates/rstest-bdd/src/registry/`
@@ -747,6 +746,7 @@ bookkeeping exactly once and applies the caller's projection to the resolved
   registration and a lazily built hash map, which a bounded harness cannot
   model cheaply, and the property suite already exercises every variant
   against hit and miss lookups.
+
 ## Planned internal APIs and tooling (ADR-010 to ADR-012)
 
 Three accepted-as-`Proposed` ADRs schedule internal-API and build-tooling

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -723,6 +723,30 @@ feature-gated regression suite in
 `crates/rstest-bdd-harness-gpui/tests/scenario_name_in_logs.rs` apply the
 attribute to every `GpuiHarness::run`-driving test.
 
+
+## Registry lookup usage-marking invariant
+
+Every public step-lookup function in `crates/rstest-bdd/src/registry/`
+(`lookup_step`, `find_step`, `lookup_step_async`, `find_step_async`,
+`lookup_step_async_with_mode`, `find_step_async_with_mode`, and
+`find_step_with_metadata`) funnels through the canonical private helper
+`mark_and_project` in `registry/mod.rs`. The helper performs the `mark_used`
+bookkeeping exactly once and applies the caller's projection to the resolved
+`Step`.
+
+- **Invariant:** every lookup that returns `Some` marks exactly the resolved
+  step as used (feeding the unused-step diagnostics behind `cargo bdd`); a
+  lookup that returns `None` marks nothing.
+- **Permitted call-sites:** the public lookup wrappers in `registry/mod.rs`
+  and `registry/async_lookup.rs`. New lookup variants must resolve a step
+  (via `resolve_exact_step` / `resolve_step`) and pass it through
+  `mark_and_project`; calling `mark_used` directly from a lookup is a bug.
+- The invariant is pinned across all variants by the property suite in
+  `crates/rstest-bdd/tests/registry_mark_used_props.rs`. A `kani` harness was
+  considered and omitted: the registry is backed by link-time `inventory`
+  registration and a lazily built hash map, which a bounded harness cannot
+  model cheaply, and the property suite already exercises every variant
+  against hit and miss lookups.
 ## Planned internal APIs and tooling (ADR-010 to ADR-012)
 
 Three accepted-as-`Proposed` ADRs schedule internal-API and build-tooling


### PR DESCRIPTION
## Summary

Closes #507

- Introduce one canonical private helper `mark_and_project(step, project)` in `registry/mod.rs` that performs the `mark_used` bookkeeping exactly once and applies the caller's projection to the resolved `Step`.
- Rewrite all six lookup functions (`lookup_step`, `find_step`, `lookup_step_async`, `find_step_async`, `lookup_step_async_with_mode`, `find_step_async_with_mode`) — plus `find_step_with_metadata`, which carried the same copy — as thin wrappers over the helper. The `mark_used` invariant now exists in exactly one place.
- Property suite (`tests/registry_mark_used_props.rs`) pins the invariant across every variant: a lookup returning `Some` marks exactly the resolved step used; a lookup returning `None` marks nothing (verified via never-resolved sentinel steps).
- `kani` harness omitted with justification recorded in the developers' guide: the registry is backed by link-time `inventory` registration and a lazily built hash map, which a bounded harness cannot model cheaply; the property suite exercises every variant against hit and miss lookups.
- Developers' guide documents the helper, the usage-marking invariant, and permitted call-sites.

## Testing

- `make check-fmt`, `make lint`, `make typecheck`, `make test` (1487 passed), `make markdownlint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Centralize registry step lookup usage-marking via a canonical helper and validate its invariant with property-based tests.

Enhancements:
- Introduce a canonical mark_and_project helper to unify step resolution, usage-marking, and projection across all registry lookup functions.
- Refactor synchronous and asynchronous step lookup APIs to delegate to the shared helper, ensuring consistent unused-step diagnostics behavior.

Documentation:
- Document the registry lookup usage-marking invariant, the mark_and_project helper, and permitted call sites in the developers' guide.

Tests:
- Add property-based tests that exercise all step lookup variants to assert the usage-marking invariant for successful and failed lookups.