### PR TITLE
Clarify and document intent of StepContext harness-context wrapper methods (#516)

### DIFF
--- a/crates/rstest-bdd/src/context/mod.rs
+++ b/crates/rstest-bdd/src/context/mod.rs
@@ -101,12 +101,36 @@ impl<'a> StepContext<'a> {
         self.fixtures.insert(name, FixtureEntry::owned::<T>(cell));
     }
 
+    // ------------------------------------------------------------------
+    // Harness-context wrappers (ADR-007).
+    //
+    // These thin wrappers hard-code the reserved
+    // `RSTEST_BDD_HARNESS_CONTEXT_FIXTURE` key over the generic fixture API.
+    // They are deliberate API surface, not dead code: the insert side is
+    // emitted by macro-generated harness scenarios, and the borrow side is
+    // the supported typed-extraction surface for adapters and step code.
+    // Do not add further wrappers here for new generic access patterns
+    // unless generated code or the documented step-authoring path needs
+    // them; see ADR-007 ("Phase 2 convention: StepContext mapping").
+    // ------------------------------------------------------------------
+
     /// Insert harness-provided context using the reserved fixture key.
+    ///
+    /// Part of the ADR-007 harness-context contract. This shared-reference
+    /// variant exists for adapters that keep ownership of their context;
+    /// macro-generated code uses
+    /// [`insert_owned_harness_context`](Self::insert_owned_harness_context).
     pub fn insert_harness_context<T: Any>(&mut self, context: &'a T) {
         self.insert(RSTEST_BDD_HARNESS_CONTEXT_FIXTURE, context);
     }
 
     /// Insert owned harness-provided context using the reserved fixture key.
+    ///
+    /// Part of the ADR-007 harness-context contract. This is the variant
+    /// emitted by macro-generated harness scenarios (see
+    /// `codegen/scenario/runtime/harness.rs` in `rstest-bdd-macros`), which
+    /// wrap the adapter's `HarnessAdapter::Context` in an owned cell so
+    /// steps can borrow it mutably.
     pub fn insert_owned_harness_context<T: Any>(&mut self, cell: &'a RefCell<Box<dyn Any>>) {
         self.insert_owned::<T>(RSTEST_BDD_HARNESS_CONTEXT_FIXTURE, cell);
     }
@@ -125,6 +149,10 @@ impl<'a> StepContext<'a> {
     }
 
     /// Borrow harness-provided context by type.
+    ///
+    /// Part of the ADR-007 harness-context contract: the supported typed
+    /// read accessor for context stored by
+    /// [`insert_owned_harness_context`](Self::insert_owned_harness_context).
     #[must_use]
     pub fn borrow_harness_context<'b, T: Any>(&'b self) -> Option<FixtureRef<'b, T>>
     where
@@ -134,6 +162,10 @@ impl<'a> StepContext<'a> {
     }
 
     /// Borrow harness-provided context mutably by type.
+    ///
+    /// Part of the ADR-007 harness-context contract: the supported typed
+    /// mutable accessor for context stored by
+    /// [`insert_owned_harness_context`](Self::insert_owned_harness_context).
     pub fn borrow_harness_context_mut<'b, T: Any>(&'b mut self) -> Option<FixtureRefMut<'b, T>>
     where
         'a: 'b,

--- a/docs/adr-007-harness-context-injection.md
+++ b/docs/adr-007-harness-context-injection.md
@@ -173,6 +173,31 @@ mapping. We chose explicit helper methods on `StepContext` instead
 the integration path local to existing context APIs and reduce codegen
 indirection.
 
+### Harness-context wrapper contract
+
+`StepContext` exposes a fixed set of thin wrappers that hard-code the
+reserved `RSTEST_BDD_HARNESS_CONTEXT_FIXTURE` key over the generic fixture
+API. They are deliberate API surface, not dead code, and divide into two
+roles:
+
+| Wrapper | Role |
+| --- | --- |
+| `insert_owned_harness_context` | **Required by codegen.** Emitted by macro-generated harness scenarios (`codegen/scenario/runtime/harness.rs`), which wrap `HarnessAdapter::Context` in an owned cell so steps can borrow it mutably. |
+| `insert_harness_context` | Insert-side counterpart for adapters that keep ownership of their context and share it by reference. |
+| `borrow_harness_context` / `borrow_harness_context_mut` | The supported typed read/write accessors for context stored by the owned insert path. |
+| `harness_context` | Typed accessor for the shared-reference insert path (returns `None` for owned entries). |
+
+Collapsing these onto the generic API
+(`ctx.get(RSTEST_BDD_HARNESS_CONTEXT_FIXTURE)` and friends) was considered
+and rejected: the reserved key would then be repeated at every call-site,
+including inside generated code, and the typed pairing between the insert
+and borrow sides would no longer be discoverable from the API surface.
+
+The wrapper set is intentionally closed. New generic fixture-access patterns
+on `StepContext` must **not** gain a matching `*_harness_context` wrapper by
+default; add one only when macro-generated code or the documented
+step-authoring path needs it, and record the addition here.
+
 ## Goals and non-goals
 
 ### Goals

--- a/docs/adr-007-harness-context-injection.md
+++ b/docs/adr-007-harness-context-injection.md
@@ -182,7 +182,7 @@ roles:
 
 | Wrapper | Role |
 | --- | --- |
-| `insert_owned_harness_context` | **Required by codegen.** Emitted by macro-generated harness scenarios (`codegen/scenario/runtime/harness.rs`), which wrap `HarnessAdapter::Context` in an owned cell so steps can borrow it mutably. |
+| `insert_owned_harness_context` | **Required by codegen.** Emitted by macro-generated harness scenarios (`codegen/scenario/runtime/harness.rs`), which wrap `HarnessAdapter::Context` in an owned cell, so steps can borrow it mutably. |
 | `insert_harness_context` | Insert-side counterpart for adapters that keep ownership of their context and share it by reference. |
 | `borrow_harness_context` / `borrow_harness_context_mut` | The supported typed read/write accessors for context stored by the owned insert path. |
 | `harness_context` | Typed accessor for the shared-reference insert path (returns `None` for owned entries). |


### PR DESCRIPTION
## Summary

Closes #516

- **Decision:** the wrappers are kept. `insert_owned_harness_context` is required by macro-generated harness scenarios (`codegen/scenario/runtime/harness.rs` emits it); the others are the deliberate insert-side counterpart (`insert_harness_context`) and the supported typed accessors (`harness_context`, `borrow_harness_context`, `borrow_harness_context_mut`) pairing with the insert paths.
- ADR-007 gains a "Harness-context wrapper contract" section recording each wrapper's role, why collapsing onto the generic API was rejected, and the rule that the wrapper set is closed: new generic fixture-access patterns must not gain a `*_harness_context` twin unless generated code or the documented step-authoring path needs one.
- Rustdoc on each wrapper now references the ADR-007 contract and names the codegen call-site, so the methods cannot be mistaken for dead surface.
- No behavioural change; tests unchanged.

## Testing

- `make check-fmt`, `make lint`, `make typecheck`, `make test` (1486 passed), `make markdownlint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document and formalize the intended contract for StepContext harness-context wrapper methods without changing behavior.

Enhancements:
- Clarify and cross-reference the purpose and usage of StepContext harness-context wrapper methods in rustdoc, tying them to ADR-007 and codegen call sites.

Documentation:
- Expand ADR-007 with a harness-context wrapper contract describing each wrapper’s role, rationale for not using the generic fixture API directly, and the rule that the wrapper set is closed.