### PR TITLE
Document internal interfaces and mutation contracts missing /// comments (#517)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 rust_out
 .agents/mcp/context_pack/packs/
 crates/rstest-bdd-harness/.proptest-regressions/
+proptest-regressions/
 .hypothesis/
 
 # Local spelling-policy caches and helper tool state

--- a/crates/rstest-bdd-harness/src/test_utils.rs
+++ b/crates/rstest-bdd-harness/src/test_utils.rs
@@ -1,4 +1,15 @@
 //! Shared test helpers for `rstest-bdd-harness`.
+//!
+//! Provides panic-payload matching utilities for harness tests that assert
+//! panic propagation. Harness adapters must re-raise scenario panics so test
+//! runners report the original failure; these helpers let tests verify the
+//! re-raised payload carries the expected message regardless of whether the
+//! payload is a `&str` (from `panic!("literal")`) or a `String` (from
+//! `panic!("{interpolated}")` or `std::panic::resume_unwind`).
+//!
+//! Harness implementations should use [`panic_payload_matches`] when writing
+//! `catch_unwind`-based propagation tests instead of downcasting payloads
+//! inline, so the `&str`/`String` asymmetry is handled in one place.
 
 use std::any::Any;
 

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify.rs
@@ -120,6 +120,18 @@ fn should_classify_as_datatable(pat: &syn::Ident, ty: &syn::Type) -> bool {
 ///
 /// Returns an error when the attribute carries arguments (the marker form
 /// takes none) or appears more than once on the same parameter.
+///
+/// # Examples
+///
+/// Given the parameter as written in a step function, and `attr_name`
+/// `"datatable"`:
+///
+/// ```text
+/// #[datatable] table: CachedTable   => Ok(true);  `arg.attrs` left empty
+/// table: CachedTable                => Ok(false); `arg.attrs` unchanged
+/// #[datatable(1)] table: MyTable    => Err: "`#[datatable]` does not take arguments"
+/// #[datatable] #[datatable] t: T    => Err: "duplicate `#[datatable]` attribute"
+/// ```
 pub(super) fn extract_flag_attribute(arg: &mut syn::PatType, attr_name: &str) -> syn::Result<bool> {
     let mut found = false;
     let mut duplicate = false;
@@ -239,8 +251,23 @@ where
 /// Returns an error when the parameter is named `datatable` with an
 /// unsupported type, when `#[datatable]` is applied to the reserved
 /// `docstring` parameter, when a `DataTable` was already classified, when the
-/// `DataTable` appears after a `DocString` (Gherkin ordering), or when
-/// `#[datatable]` is combined with `#[from]`.
+/// `DataTable` appears after a `DocString` (Gherkin ordering), or when a
+/// matched `DataTable` parameter also carries `#[from]`. The `#[from]`
+/// rejection applies to any matched `DataTable`, whether it matched via the
+/// `#[datatable]` marker or the canonical `datatable` shape, because `#[from]`
+/// has no meaning for a table binding.
+///
+/// # Examples
+///
+/// Given the parameter as written in a step function:
+///
+/// ```text
+/// datatable: Vec<Vec<String>>       => Ok(true);  recorded as DataTable
+/// #[datatable] rows: CachedTable    => Ok(true);  marker stripped, recorded
+/// name: String                      => Ok(false); left for the next classifier
+/// datatable: u32                    => Err: unsupported `datatable` type
+/// #[from(x)] datatable: CachedTable => Err: `#[from]` rejected on a DataTable
+/// ```
 pub(super) fn classify_datatable(
     st: &mut ExtractedArgs,
     arg: &mut syn::PatType,
@@ -303,6 +330,16 @@ fn is_docstring_canonical(pat: &syn::Ident, ty: &syn::Type) -> bool {
 ///
 /// Returns an error when a parameter named `docstring` has a type other than
 /// `String`, or when a `DocString` parameter was already classified.
+///
+/// # Examples
+///
+/// Given the parameter as written in a step function:
+///
+/// ```text
+/// docstring: String   => Ok(true);  recorded as DocString
+/// name: String        => Ok(false); left for the next classifier
+/// docstring: u32      => Err: docstring parameter must have type `String`
+/// ```
 pub(super) fn classify_docstring(
     st: &mut ExtractedArgs,
     arg: &mut syn::PatType,

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify.rs
@@ -11,9 +11,21 @@ use std::collections::HashSet;
 use super::{Arg, ExtractedArgs, normalize_param_name};
 
 mod step_struct;
+mod type_shape;
 
 pub(super) use fixture_or_step::classify_fixture_or_step;
 pub(super) use step_struct::{classify_step_struct, extract_step_struct_attribute};
+use type_shape::{is_docstring_canonical, is_type_seq, should_classify_as_datatable};
+
+/// Test whether `ty` is `CachedTable`, the lazily converted table representation.
+///
+/// Shared with the wider crate because table binding code outside this module
+/// must distinguish a `CachedTable` parameter from a raw `Vec<Vec<String>>` one.
+/// It lives here rather than alongside the other shape predicates in
+/// [`type_shape`] so that `classify::is_cached_table` remains its path.
+pub(crate) fn is_cached_table(ty: &syn::Type) -> bool {
+    is_type_seq(ty, &["CachedTable"])
+}
 
 /// Diagnostic for a `datatable` parameter declared with an unsupported type.
 const DATATABLE_TYPE_ERROR: &str = concat!(
@@ -53,6 +65,12 @@ pub(super) struct ClassificationContext<'a> {
 }
 
 impl<'a> ClassificationContext<'a> {
+    /// Borrow an accumulator and a placeholder set for one classification run.
+    ///
+    /// Holds both mutably for the context's lifetime, so a caller cannot read
+    /// either while classifiers are still claiming parameters. Neither argument
+    /// is copied: mutations made through the context are visible to the caller
+    /// once it is dropped.
     pub(super) fn new(
         extracted: &'a mut ExtractedArgs,
         placeholders: &'a mut HashSet<String>,
@@ -62,52 +80,6 @@ impl<'a> ClassificationContext<'a> {
             placeholders,
         }
     }
-}
-
-fn is_type_seq(ty: &syn::Type, seq: &[&str]) -> bool {
-    use syn::{GenericArgument, PathArguments, Type};
-
-    let mut cur = ty;
-    for (i, &name) in seq.iter().enumerate() {
-        let Type::Path(tp) = cur else { return false };
-        let Some(segment) = tp.path.segments.last() else {
-            return false;
-        };
-        if segment.ident != name {
-            return false;
-        }
-        match &segment.arguments {
-            PathArguments::AngleBracketed(ab) if !ab.args.is_empty() => {
-                if let Some(GenericArgument::Type(inner)) = ab.args.get(0) {
-                    cur = inner;
-                    continue;
-                }
-                return false;
-            }
-            _ => {
-                if i + 1 != seq.len() {
-                    return false;
-                }
-            }
-        }
-    }
-    true
-}
-
-fn is_string(ty: &syn::Type) -> bool {
-    is_type_seq(ty, &["String"])
-}
-
-fn is_datatable(ty: &syn::Type) -> bool {
-    is_type_seq(ty, &["Vec", "Vec", "String"])
-}
-
-pub(crate) fn is_cached_table(ty: &syn::Type) -> bool {
-    is_type_seq(ty, &["CachedTable"])
-}
-
-fn should_classify_as_datatable(pat: &syn::Ident, ty: &syn::Type) -> bool {
-    pat == "datatable" && (is_datatable(ty) || is_cached_table(ty))
 }
 
 /// Detect and strip a marker attribute (e.g. `#[datatable]`) from `arg`.
@@ -165,17 +137,36 @@ pub(super) fn extract_flag_attribute(arg: &mut syn::PatType, attr_name: &str) ->
     Ok(found)
 }
 
+/// Outcome of a successful [`match_named_flag`] call.
 struct FlagMatch {
+    /// Whether the match came from the marker attribute rather than the
+    /// canonical name/type shape. Callers use this to apply rules that only
+    /// bind to the explicit form, such as rejecting `#[datatable]` on the
+    /// reserved `docstring` parameter.
     via_attr: bool,
 }
 
+/// The two ways a reserved parameter may be recognized, plus its diagnostic.
+///
+/// Parameterizes [`match_named_flag`] so `DataTable` and `DocString` share one
+/// matching routine: each supplies its own marker attribute (or none), its
+/// canonical identifier, the type predicate for the canonical form, and the
+/// error text used when the name matches but the type does not.
 struct FlagMatchConfig<F>
 where
     F: Fn(&syn::Ident, &syn::Type) -> bool,
 {
+    /// Marker attribute that opts a parameter in explicitly, or `None` for a
+    /// parameter kind recognized only by its canonical name and type. When
+    /// present it is stripped from the parameter during matching.
     attr_name: Option<&'static str>,
+    /// Reserved identifier for this parameter kind, used to detect a
+    /// right-name/wrong-type parameter and report `wrong_type_msg`.
     canonical_name: &'static str,
+    /// Predicate recognizing the canonical name-and-type shape.
     canonical_check: F,
+    /// Diagnostic emitted when the parameter uses `canonical_name` but
+    /// `canonical_check` rejects its type.
     wrong_type_msg: &'static str,
 }
 
@@ -183,6 +174,7 @@ impl<F> FlagMatchConfig<F>
 where
     F: Fn(&syn::Ident, &syn::Type) -> bool,
 {
+    /// Bundle the matching rules for one reserved parameter kind.
     fn new(
         attr_name: Option<&'static str>,
         canonical_name: &'static str,
@@ -198,6 +190,25 @@ where
     }
 }
 
+/// Recognize a reserved parameter by marker attribute or canonical shape.
+///
+/// Checks the marker attribute first, stripping it from `arg` in place when
+/// `config.attr_name` is set — a mutation that persists even when this function
+/// subsequently returns an error. Then tests the canonical name-and-type shape.
+/// A parameter matching either way yields `Some`, recording in
+/// [`FlagMatch::via_attr`] which route matched.
+///
+/// Returns `Ok(None)` when the parameter is unrelated to this kind, leaving it
+/// for the next classifier.
+///
+/// # Errors
+///
+/// Returns an error when the parameter uses the reserved `canonical_name` but
+/// its type fails `canonical_check` — a right-name/wrong-type parameter is
+/// reported as `config.wrong_type_msg` rather than silently falling through to
+/// be treated as a fixture. Also propagates marker-attribute validation
+/// failures from [`extract_flag_attribute`], such as a marker carrying
+/// arguments or appearing twice.
 fn match_named_flag<F>(
     arg: &mut syn::PatType,
     pat: &syn::Ident,
@@ -312,10 +323,6 @@ pub(super) fn classify_datatable(
     Ok(true)
 }
 
-fn is_docstring_canonical(pat: &syn::Ident, ty: &syn::Type) -> bool {
-    pat == "docstring" && is_string(ty)
-}
-
 /// Classify `arg` as the step’s `DocString` parameter, if it matches.
 ///
 /// A parameter matches when it is the canonical `docstring: String` shape.
@@ -367,6 +374,8 @@ pub(super) fn classify_docstring(
     st.docstring_idx = Some(idx);
     Ok(true)
 }
+#[cfg(test)]
+mod prop_tests;
 #[cfg(test)]
 mod tests;
 

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify.rs
@@ -12,6 +12,7 @@ use super::{Arg, ExtractedArgs, normalize_param_name};
 
 mod step_struct;
 
+pub(super) use fixture_or_step::classify_fixture_or_step;
 pub(super) use step_struct::{classify_step_struct, extract_step_struct_attribute};
 
 /// Diagnostic for a `datatable` parameter declared with an unsupported type.
@@ -36,8 +37,18 @@ const DATATABLE_AFTER_DOCSTRING_ERROR: &str =
 /// Diagnostic for combining `#[datatable]` with `#[from]`.
 const DATATABLE_WITH_FROM_ERROR: &str = "#[datatable] cannot be combined with #[from]";
 
+/// Mutable state threaded through the classification pipeline.
+///
+/// Bundles the accumulator of classified arguments (`extracted`) with the set
+/// of step-pattern placeholders not yet claimed by a parameter
+/// (`placeholders`). Classifiers that match a placeholder remove it from the
+/// set, so each placeholder binds at most one parameter; whatever remains
+/// after classification represents unbound placeholders.
 pub(super) struct ClassificationContext<'a> {
+    /// Accumulated classification results, appended to in place.
     pub(super) extracted: &'a mut ExtractedArgs,
+    /// Step-pattern placeholders still awaiting a matching parameter;
+    /// classifiers remove entries as they claim them.
     pub(super) placeholders: &'a mut HashSet<String>,
 }
 
@@ -99,6 +110,16 @@ fn should_classify_as_datatable(pat: &syn::Ident, ty: &syn::Type) -> bool {
     pat == "datatable" && (is_datatable(ty) || is_cached_table(ty))
 }
 
+/// Detect and strip a marker attribute (e.g. `#[datatable]`) from `arg`.
+///
+/// Mutates `arg.attrs` in place, removing every attribute whose path is
+/// `attr_name` so the generated wrapper does not re-emit it. Returns whether
+/// the attribute was present.
+///
+/// # Errors
+///
+/// Returns an error when the attribute carries arguments (the marker form
+/// takes none) or appears more than once on the same parameter.
 pub(super) fn extract_flag_attribute(arg: &mut syn::PatType, attr_name: &str) -> syn::Result<bool> {
     let mut found = false;
     let mut duplicate = false;
@@ -196,6 +217,30 @@ where
     }
 }
 
+/// Classify `arg` as the step’s `DataTable` parameter, if it matches.
+///
+/// A parameter matches when it is annotated `#[datatable]` or when it is the
+/// canonical `datatable: Vec<Vec<String>>` / `datatable: CachedTable` shape.
+/// On a match the argument is recorded in `st` (setting `st.datatable_idx`)
+/// and the `#[datatable]` marker attribute is stripped from `arg` in place
+/// via [`extract_flag_attribute`].
+///
+/// - `st` — classification accumulator, mutated on success.
+/// - `arg` — the parameter being classified; its attribute list is mutated
+///   in place even when validation subsequently fails.
+/// - `pat` / `ty` — the parameter's identifier and type, pre-extracted by
+///   the caller.
+///
+/// Returns `Ok(true)` when the parameter was claimed, `Ok(false)` to let the
+/// next classifier try.
+///
+/// # Errors
+///
+/// Returns an error when the parameter is named `datatable` with an
+/// unsupported type, when `#[datatable]` is applied to the reserved
+/// `docstring` parameter, when a `DataTable` was already classified, when the
+/// `DataTable` appears after a `DocString` (Gherkin ordering), or when
+/// `#[datatable]` is combined with `#[from]`.
 pub(super) fn classify_datatable(
     st: &mut ExtractedArgs,
     arg: &mut syn::PatType,
@@ -244,6 +289,20 @@ fn is_docstring_canonical(pat: &syn::Ident, ty: &syn::Type) -> bool {
     pat == "docstring" && is_string(ty)
 }
 
+/// Classify `arg` as the step’s `DocString` parameter, if it matches.
+///
+/// A parameter matches when it is the canonical `docstring: String` shape.
+/// On a match the argument is recorded in `st` (setting `st.docstring_idx`).
+/// Unlike [`classify_datatable`] there is no marker attribute, so `arg` is
+/// not mutated.
+///
+/// Returns `Ok(true)` when the parameter was claimed, `Ok(false)` to let the
+/// next classifier try.
+///
+/// # Errors
+///
+/// Returns an error when a parameter named `docstring` has a type other than
+/// `String`, or when a `DocString` parameter was already classified.
 pub(super) fn classify_docstring(
     st: &mut ExtractedArgs,
     arg: &mut syn::PatType,
@@ -271,101 +330,7 @@ pub(super) fn classify_docstring(
     st.docstring_idx = Some(idx);
     Ok(true)
 }
-
-fn parse_from_attribute(arg: &mut syn::PatType) -> syn::Result<Option<syn::Ident>> {
-    let mut from_name = None;
-    let mut from_attr_err = None;
-    arg.attrs.retain(|a| {
-        if !a.path().is_ident("from") {
-            return true;
-        }
-        if from_attr_err.is_some() {
-            return false;
-        }
-        match &a.meta {
-            syn::Meta::Path(_) => {}
-            syn::Meta::List(_) => match a.parse_args::<syn::Ident>() {
-                Ok(parsed) => from_name = Some(parsed),
-                Err(err) => from_attr_err = Some(err),
-            },
-            syn::Meta::NameValue(_) => {
-                from_attr_err = Some(syn::Error::new_spanned(
-                    a,
-                    "#[from] expects an identifier or no arguments",
-                ));
-            }
-        }
-        false
-    });
-    if let Some(err) = from_attr_err {
-        return Err(err);
-    }
-    Ok(from_name)
-}
-
-fn validate_no_step_struct_conflict(
-    ctx: &ClassificationContext,
-    target_name: &str,
-    pat: &syn::Ident,
-) -> syn::Result<()> {
-    if ctx.extracted.step_struct_idx.is_some()
-        && ctx.extracted.blocked_placeholders.contains(target_name)
-    {
-        Err(syn::Error::new(
-            pat.span(),
-            "#[step_args] cannot be combined with named step arguments",
-        ))
-    } else {
-        Ok(())
-    }
-}
-
-fn classify_by_placeholder_match(
-    ctx: &mut ClassificationContext,
-    from_name: Option<syn::Ident>,
-    pat: syn::Ident,
-    ty: syn::Type,
-) -> syn::Result<()> {
-    let target = from_name.clone().unwrap_or_else(|| pat.clone());
-    let target_name = target.to_string();
-    let normalized = normalize_param_name(&target_name);
-    if ctx.placeholders.remove(normalized) {
-        validate_no_step_struct_conflict(ctx, normalized, &pat)?;
-        ctx.extracted.push(Arg::Step { pat, ty });
-        Ok(())
-    } else {
-        validate_no_step_struct_conflict(ctx, &target_name, &pat)?;
-        let name = if let Some(name) = from_name {
-            name
-        } else if normalized == target_name {
-            pat.clone()
-        } else {
-            let mut name = syn::parse_str::<syn::Ident>(normalized).map_err(|_| {
-                syn::Error::new(
-                    pat.span(),
-                    format!(
-                        "normalized fixture name `{normalized}` is not a valid identifier; use #[from(...)] to specify the fixture name explicitly"
-                    ),
-                )
-            })?;
-            name.set_span(pat.span());
-            name
-        };
-        ctx.extracted.push(Arg::Fixture { pat, name, ty });
-        Ok(())
-    }
-}
-
-pub(super) fn classify_fixture_or_step(
-    ctx: &mut ClassificationContext,
-    arg: &mut syn::PatType,
-    pat: syn::Ident,
-    ty: syn::Type,
-) -> syn::Result<bool> {
-    let from_name = parse_from_attribute(arg)?;
-    classify_by_placeholder_match(ctx, from_name, pat, ty)?;
-    Ok(true)
-}
-
 #[cfg(test)]
 mod tests;
+
+mod fixture_or_step;

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/fixture_or_step.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/fixture_or_step.rs
@@ -1,0 +1,128 @@
+//! Terminal classifier: step-argument (placeholder) or fixture binding.
+//!
+//! Runs after the DataTable/DocString/step-struct classifiers have declined a
+//! parameter. Consumes any `#[from(...)]` attribute to determine the lookup
+//! name, claims a matching step-pattern placeholder where possible, and
+//! otherwise records the parameter as a fixture injection.
+
+use super::ClassificationContext;
+use super::{Arg, normalize_param_name};
+
+/// Extract the fixture name from a `#[from(...)]` attribute, if present.
+///
+/// Mutates `arg.attrs` in place, removing every `#[from]` attribute so the
+/// generated wrapper does not re-emit it. Returns the explicit fixture
+/// identifier from `#[from(name)]`, or `None` for a bare `#[from]` or no
+/// attribute.
+///
+/// # Errors
+///
+/// Returns an error when the attribute payload is not a single identifier or
+/// uses `#[from = ...]` name-value form.
+fn parse_from_attribute(arg: &mut syn::PatType) -> syn::Result<Option<syn::Ident>> {
+    let mut from_name = None;
+    let mut from_attr_err = None;
+    arg.attrs.retain(|a| {
+        if !a.path().is_ident("from") {
+            return true;
+        }
+        if from_attr_err.is_some() {
+            return false;
+        }
+        match &a.meta {
+            syn::Meta::Path(_) => {}
+            syn::Meta::List(_) => match a.parse_args::<syn::Ident>() {
+                Ok(parsed) => from_name = Some(parsed),
+                Err(err) => from_attr_err = Some(err),
+            },
+            syn::Meta::NameValue(_) => {
+                from_attr_err = Some(syn::Error::new_spanned(
+                    a,
+                    "#[from] expects an identifier or no arguments",
+                ));
+            }
+        }
+        false
+    });
+    if let Some(err) = from_attr_err {
+        return Err(err);
+    }
+    Ok(from_name)
+}
+
+fn validate_no_step_struct_conflict(
+    ctx: &ClassificationContext,
+    target_name: &str,
+    pat: &syn::Ident,
+) -> syn::Result<()> {
+    if ctx.extracted.step_struct_idx.is_some()
+        && ctx.extracted.blocked_placeholders.contains(target_name)
+    {
+        Err(syn::Error::new(
+            pat.span(),
+            "#[step_args] cannot be combined with named step arguments",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn classify_by_placeholder_match(
+    ctx: &mut ClassificationContext,
+    from_name: Option<syn::Ident>,
+    pat: syn::Ident,
+    ty: syn::Type,
+) -> syn::Result<()> {
+    let target = from_name.clone().unwrap_or_else(|| pat.clone());
+    let target_name = target.to_string();
+    let normalized = normalize_param_name(&target_name);
+    if ctx.placeholders.remove(normalized) {
+        validate_no_step_struct_conflict(ctx, normalized, &pat)?;
+        ctx.extracted.push(Arg::Step { pat, ty });
+        Ok(())
+    } else {
+        validate_no_step_struct_conflict(ctx, &target_name, &pat)?;
+        let name = if let Some(name) = from_name {
+            name
+        } else if normalized == target_name {
+            pat.clone()
+        } else {
+            let mut name = syn::parse_str::<syn::Ident>(normalized).map_err(|_| {
+                syn::Error::new(
+                    pat.span(),
+                    format!(
+                        "normalized fixture name `{normalized}` is not a valid identifier; use #[from(...)] to specify the fixture name explicitly"
+                    ),
+                )
+            })?;
+            name.set_span(pat.span());
+            name
+        };
+        ctx.extracted.push(Arg::Fixture { pat, name, ty });
+        Ok(())
+    }
+}
+
+/// Classify `arg` as a step argument (placeholder match) or fixture.
+///
+/// Consumes any `#[from(...)]` attribute on `arg` (stripping it in place via
+/// [`parse_from_attribute`]) to determine the lookup name, then claims a
+/// matching placeholder from `ctx.placeholders` or falls back to fixture
+/// injection. Always returns `Ok(true)`: this is the terminal classifier in
+/// the pipeline.
+///
+/// # Errors
+///
+/// Returns an error when the `#[from]` attribute is malformed, when the
+/// parameter conflicts with `#[step_args]` placeholder ownership, or when a
+/// normalized fixture name is not a valid identifier.
+pub(in super::super) fn classify_fixture_or_step(
+    ctx: &mut ClassificationContext,
+    arg: &mut syn::PatType,
+    pat: syn::Ident,
+    ty: syn::Type,
+) -> syn::Result<bool> {
+    let from_name = parse_from_attribute(arg)?;
+    classify_by_placeholder_match(ctx, from_name, pat, ty)?;
+    Ok(true)
+}

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/fixture_or_step.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/fixture_or_step.rs
@@ -48,20 +48,10 @@ fn parse_from_attribute(arg: &mut syn::PatType) -> syn::Result<Option<syn::Ident
         found = true;
         // Keep scanning so every `#[from]` is stripped, but stop parsing
         // payloads once the first error (malformed or duplicate) is seen.
-        if from_attr_err.is_some() || duplicate {
-            return false;
-        }
-        match &a.meta {
-            syn::Meta::Path(_) => {}
-            syn::Meta::List(_) => match a.parse_args::<syn::Ident>() {
-                Ok(parsed) => from_name = Some(parsed),
+        if from_attr_err.is_none() && !duplicate {
+            match from_attribute_ident(a) {
+                Ok(name) => from_name = name,
                 Err(err) => from_attr_err = Some(err),
-            },
-            syn::Meta::NameValue(_) => {
-                from_attr_err = Some(syn::Error::new_spanned(
-                    a,
-                    "#[from] expects an identifier or no arguments",
-                ));
             }
         }
         false
@@ -76,6 +66,27 @@ fn parse_from_attribute(arg: &mut syn::PatType) -> syn::Result<Option<syn::Ident
         ));
     }
     Ok(from_name)
+}
+
+/// Extract the explicit fixture name from a single `#[from]` attribute's
+/// payload.
+///
+/// Returns `Ok(None)` for a bare `#[from]`, `Ok(Some(name))` for
+/// `#[from(name)]`.
+///
+/// # Errors
+///
+/// Returns an error when the payload is not a single identifier or uses the
+/// `#[from = ...]` name-value form.
+fn from_attribute_ident(attr: &syn::Attribute) -> syn::Result<Option<syn::Ident>> {
+    match &attr.meta {
+        syn::Meta::Path(_) => Ok(None),
+        syn::Meta::List(_) => attr.parse_args::<syn::Ident>().map(Some),
+        syn::Meta::NameValue(_) => Err(syn::Error::new_spanned(
+            attr,
+            "#[from] expects an identifier or no arguments",
+        )),
+    }
 }
 
 /// Reject a fixture/step name that a `#[step_args]` struct already owns.
@@ -171,16 +182,17 @@ fn classify_by_placeholder_match(
     let target = from_name.clone().unwrap_or_else(|| pat.clone());
     let target_name = target.to_string();
     let normalized = normalize_param_name(&target_name);
+    // The `#[step_args]` conflict guard reads only `ctx.extracted`, so run it
+    // once before the branch. Keeping it out of both arms stops the two paths
+    // from diverging — the shape that previously let `_foo` skip the guard.
+    validate_no_step_struct_conflict(ctx, normalized, &pat)?;
     if ctx.placeholders.remove(normalized) {
-        validate_no_step_struct_conflict(ctx, normalized, &pat)?;
         ctx.extracted.push(Arg::Step { pat, ty });
-        Ok(())
     } else {
-        validate_no_step_struct_conflict(ctx, normalized, &pat)?;
         let name = resolve_fixture_name(from_name, &pat, normalized)?;
         ctx.extracted.push(Arg::Fixture { pat, name, ty });
-        Ok(())
     }
+    Ok(())
 }
 
 /// Classify `arg` as a step argument (placeholder match) or fixture.

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/fixture_or_step.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/fixture_or_step.rs
@@ -104,10 +104,13 @@ fn from_attribute_ident(attr: &syn::Attribute) -> syn::Result<Option<syn::Ident>
 ///
 /// When a `#[step_args]` struct is present it claims a set of placeholder
 /// names (`ctx.extracted.blocked_placeholders`); binding a separate parameter
-/// to one of those names would silently shadow the struct. `target_name` must
-/// be the *normalized* lookup name (leading underscore stripped) so the check
-/// uses the same key space the placeholder set and the struct do — otherwise a
-/// parameter such as `_foo` could slip past a block on `foo`.
+/// to one of those names would silently shadow the struct. `target_name` must be
+/// the key the parameter will actually request — the normalized parameter name
+/// for an implicit fixture, or the explicit `#[from(...)]` identifier verbatim —
+/// so the check uses the same key space as the placeholder set and the struct.
+/// An implicit `_foo` must therefore be tested as `foo`, or it would slip past a
+/// block on `foo`; an explicit `#[from(_foo)]` must be tested as `_foo`, or it
+/// would be rejected by a block it does not collide with.
 ///
 /// Does not mutate `ctx`; it only inspects the accumulated state.
 ///
@@ -169,20 +172,27 @@ fn resolve_fixture_name(
 
 /// Bind `pat`/`ty` to a step-pattern placeholder or, failing that, a fixture.
 ///
-/// The lookup name is `from_name` when `#[from(...)]` was supplied, otherwise
-/// the parameter identifier; either way it is normalized (leading underscore
-/// stripped) before matching. On a placeholder hit the entry is removed from
+/// The lookup name is the explicit `#[from(...)]` identifier **verbatim** when
+/// one was supplied, and otherwise the parameter identifier with one leading
+/// underscore stripped. On a placeholder hit the entry is removed from
 /// `ctx.placeholders` and an [`Arg::Step`] is pushed; otherwise an
 /// [`Arg::Fixture`] is pushed with the name from [`resolve_fixture_name`].
+///
+/// Normalization applies to the implicit name only, because only that path goes
+/// on to *record* a normalized key. An explicit `#[from(name)]` is authoritative
+/// and records `name` exactly, so matching or guarding it against a stripped
+/// form would test a key the parameter never requests: `#[from(_foo)]` would
+/// bind the placeholder `foo`, discarding the explicit name, and would be
+/// rejected by a `#[step_args]` block on `foo` it does not collide with.
 ///
 /// Mutates `ctx` in place: it removes the matched placeholder from
 /// `ctx.placeholders` and appends the classified [`Arg`] to `ctx.extracted`.
 ///
 /// # Errors
 ///
-/// Returns an error when the normalized name collides with a `#[step_args]`
-/// blocked placeholder (via [`validate_no_step_struct_conflict`]) or when a
-/// normalized fixture name is not a valid identifier (via
+/// Returns an error when the lookup name collides with a `#[step_args]` blocked
+/// placeholder (via [`validate_no_step_struct_conflict`]) or when a normalized
+/// implicit fixture name is not a valid identifier (via
 /// [`resolve_fixture_name`]).
 fn classify_by_placeholder_match(
     ctx: &mut ClassificationContext,
@@ -190,17 +200,21 @@ fn classify_by_placeholder_match(
     pat: syn::Ident,
     ty: syn::Type,
 ) -> syn::Result<()> {
-    let target = from_name.clone().unwrap_or_else(|| pat.clone());
-    let target_name = target.to_string();
-    let normalized = normalize_param_name(&target_name);
+    let pat_name = pat.to_string();
+    // Implicit name (the fallback) is normalized; an explicit `#[from(...)]`
+    // identifier is taken verbatim.
+    let lookup = from_name.as_ref().map_or_else(
+        || normalize_param_name(&pat_name).to_owned(),
+        ToString::to_string,
+    );
     // The `#[step_args]` conflict guard reads only `ctx.extracted`, so run it
     // once before the branch. Keeping it out of both arms stops the two paths
     // from diverging — the shape that previously let `_foo` skip the guard.
-    validate_no_step_struct_conflict(ctx, normalized, &pat)?;
-    if ctx.placeholders.remove(normalized) {
+    validate_no_step_struct_conflict(ctx, &lookup, &pat)?;
+    if ctx.placeholders.remove(&lookup) {
         ctx.extracted.push(Arg::Step { pat, ty });
     } else {
-        let name = resolve_fixture_name(from_name, &pat, normalized)?;
+        let name = resolve_fixture_name(from_name, &pat, &lookup)?;
         ctx.extracted.push(Arg::Fixture { pat, name, ty });
     }
     Ok(())
@@ -253,4 +267,88 @@ pub(in super::super) fn classify_fixture_or_step(
     let from_name = parse_from_attribute(arg)?;
     classify_by_placeholder_match(ctx, from_name, pat, ty)?;
     Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Regressions for the explicit-`#[from(...)]` exactness contract.
+    //!
+    //! The classifier's broader unit tests live in `classify::tests`; these two
+    //! stay beside the code because they pin the distinction that is easiest to
+    //! collapse by accident — that an explicit name is matched and guarded
+    //! verbatim, while only an implicit one is normalized.
+
+    use super::super::ExtractedArgs;
+    use super::*;
+    use proc_macro2::Span;
+    use std::collections::HashSet;
+    use syn::parse_quote;
+
+    fn ident(name: &str) -> syn::Ident {
+        syn::Ident::new(name, Span::call_site())
+    }
+
+    /// Classify `#[from(<from_name>)] state: usize` against the given state.
+    fn classify_explicit_from(
+        extracted: &mut ExtractedArgs,
+        placeholders: &mut HashSet<String>,
+        from_name: &str,
+    ) -> syn::Result<bool> {
+        let mut arg: syn::PatType = parse_quote!(state: usize);
+        let from_ident = ident(from_name);
+        arg.attrs.push(parse_quote!(#[from(#from_ident)]));
+        let ty: syn::Type = parse_quote!(usize);
+        let mut ctx = ClassificationContext::new(extracted, placeholders);
+        classify_fixture_or_step(&mut ctx, &mut arg, ident("state"), ty)
+    }
+
+    #[test]
+    fn explicit_from_name_does_not_bind_its_normalized_placeholder() {
+        let mut extracted = ExtractedArgs::default();
+        let mut placeholders = HashSet::from(["foo".to_owned()]);
+
+        let Ok(handled) = classify_explicit_from(&mut extracted, &mut placeholders, "_foo") else {
+            panic!("classification should succeed");
+        };
+
+        // `#[from(_foo)]` requests the literal `_foo` key. The placeholder `foo`
+        // is a different name, so it must survive unconsumed and the parameter
+        // must keep the explicit fixture name rather than becoming a step arg.
+        assert!(handled);
+        assert!(
+            placeholders.contains("foo"),
+            "placeholder `foo` should not be consumed by #[from(_foo)]"
+        );
+        assert!(matches!(
+            extracted.args.as_slice(),
+            [Arg::Fixture { name, .. }] if name == &ident("_foo")
+        ));
+    }
+
+    #[test]
+    fn explicit_from_name_is_guarded_verbatim_against_blocked_placeholders() {
+        let mut extracted = ExtractedArgs::default();
+        let idx = extracted.push(Arg::StepStruct {
+            pat: ident("args"),
+            ty: parse_quote!(Args),
+        });
+        extracted.step_struct_idx = Some(idx);
+        extracted.blocked_placeholders.insert("blocked".to_owned());
+        let mut placeholders = HashSet::new();
+
+        let result = classify_explicit_from(&mut extracted, &mut placeholders, "_blocked");
+
+        // The struct owns `blocked`, not `_blocked`, so an explicit request for
+        // the literal `_blocked` key does not collide with it. The implicit
+        // spelling still does, which
+        // `classify_fixture_or_step_respects_blocked_placeholders` pins.
+        assert!(
+            result.is_ok(),
+            "#[from(_blocked)] should not collide with a block on `blocked`"
+        );
+        assert!(matches!(
+            extracted.args.as_slice(),
+            [Arg::StepStruct { .. }, Arg::Fixture { name, .. }] if name == &ident("_blocked")
+        ));
+    }
 }

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/fixture_or_step.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/fixture_or_step.rs
@@ -10,10 +10,21 @@ use super::{Arg, normalize_param_name};
 
 /// Extract the fixture name from a `#[from(...)]` attribute, if present.
 ///
-/// Mutates `arg.attrs` in place, removing every `#[from]` attribute so the
-/// generated wrapper does not re-emit it. Returns the explicit fixture
-/// identifier from `#[from(name)]`, or `None` for a bare `#[from]` or no
-/// attribute.
+/// Returns the explicit fixture identifier from `#[from(name)]`, or `None` for
+/// a bare `#[from]` or no attribute at all.
+///
+/// # Mutation contract
+///
+/// On successful extraction the consumed `#[from(...)]` attribute is removed
+/// from [`syn::PatType::attrs`] in place, so the generated wrapper does not
+/// re-emit an attribute the compiler would reject in that position.
+///
+/// Stripping is unconditional rather than success-only: every `#[from]`
+/// attribute is removed before any error is returned, because the scan that
+/// removes them is also the scan that detects duplicates. A caller that
+/// recovers from an error therefore sees `arg.attrs` already cleared of
+/// `#[from]`, not restored to its original state. Only `#[from]` attributes are
+/// touched; any other attribute on the parameter is left in place and in order.
 ///
 /// # Errors
 ///
@@ -197,11 +208,23 @@ fn classify_by_placeholder_match(
 
 /// Classify `arg` as a step argument (placeholder match) or fixture.
 ///
-/// Consumes any `#[from(...)]` attribute on `arg` (stripping it in place via
-/// [`parse_from_attribute`]) to determine the lookup name, then claims a
-/// matching placeholder from `ctx.placeholders` or falls back to fixture
-/// injection. Always returns `Ok(true)`: this is the terminal classifier in
-/// the pipeline.
+/// Consumes any `#[from(...)]` attribute on `arg` to determine the lookup name,
+/// then claims a matching placeholder from `ctx.placeholders` or falls back to
+/// fixture injection. Always returns `Ok(true)`: this is the terminal classifier
+/// in the pipeline, so a parameter reaching it is claimed either as a step
+/// argument or as a fixture, and `Ok(false)` is never returned. A caller must
+/// therefore treat an error as the only non-claiming outcome.
+///
+/// # Mutation contract
+///
+/// Mutates both `arg` and `ctx`:
+///
+/// - Any `#[from]` attribute is removed from [`syn::PatType::attrs`] in place
+///   via [`parse_from_attribute`], including on the error paths.
+/// - A matched placeholder is removed from `ctx.placeholders`, so it cannot bind
+///   a second parameter.
+/// - The resulting [`Arg::Step`] or [`Arg::Fixture`] is appended to
+///   `ctx.extracted`.
 ///
 /// # Errors
 ///

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/fixture_or_step.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/fixture_or_step.rs
@@ -19,6 +19,17 @@ use super::{Arg, normalize_param_name};
 ///
 /// Returns an error when the attribute payload is not a single identifier or
 /// uses `#[from = ...]` name-value form.
+///
+/// # Examples
+///
+/// Given the parameter as written in a step function:
+///
+/// ```text
+/// #[from(user)] u: User   => Ok(Some(user)); attribute stripped
+/// #[from] u: User         => Ok(None);       attribute stripped
+/// u: User                 => Ok(None);       nothing to strip
+/// #[from = "user"] u: U   => Err: "#[from] expects an identifier or no arguments"
+/// ```
 fn parse_from_attribute(arg: &mut syn::PatType) -> syn::Result<Option<syn::Ident>> {
     let mut from_name = None;
     let mut from_attr_err = None;
@@ -116,6 +127,19 @@ fn classify_by_placeholder_match(
 /// Returns an error when the `#[from]` attribute is malformed, when the
 /// parameter conflicts with `#[step_args]` placeholder ownership, or when a
 /// normalized fixture name is not a valid identifier.
+///
+/// # Examples
+///
+/// Given the parameter as written in a step function and the current
+/// placeholder set:
+///
+/// ```text
+/// count: u32,  placeholders = {count}  => Step arg; placeholder `count` consumed
+/// pool: DbPool, placeholders = {}      => Fixture named `pool`
+/// #[from(db)] pool: DbPool, {}         => Fixture named `db` (explicit override)
+/// ```
+///
+/// Always returns `Ok(true)`; the parameter is claimed either way.
 pub(in super::super) fn classify_fixture_or_step(
     ctx: &mut ClassificationContext,
     arg: &mut syn::PatType,

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/fixture_or_step.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/fixture_or_step.rs
@@ -17,27 +17,38 @@ use super::{Arg, normalize_param_name};
 ///
 /// # Errors
 ///
-/// Returns an error when the attribute payload is not a single identifier or
-/// uses `#[from = ...]` name-value form.
+/// Returns an error when the attribute payload is not a single identifier,
+/// uses the `#[from = ...]` name-value form, or when more than one `#[from]`
+/// attribute is applied to the same parameter (which would otherwise silently
+/// pick the last one).
 ///
 /// # Examples
 ///
 /// Given the parameter as written in a step function:
 ///
 /// ```text
-/// #[from(user)] u: User   => Ok(Some(user)); attribute stripped
-/// #[from] u: User         => Ok(None);       attribute stripped
-/// u: User                 => Ok(None);       nothing to strip
-/// #[from = "user"] u: U   => Err: "#[from] expects an identifier or no arguments"
+/// #[from(user)] u: User      => Ok(Some(user)); attribute stripped
+/// #[from] u: User            => Ok(None);       attribute stripped
+/// u: User                    => Ok(None);       nothing to strip
+/// #[from = "user"] u: U      => Err: "#[from] expects an identifier or no arguments"
+/// #[from(a)] #[from(b)] u: U  => Err: "duplicate `#[from]` attribute"
 /// ```
 fn parse_from_attribute(arg: &mut syn::PatType) -> syn::Result<Option<syn::Ident>> {
     let mut from_name = None;
     let mut from_attr_err = None;
+    let mut found = false;
+    let mut duplicate = false;
     arg.attrs.retain(|a| {
         if !a.path().is_ident("from") {
             return true;
         }
-        if from_attr_err.is_some() {
+        if found {
+            duplicate = true;
+        }
+        found = true;
+        // Keep scanning so every `#[from]` is stripped, but stop parsing
+        // payloads once the first error (malformed or duplicate) is seen.
+        if from_attr_err.is_some() || duplicate {
             return false;
         }
         match &a.meta {
@@ -58,9 +69,30 @@ fn parse_from_attribute(arg: &mut syn::PatType) -> syn::Result<Option<syn::Ident
     if let Some(err) = from_attr_err {
         return Err(err);
     }
+    if duplicate {
+        return Err(syn::Error::new_spanned(
+            &arg.pat,
+            "duplicate `#[from]` attribute",
+        ));
+    }
     Ok(from_name)
 }
 
+/// Reject a fixture/step name that a `#[step_args]` struct already owns.
+///
+/// When a `#[step_args]` struct is present it claims a set of placeholder
+/// names (`ctx.extracted.blocked_placeholders`); binding a separate parameter
+/// to one of those names would silently shadow the struct. `target_name` must
+/// be the *normalized* lookup name (leading underscore stripped) so the check
+/// uses the same key space the placeholder set and the struct do — otherwise a
+/// parameter such as `_foo` could slip past a block on `foo`.
+///
+/// Does not mutate `ctx`; it only inspects the accumulated state.
+///
+/// # Errors
+///
+/// Returns an error when a `#[step_args]` struct is present and `target_name`
+/// is one of its blocked placeholders.
 fn validate_no_step_struct_conflict(
     ctx: &ClassificationContext,
     target_name: &str,
@@ -78,6 +110,58 @@ fn validate_no_step_struct_conflict(
     }
 }
 
+/// Resolve the fixture name for a parameter that matched no placeholder.
+///
+/// Prefers an explicit `#[from(name)]` override; otherwise uses the parameter
+/// identifier when normalization left it unchanged, or the normalized name
+/// (re-parsed as an identifier) when a leading underscore was stripped. Does
+/// not mutate anything.
+///
+/// # Errors
+///
+/// Returns an error when the normalized name is not a valid identifier — for
+/// example a name that becomes empty or begins with a digit after stripping —
+/// directing the caller to name the fixture explicitly with `#[from(...)]`.
+fn resolve_fixture_name(
+    from_name: Option<syn::Ident>,
+    pat: &syn::Ident,
+    normalized: &str,
+) -> syn::Result<syn::Ident> {
+    if let Some(name) = from_name {
+        return Ok(name);
+    }
+    if pat == normalized {
+        return Ok(pat.clone());
+    }
+    let mut name = syn::parse_str::<syn::Ident>(normalized).map_err(|_| {
+        syn::Error::new(
+            pat.span(),
+            format!(
+                "normalized fixture name `{normalized}` is not a valid identifier; use #[from(...)] to specify the fixture name explicitly"
+            ),
+        )
+    })?;
+    name.set_span(pat.span());
+    Ok(name)
+}
+
+/// Bind `pat`/`ty` to a step-pattern placeholder or, failing that, a fixture.
+///
+/// The lookup name is `from_name` when `#[from(...)]` was supplied, otherwise
+/// the parameter identifier; either way it is normalized (leading underscore
+/// stripped) before matching. On a placeholder hit the entry is removed from
+/// `ctx.placeholders` and an [`Arg::Step`] is pushed; otherwise an
+/// [`Arg::Fixture`] is pushed with the name from [`resolve_fixture_name`].
+///
+/// Mutates `ctx` in place: it removes the matched placeholder from
+/// `ctx.placeholders` and appends the classified [`Arg`] to `ctx.extracted`.
+///
+/// # Errors
+///
+/// Returns an error when the normalized name collides with a `#[step_args]`
+/// blocked placeholder (via [`validate_no_step_struct_conflict`]) or when a
+/// normalized fixture name is not a valid identifier (via
+/// [`resolve_fixture_name`]).
 fn classify_by_placeholder_match(
     ctx: &mut ClassificationContext,
     from_name: Option<syn::Ident>,
@@ -92,23 +176,8 @@ fn classify_by_placeholder_match(
         ctx.extracted.push(Arg::Step { pat, ty });
         Ok(())
     } else {
-        validate_no_step_struct_conflict(ctx, &target_name, &pat)?;
-        let name = if let Some(name) = from_name {
-            name
-        } else if normalized == target_name {
-            pat.clone()
-        } else {
-            let mut name = syn::parse_str::<syn::Ident>(normalized).map_err(|_| {
-                syn::Error::new(
-                    pat.span(),
-                    format!(
-                        "normalized fixture name `{normalized}` is not a valid identifier; use #[from(...)] to specify the fixture name explicitly"
-                    ),
-                )
-            })?;
-            name.set_span(pat.span());
-            name
-        };
+        validate_no_step_struct_conflict(ctx, normalized, &pat)?;
+        let name = resolve_fixture_name(from_name, &pat, normalized)?;
         ctx.extracted.push(Arg::Fixture { pat, name, ty });
         Ok(())
     }

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/prop_tests.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/prop_tests.rs
@@ -1,0 +1,331 @@
+//! Property tests for the terminal classifier's naming and `#[from]` contracts.
+//!
+//! The unit tests in [`super::tests`] pin specific parameters and the exact
+//! diagnostic text; these cover the same rules across a generated range of
+//! identifiers and attribute combinations. Both are kept: the examples document
+//! intent and anchor the diagnostic snapshots, while the properties catch cases
+//! nobody thought to enumerate.
+//!
+//! Generation is deliberately bounded to syntactically parseable parameters —
+//! identifiers are composed from a safe alphabet and attributes from a fixed set
+//! of spellings, rather than fuzzing raw token strings, which would spend nearly
+//! every case on inputs `syn` rejects before the classifier is reached.
+
+use std::collections::HashSet;
+
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use proptest::prelude::*;
+use quote::quote;
+
+use super::*;
+
+/// First character of a generated identifier base.
+///
+/// Restricted to letters so a base is never empty, never starts with a digit,
+/// and never degenerates to a bare `_`.
+const HEAD_CHARS: [char; 5] = ['a', 'b', 'm', 'q', 'z'];
+
+/// Subsequent characters of a generated identifier base.
+///
+/// Chosen so no combination with [`HEAD_CHARS`] can spell a Rust keyword; the
+/// filter in [`ident_base`] is a safety net rather than the primary defence,
+/// which keeps the strategy's rejection rate at effectively zero.
+const TAIL_CHARS: [char; 10] = ['a', 'b', 'c', 'x', 'y', 'z', '0', '1', '9', '_'];
+
+/// Strategy yielding a valid, non-keyword Rust identifier with no leading
+/// underscore.
+///
+/// Leading underscores are applied separately by the callers that exercise
+/// normalization, so this strategy owns only the "base" part of a name.
+fn ident_base() -> impl Strategy<Value = String> {
+    (
+        prop::sample::select(HEAD_CHARS.as_slice()),
+        prop::collection::vec(prop::sample::select(TAIL_CHARS.as_slice()), 0..6),
+    )
+        .prop_map(|(head, tail)| {
+            let mut base = String::from(head);
+            base.extend(tail);
+            base
+        })
+        .prop_filter("must parse as a non-keyword identifier", |base| {
+            syn::parse_str::<syn::Ident>(base).is_ok()
+        })
+}
+
+/// Strategy yielding a parameter name together with its underscore count.
+///
+/// Produces `(name, underscores, base)` where `name` is `underscores` copies of
+/// `_` followed by `base`. Three is enough to cover the contract's boundaries:
+/// none, exactly one (stripped), and more than one (only the first stripped).
+fn prefixed_name() -> impl Strategy<Value = (String, usize, String)> {
+    (ident_base(), 0usize..=3).prop_map(|(base, underscores)| {
+        let name = format!("{}{base}", "_".repeat(underscores));
+        (name, underscores, base)
+    })
+}
+
+/// Which well-formed `#[from]` spelling to emit.
+#[derive(Debug, Clone)]
+enum FromForm {
+    /// Bare `#[from]`, which carries no name and so falls back to the
+    /// normalized parameter name.
+    Bare,
+    /// `#[from(name)]`, naming the fixture explicitly and exactly.
+    Named(String),
+}
+
+impl FromForm {
+    /// Render this form as parameter attribute tokens.
+    fn tokens(&self) -> TokenStream2 {
+        match self {
+            Self::Bare => quote!(#[from]),
+            Self::Named(name) => {
+                let ident = syn::Ident::new(name, Span::call_site());
+                quote!(#[from(#ident)])
+            }
+        }
+    }
+}
+
+/// Strategy yielding either well-formed `#[from]` spelling.
+fn from_form() -> impl Strategy<Value = FromForm> {
+    prop_oneof![Just(FromForm::Bare), ident_base().prop_map(FromForm::Named)]
+}
+
+/// Everything observable after one terminal-classifier run.
+struct Outcome {
+    /// The classifier's own result: `Ok(true)` on every accepted parameter.
+    result: syn::Result<bool>,
+    /// Arguments accumulated during the run.
+    extracted: ExtractedArgs,
+    /// Placeholders still unclaimed once the run finished.
+    placeholders: HashSet<String>,
+    /// The parameter's attributes *after* the run, for asserting what was
+    /// stripped and what survived.
+    attrs: Vec<syn::Attribute>,
+}
+
+impl Outcome {
+    /// The error message, or the empty string when the run succeeded.
+    fn error(&self) -> String {
+        match &self.result {
+            Ok(_) => String::new(),
+            Err(err) => err.to_string(),
+        }
+    }
+
+    /// Name of the sole classified fixture, if exactly one fixture was recorded.
+    fn sole_fixture_name(&self) -> Option<String> {
+        match self.extracted.args.as_slice() {
+            [Arg::Fixture { name, .. }] => Some(name.to_string()),
+            _ => None,
+        }
+    }
+
+    /// Whether exactly one step argument was recorded.
+    fn is_sole_step(&self) -> bool {
+        matches!(self.extracted.args.as_slice(), [Arg::Step { .. }])
+    }
+
+    /// Whether any `#[from]` attribute survived the run.
+    ///
+    /// Generated wrapper code re-emits whatever attributes remain, so a
+    /// surviving `#[from]` would reach the compiler in a position it rejects.
+    fn retains_from_attribute(&self) -> bool {
+        self.attrs.iter().any(|a| a.path().is_ident("from"))
+    }
+}
+
+/// Build `<attrs> <name>: usize` and run the terminal classifier over it.
+///
+/// Panics rather than returning an error when the generated tokens do not parse:
+/// that indicates a defective strategy, not a property failure, and should fail
+/// loudly instead of being reported as a falsified invariant.
+fn classify(attrs: &[TokenStream2], name: &str, placeholders: HashSet<String>) -> Outcome {
+    let attr_tokens: TokenStream2 = attrs.iter().cloned().collect();
+    let name_ident = syn::Ident::new(name, Span::call_site());
+    let mut arg = match syn::parse2::<syn::FnArg>(quote!(#attr_tokens #name_ident: usize)) {
+        Ok(syn::FnArg::Typed(arg)) => arg,
+        Ok(syn::FnArg::Receiver(_)) => panic!("generated a receiver, expected a typed parameter"),
+        Err(err) => panic!("generated parameter did not parse: {err}"),
+    };
+    let syn::Pat::Ident(pat_ident) = arg.pat.as_ref() else {
+        panic!("generated parameter was not an identifier pattern");
+    };
+    let pat = pat_ident.ident.clone();
+    let ty = arg.ty.as_ref().clone();
+
+    let mut extracted = ExtractedArgs::default();
+    let mut remaining = placeholders;
+    let result = {
+        let mut ctx = ClassificationContext::new(&mut extracted, &mut remaining);
+        classify_fixture_or_step(&mut ctx, &mut arg, pat, ty)
+    };
+
+    Outcome {
+        result,
+        extracted,
+        placeholders: remaining,
+        attrs: arg.attrs,
+    }
+}
+
+proptest! {
+    /// Normalization strips exactly one leading underscore, never more.
+    #[test]
+    fn normalization_strips_exactly_one_leading_underscore(
+        (name, underscores, base) in prefixed_name(),
+    ) {
+        let expected = format!("{}{base}", "_".repeat(underscores.saturating_sub(1)));
+        prop_assert_eq!(normalize_param_name(&name), expected.as_str());
+    }
+
+    /// A parameter binds and consumes the placeholder equal to its normalized
+    /// name.
+    #[test]
+    fn normalized_name_consumes_an_exactly_matching_placeholder(
+        (name, ..) in prefixed_name(),
+    ) {
+        let normalized = normalize_param_name(&name).to_string();
+        let outcome = classify(&[], &name, HashSet::from([normalized]));
+
+        prop_assert_eq!(outcome.result.as_ref().ok(), Some(&true), "{}", outcome.error());
+        prop_assert!(outcome.is_sole_step());
+        prop_assert!(outcome.placeholders.is_empty());
+    }
+
+    /// A placeholder that does not equal the normalized name is left alone and
+    /// the parameter becomes a fixture instead.
+    #[test]
+    fn nonmatching_placeholder_survives_and_parameter_becomes_a_fixture(
+        (name, ..) in prefixed_name(),
+        other in ident_base(),
+    ) {
+        let normalized = normalize_param_name(&name).to_string();
+        prop_assume!(other != normalized);
+
+        let outcome = classify(&[], &name, HashSet::from([other.clone()]));
+
+        prop_assert_eq!(outcome.result.as_ref().ok(), Some(&true), "{}", outcome.error());
+        prop_assert_eq!(outcome.sole_fixture_name(), Some(normalized));
+        prop_assert!(outcome.placeholders.contains(&other));
+    }
+
+    /// The implicit fixture key is the normalized name, and is always a valid
+    /// identifier whenever normalization succeeded.
+    #[test]
+    fn implicit_fixture_key_is_the_normalized_name_and_a_valid_identifier(
+        (name, ..) in prefixed_name(),
+    ) {
+        let normalized = normalize_param_name(&name).to_string();
+        let outcome = classify(&[], &name, HashSet::new());
+
+        let Some(key) = outcome.sole_fixture_name() else {
+            return Err(TestCaseError::fail("expected a single fixture argument"));
+        };
+        prop_assert_eq!(&key, &normalized);
+        prop_assert!(syn::parse_str::<syn::Ident>(&key).is_ok(), "key `{}` is not an identifier", key);
+    }
+
+    /// A single bare `#[from]` is accepted and behaves as if omitted: the
+    /// fixture key is the normalized parameter name.
+    #[test]
+    fn a_single_bare_from_is_accepted_and_uses_the_normalized_name(
+        (name, ..) in prefixed_name(),
+    ) {
+        let normalized = normalize_param_name(&name).to_string();
+        let outcome = classify(&[FromForm::Bare.tokens()], &name, HashSet::new());
+
+        prop_assert_eq!(outcome.result.as_ref().ok(), Some(&true), "{}", outcome.error());
+        prop_assert_eq!(outcome.sole_fixture_name(), Some(normalized));
+        prop_assert!(!outcome.retains_from_attribute());
+    }
+
+    /// A single `#[from(name)]` is accepted and the named fixture key is used
+    /// exactly, without normalization.
+    #[test]
+    fn a_single_named_from_is_accepted_and_kept_exact(
+        (name, ..) in prefixed_name(),
+        (explicit, ..) in prefixed_name(),
+    ) {
+        let outcome = classify(
+            &[FromForm::Named(explicit.clone()).tokens()],
+            &name,
+            HashSet::new(),
+        );
+
+        prop_assert_eq!(outcome.result.as_ref().ok(), Some(&true), "{}", outcome.error());
+        prop_assert_eq!(outcome.sole_fixture_name(), Some(explicit));
+        prop_assert!(!outcome.retains_from_attribute());
+    }
+
+    /// Any two or more `#[from]` attributes are rejected as duplicates,
+    /// whatever mix and order of bare and named spellings is used.
+    #[test]
+    fn any_two_from_attributes_are_rejected_as_duplicates(
+        (name, ..) in prefixed_name(),
+        forms in prop::collection::vec(from_form(), 2..=3),
+    ) {
+        let attrs: Vec<TokenStream2> = forms.iter().map(FromForm::tokens).collect();
+        let outcome = classify(&attrs, &name, HashSet::new());
+
+        prop_assert!(outcome.result.is_err(), "expected a duplicate diagnostic");
+        prop_assert!(
+            outcome.error().contains("duplicate `#[from]` attribute"),
+            "unexpected diagnostic: {}",
+            outcome.error(),
+        );
+    }
+
+    /// The `#[from = ...]` name-value form is rejected as malformed.
+    #[test]
+    fn name_value_from_is_rejected_as_malformed(
+        (name, ..) in prefixed_name(),
+        value in prop_oneof![
+            Just(quote!("text")),
+            Just(quote!(7)),
+            Just(quote!(some_path)),
+        ],
+    ) {
+        let outcome = classify(&[quote!(#[from = #value])], &name, HashSet::new());
+
+        prop_assert!(outcome.result.is_err(), "expected a malformed-form diagnostic");
+        prop_assert!(
+            outcome.error().contains("#[from] expects an identifier or no arguments"),
+            "unexpected diagnostic: {}",
+            outcome.error(),
+        );
+    }
+
+    /// Successful classification strips the consumed `#[from]` and nothing else,
+    /// leaving unrelated attributes in their original order.
+    #[test]
+    fn extraction_strips_only_the_consumed_from_attribute(
+        (name, ..) in prefixed_name(),
+        form in from_form(),
+        position in 0usize..=2,
+    ) {
+        // Two unrelated attributes that must survive untouched, with the
+        // `#[from]` threaded in before, between, or after them.
+        let unrelated = [quote!(#[allow(unused)]), quote!(#[doc = "kept"])];
+        let mut attrs: Vec<TokenStream2> = unrelated.to_vec();
+        attrs.insert(position, form.tokens());
+
+        let outcome = classify(&attrs, &name, HashSet::new());
+
+        prop_assert_eq!(outcome.result.as_ref().ok(), Some(&true), "{}", outcome.error());
+        prop_assert!(!outcome.retains_from_attribute());
+
+        // A slice pattern rather than indexing, so the arity is asserted and the
+        // two survivors are named in one step.
+        let [first, second] = outcome.attrs.as_slice() else {
+            return Err(TestCaseError::fail(format!(
+                "expected the {} unrelated attributes to survive, found {}",
+                unrelated.len(),
+                outcome.attrs.len(),
+            )));
+        };
+        prop_assert!(first.path().is_ident("allow"));
+        prop_assert!(second.path().is_ident("doc"));
+    }
+}

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/step_struct.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/step_struct.rs
@@ -6,10 +6,30 @@ use quote::ToTokens;
 
 use super::{Arg, ExtractedArgs};
 
+/// Detect and strip the `#[step_args]` marker from `arg`.
+///
+/// Returns whether the marker was present. Mutates [`syn::PatType::attrs`] in
+/// place, removing the marker so the generated wrapper does not re-emit it; see
+/// [`super::extract_flag_attribute`] for the shared stripping contract.
+///
+/// # Errors
+///
+/// Returns an error when `#[step_args]` carries arguments (it is a bare marker)
+/// or appears more than once on the same parameter.
 pub(crate) fn extract_step_struct_attribute(arg: &mut syn::PatType) -> syn::Result<bool> {
     super::extract_flag_attribute(arg, "step_args")
 }
 
+/// Turn a *rejection* predicate into a `Result`, attributing the span to `span`.
+///
+/// Note the polarity: `condition` describes the failure, so `true` yields
+/// `Err(error_msg)` and `false` yields `Ok(())`. Each `validate_*` helper below
+/// reads as "error if …" for this reason.
+///
+/// # Errors
+///
+/// Returns an error carrying `error_msg`, spanned to `span`, when `condition`
+/// holds.
 fn validate_condition<T>(condition: bool, span: &T, error_msg: &str) -> syn::Result<()>
 where
     T: ToTokens,
@@ -21,6 +41,11 @@ where
     }
 }
 
+/// Reject a second `#[step_args]` parameter in one step signature.
+///
+/// # Errors
+///
+/// Returns an error when `st` already recorded a step struct.
 fn validate_single_step_struct(st: &ExtractedArgs, span: &syn::PatType) -> syn::Result<()> {
     validate_condition(
         st.step_struct_idx.is_some(),
@@ -29,6 +54,14 @@ fn validate_single_step_struct(st: &ExtractedArgs, span: &syn::PatType) -> syn::
     )
 }
 
+/// Reject a `#[step_args]` struct alongside individually named step arguments.
+///
+/// The struct claims every placeholder in the pattern, so a separate named
+/// parameter would have nothing left to bind.
+///
+/// # Errors
+///
+/// Returns an error when `st` already recorded at least one named step argument.
 fn validate_no_named_args(st: &ExtractedArgs, span: &syn::PatType) -> syn::Result<()> {
     validate_condition(
         st.step_args().next().is_some(),
@@ -37,6 +70,12 @@ fn validate_no_named_args(st: &ExtractedArgs, span: &syn::PatType) -> syn::Resul
     )
 }
 
+/// Reject a `#[step_args]` struct when the pattern has no placeholders to fill.
+///
+/// # Errors
+///
+/// Returns an error when `placeholders` is empty, since the struct would have
+/// no fields to populate.
 fn validate_has_placeholders(
     placeholders: &HashSet<String>,
     span: &syn::PatType,
@@ -48,6 +87,15 @@ fn validate_has_placeholders(
     )
 }
 
+/// Reject `#[from]` on a `#[step_args]` parameter.
+///
+/// `#[from]` selects a fixture by name, which is meaningless for a struct built
+/// from pattern placeholders. Inspects `arg.attrs` without mutating it, so the
+/// attribute is still present in the diagnostic's span.
+///
+/// # Errors
+///
+/// Returns an error when `arg` carries any `#[from]` attribute.
 fn validate_no_from_attr(arg: &syn::PatType) -> syn::Result<()> {
     validate_condition(
         arg.attrs.iter().any(|a| a.path().is_ident("from")),
@@ -56,6 +104,14 @@ fn validate_no_from_attr(arg: &syn::PatType) -> syn::Result<()> {
     )
 }
 
+/// Require that a `#[step_args]` parameter owns its struct type.
+///
+/// The generated wrapper constructs the struct locally and moves it into the
+/// step call, so a reference parameter would borrow a temporary.
+///
+/// # Errors
+///
+/// Returns an error when `ty` is a reference type.
 fn validate_owned_type(ty: &syn::Type) -> syn::Result<()> {
     validate_condition(
         matches!(ty, &syn::Type::Reference(_)),
@@ -64,6 +120,34 @@ fn validate_owned_type(ty: &syn::Type) -> syn::Result<()> {
     )
 }
 
+/// Classify an already-marked `#[step_args]` parameter as the step struct.
+///
+/// Called only after [`extract_step_struct_attribute`] confirmed and stripped
+/// the marker, so this function validates rather than detects: it runs the
+/// `validate_*` guards above in order and records the struct on success. There
+/// is no "not a match" outcome — the parameter is either accepted or rejected.
+///
+/// # Mutation contract
+///
+/// On success, and only on success:
+///
+/// - [`Arg::StepStruct`] is appended to `st` and `st.step_struct_idx` is set to
+///   its index.
+/// - `st.blocked_placeholders` is overwritten with a clone of `placeholders`,
+///   recording the names the struct now owns so a later parameter cannot rebind
+///   one. [`super::fixture_or_step`] consults this set.
+/// - `placeholders` is then **cleared**, since the struct consumes every
+///   placeholder at once.
+///
+/// `arg` is not mutated; the marker was already removed by the caller.
+///
+/// # Errors
+///
+/// Returns an error when the parameter is not a simple identifier pattern, when
+/// a step struct was already classified, when named step arguments are also
+/// present, when the pattern has no placeholders, when `#[from]` is combined
+/// with `#[step_args]`, or when the parameter type is a reference. On any error
+/// `st` and `placeholders` are left untouched.
 pub(crate) fn classify_step_struct(
     st: &mut ExtractedArgs,
     arg: &syn::PatType,

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/tests.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/tests.rs
@@ -170,7 +170,10 @@ fn classify_fixture_or_step_strips_from_attribute_on_success() {
 
     // The `#[from]` attribute must be stripped so the generated wrapper does
     // not re-emit it, and the explicit name overrides the parameter identifier.
-    assert!(arg.attrs.is_empty(), "#[from] should be stripped on success");
+    assert!(
+        arg.attrs.is_empty(),
+        "#[from] should be stripped on success"
+    );
     let name = ident("db");
     assert!(matches!(
         extracted.args.as_slice(),

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/tests.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/tests.rs
@@ -3,7 +3,7 @@
 use super::*;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
-use rstest::rstest;
+use rstest::{fixture, rstest};
 use std::collections::HashSet;
 use syn::{FnArg, parse_quote};
 
@@ -111,8 +111,10 @@ fn classify_fixture_or_step_falls_back_to_fixture() {
     ));
 }
 
-#[test]
-fn classify_fixture_or_step_respects_blocked_placeholders() {
+/// Accumulator holding a `#[step_args]` struct that owns the `blocked`
+/// placeholder, for the conflict-guard cases.
+#[fixture]
+fn step_struct_extracted() -> ExtractedArgs {
     let mut extracted = ExtractedArgs::default();
     let idx = extracted.push(Arg::StepStruct {
         pat: ident("args"),
@@ -120,40 +122,96 @@ fn classify_fixture_or_step_respects_blocked_placeholders() {
     });
     extracted.step_struct_idx = Some(idx);
     extracted.blocked_placeholders.insert("blocked".into());
+    extracted
+}
+
+/// Classify `arg_tokens` against `extracted` and return the rejection message.
+///
+/// Panics when classification unexpectedly succeeds, so each caller asserts
+/// only on the diagnostic it cares about.
+fn classification_error(
+    mut extracted: ExtractedArgs,
+    arg_tokens: TokenStream2,
+    pat_name: &str,
+    ty_tokens: TokenStream2,
+) -> String {
     let mut placeholders = HashSet::new();
-    let mut arg: syn::PatType = parse_quote!(blocked: String);
-    let pat = ident("blocked");
-    let ty: syn::Type = parse_quote!(String);
+    // Parse via `FnArg` so leading attributes are captured on the `PatType`;
+    // a bare `PatType` parse would drop them.
+    let mut arg = pat_type(arg_tokens);
+    let pat = ident(pat_name);
+    let ty: syn::Type = match syn::parse2(ty_tokens) {
+        Ok(parsed) => parsed,
+        Err(err) => panic!("failed to parse type: {err}"),
+    };
     let mut ctx = ClassificationContext::new(&mut extracted, &mut placeholders);
     let Err(err) = classify_fixture_or_step(&mut ctx, &mut arg, pat, ty) else {
-        panic!("classification should fail");
+        panic!("classification should fail for {pat_name}");
     };
+    err.to_string()
+}
 
+#[rstest]
+// Both the last-wins (`#[from(a)] #[from(b)]`) and the silently-stripped
+// bare-duplicate forms must fail.
+#[case::duplicate_from_named(
+    quote!(#[from(a)] #[from(b)] u: String),
+    "u",
+    quote!(String),
+    "duplicate `#[from]` attribute"
+)]
+#[case::duplicate_from_bare(
+    quote!(#[from] #[from] u: String),
+    "u",
+    quote!(String),
+    "duplicate `#[from]` attribute"
+)]
+#[case::name_value_from(
+    quote!(#[from = "db"] pool: String),
+    "pool",
+    quote!(String),
+    "expects an identifier or no arguments"
+)]
+// `_1` normalizes to `1`, which is not a valid identifier; the classifier must
+// reject it rather than emit a broken fixture name.
+#[case::invalid_normalized_name(
+    quote!(_1: usize),
+    "_1",
+    quote!(usize),
+    "is not a valid identifier"
+)]
+fn classify_fixture_or_step_rejects_malformed_parameters(
+    #[case] arg_tokens: TokenStream2,
+    #[case] pat_name: &str,
+    #[case] ty_tokens: TokenStream2,
+    #[case] expected_fragment: &str,
+) {
+    let err = classification_error(ExtractedArgs::default(), arg_tokens, pat_name, ty_tokens);
     assert!(
-        err.to_string()
-            .contains("#[step_args] cannot be combined with named step arguments")
+        err.contains(expected_fragment),
+        "expected {expected_fragment:?} in error, got {err:?}"
     );
 }
 
 #[rstest]
-#[case::two_named(quote!(#[from(a)] #[from(b)] u: String))]
-#[case::two_bare(quote!(#[from] #[from] u: String))]
-fn classify_fixture_or_step_rejects_duplicate_from_attribute(#[case] arg_tokens: TokenStream2) {
-    let mut extracted = ExtractedArgs::default();
-    let mut placeholders = HashSet::new();
-    // Parse via `FnArg` so the leading `#[from]` attributes are captured on the
-    // `PatType`; a bare `PatType` parse would drop them. Both the last-wins
-    // (`#[from(a)] #[from(b)]`) and the silently-stripped bare-duplicate forms
-    // must fail.
-    let mut arg = pat_type(arg_tokens);
-    let pat = ident("u");
-    let ty: syn::Type = parse_quote!(String);
-    let mut ctx = ClassificationContext::new(&mut extracted, &mut placeholders);
-    let Err(err) = classify_fixture_or_step(&mut ctx, &mut arg, pat, ty) else {
-        panic!("duplicate #[from] should fail");
+#[case::exact_name("blocked")]
+// `_blocked` normalizes to `blocked`, which the `#[step_args]` struct owns.
+// The guard must compare the normalized name, or the leading underscore would
+// let the parameter shadow the struct field unnoticed.
+#[case::underscore_normalized("_blocked")]
+fn classify_fixture_or_step_respects_blocked_placeholders(
+    step_struct_extracted: ExtractedArgs,
+    #[case] pat_name: &str,
+) {
+    let arg_tokens: TokenStream2 = match format!("{pat_name}: String").parse() {
+        Ok(tokens) => tokens,
+        Err(err) => panic!("failed to parse argument tokens: {err}"),
     };
-
-    assert!(err.to_string().contains("duplicate `#[from]` attribute"));
+    let err = classification_error(step_struct_extracted, arg_tokens, pat_name, quote!(String));
+    assert!(
+        err.contains("#[step_args] cannot be combined with named step arguments"),
+        "expected the step_args conflict diagnostic, got {err:?}"
+    );
 }
 
 #[test]
@@ -179,68 +237,6 @@ fn classify_fixture_or_step_strips_from_attribute_on_success() {
         extracted.args.as_slice(),
         [Arg::Fixture { name: fixture_name, .. }] if fixture_name == &name
     ));
-}
-
-#[test]
-fn classify_fixture_or_step_rejects_name_value_from() {
-    let mut extracted = ExtractedArgs::default();
-    let mut placeholders = HashSet::new();
-    let mut arg = pat_type(quote!(#[from = "db"] pool: String));
-    let pat = ident("pool");
-    let ty: syn::Type = parse_quote!(String);
-    let mut ctx = ClassificationContext::new(&mut extracted, &mut placeholders);
-    let Err(err) = classify_fixture_or_step(&mut ctx, &mut arg, pat, ty) else {
-        panic!("#[from = ...] should fail");
-    };
-
-    assert!(
-        err.to_string()
-            .contains("expects an identifier or no arguments")
-    );
-}
-
-#[test]
-fn classify_fixture_or_step_rejects_invalid_normalized_name() {
-    // `_1` normalizes to `1`, which is not a valid identifier; the classifier
-    // must reject it rather than emit a broken fixture name.
-    let mut extracted = ExtractedArgs::default();
-    let mut placeholders = HashSet::new();
-    let mut arg: syn::PatType = parse_quote!(_1: usize);
-    let pat = ident("_1");
-    let ty: syn::Type = parse_quote!(usize);
-    let mut ctx = ClassificationContext::new(&mut extracted, &mut placeholders);
-    let Err(err) = classify_fixture_or_step(&mut ctx, &mut arg, pat, ty) else {
-        panic!("invalid normalized fixture name should fail");
-    };
-
-    assert!(err.to_string().contains("is not a valid identifier"));
-}
-
-#[test]
-fn classify_fixture_or_step_blocks_underscore_normalized_step_struct_name() {
-    // `_blocked` normalizes to `blocked`, which a `#[step_args]` struct owns.
-    // The guard must compare the normalized name, or the leading underscore
-    // would let the parameter shadow the struct field unnoticed.
-    let mut extracted = ExtractedArgs::default();
-    let idx = extracted.push(Arg::StepStruct {
-        pat: ident("args"),
-        ty: parse_quote!(Args),
-    });
-    extracted.step_struct_idx = Some(idx);
-    extracted.blocked_placeholders.insert("blocked".into());
-    let mut placeholders = HashSet::new();
-    let mut arg: syn::PatType = parse_quote!(_blocked: String);
-    let pat = ident("_blocked");
-    let ty: syn::Type = parse_quote!(String);
-    let mut ctx = ClassificationContext::new(&mut extracted, &mut placeholders);
-    let Err(err) = classify_fixture_or_step(&mut ctx, &mut arg, pat, ty) else {
-        panic!("normalized fixture name should collide with blocked placeholder");
-    };
-
-    assert!(
-        err.to_string()
-            .contains("#[step_args] cannot be combined with named step arguments")
-    );
 }
 
 #[test]

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/tests.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/tests.rs
@@ -135,13 +135,17 @@ fn classify_fixture_or_step_respects_blocked_placeholders() {
     );
 }
 
-#[test]
-fn classify_fixture_or_step_rejects_duplicate_from_attribute() {
+#[rstest]
+#[case::two_named(quote!(#[from(a)] #[from(b)] u: String))]
+#[case::two_bare(quote!(#[from] #[from] u: String))]
+fn classify_fixture_or_step_rejects_duplicate_from_attribute(#[case] arg_tokens: TokenStream2) {
     let mut extracted = ExtractedArgs::default();
     let mut placeholders = HashSet::new();
     // Parse via `FnArg` so the leading `#[from]` attributes are captured on the
-    // `PatType`; a bare `PatType` parse would drop them.
-    let mut arg = pat_type(quote!(#[from(a)] #[from(b)] u: String));
+    // `PatType`; a bare `PatType` parse would drop them. Both the last-wins
+    // (`#[from(a)] #[from(b)]`) and the silently-stripped bare-duplicate forms
+    // must fail.
+    let mut arg = pat_type(arg_tokens);
     let pat = ident("u");
     let ty: syn::Type = parse_quote!(String);
     let mut ctx = ClassificationContext::new(&mut extracted, &mut placeholders);
@@ -150,6 +154,63 @@ fn classify_fixture_or_step_rejects_duplicate_from_attribute() {
     };
 
     assert!(err.to_string().contains("duplicate `#[from]` attribute"));
+}
+
+#[test]
+fn classify_fixture_or_step_strips_from_attribute_on_success() {
+    let mut extracted = ExtractedArgs::default();
+    let mut placeholders = HashSet::new();
+    let mut arg = pat_type(quote!(#[from(db)] pool: DbPool));
+    let pat = ident("pool");
+    let ty: syn::Type = parse_quote!(DbPool);
+    let mut ctx = ClassificationContext::new(&mut extracted, &mut placeholders);
+    if let Err(err) = classify_fixture_or_step(&mut ctx, &mut arg, pat, ty) {
+        panic!("classification should succeed: {err}");
+    }
+
+    // The `#[from]` attribute must be stripped so the generated wrapper does
+    // not re-emit it, and the explicit name overrides the parameter identifier.
+    assert!(arg.attrs.is_empty(), "#[from] should be stripped on success");
+    let name = ident("db");
+    assert!(matches!(
+        extracted.args.as_slice(),
+        [Arg::Fixture { name: fixture_name, .. }] if fixture_name == &name
+    ));
+}
+
+#[test]
+fn classify_fixture_or_step_rejects_name_value_from() {
+    let mut extracted = ExtractedArgs::default();
+    let mut placeholders = HashSet::new();
+    let mut arg = pat_type(quote!(#[from = "db"] pool: String));
+    let pat = ident("pool");
+    let ty: syn::Type = parse_quote!(String);
+    let mut ctx = ClassificationContext::new(&mut extracted, &mut placeholders);
+    let Err(err) = classify_fixture_or_step(&mut ctx, &mut arg, pat, ty) else {
+        panic!("#[from = ...] should fail");
+    };
+
+    assert!(
+        err.to_string()
+            .contains("expects an identifier or no arguments")
+    );
+}
+
+#[test]
+fn classify_fixture_or_step_rejects_invalid_normalized_name() {
+    // `_1` normalizes to `1`, which is not a valid identifier; the classifier
+    // must reject it rather than emit a broken fixture name.
+    let mut extracted = ExtractedArgs::default();
+    let mut placeholders = HashSet::new();
+    let mut arg: syn::PatType = parse_quote!(_1: usize);
+    let pat = ident("_1");
+    let ty: syn::Type = parse_quote!(usize);
+    let mut ctx = ClassificationContext::new(&mut extracted, &mut placeholders);
+    let Err(err) = classify_fixture_or_step(&mut ctx, &mut arg, pat, ty) else {
+        panic!("invalid normalized fixture name should fail");
+    };
+
+    assert!(err.to_string().contains("is not a valid identifier"));
 }
 
 #[test]

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/tests.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/tests.rs
@@ -136,6 +136,50 @@ fn classify_fixture_or_step_respects_blocked_placeholders() {
 }
 
 #[test]
+fn classify_fixture_or_step_rejects_duplicate_from_attribute() {
+    let mut extracted = ExtractedArgs::default();
+    let mut placeholders = HashSet::new();
+    // Parse via `FnArg` so the leading `#[from]` attributes are captured on the
+    // `PatType`; a bare `PatType` parse would drop them.
+    let mut arg = pat_type(quote!(#[from(a)] #[from(b)] u: String));
+    let pat = ident("u");
+    let ty: syn::Type = parse_quote!(String);
+    let mut ctx = ClassificationContext::new(&mut extracted, &mut placeholders);
+    let Err(err) = classify_fixture_or_step(&mut ctx, &mut arg, pat, ty) else {
+        panic!("duplicate #[from] should fail");
+    };
+
+    assert!(err.to_string().contains("duplicate `#[from]` attribute"));
+}
+
+#[test]
+fn classify_fixture_or_step_blocks_underscore_normalized_step_struct_name() {
+    // `_blocked` normalizes to `blocked`, which a `#[step_args]` struct owns.
+    // The guard must compare the normalized name, or the leading underscore
+    // would let the parameter shadow the struct field unnoticed.
+    let mut extracted = ExtractedArgs::default();
+    let idx = extracted.push(Arg::StepStruct {
+        pat: ident("args"),
+        ty: parse_quote!(Args),
+    });
+    extracted.step_struct_idx = Some(idx);
+    extracted.blocked_placeholders.insert("blocked".into());
+    let mut placeholders = HashSet::new();
+    let mut arg: syn::PatType = parse_quote!(_blocked: String);
+    let pat = ident("_blocked");
+    let ty: syn::Type = parse_quote!(String);
+    let mut ctx = ClassificationContext::new(&mut extracted, &mut placeholders);
+    let Err(err) = classify_fixture_or_step(&mut ctx, &mut arg, pat, ty) else {
+        panic!("normalized fixture name should collide with blocked placeholder");
+    };
+
+    assert!(
+        err.to_string()
+            .contains("#[step_args] cannot be combined with named step arguments")
+    );
+}
+
+#[test]
 fn extract_step_struct_attribute_detects_marker() {
     let mut arg = pat_type(quote!(#[step_args] args: Args));
     match extract_step_struct_attribute(&mut arg) {

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/type_shape.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/type_shape.rs
@@ -25,33 +25,65 @@ use super::is_cached_table;
 /// Returns `false` for any non-path type (references, tuples, slices) rather
 /// than looking through it.
 pub(super) fn is_type_seq(ty: &syn::Type, seq: &[&str]) -> bool {
-    use syn::{GenericArgument, PathArguments, Type};
-
     let mut cur = ty;
     for (i, &name) in seq.iter().enumerate() {
-        let Type::Path(tp) = cur else { return false };
-        let Some(segment) = tp.path.segments.last() else {
+        let Some(segment) = final_path_segment(cur) else {
             return false;
         };
         if segment.ident != name {
             return false;
         }
-        match &segment.arguments {
-            PathArguments::AngleBracketed(ab) if !ab.args.is_empty() => {
-                if let Some(GenericArgument::Type(inner)) = ab.args.get(0) {
-                    cur = inner;
-                    continue;
-                }
-                return false;
-            }
-            _ => {
-                if i + 1 != seq.len() {
-                    return false;
-                }
-            }
+        match generic_descent(segment) {
+            Some(Descent::Into(inner)) => cur = inner,
+            // A terminal segment satisfies `seq` only by being its last entry;
+            // names still outstanding mean the chain ran out of nesting early.
+            Some(Descent::Terminal) => return i + 1 == seq.len(),
+            None => return false,
         }
     }
     true
+}
+
+/// Borrow the final segment of `ty`'s path, or `None` if it is not a path type.
+///
+/// Only the last segment carries the name being matched, so `String` and
+/// `std::string::String` are indistinguishable here — module qualification is
+/// ignored by design. A non-path type (reference, tuple, slice) yields `None`
+/// rather than being looked through.
+fn final_path_segment(ty: &syn::Type) -> Option<&syn::PathSegment> {
+    let syn::Type::Path(path) = ty else {
+        return None;
+    };
+    path.path.segments.last()
+}
+
+/// Where the walk goes after a segment's name has matched.
+enum Descent<'a> {
+    /// The segment carries a first generic type argument to continue into.
+    Into(&'a syn::Type),
+    /// The segment has no generic argument to follow, so it can only be a leaf.
+    Terminal,
+}
+
+/// Decide whether to descend into `segment`'s first generic argument.
+///
+/// Returns `Some(Descent::Into(_))` when the segment has a non-empty
+/// angle-bracketed argument list whose first entry is a type,
+/// `Some(Descent::Terminal)` when there is no argument list to follow (a bare
+/// identifier, or a parenthesized `Fn(..)` form), and `None` when arguments are
+/// present but the first is not a type — a lifetime or const, which the walk
+/// cannot follow and treats as a mismatch rather than a leaf.
+fn generic_descent(segment: &syn::PathSegment) -> Option<Descent<'_>> {
+    let syn::PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return Some(Descent::Terminal);
+    };
+    if args.args.is_empty() {
+        return Some(Descent::Terminal);
+    }
+    match args.args.first() {
+        Some(syn::GenericArgument::Type(inner)) => Some(Descent::Into(inner)),
+        _ => None,
+    }
 }
 
 /// Test whether `ty` is `String`, the only type a `DocString` parameter accepts.
@@ -83,4 +115,85 @@ pub(super) fn should_classify_as_datatable(pat: &syn::Ident, ty: &syn::Type) -> 
 /// reject it with a type-specific diagnostic.
 pub(super) fn is_docstring_canonical(pat: &syn::Ident, ty: &syn::Type) -> bool {
     pat == "docstring" && is_string(ty)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Shape-predicate tests, pinning the walk's interior branches.
+    //!
+    //! Before these, coverage reached `is_type_seq` only indirectly through the
+    //! `DataTable`/`DocString` classifiers, which exercised a fully-formed
+    //! correct chain and a first-segment name mismatch. The early-termination
+    //! guard, a wrong leaf at depth, a non-path type at depth, and a
+    //! non-type first generic argument were all unpinned.
+
+    use super::*;
+    use rstest::rstest;
+    use syn::parse_quote;
+
+    #[rstest]
+    // Correct chains, bare and module-qualified: only the last segment counts.
+    #[case::string(parse_quote!(String), &["String"][..], true)]
+    #[case::qualified_string(parse_quote!(std::string::String), &["String"][..], true)]
+    #[case::datatable(parse_quote!(Vec<Vec<String>>), &["Vec", "Vec", "String"][..], true)]
+    #[case::qualified_datatable(
+        parse_quote!(std::vec::Vec<std::vec::Vec<std::string::String>>),
+        &["Vec", "Vec", "String"][..],
+        true
+    )]
+    // Name mismatch at the first segment, and at depth.
+    #[case::wrong_root(parse_quote!(Option<String>), &["Vec", "String"][..], false)]
+    #[case::wrong_leaf_at_depth(parse_quote!(Vec<Vec<u32>>), &["Vec", "Vec", "String"][..], false)]
+    // Terminal segment reached with names still outstanding.
+    #[case::chain_too_short(parse_quote!(Vec<String>), &["Vec", "Vec", "String"][..], false)]
+    #[case::bare_root(parse_quote!(Vec), &["Vec", "String"][..], false)]
+    // A longer type than `seq` asks for still matches: the walk stops early.
+    #[case::seq_shorter_than_type(parse_quote!(Vec<Vec<String>>), &["Vec"][..], true)]
+    // Non-path types are never looked through, at the root or at depth.
+    #[case::reference(parse_quote!(&str), &["str"][..], false)]
+    #[case::tuple(parse_quote!((String,)), &["String"][..], false)]
+    #[case::reference_at_depth(parse_quote!(Vec<&str>), &["Vec", "str"][..], false)]
+    // Arguments present, but the first is a lifetime rather than a type.
+    #[case::lifetime_first(parse_quote!(Cow<'a, str>), &["Cow", "str"][..], false)]
+    fn is_type_seq_matches_expected_shapes(
+        #[case] ty: syn::Type,
+        #[case] seq: &[&str],
+        #[case] expected: bool,
+    ) {
+        assert_eq!(is_type_seq(&ty, seq), expected);
+    }
+
+    #[rstest]
+    #[case::canonical(parse_quote!(String), true)]
+    #[case::qualified(parse_quote!(std::string::String), true)]
+    #[case::wrong(parse_quote!(usize), false)]
+    fn is_string_accepts_only_string(#[case] ty: syn::Type, #[case] expected: bool) {
+        assert_eq!(is_string(&ty), expected);
+    }
+
+    #[rstest]
+    #[case::canonical(parse_quote!(Vec<Vec<String>>), true)]
+    #[case::wrong_leaf(parse_quote!(Vec<Vec<u32>>), false)]
+    #[case::too_shallow(parse_quote!(Vec<String>), false)]
+    fn is_datatable_accepts_only_nested_string_vectors(
+        #[case] ty: syn::Type,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(is_datatable(&ty), expected);
+    }
+
+    #[rstest]
+    // A `docstring` parameter matches only at type `String`; any other name is
+    // not this classifier's concern regardless of type.
+    #[case::canonical("docstring", parse_quote!(String), true)]
+    #[case::wrong_type("docstring", parse_quote!(usize), false)]
+    #[case::other_name("body", parse_quote!(String), false)]
+    fn is_docstring_canonical_requires_name_and_type(
+        #[case] name: &str,
+        #[case] ty: syn::Type,
+        #[case] expected: bool,
+    ) {
+        let pat = syn::Ident::new(name, proc_macro2::Span::call_site());
+        assert_eq!(is_docstring_canonical(&pat, &ty), expected);
+    }
 }

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/type_shape.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/type_shape.rs
@@ -1,0 +1,86 @@
+//! Type- and name-shape predicates for the reserved step parameters.
+//!
+//! Recognizing `DataTable` and `DocString` parameters is purely a question of
+//! the parameter's identifier and type, with no access to classification state.
+//! Keeping these predicates separate from the classifiers that consult them
+//! holds the parent module within the per-file line budget and gives the shape
+//! rules one place to live.
+//!
+//! `is_cached_table` deliberately stays in the parent module: it is the one
+//! predicate re-exported beyond this subtree, and some test harnesses compile
+//! the parent without the table-binding code that consumes it, which would make
+//! a re-export here read as unused.
+
+use super::is_cached_table;
+
+/// Test whether `ty` is a chain of single-generic types naming `seq` in order.
+///
+/// Walks the type's nested first generic argument once per entry in `seq`,
+/// comparing each against the *final* path segment, so both `String` and
+/// `std::string::String` match `["String"]`. The last entry is the innermost
+/// type and is the only one permitted to have no generic arguments: `seq`
+/// `["Vec", "Vec", "String"]` matches `Vec<Vec<String>>` but not `Vec<Vec<_>>`
+/// with a different leaf, nor a longer chain that runs out of arguments early.
+///
+/// Returns `false` for any non-path type (references, tuples, slices) rather
+/// than looking through it.
+pub(super) fn is_type_seq(ty: &syn::Type, seq: &[&str]) -> bool {
+    use syn::{GenericArgument, PathArguments, Type};
+
+    let mut cur = ty;
+    for (i, &name) in seq.iter().enumerate() {
+        let Type::Path(tp) = cur else { return false };
+        let Some(segment) = tp.path.segments.last() else {
+            return false;
+        };
+        if segment.ident != name {
+            return false;
+        }
+        match &segment.arguments {
+            PathArguments::AngleBracketed(ab) if !ab.args.is_empty() => {
+                if let Some(GenericArgument::Type(inner)) = ab.args.get(0) {
+                    cur = inner;
+                    continue;
+                }
+                return false;
+            }
+            _ => {
+                if i + 1 != seq.len() {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
+/// Test whether `ty` is `String`, the only type a `DocString` parameter accepts.
+pub(super) fn is_string(ty: &syn::Type) -> bool {
+    is_type_seq(ty, &["String"])
+}
+
+/// Test whether `ty` is the raw `Vec<Vec<String>>` table representation.
+pub(super) fn is_datatable(ty: &syn::Type) -> bool {
+    is_type_seq(ty, &["Vec", "Vec", "String"])
+}
+
+/// Test whether a parameter is the canonical `DataTable` shape.
+///
+/// True only when the identifier is literally `datatable` *and* the type is one
+/// of the two supported table representations. A parameter named `datatable`
+/// with any other type is deliberately not a match here, so
+/// [`classify_datatable`] can reject it with a type-specific diagnostic rather
+/// than passing it to the next classifier.
+pub(super) fn should_classify_as_datatable(pat: &syn::Ident, ty: &syn::Type) -> bool {
+    pat == "datatable" && (is_datatable(ty) || is_cached_table(ty))
+}
+
+/// Test whether a parameter is the canonical `DocString` shape.
+///
+/// True only when the identifier is literally `docstring` *and* the type is
+/// `String`. As with [`should_classify_as_datatable`], a `docstring` parameter
+/// of another type is not a match, leaving [`classify_docstring`] free to
+/// reject it with a type-specific diagnostic.
+pub(super) fn is_docstring_canonical(pat: &syn::Ident, ty: &syn::Type) -> bool {
+    pat == "docstring" && is_string(ty)
+}

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/type_shape.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/type_shape.rs
@@ -15,33 +15,44 @@ use super::is_cached_table;
 
 /// Test whether `ty` is a chain of single-generic types naming `seq` in order.
 ///
-/// Walks the type's nested first generic argument once per entry in `seq`,
+/// Descends through each type's first generic argument once per entry in `seq`,
 /// comparing each against the *final* path segment, so both `String` and
-/// `std::string::String` match `["String"]`. The last entry is the innermost
-/// type and is the only one permitted to have no generic arguments: `seq`
-/// `["Vec", "Vec", "String"]` matches `Vec<Vec<String>>` but not `Vec<Vec<_>>`
-/// with a different leaf, nor a longer chain that runs out of arguments early.
+/// `std::string::String` match `["String"]`. `["Vec", "Vec", "String"]` matches
+/// `Vec<Vec<String>>`, but not a chain with a different leaf, nor one that runs
+/// out of nesting before the names are exhausted.
+///
+/// The final name is largely a leaf check: once it matches, the generic
+/// arguments that segment carries are not inspected, so `String<u8>` matches
+/// `["String"]` and `Vec<Vec<String>>` matches `["Vec"]`. Callers rely on this
+/// for the `CachedTable` and `String` shapes, which are matched by name alone.
+/// The one exception is a first generic argument that is a lifetime or const:
+/// `Vec<'a, String>` does *not* match `["Vec"]`. That is inherited behaviour,
+/// preserved deliberately rather than by accident — see
+/// [`has_unfollowable_generic`].
 ///
 /// Returns `false` for any non-path type (references, tuples, slices) rather
-/// than looking through it.
+/// than looking through it, and `true` for an empty `seq`, which requires
+/// nothing.
 pub(super) fn is_type_seq(ty: &syn::Type, seq: &[&str]) -> bool {
-    let mut cur = ty;
-    for (i, &name) in seq.iter().enumerate() {
-        let Some(segment) = final_path_segment(cur) else {
-            return false;
-        };
-        if segment.ident != name {
-            return false;
-        }
-        match generic_descent(segment) {
-            Some(Descent::Into(inner)) => cur = inner,
-            // A terminal segment satisfies `seq` only by being its last entry;
-            // names still outstanding mean the chain ran out of nesting early.
-            Some(Descent::Terminal) => return i + 1 == seq.len(),
-            None => return false,
-        }
+    let [name, rest @ ..] = seq else {
+        // Nothing left to require: whatever `ty` is, it satisfies the sequence.
+        return true;
+    };
+    let Some(segment) = final_path_segment(ty) else {
+        return false;
+    };
+    if segment.ident != name {
+        return false;
     }
-    true
+    if rest.is_empty() {
+        // The final name matched, and its own generic arguments are not
+        // inspected — `String<u8>` matches `["String"]`. The one exception is a
+        // first argument the walk could never follow, which the original
+        // matcher rejected even here; see `has_unfollowable_generic`.
+        return !has_unfollowable_generic(segment);
+    }
+    // Names remain, so the chain must nest one level further.
+    first_generic_type(segment).is_some_and(|inner| is_type_seq(inner, rest))
 }
 
 /// Borrow the final segment of `ty`'s path, or `None` if it is not a path type.
@@ -57,33 +68,39 @@ fn final_path_segment(ty: &syn::Type) -> Option<&syn::PathSegment> {
     path.path.segments.last()
 }
 
-/// Where the walk goes after a segment's name has matched.
-enum Descent<'a> {
-    /// The segment carries a first generic type argument to continue into.
-    Into(&'a syn::Type),
-    /// The segment has no generic argument to follow, so it can only be a leaf.
-    Terminal,
-}
-
-/// Decide whether to descend into `segment`'s first generic argument.
+/// Borrow the first generic argument of `segment`, if it is a type.
 ///
-/// Returns `Some(Descent::Into(_))` when the segment has a non-empty
-/// angle-bracketed argument list whose first entry is a type,
-/// `Some(Descent::Terminal)` when there is no argument list to follow (a bare
-/// identifier, or a parenthesized `Fn(..)` form), and `None` when arguments are
-/// present but the first is not a type — a lifetime or const, which the walk
-/// cannot follow and treats as a mismatch rather than a leaf.
-fn generic_descent(segment: &syn::PathSegment) -> Option<Descent<'_>> {
+/// Yields `None` in every case the walk cannot follow: a segment with no
+/// angle-bracketed arguments (a bare identifier, or a parenthesized `Fn(..)`
+/// form), an empty argument list, or a first argument that is a lifetime or
+/// const rather than a type. Only the *first* argument is considered, so
+/// `Result<T, E>` descends into `T`.
+fn first_generic_type(segment: &syn::PathSegment) -> Option<&syn::Type> {
     let syn::PathArguments::AngleBracketed(args) = &segment.arguments else {
-        return Some(Descent::Terminal);
+        return None;
     };
-    if args.args.is_empty() {
-        return Some(Descent::Terminal);
-    }
     match args.args.first() {
-        Some(syn::GenericArgument::Type(inner)) => Some(Descent::Into(inner)),
+        Some(syn::GenericArgument::Type(inner)) => Some(inner),
         _ => None,
     }
+}
+
+/// Whether `segment`'s first generic argument is present but not a type.
+///
+/// True only for an angle-bracketed list whose first entry is a lifetime or
+/// const — something the walk can never follow. A segment with no arguments, or
+/// an empty list, is not "unfollowable"; it is simply a leaf.
+///
+/// This exists to preserve a corner of the original matcher: it decided whether
+/// it could descend *before* asking whether any names remained, so a segment
+/// like `Vec<'a, String>` was rejected against `["Vec"]` even though the name
+/// matched and nothing further was required. Folding that check into the leaf
+/// case keeps `is_type_seq` behaviourally identical while it reads top-down.
+fn has_unfollowable_generic(segment: &syn::PathSegment) -> bool {
+    let syn::PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return false;
+    };
+    matches!(args.args.first(), Some(arg) if !matches!(arg, syn::GenericArgument::Type(_)))
 }
 
 /// Test whether `ty` is `String`, the only type a `DocString` parameter accepts.
@@ -129,71 +146,92 @@ mod tests {
 
     use super::*;
     use rstest::rstest;
-    use syn::parse_quote;
+
+    /// Parse a type from source, failing loudly when a test input is malformed.
+    ///
+    /// Types are parsed directly rather than driven through macro expansion, so
+    /// a failure here is a defective test case, not a predicate bug.
+    fn ty(source: &str) -> syn::Type {
+        match syn::parse_str::<syn::Type>(source) {
+            Ok(parsed) => parsed,
+            Err(err) => panic!("test input `{source}` did not parse as a type: {err}"),
+        }
+    }
 
     #[rstest]
     // Correct chains, bare and module-qualified: only the last segment counts.
-    #[case::string(parse_quote!(String), &["String"][..], true)]
-    #[case::qualified_string(parse_quote!(std::string::String), &["String"][..], true)]
-    #[case::datatable(parse_quote!(Vec<Vec<String>>), &["Vec", "Vec", "String"][..], true)]
+    #[case::string("String", &["String"][..], true)]
+    #[case::qualified_string("std::string::String", &["String"][..], true)]
+    #[case::datatable("Vec<Vec<String>>", &["Vec", "Vec", "String"][..], true)]
     #[case::qualified_datatable(
-        parse_quote!(std::vec::Vec<std::vec::Vec<std::string::String>>),
+        "std::vec::Vec<std::vec::Vec<std::string::String>>",
         &["Vec", "Vec", "String"][..],
         true
     )]
     // Name mismatch at the first segment, and at depth.
-    #[case::wrong_root(parse_quote!(Option<String>), &["Vec", "String"][..], false)]
-    #[case::wrong_leaf_at_depth(parse_quote!(Vec<Vec<u32>>), &["Vec", "Vec", "String"][..], false)]
-    // Terminal segment reached with names still outstanding.
-    #[case::chain_too_short(parse_quote!(Vec<String>), &["Vec", "Vec", "String"][..], false)]
-    #[case::bare_root(parse_quote!(Vec), &["Vec", "String"][..], false)]
-    // A longer type than `seq` asks for still matches: the walk stops early.
-    #[case::seq_shorter_than_type(parse_quote!(Vec<Vec<String>>), &["Vec"][..], true)]
+    #[case::wrong_root("Option<String>", &["Vec", "String"][..], false)]
+    #[case::wrong_leaf_at_depth("Vec<Vec<u32>>", &["Vec", "Vec", "String"][..], false)]
+    // Nesting runs out before the names do.
+    #[case::chain_too_short("Vec<String>", &["Vec", "Vec", "String"][..], false)]
+    #[case::bare_root("Vec", &["Vec", "String"][..], false)]
+    // Leaf contract: once the final name matches, its own generic arguments are
+    // not inspected. Both cases must stay `true`.
+    #[case::seq_shorter_than_type("Vec<Vec<String>>", &["Vec"][..], true)]
+    #[case::leaf_ignores_its_generics("String<u8>", &["String"][..], true)]
     // Non-path types are never looked through, at the root or at depth.
-    #[case::reference(parse_quote!(&str), &["str"][..], false)]
-    #[case::tuple(parse_quote!((String,)), &["String"][..], false)]
-    #[case::reference_at_depth(parse_quote!(Vec<&str>), &["Vec", "str"][..], false)]
-    // Arguments present, but the first is a lifetime rather than a type.
-    #[case::lifetime_first(parse_quote!(Cow<'a, str>), &["Cow", "str"][..], false)]
+    #[case::reference("&String", &["String"][..], false)]
+    #[case::tuple("(String,)", &["String"][..], false)]
+    #[case::reference_at_depth("Vec<&str>", &["Vec", "str"][..], false)]
+    // Arguments present, but the first is a lifetime rather than a type, so the
+    // walk cannot descend when a further name still requires it.
+    #[case::lifetime_first_blocks_descent("Wrapper<'a>", &["Wrapper", "String"][..], false)]
+    #[case::lifetime_first_with_type("Cow<'a, str>", &["Cow", "str"][..], false)]
+    // Inherited corner: an unfollowable first argument is rejected even at the
+    // final name, where the leaf rule would otherwise accept it.
+    #[case::lifetime_first_at_leaf("Vec<'a, String>", &["Vec"][..], false)]
+    #[case::const_first_at_leaf("Wrapper<3>", &["Wrapper"][..], false)]
+    // An empty sequence requires nothing.
+    #[case::empty_seq("String", &[] as &[&str], true)]
+    #[case::empty_seq_non_path("&String", &[] as &[&str], true)]
     fn is_type_seq_matches_expected_shapes(
-        #[case] ty: syn::Type,
+        #[case] source: &str,
         #[case] seq: &[&str],
         #[case] expected: bool,
     ) {
-        assert_eq!(is_type_seq(&ty, seq), expected);
+        assert_eq!(is_type_seq(&ty(source), seq), expected);
     }
 
     #[rstest]
-    #[case::canonical(parse_quote!(String), true)]
-    #[case::qualified(parse_quote!(std::string::String), true)]
-    #[case::wrong(parse_quote!(usize), false)]
-    fn is_string_accepts_only_string(#[case] ty: syn::Type, #[case] expected: bool) {
-        assert_eq!(is_string(&ty), expected);
+    #[case::canonical("String", true)]
+    #[case::qualified("std::string::String", true)]
+    #[case::wrong("usize", false)]
+    fn is_string_accepts_only_string(#[case] source: &str, #[case] expected: bool) {
+        assert_eq!(is_string(&ty(source)), expected);
     }
 
     #[rstest]
-    #[case::canonical(parse_quote!(Vec<Vec<String>>), true)]
-    #[case::wrong_leaf(parse_quote!(Vec<Vec<u32>>), false)]
-    #[case::too_shallow(parse_quote!(Vec<String>), false)]
+    #[case::canonical("Vec<Vec<String>>", true)]
+    #[case::wrong_leaf("Vec<Vec<u32>>", false)]
+    #[case::too_shallow("Vec<String>", false)]
     fn is_datatable_accepts_only_nested_string_vectors(
-        #[case] ty: syn::Type,
+        #[case] source: &str,
         #[case] expected: bool,
     ) {
-        assert_eq!(is_datatable(&ty), expected);
+        assert_eq!(is_datatable(&ty(source)), expected);
     }
 
     #[rstest]
     // A `docstring` parameter matches only at type `String`; any other name is
     // not this classifier's concern regardless of type.
-    #[case::canonical("docstring", parse_quote!(String), true)]
-    #[case::wrong_type("docstring", parse_quote!(usize), false)]
-    #[case::other_name("body", parse_quote!(String), false)]
+    #[case::canonical("docstring", "String", true)]
+    #[case::wrong_type("docstring", "usize", false)]
+    #[case::other_name("body", "String", false)]
     fn is_docstring_canonical_requires_name_and_type(
         #[case] name: &str,
-        #[case] ty: syn::Type,
+        #[case] source: &str,
         #[case] expected: bool,
     ) {
         let pat = syn::Ident::new(name, proc_macro2::Span::call_site());
-        assert_eq!(is_docstring_canonical(&pat, &ty), expected);
+        assert_eq!(is_docstring_canonical(&pat, &ty(source)), expected);
     }
 }

--- a/crates/rstest-bdd-macros/src/macros/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/mod.rs
@@ -232,6 +232,10 @@ fn signature_error_help(err_message: &str, keyword: crate::StepKeyword) -> Strin
         return "Remove one of the duplicate `#[datatable]` attributes.".to_string();
     }
 
+    if err_message.contains("duplicate `#[from]` attribute") {
+        return "Remove one of the duplicate `#[from]` attributes.".to_string();
+    }
+
     if err_message.contains(crate::codegen::wrapper::args::classify::DUPLICATE_DATATABLE_ERROR) {
         return "Remove one of the DataTable parameters.".to_string();
     }

--- a/crates/rstest-bdd/tests/trybuild_macros.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros.rs
@@ -122,6 +122,7 @@ fn run_failing_ui_tests(t: &trybuild::TestCases) {
         UiFixtureCase::from("datatable_optional_with_default.rs"),
         UiFixtureCase::from("datatable_truthy_with_parse_with.rs"),
         UiFixtureCase::from("datatable_after_docstring.rs"),
+        UiFixtureCase::from("from_duplicate.rs"),
         UiFixtureCase::from("placeholder_missing_param.rs"),
         UiFixtureCase::from("implicit_fixture_missing.rs"),
         UiFixtureCase::from("placeholder_missing_params.rs"),

--- a/crates/rstest-bdd/tests/ui_macros/from_duplicate.rs
+++ b/crates/rstest-bdd/tests/ui_macros/from_duplicate.rs
@@ -1,0 +1,8 @@
+//! Compile-fail fixture: duplicate `#[from]` attributes are rejected.
+
+use rstest_bdd_macros::given;
+
+#[given("a duplicated fixture override")]
+fn step(#[from(alpha)] #[from(beta)] value: u32) {}
+
+fn main() {}

--- a/crates/rstest-bdd/tests/ui_macros/from_duplicate.stderr
+++ b/crates/rstest-bdd/tests/ui_macros/from_duplicate.stderr
@@ -1,0 +1,8 @@
+error: invalid step function signature: duplicate `#[from]` attribute
+
+         = help: Remove one of the duplicate `#[from]` attributes.
+
+ --> tests/ui_macros/from_duplicate.rs:6:38
+  |
+6 | fn step(#[from(alpha)] #[from(beta)] value: u32) {}
+  |                                      ^^^^^

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -478,8 +478,8 @@ and the `#[from = ...]` name-value form — and threads a
 `placeholders` accumulators) into `classify_by_placeholder_match()`. That
 helper first checks whether the argument maps to a step placeholder. If it does
 not, the argument is classified as a fixture. For implicit fixture arguments,
-it records the normalized fixture name so the generated wrapper asks for the
-same key that scenario fixture registration produced.
+it records the normalized fixture name, so the generated wrapper asks for
+the same key that scenario fixture registration produced.
 
 Explicit `#[from(...)]` names are authoritative and bypass normalization. Use
 that escape hatch when the intended fixture name starts with an underscore or

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -470,12 +470,16 @@ derives a fixture key from a Rust parameter name without an explicit override.
 Keeping the rule centralized avoids one side of macro expansion stripping a
 leading underscore while another side keeps it.
 
-Step wrapper argument classification is handled by
-`classify_by_placeholder_match()` in the macros crate. The function first
-checks whether the argument maps to a step placeholder. If it does not, the
-argument is classified as a fixture. For implicit fixture arguments, it records
-the normalized fixture name so the generated wrapper asks for the same key that
-scenario fixture registration produced.
+Step wrapper argument classification enters through
+`classify_fixture_or_step()`, the terminal classifier in the pipeline. It
+strips any `#[from(...)]` attribute in place — rejecting a duplicate `#[from]`
+and the `#[from = ...]` name-value form — and threads a
+`ClassificationContext` (the mutable `extracted` results and remaining
+`placeholders` accumulators) into `classify_by_placeholder_match()`. That
+helper first checks whether the argument maps to a step placeholder. If it does
+not, the argument is classified as a fixture. For implicit fixture arguments,
+it records the normalized fixture name so the generated wrapper asks for the
+same key that scenario fixture registration produced.
 
 Explicit `#[from(...)]` names are authoritative and bypass normalization. Use
 that escape hatch when the intended fixture name starts with an underscore or

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -157,6 +157,54 @@ to the implicit fixture key `world`, while `__world` resolves to `_world`.
 Explicit `#[from(...)]` names remain exact and bypass this normalization, so
 `#[from(_world)]` still requests the literal `_world` fixture key.
 
+#### Supported `#[from]` forms
+
+`#[from]` selects which fixture key a parameter binds to. It accepts either no
+arguments or exactly one identifier in parentheses:
+
+```rust,no_run
+#[given("the catalogue is loaded")]
+fn catalogue_loaded(
+    // Named: binds the `db_pool` fixture to a differently named parameter.
+    #[from(db_pool)] pool: DbPool,
+    // Bare: binds the fixture named after the parameter itself, `cache`.
+    #[from] cache: Cache,
+) {}
+```
+
+`#[from(name)]` requests the fixture key `name` exactly. Use it when the
+parameter cannot carry the fixture's own name — because that name is already
+taken at the call site, or because a shorter local name reads better.
+
+Bare `#[from]` requests the parameter's own normalized fixture name, which is
+what an unannotated parameter already does. It changes no lookup, so its purpose
+is documentary: it marks a parameter as a deliberate fixture injection at the
+binding site, rather than leaving a reader to infer that from the absence of a
+matching placeholder in the step pattern.
+
+Two spellings are rejected when the macro expands.
+
+The name-value form is invalid, because `from` takes either no arguments or one
+parenthesized identifier and never `= value`:
+
+```text
+error: invalid step function signature: #[from] expects an identifier or no arguments
+```
+
+Rewrite `#[from = "db_pool"]` as `#[from(db_pool)]`.
+
+More than one `#[from]` on the same parameter is also invalid, including a
+mixture of the bare and named forms, because the second would silently displace
+the first:
+
+```text
+error: invalid step function signature: duplicate `#[from]` attribute
+
+         = help: Remove one of the duplicate `#[from]` attributes.
+```
+
+Keep the single attribute naming the intended fixture and delete the others.
+
 Internally, the step macros record the fixture names and generate wrapper code
 that, at runtime, retrieves references from a `StepContext`. This context is a
 key–value map of fixture names to type‑erased references. When a scenario runs,


### PR DESCRIPTION
## Summary

Closes #517

- Add `///` docs (purpose, parameter meanings, return interpretation, mutation contracts, error conditions) to the argument-classifier internals: `ClassificationContext`, `classify_datatable`, `classify_docstring`, `classify_fixture_or_step`, `extract_flag_attribute`, and `parse_from_attribute`. In-place `arg.attrs` mutation is called out explicitly wherever it happens.
- Expand the `rstest-bdd-harness/src/test_utils.rs` module header to explain the panic-payload matching helpers, the `&str`/`String` payload asymmetry they absorb, and when harness implementations should use them.
- The added docs pushed `classify.rs` past the 400-line budget, so the terminal classifier (`classify_fixture_or_step` plus its `#[from]` parsing and placeholder-match helpers) moves to a focused `classify/fixture_or_step.rs` submodule with a `//!` header.
- The `cargo-bdd` `output.rs` helpers listed in the issue received their documentation (purpose plus leading-space/leading-newline contract) as part of the #513 consolidation in PR #529; re-documenting the pre-consolidation shapes here would only create merge conflicts with that PR.
- `cargo doc --workspace --no-deps` builds with no new warnings (the 20 pre-existing warnings on `main` are unchanged).

## Testing

- `make check-fmt`, `make lint`, `make typecheck`, `make test` (1486 passed) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)