### PR TITLE
Share a canonical attribute-policy conformance test across harness crates (#515)

### DIFF
--- a/crates/rstest-bdd-harness-gpui/src/policy.rs
+++ b/crates/rstest-bdd-harness-gpui/src/policy.rs
@@ -33,30 +33,19 @@ impl AttributePolicy for GpuiAttributePolicy {
 #[cfg(test)]
 mod tests {
     //! Unit tests for the GPUI attribute policy.
+    //!
+    //! The emit/render/"rstest is first" invariants are asserted by the
+    //! shared conformance check in `rstest-bdd-harness`; only the expected
+    //! rendered attributes are crate-specific.
 
-    use super::{GPUI_TEST_ATTRIBUTES, GpuiAttributePolicy};
-    use rstest_bdd_harness::{AttributePolicy, TestAttribute};
-
-    #[test]
-    fn gpui_policy_emits_rstest_and_gpui_test() {
-        let attributes = GpuiAttributePolicy::test_attributes();
-        assert_eq!(attributes, GPUI_TEST_ATTRIBUTES);
-    }
+    use super::GpuiAttributePolicy;
+    use rstest_bdd_harness::policy_conformance::assert_attribute_policy_conformance;
 
     #[test]
-    fn gpui_policy_renders_correct_attributes() {
-        let attributes = GpuiAttributePolicy::test_attributes();
-        let rendered: Vec<_> = attributes
-            .iter()
-            .copied()
-            .map(TestAttribute::render)
-            .collect();
-        assert_eq!(rendered, vec!["#[rstest::rstest]", "#[gpui::test]"]);
-    }
-
-    #[test]
-    fn rstest_attribute_is_first() {
-        let attributes = GpuiAttributePolicy::test_attributes();
-        assert_eq!(attributes.first().map(|a| a.path()), Some("rstest::rstest"));
+    fn gpui_policy_conforms_to_attribute_policy_contract() {
+        assert_attribute_policy_conformance::<GpuiAttributePolicy>(&[
+            "#[rstest::rstest]",
+            "#[gpui::test]",
+        ]);
     }
 }

--- a/crates/rstest-bdd-harness-gpui/src/policy.rs
+++ b/crates/rstest-bdd-harness-gpui/src/policy.rs
@@ -30,22 +30,7 @@ impl AttributePolicy for GpuiAttributePolicy {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    //! Unit tests for the GPUI attribute policy.
-    //!
-    //! The emit/render/"rstest is first" invariants are asserted by the
-    //! shared conformance check in `rstest-bdd-harness`; only the expected
-    //! rendered attributes are crate-specific.
-
-    use super::GpuiAttributePolicy;
-    use rstest_bdd_harness::policy_conformance::assert_attribute_policy_conformance;
-
-    #[test]
-    fn gpui_policy_conforms_to_attribute_policy_contract() {
-        assert_attribute_policy_conformance::<GpuiAttributePolicy>(&[
-            "#[rstest::rstest]",
-            "#[gpui::test]",
-        ]);
-    }
-}
+// The attribute-policy conformance check lives in
+// `tests/attribute_policy_behaviour.rs` rather than an in-module
+// `#[cfg(test)]` block: this crate's library target sets `test = false`, so an
+// in-module test would never be compiled or run.

--- a/crates/rstest-bdd-harness-gpui/tests/attribute_policy_behaviour.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/attribute_policy_behaviour.rs
@@ -1,30 +1,18 @@
 //! Behavioural tests for GPUI attribute policy output.
+//!
+//! The GPUI library target sets `test = false`, so the policy's conformance
+//! check cannot live in an in-module `#[cfg(test)]` block — it would never be
+//! compiled or run. It runs here instead, in an integration target that is
+//! built under `--all-features` (which enables `native-gpui-tests`).
 #![cfg(feature = "native-gpui-tests")]
 
-use rstest_bdd_harness::{AttributePolicy, TestAttribute};
+use rstest_bdd_harness::policy_conformance::assert_attribute_policy_conformance;
 use rstest_bdd_harness_gpui::GpuiAttributePolicy;
 
 #[test]
-fn gpui_policy_emits_rstest_and_gpui_test_attributes() {
-    let attributes = GpuiAttributePolicy::test_attributes();
-    assert_eq!(
-        attributes,
-        [
-            TestAttribute::new("rstest::rstest"),
-            TestAttribute::new("gpui::test"),
-        ]
-    );
-    let rendered: Vec<_> = attributes
-        .iter()
-        .copied()
-        .map(TestAttribute::render)
-        .collect();
-    assert_eq!(rendered, vec!["#[rstest::rstest]", "#[gpui::test]"]);
-}
-
-#[test]
-fn gpui_policy_attributes_preserve_order() {
-    let attributes = GpuiAttributePolicy::test_attributes();
-    assert_eq!(attributes.first().map(|a| a.path()), Some("rstest::rstest"));
-    assert_eq!(attributes.get(1).map(|a| a.path()), Some("gpui::test"));
+fn gpui_policy_conforms_to_attribute_policy_contract() {
+    assert_attribute_policy_conformance::<GpuiAttributePolicy>(&[
+        "#[rstest::rstest]",
+        "#[gpui::test]",
+    ]);
 }

--- a/crates/rstest-bdd-harness-tokio/src/policy.rs
+++ b/crates/rstest-bdd-harness-tokio/src/policy.rs
@@ -38,36 +38,19 @@ impl AttributePolicy for TokioAttributePolicy {
 #[cfg(test)]
 mod tests {
     //! Unit tests for the Tokio attribute policy.
+    //!
+    //! The emit/render/"rstest is first" invariants are asserted by the
+    //! shared conformance check in `rstest-bdd-harness`; only the expected
+    //! rendered attributes are crate-specific.
 
-    use super::{TOKIO_TEST_ATTRIBUTES, TokioAttributePolicy};
-    use rstest_bdd_harness::{AttributePolicy, TestAttribute};
-
-    #[test]
-    fn tokio_policy_emits_rstest_and_tokio_test() {
-        let attributes = TokioAttributePolicy::test_attributes();
-        assert_eq!(attributes, TOKIO_TEST_ATTRIBUTES);
-    }
+    use super::TokioAttributePolicy;
+    use rstest_bdd_harness::policy_conformance::assert_attribute_policy_conformance;
 
     #[test]
-    fn tokio_policy_renders_correct_attributes() {
-        let attributes = TokioAttributePolicy::test_attributes();
-        let rendered: Vec<_> = attributes
-            .iter()
-            .copied()
-            .map(TestAttribute::render)
-            .collect();
-        assert_eq!(
-            rendered,
-            vec![
-                "#[rstest::rstest]",
-                "#[tokio::test(flavor = \"current_thread\")]"
-            ]
-        );
-    }
-
-    #[test]
-    fn rstest_attribute_is_first() {
-        let attributes = TokioAttributePolicy::test_attributes();
-        assert_eq!(attributes.first().map(|a| a.path()), Some("rstest::rstest"));
+    fn tokio_policy_conforms_to_attribute_policy_contract() {
+        assert_attribute_policy_conformance::<TokioAttributePolicy>(&[
+            "#[rstest::rstest]",
+            "#[tokio::test(flavor = \"current_thread\")]",
+        ]);
     }
 }

--- a/crates/rstest-bdd-harness/src/lib.rs
+++ b/crates/rstest-bdd-harness/src/lib.rs
@@ -10,6 +10,7 @@ mod error;
 #[doc(hidden)]
 pub mod macrotest_support;
 mod policy;
+pub mod policy_conformance;
 mod runner;
 mod std_harness;
 #[cfg(test)]

--- a/crates/rstest-bdd-harness/src/policy_conformance.rs
+++ b/crates/rstest-bdd-harness/src/policy_conformance.rs
@@ -1,0 +1,65 @@
+//! Shared conformance check for [`AttributePolicy`] implementations.
+//!
+//! Harness adapter crates implement small, deliberately independent
+//! attribute policies whose test scaffolding would otherwise be duplicated
+//! line-for-line. This module provides the canonical conformance check: each
+//! policy crate supplies only its expected rendered attributes and gets the
+//! emit / render / "rstest is first" invariants for free.
+
+use crate::policy::{AttributePolicy, TestAttribute};
+
+/// Attribute path that must lead every policy's attribute list so `rstest`
+/// expands fixtures before the runtime-specific test macro.
+const RSTEST_ATTRIBUTE_PATH: &str = "rstest::rstest";
+
+/// Assert that policy `P` conforms to the attribute-policy contract.
+///
+/// The check pins three invariants shared by every first-party policy:
+///
+/// 1. **Emit** — the policy emits exactly `expected_rendered.len()`
+///    attributes.
+/// 2. **Render** — each attribute renders to the corresponding entry of
+///    `expected_rendered`, in order.
+/// 3. **rstest is first** — the first attribute path is `rstest::rstest`, so
+///    fixture expansion precedes the runtime-specific test macro.
+///
+/// # Panics
+///
+/// Panics with a descriptive message when any invariant is violated; this is
+/// a test helper and is expected to run inside `#[test]` functions.
+///
+/// # Examples
+///
+/// ```
+/// use rstest_bdd_harness::DefaultAttributePolicy;
+/// use rstest_bdd_harness::policy_conformance::assert_attribute_policy_conformance;
+///
+/// assert_attribute_policy_conformance::<DefaultAttributePolicy>(&["#[rstest::rstest]"]);
+/// ```
+pub fn assert_attribute_policy_conformance<P: AttributePolicy>(expected_rendered: &[&str]) {
+    let attributes = P::test_attributes();
+    assert_eq!(
+        attributes.len(),
+        expected_rendered.len(),
+        "policy must emit exactly {} attribute(s), got {}",
+        expected_rendered.len(),
+        attributes.len(),
+    );
+
+    let rendered: Vec<String> = attributes
+        .iter()
+        .copied()
+        .map(TestAttribute::render)
+        .collect();
+    assert_eq!(
+        rendered, expected_rendered,
+        "policy attributes must render to the expected list, in order",
+    );
+
+    assert_eq!(
+        attributes.first().map(|attribute| attribute.path()),
+        Some(RSTEST_ATTRIBUTE_PATH),
+        "`{RSTEST_ATTRIBUTE_PATH}` must be the first attribute so fixture \
+         expansion precedes the runtime test macro",
+    );
+}

--- a/crates/rstest-bdd-harness/src/policy_conformance.rs
+++ b/crates/rstest-bdd-harness/src/policy_conformance.rs
@@ -66,3 +66,84 @@ pub fn assert_attribute_policy_conformance<P: AttributePolicy>(expected_rendered
         RSTEST_ATTRIBUTE_PATH,
     );
 }
+
+#[cfg(test)]
+mod tests {
+    //! The conformance helper is itself conformance-checked here: a
+    //! deliberately broken policy must make it panic, so a no-op or weakened
+    //! helper cannot pass on the happy path alone.
+
+    use super::assert_attribute_policy_conformance;
+    use crate::policy::{AttributePolicy, TestAttribute};
+
+    const EXPECTED: &[&str] = &["#[rstest::rstest]", "#[gpui::test]"];
+    const GOOD: [TestAttribute; 2] = [
+        TestAttribute::new("rstest::rstest"),
+        TestAttribute::new("gpui::test"),
+    ];
+    const WRONG_COUNT: [TestAttribute; 1] = [TestAttribute::new("rstest::rstest")];
+    const WRONG_RENDER: [TestAttribute; 2] = [
+        TestAttribute::new("rstest::rstest"),
+        TestAttribute::new("tokio::test"),
+    ];
+    const RSTEST_NOT_FIRST: [TestAttribute; 2] = [
+        TestAttribute::new("gpui::test"),
+        TestAttribute::new("rstest::rstest"),
+    ];
+
+    struct GoodPolicy;
+    impl AttributePolicy for GoodPolicy {
+        fn test_attributes() -> &'static [TestAttribute] {
+            &GOOD
+        }
+    }
+
+    struct WrongCountPolicy;
+    impl AttributePolicy for WrongCountPolicy {
+        fn test_attributes() -> &'static [TestAttribute] {
+            &WRONG_COUNT
+        }
+    }
+
+    struct WrongRenderPolicy;
+    impl AttributePolicy for WrongRenderPolicy {
+        fn test_attributes() -> &'static [TestAttribute] {
+            &WRONG_RENDER
+        }
+    }
+
+    struct RstestNotFirstPolicy;
+    impl AttributePolicy for RstestNotFirstPolicy {
+        fn test_attributes() -> &'static [TestAttribute] {
+            &RSTEST_NOT_FIRST
+        }
+    }
+
+    #[test]
+    fn accepts_a_conforming_policy() {
+        // Guards against an over-strict helper that rejects valid policies.
+        assert_attribute_policy_conformance::<GoodPolicy>(EXPECTED);
+    }
+
+    #[test]
+    #[should_panic(expected = "must emit exactly")]
+    fn rejects_wrong_attribute_count() {
+        assert_attribute_policy_conformance::<WrongCountPolicy>(EXPECTED);
+    }
+
+    #[test]
+    #[should_panic(expected = "render to the expected list")]
+    fn rejects_wrong_rendered_attribute() {
+        assert_attribute_policy_conformance::<WrongRenderPolicy>(EXPECTED);
+    }
+
+    #[test]
+    #[should_panic(expected = "must be the first attribute")]
+    fn rejects_rstest_not_first() {
+        // Count and render match; only the ordering (rstest first) is wrong.
+        assert_attribute_policy_conformance::<RstestNotFirstPolicy>(&[
+            "#[gpui::test]",
+            "#[rstest::rstest]",
+        ]);
+    }
+}

--- a/crates/rstest-bdd-harness/src/policy_conformance.rs
+++ b/crates/rstest-bdd-harness/src/policy_conformance.rs
@@ -59,7 +59,10 @@ pub fn assert_attribute_policy_conformance<P: AttributePolicy>(expected_rendered
     assert_eq!(
         attributes.first().map(|attribute| attribute.path()),
         Some(RSTEST_ATTRIBUTE_PATH),
-        "`{RSTEST_ATTRIBUTE_PATH}` must be the first attribute so fixture \
-         expansion precedes the runtime test macro",
+        concat!(
+            "`{}` must be the first attribute so fixture ",
+            "expansion precedes the runtime test macro",
+        ),
+        RSTEST_ATTRIBUTE_PATH,
     );
 }

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -888,9 +888,10 @@ attribute to every `GpuiHarness::run`-driving test.
 
 ## Attribute-policy conformance check
 
-`rstest_bdd_harness::policy_conformance::assert_attribute_policy_conformance::<P>(expected_rendered)`
-is the canonical conformance test for `AttributePolicy` implementations. It
-pins three invariants for any policy `P`:
+The canonical conformance test for `AttributePolicy` implementations —
+`assert_attribute_policy_conformance::<P>(expected_rendered)`, in the
+`rstest_bdd_harness::policy_conformance` module — pins three invariants for any
+policy `P`:
 
 1. **Emit** — the policy emits exactly the expected number of attributes.
 2. **Render** — each attribute renders to the corresponding expected string,

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -886,6 +886,26 @@ feature-gated regression suite in
 `crates/rstest-bdd-harness-gpui/tests/scenario_name_in_logs.rs` apply the
 attribute to every `GpuiHarness::run`-driving test.
 
+
+## Attribute-policy conformance check
+
+`rstest_bdd_harness::policy_conformance::assert_attribute_policy_conformance::<P>(expected_rendered)`
+is the canonical conformance test for `AttributePolicy` implementations. It
+pins three invariants for any policy `P`:
+
+1. **Emit** — the policy emits exactly the expected number of attributes.
+2. **Render** — each attribute renders to the corresponding expected string,
+   in order.
+3. **rstest is first** — the first attribute path is `rstest::rstest`, so
+   fixture expansion precedes the runtime-specific test macro.
+
+Harness adapter crates (`rstest-bdd-harness-tokio`,
+`rstest-bdd-harness-gpui`, and any future adapter) must exercise their policy
+through this helper, supplying only the crate-specific expected rendered
+attributes; do not re-implement the emit/render/ordering assertions per
+crate. New harness crates get the policy contract for free by calling the
+helper from one `#[test]`.
+
 ## Canonical step-keyword table
 
 `crates/rstest-bdd-patterns/src/keyword.rs` drives the string ↔ `StepKeyword`

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -886,7 +886,6 @@ feature-gated regression suite in
 `crates/rstest-bdd-harness-gpui/tests/scenario_name_in_logs.rs` apply the
 attribute to every `GpuiHarness::run`-driving test.
 
-
 ## Attribute-policy conformance check
 
 `rstest_bdd_harness::policy_conformance::assert_attribute_policy_conformance::<P>(expected_rendered)`
@@ -905,6 +904,12 @@ through this helper, supplying only the crate-specific expected rendered
 attributes; do not re-implement the emit/render/ordering assertions per
 crate. New harness crates get the policy contract for free by calling the
 helper from one `#[test]`.
+
+The GPUI adapter's library target sets `test = false`, so an in-module
+`#[cfg(test)]` block there would never be compiled or run. Its conformance
+test therefore lives in the `tests/attribute_policy_behaviour.rs` integration
+target, exercised under `--all-features` (which enables the crate's
+`native-gpui-tests` feature) — the arrangement `make test` uses.
 
 ## Canonical step-keyword table
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -2053,6 +2053,38 @@ Tokio runtime options, while keeping those dependencies out of the core
 first-party canonical policy paths for Tokio and GPUI; unknown third-party
 policy paths fall back to `#[rstest::rstest]`.
 
+### Verifying an attribute policy
+
+`rstest-bdd-harness` ships the conformance check every adapter policy is
+expected to pass. Supply the attributes the policy should render, in order:
+
+```rust,no_run
+use rstest_bdd_harness::DefaultAttributePolicy;
+use rstest_bdd_harness::policy_conformance::assert_attribute_policy_conformance;
+
+assert_attribute_policy_conformance::<DefaultAttributePolicy>(
+    &["#[rstest::rstest]"],
+);
+```
+
+It pins three invariants, panicking with a descriptive message when any of
+them is violated:
+
+- **Emit** — the policy returns exactly as many attributes as expected.
+- **Render** — each attribute renders to the corresponding expected string, in
+  the same order.
+- **`rstest` is first** — the leading attribute path is `rstest::rstest`, so
+  fixture expansion runs before the runtime-specific test macro.
+
+Call it from a single `#[test]` in your adapter crate rather than
+re-implementing the assertions; only the expected rendered attributes are
+adapter-specific.
+
+One placement caveat: if the adapter's library target sets `test = false` in
+its manifest — as the GPUI adapter does — an in-module `#[cfg(test)]` block is
+never compiled, so the check would silently never run. Put the call in an
+integration test under `tests/` in that case.
+
 ## Running and maintaining tests
 
 Once feature files and step definitions are in place, scenarios run via the


### PR DESCRIPTION
## Summary

Closes #515

- Add `rstest_bdd_harness::policy_conformance::assert_attribute_policy_conformance::<P>(expected_rendered)` — the canonical, reusable conformance check parameterised over the policy type and its expected rendered attributes. It pins the emit (count), render (strings, in order), and "rstest is first" invariants.
- Both `rstest-bdd-harness-tokio` and `rstest-bdd-harness-gpui` now call the shared helper from a single `#[test]`, keeping only their crate-specific expected attribute strings; the duplicated per-crate test bodies are removed.
- The runtime `impl`s remain deliberately independent, per the issue's scoping (the canonical artefact is the shared test contract, not the impl).
- Property/model-checking/snapshot testing not applicable per the issue (fixed, finite attribute sets asserted directly).
- Conformance helper and policy contract documented in `docs/developers-guide.md`.

## Testing

- `make check-fmt`, `make lint`, `make typecheck`, `make test` (1482 passed) all pass; the GPUI conformance test additionally verified under `--all-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a shared attribute-policy conformance helper and refactor harness crates to use it for consistent testing.

New Features:
- Add a canonical assert_attribute_policy_conformance helper for AttributePolicy implementations to enforce shared invariants on emitted and rendered attributes.

Enhancements:
- Refactor Tokio and GPUI harness attribute policy tests to use the shared conformance helper, removing duplicated per-crate test logic.

Documentation:
- Document the attribute-policy conformance contract and usage of the shared helper in the developer guide.