### PR TITLE
Add runtime error-path integration tests for harness-led attribute-policy defaults (#498)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,17 +5,25 @@ slow-timeout = { period = "60s", terminate-after = 1, grace-period = "5s" }
 # Put a hard ceiling on the whole run.
 global-timeout = "5m"
 
+[test-groups.cargo-spawning]
+# Tests that shell out to `cargo` contend for the package-cache lock and for
+# build parallelism. Run them one at a time so they neither starve the rest of
+# the run nor trip their own slow-timeout waiting on a sibling's lock.
+max-threads = 1
+
 [[profile.default.overrides]]
 # `cargo-bdd` CLI smoke tests spawn `cargo` to build fixture crates, which can
 # legitimately exceed the default 60s slow-timeout on cold caches.
 filter = "binary_id(cargo-bdd::cli)"
 slow-timeout = { period = "180s", terminate-after = 1, grace-period = "5s" }
+test-group = "cargo-spawning"
 
 [[profile.default.overrides]]
 # trybuild-based compile tests invoke `cargo build` against a large dependency
 # tree; on cold caches this can legitimately exceed the default 60 s limit.
 filter = "binary_id(rstest-bdd-harness-tokio::macro_compile) | binary_id(rstest-bdd-harness-gpui::macro_compile) | binary_id(rstest-bdd::trybuild_macros)"
-slow-timeout = { period = "180s", terminate-after = 1, grace-period = "5s" }
+slow-timeout = { period = "300s", terminate-after = 1, grace-period = "5s" }
+test-group = "cargo-spawning"
 
 [profile.long]
 slow-timeout = { period = "180s", terminate-after = 1, grace-period = "5s" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
           # CodeScene's `cs-coverage check` diffs the pull request against
           # its merge base, so the full history must be reachable.
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Free disk space
         if: ${{ runner.os == 'Linux' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,17 @@ jobs:
             features: ''
             with-default-features: true
             tools: false
-            use-nextest: false   # trybuild + nextest deadlocks on Windows
+            # Avoid Windows nested Cargo/nextest hangs; see
+            # rust-lang/cargo#15744 and nextest-rs/nextest#2463.
+            use-nextest: false
           - os: windows-latest
             coverage: true
             features: strict-compile-time-validation
             with-default-features: false
             tools: false
-            use-nextest: false   # trybuild + nextest deadlocks on Windows
+            # Avoid Windows nested Cargo/nextest hangs; see
+            # rust-lang/cargo#15744 and nextest-rs/nextest#2463.
+            use-nextest: false
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -123,7 +123,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -154,41 +154,41 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
-version = "0.12.1"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "hybrid-array",
+ "generic-array",
 ]
 
 [[package]]
 name = "bstr"
-version = "1.13.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde_core",
+ "serde",
 ]
 
 [[package]]
 name = "bytes"
-version = "1.12.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "camino"
-version = "1.2.4"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 dependencies = [
  "serde_core",
 ]
@@ -274,9 +274,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.3"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -296,14 +296,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.3"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -320,20 +320,14 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
-version = "0.16.4"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
@@ -352,18 +346,18 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.7"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -371,26 +365,27 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
-version = "0.2.2"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "hybrid-array",
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -400,7 +395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.119",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -426,7 +421,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.119",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -443,12 +438,11 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
-version = "0.11.3"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common",
 ]
 
@@ -460,7 +454,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -482,7 +476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -497,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.5.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-crate"
@@ -561,7 +555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54f0d287c53ffd184d04d8677f590f4ac5379785529e5e08b1c8083acdd5c198"
 dependencies = [
  "memchr",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -592,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -607,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -617,15 +611,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -634,32 +628,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
@@ -669,9 +663,9 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -685,6 +679,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,19 +696,8 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 5.3.0",
+ "r-efi",
  "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -718,7 +711,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.119",
+ "syn 2.0.117",
  "textwrap",
  "thiserror 1.0.69",
  "typed-builder",
@@ -726,15 +719,15 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.4"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"
-version = "0.4.19"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -749,7 +742,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "ignore",
  "walkdir",
 ]
@@ -779,7 +772,7 @@ version = "0.2.2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -816,15 +809,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "i18n-config"
@@ -870,7 +854,7 @@ dependencies = [
  "i18n-config",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -978,9 +962,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.31"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -1101,9 +1085,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.189"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1128,9 +1112,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lsp-types"
@@ -1158,8 +1142,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "syn 2.0.119",
- "toml 1.1.3+spec-1.1.0",
+ "syn 2.0.117",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -1179,31 +1163,15 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
-version = "2.8.3"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1228,7 +1196,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1369,7 +1337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.119",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1388,7 +1356,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.13+spec-1.1.0",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -1423,9 +1391,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.107"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1436,7 +1404,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -1447,9 +1415,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.47"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1461,16 +1429,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
 name = "rand"
-version = "0.9.5"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1492,7 +1454,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom",
 ]
 
 [[package]]
@@ -1510,14 +1472,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.13.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1527,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1538,9 +1500,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.11"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relative-path"
@@ -1588,7 +1550,7 @@ dependencies = [
  "temp-env",
  "tempfile",
  "the-newtype",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "trybuild",
  "unic-langid",
@@ -1604,7 +1566,7 @@ dependencies = [
  "rstest",
  "temp-env",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -1623,6 +1585,7 @@ dependencies = [
  "rstest-bdd-harness",
  "rstest-bdd-macros",
  "serial_test 2.0.0",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "trybuild",
@@ -1665,9 +1628,9 @@ dependencies = [
  "rstest-bdd-patterns",
  "rstest-bdd-policy",
  "serial_test 2.0.0",
- "syn 2.0.119",
+ "syn 2.0.117",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "walkdir",
 ]
 
@@ -1679,7 +1642,7 @@ dependencies = [
  "proptest",
  "regex",
  "rstest",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1707,9 +1670,9 @@ dependencies = [
  "rstest-bdd-server",
  "serde",
  "serde_json",
- "syn 2.0.119",
+ "syn 2.0.117",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tower",
@@ -1731,15 +1694,15 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.119",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
 [[package]]
 name = "rust-embed"
-version = "8.12.0"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -1748,23 +1711,22 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.12.0"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
 dependencies = [
- "mime_guess",
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.119",
+ "syn 2.0.117",
  "walkdir",
 ]
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.12.0"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
  "sha2",
  "walkdir",
@@ -1772,9 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.3"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -1791,11 +1753,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1810,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.23"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "same-file"
@@ -1831,9 +1793,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "self_cell"
-version = "1.3.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
@@ -1847,9 +1809,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1857,29 +1819,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.151"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1890,13 +1852,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.21"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1944,7 +1906,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1955,14 +1917,14 @@ checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.11.0"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1992,21 +1954,21 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smawk"
-version = "0.3.3"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
-version = "0.6.5"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2046,20 +2008,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.119"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2074,7 +2025,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2088,9 +2039,9 @@ dependencies = [
 
 [[package]]
 name = "target-triple"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
 
 [[package]]
 name = "temp-env"
@@ -2108,10 +2059,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2179,11 +2130,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2194,25 +2145,25 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.10"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
@@ -2246,9 +2197,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.53.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -2261,13 +2212,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2278,15 +2229,15 @@ dependencies = [
  "rstest-bdd",
  "rstest-bdd-harness-tokio",
  "rstest-bdd-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.19"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2322,9 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -2332,7 +2283,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.4",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -2372,14 +2323,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.13+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.4",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -2388,14 +2339,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.4",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -2440,7 +2391,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2484,9 +2435,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.118"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06649c6f63d86604ba0c8950d5a1829fc9a17afd70fc6629f481d75b6a624c78"
+checksum = "0710d4dfbeae4f9c390baa784c49858a7468fa433f3fe5d0ec5ebef651cf59f9"
 dependencies = [
  "glob",
  "serde",
@@ -2494,7 +2445,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -2523,7 +2474,7 @@ checksum = "29a3151c41d0b13e3d011f98adc24434560ef06673a155a6c7f66b9879eecce2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2578,15 +2529,9 @@ checksum = "a1249a628de3ad34b821ecb1001355bca3940bcb2f88558f1a8bd82e977f75b5"
 dependencies = [
  "proc-macro-hack",
  "quote",
- "syn 2.0.119",
+ "syn 2.0.117",
  "unic-langid-impl",
 ]
-
-[[package]]
-name = "unicase"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -2695,9 +2640,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
  "wit-bindgen",
 ]
@@ -2708,7 +2653,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2816,9 +2761,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.4"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -2829,7 +2774,7 @@ version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "windows-sys 0.59.0",
 ]
 
@@ -2864,28 +2809,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2905,7 +2850,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2940,11 +2885,11 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.23"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-bdd"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 dependencies = [
  "assert_cmd",
  "cargo_metadata",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "gpui-counter"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 dependencies = [
  "gpui",
  "rstest",
@@ -1070,7 +1070,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "japanese-ledger"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 dependencies = [
  "rstest",
  "rstest-bdd",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "rstest-bdd"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 dependencies = [
  "camino",
  "cap-std",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "rstest-bdd-harness"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 dependencies = [
  "cargo_metadata",
  "insta",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "rstest-bdd-harness-gpui"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 dependencies = [
  "cargo_metadata",
  "gpui",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "rstest-bdd-harness-tokio"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 dependencies = [
  "cargo_metadata",
  "macrotest",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "rstest-bdd-macros"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 dependencies = [
  "camino",
  "cap-std",
@@ -1636,7 +1636,7 @@ dependencies = [
 
 [[package]]
 name = "rstest-bdd-patterns"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 dependencies = [
  "gherkin",
  "proptest",
@@ -1647,14 +1647,14 @@ dependencies = [
 
 [[package]]
 name = "rstest-bdd-policy"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 dependencies = [
  "rstest",
 ]
 
 [[package]]
 name = "rstest-bdd-server"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 dependencies = [
  "async-lsp",
  "cargo_metadata",
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "todo-cli"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 dependencies = [
  "assert_cmd",
  "assert_fs",
@@ -2223,7 +2223,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-reminders"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 dependencies = [
  "rstest",
  "rstest-bdd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -123,7 +123,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -154,41 +154,41 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "camino"
-version = "1.2.2"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
 dependencies = [
  "serde_core",
 ]
@@ -274,9 +274,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -296,14 +296,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -320,14 +320,20 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
@@ -346,18 +352,18 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -365,27 +371,26 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -395,7 +400,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -421,7 +426,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -438,11 +443,12 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -454,7 +460,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -476,7 +482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -491,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-crate"
@@ -555,7 +561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54f0d287c53ffd184d04d8677f590f4ac5379785529e5e08b1c8083acdd5c198"
 dependencies = [
  "memchr",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -586,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -601,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -611,15 +617,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -628,32 +634,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-timer"
@@ -663,9 +669,9 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -679,16 +685,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,8 +692,19 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -711,7 +718,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.117",
+ "syn 2.0.119",
  "textwrap",
  "thiserror 1.0.69",
  "typed-builder",
@@ -719,15 +726,15 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "globset"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -742,7 +749,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "ignore",
  "walkdir",
 ]
@@ -772,7 +779,7 @@ version = "0.2.2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -809,6 +816,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "i18n-config"
@@ -854,7 +870,7 @@ dependencies = [
  "i18n-config",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -962,9 +978,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.26"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
+checksum = "7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -1085,9 +1101,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1112,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lsp-types"
@@ -1142,8 +1158,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "syn 2.0.117",
- "toml 1.1.2+spec-1.1.0",
+ "syn 2.0.119",
+ "toml 1.1.3+spec-1.1.0",
 ]
 
 [[package]]
@@ -1163,15 +1179,31 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -1196,7 +1228,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1337,7 +1369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1356,7 +1388,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.12+spec-1.1.0",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -1391,9 +1423,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1404,7 +1436,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -1415,9 +1447,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1429,10 +1461,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.9.4"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1454,7 +1492,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1472,14 +1510,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1489,9 +1527,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1500,9 +1538,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "relative-path"
@@ -1547,9 +1585,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test 2.0.0",
+ "temp-env",
  "tempfile",
  "the-newtype",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "trybuild",
  "unic-langid",
@@ -1565,7 +1604,7 @@ dependencies = [
  "rstest",
  "temp-env",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -1626,9 +1665,9 @@ dependencies = [
  "rstest-bdd-patterns",
  "rstest-bdd-policy",
  "serial_test 2.0.0",
- "syn 2.0.117",
+ "syn 2.0.119",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
 ]
 
@@ -1640,7 +1679,7 @@ dependencies = [
  "proptest",
  "regex",
  "rstest",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1668,9 +1707,9 @@ dependencies = [
  "rstest-bdd-server",
  "serde",
  "serde_json",
- "syn 2.0.117",
+ "syn 2.0.119",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tower",
@@ -1692,15 +1731,15 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.119",
  "unicode-ident",
 ]
 
 [[package]]
 name = "rust-embed"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -1709,22 +1748,23 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
 dependencies = [
+ "mime_guess",
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.117",
+ "syn 2.0.119",
  "walkdir",
 ]
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
 dependencies = [
  "sha2",
  "walkdir",
@@ -1732,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -1751,11 +1791,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1770,9 +1810,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "same-file"
@@ -1791,9 +1831,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "self_cell"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "semver"
@@ -1807,9 +1847,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1817,29 +1857,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1850,13 +1890,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1904,7 +1944,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1915,14 +1955,14 @@ checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1952,21 +1992,21 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smawk"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2006,9 +2046,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2023,7 +2074,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2037,9 +2088,9 @@ dependencies = [
 
 [[package]]
 name = "target-triple"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
 
 [[package]]
 name = "temp-env"
@@ -2057,10 +2108,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2128,11 +2179,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -2143,25 +2194,25 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -2195,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -2210,13 +2261,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2227,15 +2278,15 @@ dependencies = [
  "rstest-bdd",
  "rstest-bdd-harness-tokio",
  "rstest-bdd-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2271,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -2281,7 +2332,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -2321,14 +2372,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -2337,14 +2388,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -2389,7 +2440,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2433,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0710d4dfbeae4f9c390baa784c49858a7468fa433f3fe5d0ec5ebef651cf59f9"
+checksum = "06649c6f63d86604ba0c8950d5a1829fc9a17afd70fc6629f481d75b6a624c78"
 dependencies = [
  "glob",
  "serde",
@@ -2443,7 +2494,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
 ]
 
 [[package]]
@@ -2472,7 +2523,7 @@ checksum = "29a3151c41d0b13e3d011f98adc24434560ef06673a155a6c7f66b9879eecce2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2527,9 +2578,15 @@ checksum = "a1249a628de3ad34b821ecb1001355bca3940bcb2f88558f1a8bd82e977f75b5"
 dependencies = [
  "proc-macro-hack",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "unic-langid-impl",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -2638,9 +2695,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
@@ -2651,7 +2708,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2759,9 +2816,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -2772,7 +2829,7 @@ version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "windows-sys 0.59.0",
 ]
 
@@ -2807,28 +2864,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2848,7 +2905,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -2883,11 +2940,11 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,6 +1564,7 @@ dependencies = [
  "insta",
  "proptest",
  "rstest",
+ "rstest-bdd-harness",
  "temp-env",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 rust-version = "1.85"
 license = "ISC"
 authors = ["Payton McIntosh <pmcintosh@df12.net>"]
@@ -53,13 +53,13 @@ eyre = "0.6"
 ctor = "0.2"
 newt-hype = "0.2.0"
 proptest = { version = "1.9.0", default-features = false, features = ["std"] }
-rstest-bdd = { version = "0.6.0-beta3", path = "crates/rstest-bdd" }
-rstest-bdd-harness = { version = "0.6.0-beta3", path = "crates/rstest-bdd-harness" }
-rstest-bdd-harness-gpui = { version = "0.6.0-beta3", path = "crates/rstest-bdd-harness-gpui" }
-rstest-bdd-harness-tokio = { version = "0.6.0-beta3", path = "crates/rstest-bdd-harness-tokio" }
-rstest-bdd-macros = { version = "0.6.0-beta3", path = "crates/rstest-bdd-macros" }
-rstest-bdd-policy = { version = "0.6.0-beta3", path = "crates/rstest-bdd-policy" }
-rstest-bdd-patterns = { version = "0.6.0-beta3", path = "crates/rstest-bdd-patterns" }
+rstest-bdd = { version = "0.6.0-beta4", path = "crates/rstest-bdd" }
+rstest-bdd-harness = { version = "0.6.0-beta4", path = "crates/rstest-bdd-harness" }
+rstest-bdd-harness-gpui = { version = "0.6.0-beta4", path = "crates/rstest-bdd-harness-gpui" }
+rstest-bdd-harness-tokio = { version = "0.6.0-beta4", path = "crates/rstest-bdd-harness-tokio" }
+rstest-bdd-macros = { version = "0.6.0-beta4", path = "crates/rstest-bdd-macros" }
+rstest-bdd-policy = { version = "0.6.0-beta4", path = "crates/rstest-bdd-policy" }
+rstest-bdd-patterns = { version = "0.6.0-beta4", path = "crates/rstest-bdd-patterns" }
 log = "0.4"
 temp-env = "0.3.6"
 tempfile = "3.23"

--- a/crates/cargo-bdd/Cargo.toml
+++ b/crates/cargo-bdd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-bdd"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/cargo-bdd/tests/fixtures/minimal/Cargo.lock
+++ b/crates/cargo-bdd/tests/fixtures/minimal/Cargo.lock
@@ -758,7 +758,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rstest-bdd"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 dependencies = [
  "ctor",
  "derive_more",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "rstest-bdd-harness"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 dependencies = [
  "cargo_metadata",
  "thiserror 2.0.18",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "rstest-bdd-macros"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 dependencies = [
  "camino",
  "cap-std",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "rstest-bdd-patterns"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 dependencies = [
  "gherkin",
  "regex",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "rstest-bdd-policy"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 
 [[package]]
 name = "rust-embed"

--- a/crates/rstest-bdd-harness-gpui/Cargo.toml
+++ b/crates/rstest-bdd-harness-gpui/Cargo.toml
@@ -38,6 +38,7 @@ macrotest.workspace = true
 prettyplease.workspace = true
 proptest.workspace = true
 serial_test.workspace = true
+tokio.workspace = true
 tracing-subscriber.workspace = true
 trybuild.workspace = true
 

--- a/crates/rstest-bdd-harness-gpui/Cargo.toml
+++ b/crates/rstest-bdd-harness-gpui/Cargo.toml
@@ -31,6 +31,7 @@ tracing.workspace = true
 [dev-dependencies]
 rstest.workspace = true
 rstest-bdd.workspace = true
+rstest-bdd-harness = { workspace = true, features = ["testing"] }
 rstest-bdd-macros.workspace = true
 cargo_metadata.workspace = true
 insta = { workspace = true, features = ["filters"] }

--- a/crates/rstest-bdd-harness-gpui/Cargo.toml
+++ b/crates/rstest-bdd-harness-gpui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rstest-bdd-harness-gpui"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/rstest-bdd-harness-gpui/tests/features/harness_led_defaults.feature
+++ b/crates/rstest-bdd-harness-gpui/tests/features/harness_led_defaults.feature
@@ -1,0 +1,7 @@
+Feature: Harness-led attribute-policy defaults at runtime
+
+  Scenario: Inferred GPUI policy provides the test context
+    Given the inferred GPUI context is observed
+
+  Scenario: Failing harness initialisation propagates
+    Given a step that must never run

--- a/crates/rstest-bdd-harness-gpui/tests/features/harness_led_defaults.feature
+++ b/crates/rstest-bdd-harness-gpui/tests/features/harness_led_defaults.feature
@@ -2,6 +2,8 @@ Feature: Harness-led attribute-policy defaults at runtime
 
   Scenario: Inferred GPUI policy provides the test context
     Given the inferred GPUI context is observed
+    When the inferred GPUI context is mutated
+    Then the inferred GPUI context remains available
 
   Scenario: Failing harness initialisation propagates
     Given a step that must never run

--- a/crates/rstest-bdd-harness-gpui/tests/features/harness_led_defaults.feature
+++ b/crates/rstest-bdd-harness-gpui/tests/features/harness_led_defaults.feature
@@ -5,5 +5,5 @@ Feature: Harness-led attribute-policy defaults at runtime
     When the inferred GPUI context is mutated
     Then the inferred GPUI context remains available
 
-  Scenario: Failing harness initialisation propagates
+  Scenario: Failing harness initialization propagates
     Given a step that must never run

--- a/crates/rstest-bdd-harness-gpui/tests/harness_led_defaults.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/harness_led_defaults.rs
@@ -15,8 +15,9 @@
 //!   `native-gpui-tests` gate (and `#[serial]` discipline) with the rest of
 //!   the GPUI scenario suite.
 
-use rstest_bdd_harness::FailingHarness;
 use rstest_bdd_macros::{given, scenario};
+
+include!("../../rstest-bdd-harness/tests/support/failing_harness_error_path.rs");
 
 // --- Failing-harness error path (no native GPUI runtime required) --------
 
@@ -25,16 +26,7 @@ fn step_that_must_never_run() {
     unreachable!("the failing harness must abort the scenario before steps run");
 }
 
-/// A harness `run` returning `Err` must surface the macro's
-/// `harness failed to initialise scenario: ...` panic, carrying the
-/// underlying error and scenario context, and must not execute any step.
-#[scenario(
-    path = "tests/features/harness_led_defaults.feature",
-    name = "Failing harness initialisation propagates",
-    harness = FailingHarness,
-)]
-#[should_panic(expected = "harness failed to initialise scenario: failed to build runtime")]
-fn failing_harness_panics_with_meaningful_message() {}
+failing_harness_error_path_scenario!();
 
 // --- Inferred-policy happy path (requires the native GPUI runtime) -------
 
@@ -58,6 +50,10 @@ mod native {
         CONTEXT_POINTER.store(std::ptr::from_ref(context) as usize, Ordering::SeqCst);
         CONTEXT_MUTATED.store(false, Ordering::SeqCst);
         assert!(context.test_function_name().is_none());
+        assert!(
+            !context.did_prompt_for_new_path(),
+            "freshly-injected GPUI context must not have prompted for a new path"
+        );
         std::future::ready(()).await;
     }
 
@@ -87,6 +83,10 @@ mod native {
         assert!(
             CONTEXT_MUTATED.load(Ordering::SeqCst),
             "mutations through &mut TestAppContext should be visible later"
+        );
+        assert!(
+            !context.did_prompt_for_new_path(),
+            "later steps should observe the same unprompted GPUI context"
         );
         let _executor = context.executor();
         std::future::ready(()).await;

--- a/crates/rstest-bdd-harness-gpui/tests/harness_led_defaults.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/harness_led_defaults.rs
@@ -15,24 +15,10 @@
 //!   `native-gpui-tests` gate (and `#[serial]` discipline) with the rest of
 //!   the GPUI scenario suite.
 
-use rstest_bdd_harness::{HarnessAdapter, HarnessError, HarnessResult, ScenarioRunRequest};
+use rstest_bdd_harness::FailingHarness;
 use rstest_bdd_macros::{given, scenario};
 
 // --- Failing-harness error path (no native GPUI runtime required) --------
-
-/// Harness whose `run` always fails before invoking the scenario runner.
-#[derive(Default)]
-struct FailingHarness;
-
-impl HarnessAdapter for FailingHarness {
-    type Context = ();
-
-    fn run<T>(&self, _request: ScenarioRunRequest<'_, Self::Context, T>) -> HarnessResult<T> {
-        Err(HarnessError::RuntimeBuildFailed(std::io::Error::other(
-            "synthetic harness initialisation failure",
-        )))
-    }
-}
 
 #[given("a step that must never run")]
 fn step_that_must_never_run() {

--- a/crates/rstest-bdd-harness-gpui/tests/harness_led_defaults.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/harness_led_defaults.rs
@@ -1,0 +1,81 @@
+//! Runtime integration tests for ADR-008 harness-led attribute-policy
+//! defaults and their error paths in the GPUI harness crate.
+//!
+//! Unlike the snapshot and `RSTEST_BDD_RUN_MACROTEST`-gated expansion tests,
+//! these run unconditionally under `cargo test` / `nextest` and assert
+//! observable runtime behaviour:
+//!
+//! - A harness whose `HarnessAdapter::run` returns `Err` propagates the
+//!   `harness failed to initialise scenario: ...` panic emitted by the
+//!   expanded macro, and the scenario body never runs. This path needs no
+//!   native GPUI runtime, so it is not feature-gated.
+//! - `harness = GpuiHarness` without `attributes = ...` runs through the
+//!   inferred `GpuiAttributePolicy` path with a live `TestAppContext`. This
+//!   requires the native GPUI test runtime, so it shares the
+//!   `native-gpui-tests` gate (and `#[serial]` discipline) with the rest of
+//!   the GPUI scenario suite.
+
+use rstest_bdd_harness::{HarnessAdapter, HarnessError, HarnessResult, ScenarioRunRequest};
+use rstest_bdd_macros::{given, scenario};
+
+// --- Failing-harness error path (no native GPUI runtime required) --------
+
+/// Harness whose `run` always fails before invoking the scenario runner.
+#[derive(Default)]
+struct FailingHarness;
+
+impl HarnessAdapter for FailingHarness {
+    type Context = ();
+
+    fn run<T>(&self, _request: ScenarioRunRequest<'_, Self::Context, T>) -> HarnessResult<T> {
+        Err(HarnessError::RuntimeBuildFailed(std::io::Error::other(
+            "synthetic harness initialisation failure",
+        )))
+    }
+}
+
+#[given("a step that must never run")]
+fn step_that_must_never_run() {
+    unreachable!("the failing harness must abort the scenario before steps run");
+}
+
+/// A harness `run` returning `Err` must surface the macro's
+/// `harness failed to initialise scenario: ...` panic, carrying the
+/// underlying error and scenario context, and must not execute any step.
+#[scenario(
+    path = "tests/features/harness_led_defaults.feature",
+    name = "Failing harness initialisation propagates",
+    harness = FailingHarness,
+)]
+#[should_panic(expected = "harness failed to initialise scenario: failed to build runtime")]
+fn failing_harness_panics_with_meaningful_message() {}
+
+// --- Inferred-policy happy path (requires the native GPUI runtime) -------
+
+#[cfg(feature = "native-gpui-tests")]
+mod native {
+    //! Inferred-policy coverage that drives the real GPUI test runtime.
+
+    use rstest_bdd_macros::{given, scenario};
+    use serial_test::serial;
+
+    #[given("the inferred GPUI context is observed")]
+    fn inferred_gpui_context_is_observed(
+        #[from(rstest_bdd_harness_context)] context: &gpui::TestAppContext,
+    ) {
+        // Receiving the reserved harness-context fixture proves the
+        // inferred policy + harness pairing injected the GPUI context.
+        assert!(context.test_function_name().is_none());
+    }
+
+    /// `harness = GpuiHarness` with no `attributes = ...`: the macro infers
+    /// `GpuiAttributePolicy` (ADR-008) and the step observes the injected
+    /// `TestAppContext` at runtime.
+    #[scenario(
+        path = "tests/features/harness_led_defaults.feature",
+        name = "Inferred GPUI policy provides the test context",
+        harness = rstest_bdd_harness_gpui::GpuiHarness,
+    )]
+    #[serial]
+    fn inferred_policy_runs_scenario_through_gpui_harness() {}
+}

--- a/crates/rstest-bdd-harness-gpui/tests/harness_led_defaults.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/harness_led_defaults.rs
@@ -6,7 +6,7 @@
 //! observable runtime behaviour:
 //!
 //! - A harness whose `HarnessAdapter::run` returns `Err` propagates the
-//!   `harness failed to initialise scenario: ...` panic emitted by the
+//!   `harness failed to initialize scenario: ...` panic emitted by the
 //!   expanded macro, and the scenario body never runs. This path needs no
 //!   native GPUI runtime, so it is not feature-gated.
 //! - `harness = GpuiHarness` without `attributes = ...` runs through the

--- a/crates/rstest-bdd-harness-gpui/tests/harness_led_defaults.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/harness_led_defaults.rs
@@ -56,21 +56,62 @@ fn failing_harness_panics_with_meaningful_message() {}
 mod native {
     //! Inferred-policy coverage that drives the real GPUI test runtime.
 
-    use rstest_bdd_macros::{given, scenario};
+    use rstest_bdd_macros::{given, scenario, then, when};
     use serial_test::serial;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    static CONTEXT_POINTER: AtomicUsize = AtomicUsize::new(0);
+    static CONTEXT_MUTATED: AtomicBool = AtomicBool::new(false);
 
     #[given("the inferred GPUI context is observed")]
-    fn inferred_gpui_context_is_observed(
+    async fn inferred_gpui_context_is_observed(
         #[from(rstest_bdd_harness_context)] context: &gpui::TestAppContext,
     ) {
         // Receiving the reserved harness-context fixture proves the
         // inferred policy + harness pairing injected the GPUI context.
+        CONTEXT_POINTER.store(std::ptr::from_ref(context) as usize, Ordering::SeqCst);
+        CONTEXT_MUTATED.store(false, Ordering::SeqCst);
         assert!(context.test_function_name().is_none());
+        std::future::ready(()).await;
+    }
+
+    #[when("the inferred GPUI context is mutated")]
+    async fn inferred_gpui_context_is_mutated(
+        #[from(rstest_bdd_harness_context)] context: &mut gpui::TestAppContext,
+    ) {
+        assert_eq!(
+            std::ptr::from_ref(context) as usize,
+            CONTEXT_POINTER.load(Ordering::SeqCst),
+            "harness should inject one stable TestAppContext instance"
+        );
+        context.on_quit(|| {});
+        CONTEXT_MUTATED.store(true, Ordering::SeqCst);
+        std::future::ready(()).await;
+    }
+
+    #[then("the inferred GPUI context remains available")]
+    async fn inferred_gpui_context_remains_available(
+        #[from(rstest_bdd_harness_context)] context: &gpui::TestAppContext,
+    ) {
+        assert_eq!(
+            std::ptr::from_ref(context) as usize,
+            CONTEXT_POINTER.load(Ordering::SeqCst),
+            "later steps should observe the same injected TestAppContext"
+        );
+        assert!(
+            CONTEXT_MUTATED.load(Ordering::SeqCst),
+            "mutations through &mut TestAppContext should be visible later"
+        );
+        let _executor = context.executor();
+        std::future::ready(()).await;
     }
 
     /// `harness = GpuiHarness` with no `attributes = ...`: the macro infers
     /// `GpuiAttributePolicy` (ADR-008) and the step observes the injected
-    /// `TestAppContext` at runtime.
+    /// `TestAppContext` at runtime. Async steps force the macro to execute
+    /// the scenario body through the async step path, while the reserved
+    /// fixture proves the context came from `GpuiHarness` rather than from
+    /// `GpuiAttributePolicy` alone.
     #[scenario(
         path = "tests/features/harness_led_defaults.feature",
         name = "Inferred GPUI policy provides the test context",

--- a/crates/rstest-bdd-harness-gpui/tests/harness_led_defaults.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/harness_led_defaults.rs
@@ -38,10 +38,9 @@ mod native {
 
     use rstest_bdd_macros::{given, scenario, then, when};
     use serial_test::serial;
-    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     static CONTEXT_POINTER: AtomicUsize = AtomicUsize::new(0);
-    static CONTEXT_MUTATED: AtomicBool = AtomicBool::new(false);
 
     #[given("the inferred GPUI context is observed")]
     async fn inferred_gpui_context_is_observed(
@@ -50,7 +49,6 @@ mod native {
         // Receiving the reserved harness-context fixture proves the
         // inferred policy + harness pairing injected the GPUI context.
         CONTEXT_POINTER.store(std::ptr::from_ref(context) as usize, Ordering::SeqCst);
-        CONTEXT_MUTATED.store(false, Ordering::SeqCst);
         assert!(context.test_function_name().is_none());
         assert!(
             !context.did_prompt_for_new_path(),
@@ -68,7 +66,7 @@ mod native {
             CONTEXT_POINTER.load(Ordering::SeqCst),
             "harness should inject one stable TestAppContext instance"
         );
-        CONTEXT_MUTATED.store(true, Ordering::SeqCst);
+        context.add_window_view(|_| ());
         std::future::ready(()).await;
     }
 
@@ -81,9 +79,10 @@ mod native {
             CONTEXT_POINTER.load(Ordering::SeqCst),
             "later steps should observe the same injected TestAppContext"
         );
-        assert!(
-            CONTEXT_MUTATED.load(Ordering::SeqCst),
-            "the mutation step should run before the final context assertion"
+        assert_eq!(
+            context.windows().len(),
+            1,
+            "later steps should observe the window added through the GPUI context"
         );
         assert!(
             !context.did_prompt_for_new_path(),

--- a/crates/rstest-bdd-harness-gpui/tests/harness_led_defaults.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/harness_led_defaults.rs
@@ -13,7 +13,10 @@
 //!   inferred `GpuiAttributePolicy` path with a live `TestAppContext`. This
 //!   requires the native GPUI test runtime, so it shares the
 //!   `native-gpui-tests` gate (and `#[serial]` discipline) with the rest of
-//!   the GPUI scenario suite.
+//!   the GPUI scenario suite. Cross-step context identity is proved through a
+//!   single recorded address whose lifetime is owned by a fixture guard, so
+//!   success, failure, and skip paths all clear it before the next serial
+//!   scenario runs — the same reset protocol as `tests/stateful_window.rs`.
 
 use rstest_bdd_macros::{given, scenario};
 
@@ -36,11 +39,48 @@ failing_harness_error_path_scenario!();
 mod native {
     //! Inferred-policy coverage that drives the real GPUI test runtime.
 
+    use rstest::fixture;
     use rstest_bdd_macros::{given, scenario, then, when};
     use serial_test::serial;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    /// Address of the `TestAppContext` the harness injected into the current
+    /// scenario, recorded solely so later steps can assert pointer identity.
+    ///
+    /// Ownership protocol: the `Given` step is the sole writer and stores the
+    /// address before any reader runs; the `When` and `Then` steps are readers
+    /// only. The value is never dereferenced, so it cannot outlive the context
+    /// it describes in any meaningful sense. [`ContextPointerCleanup`] clears
+    /// it before assignment and again at scenario teardown, so a failed,
+    /// panicking, or skipped scenario cannot leak a stale address into the
+    /// next scenario on the reused `#[serial]` test thread. The sentinel value
+    /// `0` never matches a live reference, so a missing `Given` step fails the
+    /// identity assertions loudly rather than passing on stale data.
     static CONTEXT_POINTER: AtomicUsize = AtomicUsize::new(0);
+
+    const UNSET_CONTEXT_POINTER: usize = 0;
+
+    fn reset_context_pointer() {
+        CONTEXT_POINTER.store(UNSET_CONTEXT_POINTER, Ordering::SeqCst);
+    }
+
+    /// Fixture guard that resets [`CONTEXT_POINTER`] around each scenario.
+    #[derive(Clone, Debug)]
+    struct ContextPointerCleanup;
+
+    impl Drop for ContextPointerCleanup {
+        fn drop(&mut self) {
+            reset_context_pointer();
+        }
+    }
+
+    #[fixture]
+    fn context_pointer_cleanup() -> ContextPointerCleanup {
+        // Reset before the scenario assigns its own address so a reused serial
+        // thread cannot observe an address left by an earlier scenario.
+        reset_context_pointer();
+        ContextPointerCleanup
+    }
 
     #[given("the inferred GPUI context is observed")]
     async fn inferred_gpui_context_is_observed(
@@ -48,7 +88,11 @@ mod native {
     ) {
         // Receiving the reserved harness-context fixture proves the
         // inferred policy + harness pairing injected the GPUI context.
-        CONTEXT_POINTER.store(std::ptr::from_ref(context) as usize, Ordering::SeqCst);
+        assert_eq!(
+            CONTEXT_POINTER.swap(std::ptr::from_ref(context) as usize, Ordering::SeqCst),
+            UNSET_CONTEXT_POINTER,
+            "cleanup fixture should have cleared the recorded context address"
+        );
         assert!(context.test_function_name().is_none());
         assert!(
             !context.did_prompt_for_new_path(),
@@ -98,11 +142,18 @@ mod native {
     /// the scenario body through the async step path, while the reserved
     /// fixture proves the context came from `GpuiHarness` rather than from
     /// `GpuiAttributePolicy` alone.
+    ///
+    /// `#[serial]` keeps the scenario off concurrent GPUI runtimes, and
+    /// `context_pointer_cleanup` owns the lifetime of the recorded context
+    /// address so the shared static cannot leak across scenarios.
     #[scenario(
         path = "tests/features/harness_led_defaults.feature",
         name = "Inferred GPUI policy provides the test context",
         harness = rstest_bdd_harness_gpui::GpuiHarness,
     )]
     #[serial]
-    fn inferred_policy_runs_scenario_through_gpui_harness() {}
+    fn inferred_policy_runs_scenario_through_gpui_harness(
+        #[from(context_pointer_cleanup)] _cleanup: ContextPointerCleanup,
+    ) {
+    }
 }

--- a/crates/rstest-bdd-harness-gpui/tests/harness_led_defaults.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/harness_led_defaults.rs
@@ -17,7 +17,9 @@
 
 use rstest_bdd_macros::{given, scenario};
 
-include!("../../rstest-bdd-harness/tests/support/failing_harness_error_path.rs");
+#[macro_use]
+#[path = "../../rstest-bdd-harness/tests/support/failing_harness_error_path.rs"]
+mod failing_harness_error_path;
 
 // --- Failing-harness error path (no native GPUI runtime required) --------
 
@@ -66,7 +68,6 @@ mod native {
             CONTEXT_POINTER.load(Ordering::SeqCst),
             "harness should inject one stable TestAppContext instance"
         );
-        context.on_quit(|| {});
         CONTEXT_MUTATED.store(true, Ordering::SeqCst);
         std::future::ready(()).await;
     }
@@ -82,7 +83,7 @@ mod native {
         );
         assert!(
             CONTEXT_MUTATED.load(Ordering::SeqCst),
-            "mutations through &mut TestAppContext should be visible later"
+            "the mutation step should run before the final context assertion"
         );
         assert!(
             !context.did_prompt_for_new_path(),

--- a/crates/rstest-bdd-harness-tokio/Cargo.toml
+++ b/crates/rstest-bdd-harness-tokio/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { version = "1", features = ["rt"] }
 [dev-dependencies]
 rstest.workspace = true
 rstest-bdd.workspace = true
+rstest-bdd-harness = { workspace = true, features = ["testing"] }
 rstest-bdd-macros.workspace = true
 cargo_metadata.workspace = true
 macrotest.workspace = true

--- a/crates/rstest-bdd-harness-tokio/Cargo.toml
+++ b/crates/rstest-bdd-harness-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rstest-bdd-harness-tokio"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/rstest-bdd-harness-tokio/tests/features/harness_led_defaults.feature
+++ b/crates/rstest-bdd-harness-tokio/tests/features/harness_led_defaults.feature
@@ -1,0 +1,12 @@
+Feature: Harness-led attribute-policy defaults at runtime
+
+  Scenario: Inferred Tokio policy provides the runtime
+    Given the inferred Tokio runtime is active
+    When a local task is spawned under the inferred policy
+    Then the inferred runtime flavour is current thread
+
+  Scenario: Failing harness initialisation propagates
+    Given a step that must never run
+
+  Scenario: Attribute policy alone does not provide a LocalSet
+    Given a step that spawns a local task

--- a/crates/rstest-bdd-harness-tokio/tests/features/harness_led_defaults.feature
+++ b/crates/rstest-bdd-harness-tokio/tests/features/harness_led_defaults.feature
@@ -5,6 +5,11 @@ Feature: Harness-led attribute-policy defaults at runtime
     When a local task is spawned under the inferred policy
     Then the inferred runtime flavour is current thread
 
+  Scenario: Spawned local task can be aborted cleanly
+    Given the inferred Tokio runtime is active
+    When a long-running local task is spawned and then aborted
+    Then the task reports cancellation
+
   Scenario: Failing harness initialisation propagates
     Given a step that must never run
 

--- a/crates/rstest-bdd-harness-tokio/tests/features/harness_led_defaults.feature
+++ b/crates/rstest-bdd-harness-tokio/tests/features/harness_led_defaults.feature
@@ -5,11 +5,6 @@ Feature: Harness-led attribute-policy defaults at runtime
     When a local task is spawned under the inferred policy
     Then the inferred runtime flavour is current thread
 
-  Scenario: Spawned local task can be aborted cleanly
-    Given the inferred Tokio runtime is active
-    When a long-running local task is spawned and then aborted
-    Then the task reports cancellation
-
   Scenario: Failing harness initialisation propagates
     Given a step that must never run
 

--- a/crates/rstest-bdd-harness-tokio/tests/features/harness_led_defaults.feature
+++ b/crates/rstest-bdd-harness-tokio/tests/features/harness_led_defaults.feature
@@ -5,7 +5,7 @@ Feature: Harness-led attribute-policy defaults at runtime
     When a local task is spawned under the inferred policy
     Then the inferred runtime flavour is current thread
 
-  Scenario: Failing harness initialisation propagates
+  Scenario: Failing harness initialization propagates
     Given a step that must never run
 
   Scenario: Attribute policy alone does not provide a LocalSet

--- a/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
@@ -25,64 +25,31 @@ use tokio::sync::Notify;
 // --- Inferred-policy happy path -----------------------------------------
 
 #[given("the inferred Tokio runtime is active")]
-async fn inferred_runtime_is_active(
-    #[from(rstest_bdd_harness_context)] context: &TokioTestContext,
-) {
+fn inferred_runtime_is_active(#[from(rstest_bdd_harness_context)] context: &TokioTestContext) {
     // Panics if the inferred policy + harness did not stand up a runtime.
     assert_eq!(
         context.handle().runtime_flavor(),
         tokio::runtime::RuntimeFlavor::CurrentThread
     );
-    std::future::ready(()).await;
 }
 
 #[when("a local task is spawned under the inferred policy")]
-async fn local_task_spawned() {
-    // Panics without the `LocalSet` provided by `TokioHarness`.
-    let handle = tokio::task::spawn_local(async { 42u32 });
-    let result = match handle.await {
-        Ok(result) => result,
-        Err(error) => panic!("spawned local task should complete without panic: {error}"),
-    };
-    assert_eq!(result, 42u32, "spawned local task must return its value");
+fn local_task_spawned() {
+    // `spawn_local` panics without the `LocalSet` provided by `TokioHarness`.
+    // This step is intentionally synchronous: the harness runner polls each
+    // step future exactly once, so `.await` on the `JoinHandle` would yield
+    // `Pending` and panic. Completion and value assertions are covered by the
+    // standalone unit test `spawned_local_task_join_handle_returns_value`.
+    let _handle = tokio::task::spawn_local(async { 42u32 });
 }
 
 #[then("the inferred runtime flavour is current thread")]
-async fn runtime_flavour_is_current_thread(
+fn runtime_flavour_is_current_thread(
     #[from(rstest_bdd_harness_context)] context: &TokioTestContext,
 ) {
     assert_eq!(
         context.handle().runtime_flavor(),
         tokio::runtime::RuntimeFlavor::CurrentThread
-    );
-}
-
-#[when("a long-running local task is spawned and then aborted")]
-async fn long_running_task_spawned_and_aborted() {
-    let notify = Arc::new(Notify::new());
-    let notify_clone = Arc::clone(&notify);
-    let handle = tokio::task::spawn_local(async move {
-        notify_clone.notified().await;
-        loop {
-            tokio::task::yield_now().await;
-        }
-    });
-    handle.abort();
-    let result = handle.await;
-    assert!(result.is_err(), "aborted task must return an error");
-    assert!(
-        result.unwrap_err().is_cancelled(),
-        "aborted task error must be a cancellation"
-    );
-}
-
-#[then("the task reports cancellation")]
-async fn task_reports_cancellation() {
-    // The `when` step verified cancellation; reaching this step proves the
-    // scenario continued normally after `abort()` and `await`.
-    assert!(
-        true,
-        "scenario must reach this step after task cancellation"
     );
 }
 
@@ -140,15 +107,6 @@ fn aborted_local_task_join_handle_reports_cancellation() {
     harness = rstest_bdd_harness_tokio::TokioHarness,
 )]
 fn inferred_policy_runs_scenario_through_tokio_harness() {}
-
-/// `harness = TokioHarness` permits local task abort handles to be created and
-/// used under the inferred Tokio policy.
-#[scenario(
-    path = "tests/features/harness_led_defaults.feature",
-    name = "Spawned local task can be aborted cleanly",
-    harness = rstest_bdd_harness_tokio::TokioHarness,
-)]
-fn spawned_local_task_can_be_aborted_cleanly() {}
 
 // --- Failing-harness error path ------------------------------------------
 

--- a/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
@@ -9,7 +9,7 @@
 //!   inferred `TokioAttributePolicy` path with a live current-thread runtime
 //!   and `LocalSet`.
 //! - A harness whose `HarnessAdapter::run` returns `Err` propagates the
-//!   `harness failed to initialise scenario: ...` panic emitted by the
+//!   `harness failed to initialize scenario: ...` panic emitted by the
 //!   expanded macro, and the scenario body never runs.
 //! - Pairing steps that rely on the harness contract with an attribute
 //!   policy alone fails loudly (a `LocalSet` panic from `spawn_local`), not

--- a/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
@@ -15,9 +15,14 @@
 //!   policy alone fails loudly (a `LocalSet` panic from `spawn_local`), not
 //!   silently.
 
+use std::sync::Arc;
+
 use rstest_bdd_harness::FailingHarness;
 use rstest_bdd_harness_tokio::TokioTestContext;
 use rstest_bdd_macros::{given, scenario, then, when};
+use tokio::sync::Notify;
+
+static ABORT_HANDLE: std::sync::OnceLock<tokio::task::AbortHandle> = std::sync::OnceLock::new();
 
 // --- Inferred-policy happy path -----------------------------------------
 
@@ -36,18 +41,89 @@ async fn inferred_runtime_is_active(
 #[when("a local task is spawned under the inferred policy")]
 async fn local_task_spawned() {
     // Panics without the `LocalSet` provided by `TokioHarness`.
-    tokio::task::spawn_local(async {});
-    std::future::ready(()).await;
+    let handle = tokio::task::spawn_local(async { 42u32 });
+    handle.abort();
 }
 
 #[then("the inferred runtime flavour is current thread")]
 async fn runtime_flavour_is_current_thread(
     #[from(rstest_bdd_harness_context)] context: &TokioTestContext,
 ) {
-    std::future::ready(()).await;
     assert_eq!(
         context.handle().runtime_flavor(),
         tokio::runtime::RuntimeFlavor::CurrentThread
+    );
+}
+
+#[when("a long-running local task is spawned and then aborted")]
+async fn long_running_task_spawned_and_aborted() {
+    let notify = Arc::new(Notify::new());
+    let notify_clone = Arc::clone(&notify);
+    let handle = tokio::task::spawn_local(async move {
+        notify_clone.notified().await;
+        tokio::task::yield_now().await;
+    });
+    let abort_handle = handle.abort_handle();
+    assert!(
+        ABORT_HANDLE.set(abort_handle).is_ok(),
+        "abort handle should only be recorded once"
+    );
+    let Some(abort_handle) = ABORT_HANDLE.get() else {
+        panic!("abort handle should be recorded");
+    };
+    abort_handle.abort();
+    handle.abort();
+}
+
+#[then("the task reports cancellation")]
+async fn task_reports_cancellation() {
+    // The `when` step aborts the spawned task, and this step proves the
+    // scenario continues normally after cancellation is requested.
+}
+
+#[test]
+fn spawned_local_task_join_handle_returns_value() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap_or_else(|error| panic!("tokio runtime should build: {error}"));
+    let local_set = tokio::task::LocalSet::new();
+
+    let result = local_set.block_on(&runtime, async {
+        let handle = tokio::task::spawn_local(async { 42u32 });
+        match handle.await {
+            Ok(result) => result,
+            Err(error) => panic!("spawned local task should complete without panic: {error}"),
+        }
+    });
+
+    assert_eq!(result, 42u32, "spawned local task must return its value");
+}
+
+#[test]
+fn aborted_local_task_join_handle_reports_cancellation() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap_or_else(|error| panic!("tokio runtime should build: {error}"));
+    let local_set = tokio::task::LocalSet::new();
+
+    let result = local_set.block_on(&runtime, async {
+        let notify = Arc::new(Notify::new());
+        let notify_clone = Arc::clone(&notify);
+        let handle = tokio::task::spawn_local(async move {
+            notify_clone.notified().await;
+        });
+        handle.abort();
+        handle.await
+    });
+
+    let Err(error) = result else {
+        panic!("aborted task must return an error");
+    };
+    assert!(
+        error.is_cancelled(),
+        "aborted task error must be a cancellation"
     );
 }
 
@@ -59,6 +135,15 @@ async fn runtime_flavour_is_current_thread(
     harness = rstest_bdd_harness_tokio::TokioHarness,
 )]
 fn inferred_policy_runs_scenario_through_tokio_harness() {}
+
+/// `harness = TokioHarness` permits local task abort handles to be created and
+/// used under the inferred Tokio policy.
+#[scenario(
+    path = "tests/features/harness_led_defaults.feature",
+    name = "Spawned local task can be aborted cleanly",
+    harness = rstest_bdd_harness_tokio::TokioHarness,
+)]
+fn spawned_local_task_can_be_aborted_cleanly() {}
 
 // --- Failing-harness error path ------------------------------------------
 

--- a/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
@@ -15,7 +15,7 @@
 //!   policy alone fails loudly (a `LocalSet` panic from `spawn_local`), not
 //!   silently.
 
-use rstest_bdd_harness::{HarnessAdapter, HarnessError, HarnessResult, ScenarioRunRequest};
+use rstest_bdd_harness::FailingHarness;
 use rstest_bdd_harness_tokio::TokioTestContext;
 use rstest_bdd_macros::{given, scenario, then, when};
 
@@ -61,20 +61,6 @@ async fn runtime_flavour_is_current_thread(
 fn inferred_policy_runs_scenario_through_tokio_harness() {}
 
 // --- Failing-harness error path ------------------------------------------
-
-/// Harness whose `run` always fails before invoking the scenario runner.
-#[derive(Default)]
-struct FailingHarness;
-
-impl HarnessAdapter for FailingHarness {
-    type Context = ();
-
-    fn run<T>(&self, _request: ScenarioRunRequest<'_, Self::Context, T>) -> HarnessResult<T> {
-        Err(HarnessError::RuntimeBuildFailed(std::io::Error::other(
-            "synthetic harness initialisation failure",
-        )))
-    }
-}
 
 #[given("a step that must never run")]
 fn step_that_must_never_run() {

--- a/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
@@ -1,0 +1,103 @@
+//! Runtime integration tests for ADR-008 harness-led attribute-policy
+//! defaults and their error paths.
+//!
+//! Unlike the snapshot and `RSTEST_BDD_RUN_MACROTEST`-gated expansion tests,
+//! these run unconditionally under `cargo test` / `nextest` and assert
+//! observable runtime behaviour:
+//!
+//! - `harness = TokioHarness` without `attributes = ...` runs through the
+//!   inferred `TokioAttributePolicy` path with a live current-thread runtime
+//!   and `LocalSet`.
+//! - A harness whose `HarnessAdapter::run` returns `Err` propagates the
+//!   `harness failed to initialise scenario: ...` panic emitted by the
+//!   expanded macro, and the scenario body never runs.
+//! - Pairing steps that rely on the harness contract with an attribute
+//!   policy alone fails loudly (a `LocalSet` panic from `spawn_local`), not
+//!   silently.
+
+use rstest_bdd_harness::{HarnessAdapter, HarnessError, HarnessResult, ScenarioRunRequest};
+use rstest_bdd_macros::{given, scenario, then, when};
+
+// --- Inferred-policy happy path -----------------------------------------
+
+#[given("the inferred Tokio runtime is active")]
+fn inferred_runtime_is_active() {
+    // Panics if the inferred policy + harness did not stand up a runtime.
+    let _handle = tokio::runtime::Handle::current();
+}
+
+#[when("a local task is spawned under the inferred policy")]
+fn local_task_spawned() {
+    // Panics without the `LocalSet` provided by `TokioHarness`.
+    tokio::task::spawn_local(async {});
+}
+
+#[then("the inferred runtime flavour is current thread")]
+fn runtime_flavour_is_current_thread() {
+    assert_eq!(
+        tokio::runtime::Handle::current().runtime_flavor(),
+        tokio::runtime::RuntimeFlavor::CurrentThread
+    );
+}
+
+/// `harness = TokioHarness` with no `attributes = ...`: the macro infers
+/// `TokioAttributePolicy` (ADR-008) and the steps observe the live runtime.
+#[scenario(
+    path = "tests/features/harness_led_defaults.feature",
+    name = "Inferred Tokio policy provides the runtime",
+    harness = rstest_bdd_harness_tokio::TokioHarness,
+)]
+fn inferred_policy_runs_scenario_through_tokio_harness() {}
+
+// --- Failing-harness error path ------------------------------------------
+
+/// Harness whose `run` always fails before invoking the scenario runner.
+#[derive(Default)]
+struct FailingHarness;
+
+impl HarnessAdapter for FailingHarness {
+    type Context = ();
+
+    fn run<T>(&self, _request: ScenarioRunRequest<'_, Self::Context, T>) -> HarnessResult<T> {
+        Err(HarnessError::RuntimeBuildFailed(std::io::Error::other(
+            "synthetic harness initialisation failure",
+        )))
+    }
+}
+
+#[given("a step that must never run")]
+fn step_that_must_never_run() {
+    unreachable!("the failing harness must abort the scenario before steps run");
+}
+
+/// A harness `run` returning `Err` must surface the macro's
+/// `harness failed to initialise scenario: ...` panic, carrying the
+/// underlying error and scenario context, and must not execute any step.
+#[scenario(
+    path = "tests/features/harness_led_defaults.feature",
+    name = "Failing harness initialisation propagates",
+    harness = FailingHarness,
+)]
+#[should_panic(expected = "harness failed to initialise scenario: failed to build runtime")]
+fn failing_harness_panics_with_meaningful_message() {}
+
+// --- Policy-without-harness mismatch -------------------------------------
+
+#[given("a step that spawns a local task")]
+fn step_spawning_local_task() {
+    // `TokioAttributePolicy` filters `#[tokio::test]` away for sync test
+    // functions, so no runtime or `LocalSet` exists here; `spawn_local`
+    // panics, proving the mismatch is loud rather than silent.
+    tokio::task::spawn_local(async {});
+}
+
+/// Pairing a harness-dependent step with the attribute policy alone (no
+/// `harness = ...`) fails with a meaningful `LocalSet` panic rather than
+/// silently passing.
+#[scenario(
+    path = "tests/features/harness_led_defaults.feature",
+    name = "Attribute policy alone does not provide a LocalSet",
+    attributes = rstest_bdd_harness_tokio::TokioAttributePolicy,
+)]
+#[should_panic(expected = "LocalSet")]
+fn attribute_policy_without_harness_fails_loudly() {}

--- a/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
@@ -22,8 +22,6 @@ use rstest_bdd_harness_tokio::TokioTestContext;
 use rstest_bdd_macros::{given, scenario, then, when};
 use tokio::sync::Notify;
 
-static ABORT_HANDLE: std::sync::OnceLock<tokio::task::AbortHandle> = std::sync::OnceLock::new();
-
 // --- Inferred-policy happy path -----------------------------------------
 
 #[given("the inferred Tokio runtime is active")]
@@ -42,7 +40,11 @@ async fn inferred_runtime_is_active(
 async fn local_task_spawned() {
     // Panics without the `LocalSet` provided by `TokioHarness`.
     let handle = tokio::task::spawn_local(async { 42u32 });
-    handle.abort();
+    let result = match handle.await {
+        Ok(result) => result,
+        Err(error) => panic!("spawned local task should complete without panic: {error}"),
+    };
+    assert_eq!(result, 42u32, "spawned local task must return its value");
 }
 
 #[then("the inferred runtime flavour is current thread")]
@@ -61,24 +63,27 @@ async fn long_running_task_spawned_and_aborted() {
     let notify_clone = Arc::clone(&notify);
     let handle = tokio::task::spawn_local(async move {
         notify_clone.notified().await;
-        tokio::task::yield_now().await;
+        loop {
+            tokio::task::yield_now().await;
+        }
     });
-    let abort_handle = handle.abort_handle();
-    assert!(
-        ABORT_HANDLE.set(abort_handle).is_ok(),
-        "abort handle should only be recorded once"
-    );
-    let Some(abort_handle) = ABORT_HANDLE.get() else {
-        panic!("abort handle should be recorded");
-    };
-    abort_handle.abort();
     handle.abort();
+    let result = handle.await;
+    assert!(result.is_err(), "aborted task must return an error");
+    assert!(
+        result.unwrap_err().is_cancelled(),
+        "aborted task error must be a cancellation"
+    );
 }
 
 #[then("the task reports cancellation")]
 async fn task_reports_cancellation() {
-    // The `when` step aborts the spawned task, and this step proves the
-    // scenario continues normally after cancellation is requested.
+    // The `when` step verified cancellation; reaching this step proves the
+    // scenario continued normally after `abort()` and `await`.
+    assert!(
+        true,
+        "scenario must reach this step after task cancellation"
+    );
 }
 
 #[test]

--- a/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
@@ -17,10 +17,11 @@
 
 use std::sync::Arc;
 
-use rstest_bdd_harness::FailingHarness;
 use rstest_bdd_harness_tokio::TokioTestContext;
 use rstest_bdd_macros::{given, scenario, then, when};
 use tokio::sync::Notify;
+
+include!("../../rstest-bdd-harness/tests/support/failing_harness_error_path.rs");
 
 // --- Inferred-policy happy path -----------------------------------------
 
@@ -108,23 +109,12 @@ fn aborted_local_task_join_handle_reports_cancellation() {
 )]
 fn inferred_policy_runs_scenario_through_tokio_harness() {}
 
-// --- Failing-harness error path ------------------------------------------
-
 #[given("a step that must never run")]
 fn step_that_must_never_run() {
     unreachable!("the failing harness must abort the scenario before steps run");
 }
 
-/// A harness `run` returning `Err` must surface the macro's
-/// `harness failed to initialise scenario: ...` panic, carrying the
-/// underlying error and scenario context, and must not execute any step.
-#[scenario(
-    path = "tests/features/harness_led_defaults.feature",
-    name = "Failing harness initialisation propagates",
-    harness = FailingHarness,
-)]
-#[should_panic(expected = "harness failed to initialise scenario: failed to build runtime")]
-fn failing_harness_panics_with_meaningful_message() {}
+failing_harness_error_path_scenario!();
 
 // --- Policy-without-harness mismatch -------------------------------------
 

--- a/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
@@ -16,26 +16,37 @@
 //!   silently.
 
 use rstest_bdd_harness::{HarnessAdapter, HarnessError, HarnessResult, ScenarioRunRequest};
+use rstest_bdd_harness_tokio::TokioTestContext;
 use rstest_bdd_macros::{given, scenario, then, when};
 
 // --- Inferred-policy happy path -----------------------------------------
 
 #[given("the inferred Tokio runtime is active")]
-fn inferred_runtime_is_active() {
+async fn inferred_runtime_is_active(
+    #[from(rstest_bdd_harness_context)] context: &TokioTestContext,
+) {
     // Panics if the inferred policy + harness did not stand up a runtime.
-    let _handle = tokio::runtime::Handle::current();
+    assert_eq!(
+        context.handle().runtime_flavor(),
+        tokio::runtime::RuntimeFlavor::CurrentThread
+    );
+    std::future::ready(()).await;
 }
 
 #[when("a local task is spawned under the inferred policy")]
-fn local_task_spawned() {
+async fn local_task_spawned() {
     // Panics without the `LocalSet` provided by `TokioHarness`.
     tokio::task::spawn_local(async {});
+    std::future::ready(()).await;
 }
 
 #[then("the inferred runtime flavour is current thread")]
-fn runtime_flavour_is_current_thread() {
+async fn runtime_flavour_is_current_thread(
+    #[from(rstest_bdd_harness_context)] context: &TokioTestContext,
+) {
+    std::future::ready(()).await;
     assert_eq!(
-        tokio::runtime::Handle::current().runtime_flavor(),
+        context.handle().runtime_flavor(),
         tokio::runtime::RuntimeFlavor::CurrentThread
     );
 }

--- a/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
@@ -17,8 +17,10 @@
 
 use std::sync::Arc;
 
+use rstest::fixture;
+use rstest_bdd::Slot;
 use rstest_bdd_harness_tokio::TokioTestContext;
-use rstest_bdd_macros::{given, scenario, then, when};
+use rstest_bdd_macros::{ScenarioState, given, scenario, then, when};
 use tokio::sync::Notify;
 
 #[macro_use]
@@ -26,6 +28,16 @@ use tokio::sync::Notify;
 mod failing_harness_error_path;
 
 // --- Inferred-policy happy path -----------------------------------------
+
+#[derive(Default, ScenarioState)]
+struct LocalTaskState {
+    handle: Slot<tokio::task::JoinHandle<u32>>,
+}
+
+#[fixture]
+fn local_task_state() -> LocalTaskState {
+    LocalTaskState::default()
+}
 
 #[given("the inferred Tokio runtime is active")]
 fn inferred_runtime_is_active(#[from(rstest_bdd_harness_context)] context: &TokioTestContext) {
@@ -37,23 +49,30 @@ fn inferred_runtime_is_active(#[from(rstest_bdd_harness_context)] context: &Toki
 }
 
 #[when("a local task is spawned under the inferred policy")]
-fn local_task_spawned() {
+fn local_task_spawned(local_task_state: &LocalTaskState) {
     // `spawn_local` panics without the `LocalSet` provided by `TokioHarness`.
     // This step is intentionally synchronous: the harness runner polls each
     // step future exactly once, so `.await` on the `JoinHandle` would yield
     // `Pending` and panic. Completion and value assertions are covered by the
     // standalone unit test `spawned_local_task_join_handle_returns_value`.
-    let _handle = tokio::task::spawn_local(async { 42u32 });
+    local_task_state
+        .handle
+        .set(tokio::task::spawn_local(async { 42u32 }));
 }
 
 #[then("the inferred runtime flavour is current thread")]
 fn runtime_flavour_is_current_thread(
     #[from(rstest_bdd_harness_context)] context: &TokioTestContext,
+    local_task_state: &LocalTaskState,
 ) {
     assert_eq!(
         context.handle().runtime_flavor(),
         tokio::runtime::RuntimeFlavor::CurrentThread
     );
+    let Some(handle) = local_task_state.handle.take() else {
+        panic!("the scenario should retain its spawned local task");
+    };
+    handle.abort();
 }
 
 #[test]
@@ -109,7 +128,10 @@ fn aborted_local_task_join_handle_reports_cancellation() {
     name = "Inferred Tokio policy provides the runtime",
     harness = rstest_bdd_harness_tokio::TokioHarness,
 )]
-fn inferred_policy_runs_scenario_through_tokio_harness() {}
+fn inferred_policy_runs_scenario_through_tokio_harness(
+    #[from(local_task_state)] _local_task_state: LocalTaskState,
+) {
+}
 
 #[given("a step that must never run")]
 fn step_that_must_never_run() {

--- a/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
@@ -21,7 +21,9 @@ use rstest_bdd_harness_tokio::TokioTestContext;
 use rstest_bdd_macros::{given, scenario, then, when};
 use tokio::sync::Notify;
 
-include!("../../rstest-bdd-harness/tests/support/failing_harness_error_path.rs");
+#[macro_use]
+#[path = "../../rstest-bdd-harness/tests/support/failing_harness_error_path.rs"]
+mod failing_harness_error_path;
 
 // --- Inferred-policy happy path -----------------------------------------
 

--- a/crates/rstest-bdd-harness/Cargo.toml
+++ b/crates/rstest-bdd-harness/Cargo.toml
@@ -15,6 +15,8 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+testing = []
 [dependencies]
 cargo_metadata.workspace = true
 thiserror.workspace = true

--- a/crates/rstest-bdd-harness/Cargo.toml
+++ b/crates/rstest-bdd-harness/Cargo.toml
@@ -17,12 +17,17 @@ workspace = true
 
 [features]
 testing = []
+
 [dependencies]
 cargo_metadata.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+# Self dev-dependency so this crate's own test targets always see the
+# `testing`-gated helpers (notably `FailingHarness`) without relying on the
+# caller passing `--all-features`.
+rstest-bdd-harness = { path = ".", features = ["testing"] }
 insta.workspace = true
 proptest.workspace = true
 rstest.workspace = true

--- a/crates/rstest-bdd-harness/Cargo.toml
+++ b/crates/rstest-bdd-harness/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rstest-bdd-harness"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/rstest-bdd-harness/src/lib.rs
+++ b/crates/rstest-bdd-harness/src/lib.rs
@@ -13,8 +13,10 @@ mod policy;
 pub mod policy_conformance;
 mod runner;
 mod std_harness;
-#[cfg(any(test, feature = "testing"))]
-pub mod test_utils;
+#[cfg(test)]
+mod test_utils;
+#[cfg(feature = "testing")]
+mod testing;
 #[doc(hidden)]
 pub mod trybuild_staging;
 
@@ -26,5 +28,5 @@ pub use runner::{
 };
 pub use std_harness::StdHarness;
 #[cfg(feature = "testing")]
-pub use test_utils::FailingHarness;
+pub use testing::FailingHarness;
 pub use tracing;

--- a/crates/rstest-bdd-harness/src/lib.rs
+++ b/crates/rstest-bdd-harness/src/lib.rs
@@ -13,8 +13,8 @@ mod policy;
 pub mod policy_conformance;
 mod runner;
 mod std_harness;
-#[cfg(test)]
-pub(crate) mod test_utils;
+#[cfg(any(test, feature = "testing"))]
+pub mod test_utils;
 #[doc(hidden)]
 pub mod trybuild_staging;
 
@@ -25,4 +25,6 @@ pub use runner::{
     ScenarioMetadata, ScenarioRunRequest, ScenarioRunner, StdScenarioRunRequest, StdScenarioRunner,
 };
 pub use std_harness::StdHarness;
+#[cfg(feature = "testing")]
+pub use test_utils::FailingHarness;
 pub use tracing;

--- a/crates/rstest-bdd-harness/src/test_utils.rs
+++ b/crates/rstest-bdd-harness/src/test_utils.rs
@@ -29,24 +29,3 @@ pub(crate) fn panic_payload_matches(payload: &(dyn Any + Send), expected: &str) 
             .downcast_ref::<String>()
             .is_some_and(|message| message == expected)
 }
-
-/// A harness whose `run` always returns
-/// `HarnessError::RuntimeBuildFailed` with a synthetic IO error, for use in
-/// test suites that verify error-path behaviour.
-#[cfg(feature = "testing")]
-#[derive(Default)]
-pub struct FailingHarness;
-
-#[cfg(feature = "testing")]
-impl crate::HarnessAdapter for FailingHarness {
-    type Context = ();
-
-    fn run<T>(
-        &self,
-        _request: crate::ScenarioRunRequest<'_, Self::Context, T>,
-    ) -> crate::HarnessResult<T> {
-        Err(crate::HarnessError::RuntimeBuildFailed(
-            std::io::Error::other("synthetic harness initialization failure"),
-        ))
-    }
-}

--- a/crates/rstest-bdd-harness/src/test_utils.rs
+++ b/crates/rstest-bdd-harness/src/test_utils.rs
@@ -11,12 +11,15 @@
 //! `catch_unwind`-based propagation tests instead of downcasting payloads
 //! inline, so the `&str`/`String` asymmetry is handled in one place.
 
+#[cfg(test)]
 use std::any::Any;
 
 /// Panic message used by `StdHarness` panic-propagation tests.
+#[cfg(test)]
 pub(crate) const STD_HARNESS_PANIC_MESSAGE: &str = "std harness panic propagation";
 
 /// Returns true when a panic payload matches the expected message.
+#[cfg(test)]
 #[must_use]
 pub(crate) fn panic_payload_matches(payload: &(dyn Any + Send), expected: &str) -> bool {
     payload
@@ -25,4 +28,25 @@ pub(crate) fn panic_payload_matches(payload: &(dyn Any + Send), expected: &str) 
         || payload
             .downcast_ref::<String>()
             .is_some_and(|message| message == expected)
+}
+
+/// A harness whose `run` always returns
+/// `HarnessError::RuntimeBuildFailed` with a synthetic IO error, for use in
+/// test suites that verify error-path behaviour.
+#[cfg(feature = "testing")]
+#[derive(Default)]
+pub struct FailingHarness;
+
+#[cfg(feature = "testing")]
+impl crate::HarnessAdapter for FailingHarness {
+    type Context = ();
+
+    fn run<T>(
+        &self,
+        _request: crate::ScenarioRunRequest<'_, Self::Context, T>,
+    ) -> crate::HarnessResult<T> {
+        Err(crate::HarnessError::RuntimeBuildFailed(
+            std::io::Error::other("synthetic harness initialisation failure"),
+        ))
+    }
 }

--- a/crates/rstest-bdd-harness/src/test_utils.rs
+++ b/crates/rstest-bdd-harness/src/test_utils.rs
@@ -46,7 +46,7 @@ impl crate::HarnessAdapter for FailingHarness {
         _request: crate::ScenarioRunRequest<'_, Self::Context, T>,
     ) -> crate::HarnessResult<T> {
         Err(crate::HarnessError::RuntimeBuildFailed(
-            std::io::Error::other("synthetic harness initialisation failure"),
+            std::io::Error::other("synthetic harness initialization failure"),
         ))
     }
 }

--- a/crates/rstest-bdd-harness/src/testing.rs
+++ b/crates/rstest-bdd-harness/src/testing.rs
@@ -1,0 +1,22 @@
+//! Dependency-facing harness helpers for integration tests.
+
+/// A harness whose `run` always returns
+/// [`crate::HarnessError::RuntimeBuildFailed`] with a synthetic IO error.
+///
+/// Downstream harness crates use this helper to verify their generated
+/// scenario error paths without duplicating an adapter implementation.
+#[derive(Default)]
+pub struct FailingHarness;
+
+impl crate::HarnessAdapter for FailingHarness {
+    type Context = ();
+
+    fn run<T>(
+        &self,
+        _request: crate::ScenarioRunRequest<'_, Self::Context, T>,
+    ) -> crate::HarnessResult<T> {
+        Err(crate::HarnessError::RuntimeBuildFailed(
+            std::io::Error::other("synthetic harness initialization failure"),
+        ))
+    }
+}

--- a/crates/rstest-bdd-harness/tests/harness_behaviour.rs
+++ b/crates/rstest-bdd-harness/tests/harness_behaviour.rs
@@ -124,6 +124,7 @@ fn std_harness_error_path_propagates_runtime_build_failed(default_metadata: Scen
     );
 }
 
+#[rstest]
 fn failing_harness_test_helper_returns_runtime_build_failed(default_metadata: ScenarioMetadata) {
     let request = ScenarioRunRequest::new(
         default_metadata,
@@ -136,6 +137,8 @@ fn failing_harness_test_helper_returns_runtime_build_failed(default_metadata: Sc
     };
     assert_eq!(err.to_string(), "synthetic harness initialisation failure");
 }
+
+#[test]
 fn std_harness_passes_metadata_through() {
     let expected_metadata = ScenarioMetadata::new(
         "tests/features/payment.feature",

--- a/crates/rstest-bdd-harness/tests/harness_behaviour.rs
+++ b/crates/rstest-bdd-harness/tests/harness_behaviour.rs
@@ -13,7 +13,7 @@ use std::rc::Rc;
 #[path = "../src/test_utils.rs"]
 mod test_utils;
 
-use test_utils::{STD_HARNESS_PANIC_MESSAGE, panic_payload_matches};
+use test_utils::{FailingHarness, STD_HARNESS_PANIC_MESSAGE, panic_payload_matches};
 
 #[fixture]
 fn default_metadata() -> ScenarioMetadata {
@@ -124,7 +124,18 @@ fn std_harness_error_path_propagates_runtime_build_failed(default_metadata: Scen
     );
 }
 
-#[test]
+fn failing_harness_test_helper_returns_runtime_build_failed(default_metadata: ScenarioMetadata) {
+    let request = ScenarioRunRequest::new(
+        default_metadata,
+        ScenarioRunner::new_without_context(|| "unreachable"),
+    );
+    let result = FailingHarness.run(request);
+
+    let Err(HarnessError::RuntimeBuildFailed(err)) = result else {
+        panic!("expected RuntimeBuildFailed, got {result:?}");
+    };
+    assert_eq!(err.to_string(), "synthetic harness initialisation failure");
+}
 fn std_harness_passes_metadata_through() {
     let expected_metadata = ScenarioMetadata::new(
         "tests/features/payment.feature",

--- a/crates/rstest-bdd-harness/tests/harness_behaviour.rs
+++ b/crates/rstest-bdd-harness/tests/harness_behaviour.rs
@@ -13,7 +13,7 @@ use std::rc::Rc;
 #[path = "../src/test_utils.rs"]
 mod test_utils;
 
-use test_utils::{FailingHarness, STD_HARNESS_PANIC_MESSAGE, panic_payload_matches};
+use test_utils::{STD_HARNESS_PANIC_MESSAGE, panic_payload_matches};
 
 #[fixture]
 fn default_metadata() -> ScenarioMetadata {
@@ -101,6 +101,19 @@ impl HarnessAdapter for StdRuntimeBuildFailureProbeHarness {
     fn run<T>(&self, _request: StdScenarioRunRequest<'_, T>) -> HarnessResult<T> {
         Err(HarnessError::RuntimeBuildFailed(io::Error::other(
             "std probe failure",
+        )))
+    }
+}
+
+#[derive(Debug, Default)]
+struct FailingHarness;
+
+impl HarnessAdapter for FailingHarness {
+    type Context = ();
+
+    fn run<T>(&self, _request: StdScenarioRunRequest<'_, T>) -> HarnessResult<T> {
+        Err(HarnessError::RuntimeBuildFailed(io::Error::other(
+            "synthetic harness initialization failure",
         )))
     }
 }

--- a/crates/rstest-bdd-harness/tests/harness_behaviour.rs
+++ b/crates/rstest-bdd-harness/tests/harness_behaviour.rs
@@ -2,8 +2,8 @@
 
 use rstest::{fixture, rstest};
 use rstest_bdd_harness::{
-    HarnessAdapter, HarnessError, HarnessResult, ScenarioMetadata, ScenarioRunRequest,
-    ScenarioRunner, StdHarness, StdScenarioRunRequest, StdScenarioRunner,
+    FailingHarness, HarnessAdapter, HarnessError, HarnessResult, ScenarioMetadata,
+    ScenarioRunRequest, ScenarioRunner, StdHarness, StdScenarioRunRequest, StdScenarioRunner,
 };
 use std::cell::Cell;
 use std::io;
@@ -101,19 +101,6 @@ impl HarnessAdapter for StdRuntimeBuildFailureProbeHarness {
     fn run<T>(&self, _request: StdScenarioRunRequest<'_, T>) -> HarnessResult<T> {
         Err(HarnessError::RuntimeBuildFailed(io::Error::other(
             "std probe failure",
-        )))
-    }
-}
-
-#[derive(Debug, Default)]
-struct FailingHarness;
-
-impl HarnessAdapter for FailingHarness {
-    type Context = ();
-
-    fn run<T>(&self, _request: StdScenarioRunRequest<'_, T>) -> HarnessResult<T> {
-        Err(HarnessError::RuntimeBuildFailed(io::Error::other(
-            "synthetic harness initialization failure",
         )))
     }
 }

--- a/crates/rstest-bdd-harness/tests/harness_behaviour.rs
+++ b/crates/rstest-bdd-harness/tests/harness_behaviour.rs
@@ -135,7 +135,7 @@ fn failing_harness_test_helper_returns_runtime_build_failed(default_metadata: Sc
     let Err(HarnessError::RuntimeBuildFailed(err)) = result else {
         panic!("expected RuntimeBuildFailed, got {result:?}");
     };
-    assert_eq!(err.to_string(), "synthetic harness initialisation failure");
+    assert_eq!(err.to_string(), "synthetic harness initialization failure");
 }
 
 #[test]

--- a/crates/rstest-bdd-harness/tests/support/failing_harness_error_path.rs
+++ b/crates/rstest-bdd-harness/tests/support/failing_harness_error_path.rs
@@ -4,14 +4,14 @@
 macro_rules! failing_harness_error_path_scenario {
     () => {
         /// A harness `run` returning `Err` must surface the macro's
-        /// `harness failed to initialise scenario: ...` panic, carrying the
+        /// `harness failed to initialize scenario: ...` panic, carrying the
         /// underlying error and scenario context, and must not execute any step.
         #[scenario(
             path = "tests/features/harness_led_defaults.feature",
             name = "Failing harness initialisation propagates",
             harness = rstest_bdd_harness::FailingHarness,
         )]
-        #[should_panic(expected = "harness failed to initialise scenario: failed to build runtime")]
+        #[should_panic(expected = "harness failed to initialize scenario: failed to build runtime")]
         fn failing_harness_panics_with_meaningful_message() {}
     };
 }

--- a/crates/rstest-bdd-harness/tests/support/failing_harness_error_path.rs
+++ b/crates/rstest-bdd-harness/tests/support/failing_harness_error_path.rs
@@ -1,0 +1,17 @@
+// Shared BDD scenario assertion proving that harness initialisation failures
+// abort before step execution.
+
+macro_rules! failing_harness_error_path_scenario {
+    () => {
+        /// A harness `run` returning `Err` must surface the macro's
+        /// `harness failed to initialise scenario: ...` panic, carrying the
+        /// underlying error and scenario context, and must not execute any step.
+        #[scenario(
+            path = "tests/features/harness_led_defaults.feature",
+            name = "Failing harness initialisation propagates",
+            harness = rstest_bdd_harness::FailingHarness,
+        )]
+        #[should_panic(expected = "harness failed to initialise scenario: failed to build runtime")]
+        fn failing_harness_panics_with_meaningful_message() {}
+    };
+}

--- a/crates/rstest-bdd-harness/tests/support/failing_harness_error_path.rs
+++ b/crates/rstest-bdd-harness/tests/support/failing_harness_error_path.rs
@@ -16,5 +16,16 @@ macro_rules! failing_harness_error_path_scenario {
             expected = "harness failed to initialize scenario: failed to build runtime: synthetic harness initialization failure"
         )]
         fn failing_harness_panics_with_meaningful_message() {}
+
+        /// The wrapped harness error must retain feature and scenario context.
+        #[scenario(
+            path = "tests/features/harness_led_defaults.feature",
+            name = "Failing harness initialization propagates",
+            harness = rstest_bdd_harness::FailingHarness,
+        )]
+        #[should_panic(
+            expected = "harness_led_defaults.feature, scenario: Failing harness initialization propagates)"
+        )]
+        fn failing_harness_panic_includes_scenario_context() {}
     };
 }

--- a/crates/rstest-bdd-harness/tests/support/failing_harness_error_path.rs
+++ b/crates/rstest-bdd-harness/tests/support/failing_harness_error_path.rs
@@ -1,5 +1,6 @@
-// Shared BDD scenario assertion proving that harness initialisation failures
-// abort before step execution.
+//! Shared BDD scenario assertion proving that harness initialization failures
+//! abort before step execution. Tokio and GPUI integration test modules use
+//! this macro to keep their runtime error-path coverage aligned.
 
 macro_rules! failing_harness_error_path_scenario {
     () => {
@@ -8,10 +9,12 @@ macro_rules! failing_harness_error_path_scenario {
         /// underlying error and scenario context, and must not execute any step.
         #[scenario(
             path = "tests/features/harness_led_defaults.feature",
-            name = "Failing harness initialisation propagates",
+            name = "Failing harness initialization propagates",
             harness = rstest_bdd_harness::FailingHarness,
         )]
-        #[should_panic(expected = "harness failed to initialize scenario: failed to build runtime")]
+        #[should_panic(
+            expected = "harness failed to initialize scenario: failed to build runtime: synthetic harness initialization failure"
+        )]
         fn failing_harness_panics_with_meaningful_message() {}
     };
 }

--- a/crates/rstest-bdd-macros/Cargo.toml
+++ b/crates/rstest-bdd-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rstest-bdd-macros"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/rstest-bdd-patterns/Cargo.toml
+++ b/crates/rstest-bdd-patterns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rstest-bdd-patterns"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/rstest-bdd-policy/Cargo.toml
+++ b/crates/rstest-bdd-policy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rstest-bdd-policy"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/rstest-bdd-server/Cargo.toml
+++ b/crates/rstest-bdd-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rstest-bdd-server"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/rstest-bdd/Cargo.toml
+++ b/crates/rstest-bdd/Cargo.toml
@@ -39,7 +39,7 @@ cap-std.workspace = true
 insta.workspace = true
 rstest.workspace = true
 rstest-bdd-macros.workspace = true
-rstest-bdd-harness.workspace = true
+rstest-bdd-harness = { workspace = true, features = ["testing"] }
 trybuild.workspace = true
 proptest.workspace = true
 serial_test.workspace = true

--- a/crates/rstest-bdd/Cargo.toml
+++ b/crates/rstest-bdd/Cargo.toml
@@ -43,6 +43,7 @@ rstest-bdd-harness = { workspace = true, features = ["testing"] }
 trybuild.workspace = true
 proptest.workspace = true
 serial_test.workspace = true
+temp-env.workspace = true
 the-newtype = "0.1.1"
 tokio.workspace = true
 tempfile.workspace = true

--- a/crates/rstest-bdd/Cargo.toml
+++ b/crates/rstest-bdd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rstest-bdd"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/rstest-bdd/tests/fixtures_macros/scenario_harness_failing.rs
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenario_harness_failing.rs
@@ -1,22 +1,6 @@
 //! Compile-pass fixture validating generated delegation for harness failures.
-use rstest_bdd_harness::{
-    HarnessAdapter, HarnessError, HarnessResult, ScenarioRunRequest,
-};
+use rstest_bdd_harness::FailingHarness;
 use rstest_bdd_macros::{given, scenario, then, when};
-use std::io;
-
-#[derive(Default)]
-struct FailingHarness;
-
-impl HarnessAdapter for FailingHarness {
-    type Context = ();
-
-    fn run<T>(&self, _request: ScenarioRunRequest<'_, Self::Context, T>) -> HarnessResult<T> {
-        Err(HarnessError::RuntimeBuildFailed(io::Error::other(
-            "synthetic harness failure",
-        )))
-    }
-}
 
 #[given("a precondition")]
 fn precondition() {}

--- a/crates/rstest-bdd/tests/fixtures_macros/scenario_harness_invalid.stderr
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenario_harness_invalid.stderr
@@ -9,11 +9,16 @@ help: the trait `HarnessAdapter` is not implemented for `NotAHarness`
    |
  4 | struct NotAHarness;
    | ^^^^^^^^^^^^^^^^^^
-help: the trait `HarnessAdapter` is implemented for `StdHarness`
-  --> $WORKSPACE/crates/rstest-bdd-harness/src/std_harness.rs
+help: the following other types implement trait `HarnessAdapter`
+  --> $WORKSPACE/crates/rstest-bdd-harness/src/test_utils.rs
+   |
+   | impl crate::HarnessAdapter for FailingHarness {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `FailingHarness`
+   |
+  ::: $WORKSPACE/crates/rstest-bdd-harness/src/std_harness.rs
    |
    | impl HarnessAdapter for StdHarness {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `StdHarness`
 note: required by a bound in `__assert_harness`
   --> tests/fixtures_macros/scenario_harness_invalid.rs:15:1
    |

--- a/crates/rstest-bdd/tests/fixtures_macros/scenario_harness_invalid.stderr
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenario_harness_invalid.stderr
@@ -10,7 +10,7 @@ help: the trait `HarnessAdapter` is not implemented for `NotAHarness`
  4 | struct NotAHarness;
    | ^^^^^^^^^^^^^^^^^^
 help: the following other types implement trait `HarnessAdapter`
-  --> $WORKSPACE/crates/rstest-bdd-harness/src/test_utils.rs
+  --> $WORKSPACE/crates/rstest-bdd-harness/src/testing.rs
    |
    | impl crate::HarnessAdapter for FailingHarness {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `FailingHarness`

--- a/crates/rstest-bdd/tests/fixtures_macros/scenarios_harness_invalid.stderr
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenarios_harness_invalid.stderr
@@ -9,11 +9,16 @@ help: the trait `HarnessAdapter` is not implemented for `NotAHarness`
    |
  5 | struct NotAHarness;
    | ^^^^^^^^^^^^^^^^^^
-help: the trait `HarnessAdapter` is implemented for `StdHarness`
-  --> $WORKSPACE/crates/rstest-bdd-harness/src/std_harness.rs
+help: the following other types implement trait `HarnessAdapter`
+  --> $WORKSPACE/crates/rstest-bdd-harness/src/test_utils.rs
+   |
+   | impl crate::HarnessAdapter for FailingHarness {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `FailingHarness`
+   |
+  ::: $WORKSPACE/crates/rstest-bdd-harness/src/std_harness.rs
    |
    | impl HarnessAdapter for StdHarness {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `StdHarness`
 note: required by a bound in `auto_scenarios::_::__assert_harness`
   --> tests/fixtures_macros/scenarios_harness_invalid.rs:7:1
    |

--- a/crates/rstest-bdd/tests/fixtures_macros/scenarios_harness_invalid.stderr
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenarios_harness_invalid.stderr
@@ -10,7 +10,7 @@ help: the trait `HarnessAdapter` is not implemented for `NotAHarness`
  5 | struct NotAHarness;
    | ^^^^^^^^^^^^^^^^^^
 help: the following other types implement trait `HarnessAdapter`
-  --> $WORKSPACE/crates/rstest-bdd-harness/src/test_utils.rs
+  --> $WORKSPACE/crates/rstest-bdd-harness/src/testing.rs
    |
    | impl crate::HarnessAdapter for FailingHarness {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `FailingHarness`

--- a/crates/rstest-bdd/tests/scenario_harness.rs
+++ b/crates/rstest-bdd/tests/scenario_harness.rs
@@ -273,6 +273,8 @@ impl HarnessAdapter for StepContextInjectingHarness {
         }))
     }
 }
+
+#[given("harness context starts with {start}")]
 fn harness_context_starts_with(
     #[from(rstest_bdd_harness_context)] context: &HarnessCounterContext,
     start: usize,
@@ -336,8 +338,10 @@ fn harness_initialization_panic_includes_error_context() {
     let message = payload
         .downcast_ref::<&str>()
         .copied()
-        .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
-        .unwrap_or_else(|| panic!("expected panic payload to be a string"));
+        .or_else(|| payload.downcast_ref::<String>().map(String::as_str));
+    let Some(message) = message else {
+        panic!("expected panic payload to be a string");
+    };
     assert!(message.contains("harness failed to initialise scenario"));
     assert!(message.contains("synthetic harness initialisation failure"));
 }

--- a/crates/rstest-bdd/tests/scenario_harness.rs
+++ b/crates/rstest-bdd/tests/scenario_harness.rs
@@ -2,8 +2,8 @@
 //! `attributes` parameters and delegates execution through the harness adapter.
 
 use rstest_bdd_harness::{
-    HarnessAdapter, HarnessError, ScenarioMetadata, ScenarioRunRequest, StdScenarioRunRequest,
-    StdScenarioRunner,
+    FailingHarness, HarnessAdapter, HarnessError, ScenarioMetadata, ScenarioRunRequest,
+    StdScenarioRunRequest, StdScenarioRunner,
 };
 use rstest_bdd_macros::{given, scenario, then, when};
 use serial_test::serial;
@@ -273,21 +273,6 @@ impl HarnessAdapter for StepContextInjectingHarness {
         }))
     }
 }
-
-#[derive(Default)]
-struct FailingHarness;
-
-impl HarnessAdapter for FailingHarness {
-    type Context = ();
-
-    fn run<T>(&self, _request: StdScenarioRunRequest<'_, T>) -> Result<T, HarnessError> {
-        Err(HarnessError::RuntimeBuildFailed(std::io::Error::other(
-            "synthetic harness failure",
-        )))
-    }
-}
-
-#[given("harness context starts with {start}")]
 fn harness_context_starts_with(
     #[from(rstest_bdd_harness_context)] context: &HarnessCounterContext,
     start: usize,
@@ -341,7 +326,7 @@ fn harness_initialization_panic_includes_error_context() {
         );
 
         FailingHarness.run(request).unwrap_or_else(|err| {
-            panic!("harness failed to initialize scenario: {err}");
+            panic!("harness failed to initialise scenario: {err}");
         });
     }));
 
@@ -351,10 +336,8 @@ fn harness_initialization_panic_includes_error_context() {
     let message = payload
         .downcast_ref::<&str>()
         .copied()
-        .or_else(|| payload.downcast_ref::<String>().map(String::as_str));
-    let Some(message) = message else {
-        panic!("expected panic payload to be a string");
-    };
-    assert!(message.contains("harness failed to initialize scenario"));
-    assert!(message.contains("synthetic harness failure"));
+        .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+        .unwrap_or_else(|| panic!("expected panic payload to be a string"));
+    assert!(message.contains("harness failed to initialise scenario"));
+    assert!(message.contains("synthetic harness initialisation failure"));
 }

--- a/crates/rstest-bdd/tests/scenario_harness.rs
+++ b/crates/rstest-bdd/tests/scenario_harness.rs
@@ -328,7 +328,7 @@ fn harness_initialization_panic_includes_error_context() {
         );
 
         FailingHarness.run(request).unwrap_or_else(|err| {
-            panic!("harness failed to initialise scenario: {err}");
+            panic!("harness failed to initialize scenario: {err}");
         });
     }));
 
@@ -342,6 +342,6 @@ fn harness_initialization_panic_includes_error_context() {
     let Some(message) = message else {
         panic!("expected panic payload to be a string");
     };
-    assert!(message.contains("harness failed to initialise scenario"));
-    assert!(message.contains("synthetic harness initialisation failure"));
+    assert!(message.contains("harness failed to initialize scenario"));
+    assert!(message.contains("synthetic harness initialization failure"));
 }

--- a/crates/rstest-bdd/tests/trybuild_macros.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros.rs
@@ -43,17 +43,28 @@ fn step_macros_compile() {
     if env::var_os("NEXTEST_RUN_ID").is_some() {
         return;
     }
-    let t = trybuild::TestCases::new();
+    // Prevent RUST_BACKTRACE from contaminating compiler diagnostic output.
+    // Trybuild snapshots are compared verbatim; CI's `RUST_BACKTRACE=short`
+    // injects backtrace fragments on Windows MSVC that diverge from the
+    // Linux-generated snapshots. Trybuild tests are about structured
+    // diagnostics, not runtime backtraces.
+    //
+    // `std::env::remove_var` is unsafe from Rust 1.87 onward, and this
+    // workspace forbids unsafe code. `temp_env` provides the same scoped
+    // mutation without weakening that lint.
+    temp_env::with_var_unset("RUST_BACKTRACE", || {
+        let t = trybuild::TestCases::new();
 
-    run_passing_macro_tests(&t);
-    run_failing_macro_tests(&t);
-    run_failing_ui_tests(&t);
-    run_lint_ui_tests();
-    t.compile_fail(
-        macros_fixture(MacroFixtureCase::from("scenarios_missing_dir.rs")).as_std_path(),
-    );
-    run_conditional_ordering_tests(&t);
-    run_conditional_ambiguous_step_test(&t);
+        run_passing_macro_tests(&t);
+        run_failing_macro_tests(&t);
+        run_failing_ui_tests(&t);
+        run_lint_ui_tests();
+        t.compile_fail(
+            macros_fixture(MacroFixtureCase::from("scenarios_missing_dir.rs")).as_std_path(),
+        );
+        run_conditional_ordering_tests(&t);
+        run_conditional_ambiguous_step_test(&t);
+    });
 }
 
 fn run_passing_macro_tests(t: &trybuild::TestCases) {

--- a/crates/rstest-bdd/tests/trybuild_macros.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros.rs
@@ -49,9 +49,9 @@ fn step_macros_compile() {
     // Linux-generated snapshots. Trybuild tests are about structured
     // diagnostics, not runtime backtraces.
     //
-    // `std::env::remove_var` is unsafe from Rust 1.87 onward, and this
-    // workspace forbids unsafe code. `temp_env` provides the same scoped
-    // mutation without weakening that lint.
+    // Rust 2024 makes `std::env::remove_var` unsafe; Rust 1.85.0 is the first
+    // release supporting that edition. This workspace forbids unsafe code, so
+    // `temp_env` provides the same scoped mutation without weakening that lint.
     temp_env::with_var_unset("RUST_BACKTRACE", || {
         let t = trybuild::TestCases::new();
 

--- a/crates/rstest-bdd/tests/trybuild_macros.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros.rs
@@ -39,9 +39,9 @@ fn ui_fixture(case: impl Into<UiFixtureCase>) -> Utf8PathBuf {
 }
 
 #[test]
-fn step_macros_compile() {
+fn step_macros_compile() -> io::Result<()> {
     if env::var_os("NEXTEST_RUN_ID").is_some() {
-        return;
+        return Ok(());
     }
     // Prevent RUST_BACKTRACE from contaminating compiler diagnostic output.
     // Trybuild snapshots are compared verbatim; CI's `RUST_BACKTRACE=short`
@@ -58,13 +58,14 @@ fn step_macros_compile() {
         run_passing_macro_tests(&t);
         run_failing_macro_tests(&t);
         run_failing_ui_tests(&t);
-        run_lint_ui_tests();
+        run_lint_ui_tests()?;
         t.compile_fail(
             macros_fixture(MacroFixtureCase::from("scenarios_missing_dir.rs")).as_std_path(),
         );
         run_conditional_ordering_tests(&t);
         run_conditional_ambiguous_step_test(&t);
-    });
+        Ok(())
+    })
 }
 
 fn run_passing_macro_tests(t: &trybuild::TestCases) {
@@ -144,7 +145,7 @@ fn run_failing_ui_tests(t: &trybuild::TestCases) {
     }
 }
 
-fn run_lint_ui_tests() {
+fn run_lint_ui_tests() -> io::Result<()> {
     let cases = [
         (
             "scenario_unused_fixture_param",
@@ -157,18 +158,20 @@ fn run_lint_ui_tests() {
     ];
 
     for (bin, lint_args) in cases {
-        run_lint_ui_case(bin, lint_args);
+        run_lint_ui_case(bin, lint_args)?;
     }
+
+    Ok(())
 }
 
-fn run_lint_ui_case(bin: &str, lint_args: &[&str]) {
+fn run_lint_ui_case(bin: &str, lint_args: &[&str]) -> io::Result<()> {
     let manifest_dir = Utf8Path::new(env!("CARGO_MANIFEST_DIR"));
     let manifest_path = manifest_dir.join("tests/ui_lints/Cargo.toml");
     // Keep lint runs isolated from the workspace target directory to avoid
     // artefact/cache conflicts and cross-test contamination; this makes
     // per-bin `cargo clippy` checks deterministic.
     let target_dir = manifest_dir.join("target/tests/ui_lints_clippy");
-    let output = match Command::new("cargo")
+    let output = Command::new("cargo")
         .current_dir(manifest_dir.as_std_path())
         .env("CARGO_TARGET_DIR", target_dir.as_str())
         .arg("clippy")
@@ -179,11 +182,7 @@ fn run_lint_ui_case(bin: &str, lint_args: &[&str]) {
         .arg(bin)
         .arg("--")
         .args(lint_args)
-        .output()
-    {
-        Ok(output) => output,
-        Err(err) => panic!("failed to run cargo clippy for {bin}: {err}"),
-    };
+        .output()?;
 
     if !output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);
@@ -193,6 +192,8 @@ fn run_lint_ui_case(bin: &str, lint_args: &[&str]) {
             output.status, stdout, stderr
         );
     }
+
+    Ok(())
 }
 
 #[expect(

--- a/crates/rstest-bdd/tests/trybuild_macros.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros.rs
@@ -40,7 +40,15 @@ fn ui_fixture(case: impl Into<UiFixtureCase>) -> Utf8PathBuf {
 
 #[test]
 fn step_macros_compile() -> io::Result<()> {
-    if env::var_os("NEXTEST_RUN_ID").is_some() {
+    // This test spawns `cargo` (through `trybuild` and `cargo clippy`). On
+    // Windows, nextest wraps test binaries in Job Objects and those child
+    // processes inherit the write end of nextest's capture pipe, which never
+    // closes; see "nextest on Windows: trybuild deadlock" in
+    // `docs/developers-guide.md`. Skip only on that platform combination so
+    // the fixtures still run under nextest everywhere else. The
+    // `rstest-bdd::trybuild_macros` test group in `.config/nextest.toml`
+    // keeps this binary from running alongside other cargo-spawning tests.
+    if cfg!(windows) && env::var_os("NEXTEST_RUN_ID").is_some() {
         return Ok(());
     }
     // Prevent RUST_BACKTRACE from contaminating compiler diagnostic output.

--- a/crates/rstest-bdd/tests/ui_lints/Cargo.lock
+++ b/crates/rstest-bdd/tests/ui_lints/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -43,24 +43,24 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "camino"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
+checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
 dependencies = [
  "serde_core",
 ]
@@ -126,6 +126,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,21 +148,20 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -166,7 +171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -179,28 +184,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -270,7 +276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54f0d287c53ffd184d04d8677f590f4ac5379785529e5e08b1c8083acdd5c198"
 dependencies = [
  "memchr",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -292,26 +298,26 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-timer"
@@ -321,25 +327,15 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -353,7 +349,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.118",
+ "syn 2.0.119",
  "textwrap",
  "thiserror 1.0.69",
  "typed-builder",
@@ -361,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "hashbrown"
@@ -387,6 +383,15 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "i18n-config"
@@ -432,7 +437,7 @@ dependencies = [
  "i18n-config",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -491,9 +496,9 @@ checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "itoa"
@@ -503,9 +508,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -536,9 +541,25 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "newt-hype"
@@ -649,18 +670,18 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -676,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -688,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -722,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "rstest-bdd"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 dependencies = [
  "ctor",
  "derive_more",
@@ -738,22 +759,22 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "unic-langid",
 ]
 
 [[package]]
 name = "rstest-bdd-harness"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 dependencies = [
  "cargo_metadata",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "rstest-bdd-macros"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 dependencies = [
  "camino",
  "cap-std",
@@ -769,23 +790,23 @@ dependencies = [
  "rstest-bdd-harness",
  "rstest-bdd-patterns",
  "rstest-bdd-policy",
- "syn 2.0.118",
- "thiserror 2.0.18",
+ "syn 2.0.119",
+ "thiserror 2.0.19",
  "walkdir",
 ]
 
 [[package]]
 name = "rstest-bdd-patterns"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 dependencies = [
  "gherkin",
  "regex",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "rstest-bdd-policy"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 
 [[package]]
 name = "rstest-bdd-ui-lints"
@@ -810,15 +831,15 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
  "unicode-ident",
 ]
 
 [[package]]
 name = "rust-embed"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -827,22 +848,23 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
 dependencies = [
+ "mime_guess",
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.118",
+ "syn 2.0.119",
  "walkdir",
 ]
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
 dependencies = [
  "sha2",
  "walkdir",
@@ -909,9 +931,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "self_cell"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "semver"
@@ -925,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -935,29 +957,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -968,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1007,9 +1029,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1047,11 +1080,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -1062,18 +1095,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1107,9 +1140,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1119,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
@@ -1145,7 +1178,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1183,7 +1216,7 @@ checksum = "29a3151c41d0b13e3d011f98adc24434560ef06673a155a6c7f66b9879eecce2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1232,9 +1265,15 @@ checksum = "a1249a628de3ad34b821ecb1001355bca3940bcb2f88558f1a8bd82e977f75b5"
 dependencies = [
  "proc-macro-hack",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "unic-langid-impl",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -1375,9 +1414,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -1410,6 +1449,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1227,9 +1227,11 @@ When maintaining the pin:
 Do not replace invariant checks with `.expect(...)`, `.unwrap()`, or
 `unwrap_or_else(|| panic!(...))`. Use a copyable invariant check such as
 `let Some(value) = value else { panic!("expected value to be present"); };`,
-or return `Result` and use `?` where the failure is part of the tested domain
-behaviour. Fixture functions and test helpers are not tests: they must return
-`Result` and propagate errors rather than calling `.expect(...)`, and shared
+or return `Result` and use `?` when an operation is fallible. Fixture functions
+and test helpers that perform fallible operations must return `Result` and
+propagate errors with `?`; infallible helpers need not introduce an artificial
+`Result` type. Shared helpers should avoid `.expect(...)` for invariant checks
+and instead use explicit, context-appropriate invariant handling. Shared
 assertion shapes belong in macros so panic line numbers point at the calling
 test.
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -152,13 +152,16 @@ The file sets the timeout policy for the test suite:
 - A `[[profile.default.overrides]]` entry raises the `slow-timeout` to 180 s
   for `cargo-bdd::cli`, whose smoke tests spawn `cargo` to build fixture crates
   and can legitimately exceed 60 s on cold caches.
-- A second override applies the same 180 s `slow-timeout` to the
+- A second override raises the `slow-timeout` further, to 300 s, for the
   trybuild-based compile-test binaries:
   `rstest-bdd-harness-tokio::macro_compile`,
   `rstest-bdd-harness-gpui::macro_compile`, and `rstest-bdd::trybuild_macros`.
   These tests invoke `cargo build` against a large dependency tree, so a cold
   cache (or CPU contention when several compile tests run concurrently) can
   push a single test well past the default limit even though nothing is wrong.
+- Both overrides also place their binaries in a `cargo-spawning` test group
+  (`max-threads = 1`), so `cargo-bdd::cli` and the three trybuild binaries run
+  one at a time instead of contending for CPU with concurrent `cargo` builds.
 - A `long` profile (`--profile long`) relaxes the limits further (180 s
   `slow-timeout`, 15 m `global-timeout`) for deliberately slow local runs.
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -386,12 +386,12 @@ The GPUI `harness_led_defaults` happy-path scenario is gated by
 suite. Its failing-harness error-path scenario does not require the native GPUI
 runtime and runs without the feature gate.
 
-The `Failing harness initialisation propagates` scenario's panic assertion is
+The `Failing harness initialization propagates` scenario's panic assertion is
 de-duplicated for harness integration coverage: the shared scenario assertion
 macro lives under `crates/rstest-bdd-harness/tests/support/` and is included
 from both `harness_led_defaults.rs` test binaries (Tokio and GPUI) to keep
 runtime-error-path assertions aligned. The guard step remains local to each
-test binary so the `#[scenario]` macro can discover it from the test source.
+test binary, so the `#[scenario]` macro can discover it from the test source.
 
 ### Bulk-migration cookbook reference suite
 
@@ -1207,12 +1207,13 @@ When maintaining the pin:
 3. Update ADR-013 only if the mechanism or adopted lint set changes.
 
 Do not replace invariant checks with `.expect(...)`, `.unwrap()`, or
-`unwrap_or_else(|| panic!(…))`. Use `let … else { panic!(…) }` for invariant
-panics, or return `Result` and use `?` where the failure is part of the tested
-domain behaviour. Fixture functions and test helpers are not tests: they must
-return `Result` and propagate errors rather than calling `.expect(...)`, and
-shared assertion shapes belong in macros so panic line numbers point at the
-calling test.
+`unwrap_or_else(|| panic!(...))`. Use a copyable invariant check such as
+`let Some(value) = value else { panic!("expected value to be present"); };`,
+or return `Result` and use `?` where the failure is part of the tested domain
+behaviour. Fixture functions and test helpers are not tests: they must return
+`Result` and propagate errors rather than calling `.expect(...)`, and shared
+assertion shapes belong in macros so panic line numbers point at the calling
+test.
 
 ## Step-return overrides and `InsertOutcome` (ADR-015)
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -205,10 +205,20 @@ Mitigation:
 - Continuous Integration (CI) sets `use-nextest: false` for all Windows
   matrix legs (see `.github/workflows/ci.yml`). Windows coverage runs use
   `cargo llvm-cov test` (libtest) instead.
+- `step_macros_compile` (`crates/rstest-bdd/tests/trybuild_macros.rs`) guards
+  its early return with `cfg!(windows) && env::var_os("NEXTEST_RUN_ID")`, so
+  it only skips its trybuild and Clippy UI fixtures under nextest on Windows,
+  where this deadlock applies. On Linux and macOS the fixtures run under
+  nextest like any other test.
 - `.config/nextest.toml` raises the `slow-timeout` for the trybuild
-  compile-test binaries (including both `macro_compile` binaries) to 180 s as a
-  local-development safety net. This does not fix the deadlock; it only delays
-  termination to allow the build to complete on fast machines.
+  compile-test binaries (including both `macro_compile` binaries and
+  `rstest-bdd::trybuild_macros`) to 300 s as a local-development safety net.
+  This does not fix the deadlock; it only delays termination to allow the
+  build to complete on fast machines.
+- `.config/nextest.toml` also places the `cargo-bdd::cli` and trybuild
+  binaries in a `cargo-spawning` test group with `max-threads = 1`, so these
+  cargo-spawning tests run one at a time rather than contending for the
+  package-cache lock and build parallelism.
 - Do not add `macro_compile`-style tests (tests that spawn `cargo` via
   `trybuild` or `cargo_metadata`) to nextest-managed binaries intended to run
   on Windows.
@@ -397,7 +407,18 @@ test binary, so the `#[scenario]` macro can discover it from the test source.
 `testing` feature is enabled. This dependency-facing test API always returns a
 synthetic `HarnessError::RuntimeBuildFailed`, allowing adapter crates to share
 the generated scenario error-path assertions without duplicating a failing
-adapter. Enable it only for tests:
+adapter. `rstest-bdd-harness`'s own test targets (for example
+`tests/harness_behaviour.rs`) reach it through a self dev-dependency in its
+`Cargo.toml`:
+
+```toml
+[dev-dependencies]
+rstest-bdd-harness = { path = ".", features = ["testing"] }
+```
+
+This keeps `FailingHarness` defined once, with no local duplicate in the
+test binary, and works without requiring `--all-features`. Downstream crates
+enable it only for tests:
 
 ```toml
 [dev-dependencies]
@@ -423,11 +444,11 @@ that "zero steps in the binding" property is the reuse proof and must be
 preserved. A trybuild compile-pass mirror,
 `tests/fixtures_macros/scenario_bulk_migration_cookbook.rs`, compile-checks the
 same shape and is registered in `run_passing_macro_tests`
-(`tests/trybuild_macros.rs`). Because `step_macros_compile` returns early when
-`NEXTEST_RUN_ID` is set, this fixture is skipped under nextest and must be
-validated with plain `cargo test`. (This is specific to `step_macros_compile`;
-the harness `macro_compile` binaries have no such guard and do run their
-trybuild fixtures under nextest.)
+(`tests/trybuild_macros.rs`). `step_macros_compile` runs this fixture under
+nextest on Linux and macOS; it is skipped only under nextest on Windows,
+where the Job Object capture-pipe deadlock applies (see "nextest on Windows:
+trybuild deadlock" above), and must instead be validated with plain
+`cargo test` (or `cargo llvm-cov test` for coverage).
 
 Doc↔suite parity for this cookbook is guarded by prose, not a checker (the
 subsection states "if a snippet drifts, the suite wins"), matching the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -128,8 +128,8 @@ and promotes every Rustdoc warning to an error. `--workspace` checks every
 member crate, while `--no-deps` keeps the gate focused on documentation owned
 by this repository.
 
-`make test` separately compiles and runs documentation examples across every
-workspace crate and feature combination with:
+`make test` separately compiles and runs documentation examples for every
+workspace crate with all features enabled:
 
 ```makefile
 RUSTFLAGS="$(RUST_FLAGS)" $(CARGO) test --doc --workspace --all-features $(BUILD_JOBS)

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -234,7 +234,10 @@ than relative paths. `scripts/check_users_guide_links.py`, run automatically by
 - The check also fails if the guide contains no repository references at
   all, so a reformat cannot silently defang it.
 
-Non-repository URLs (for example docs.rs links) are ignored.
+Non-repository URLs (for example docs.rs links) are ignored. Unit tests live in
+`scripts/tests/test_check_users_guide_links.py` and run with the Python suite in
+`make test`. Issue #537 tracks generating the reference block from `BASE_URL`
+so the base lives in exactly one place.
 
 ### Running the checker
 
@@ -364,10 +367,12 @@ Table: Test binaries for `rstest-bdd-harness-tokio` and
 | `rstest-bdd-harness-tokio` | `harness_behaviour`          | Tokio harness adapter execution semantics                            |
 | `rstest-bdd-harness-tokio` | `attribute_policy_behaviour` | Tokio attribute policy output                                        |
 | `rstest-bdd-harness-tokio` | `scenario_macros`            | `#[scenario]` + Tokio adapter                                        |
+| `rstest-bdd-harness-tokio` | `harness_led_defaults`       | harness-led default inference and runtime error paths                |
 | `rstest-bdd-harness-tokio` | `macro_compile`              | trybuild compile-pass/fail for Tokio fixtures                        |
 | `rstest-bdd-harness-gpui`  | `harness_behaviour`          | GPUI harness adapter execution semantics (feature-gated)             |
 | `rstest-bdd-harness-gpui`  | `attribute_policy_behaviour` | GPUI attribute policy output (feature-gated)                         |
 | `rstest-bdd-harness-gpui`  | `scenario_macros`            | `#[scenario]` + GPUI adapter (feature-gated)                         |
+| `rstest-bdd-harness-gpui`  | `harness_led_defaults`       | harness-led default inference and runtime error paths                |
 | `rstest-bdd-harness-gpui`  | `stateful_window`            | durable GPUI handles + visual context reconstruction (feature-gated) |
 | `rstest-bdd-harness-gpui`  | `scenario_name_in_logs`      | GPUI step-panic diagnostics include scenario context (feature-gated) |
 | `rstest-bdd-harness-gpui`  | `macro_compile`              | trybuild compile-pass for GPUI fixtures (feature-gated)              |
@@ -375,6 +380,11 @@ Table: Test binaries for `rstest-bdd-harness-tokio` and
 These tests were moved out of `rstest-bdd` in this release to decouple the core
 crate from Tokio and GPUI dev-dependencies, making it publishable to crates.io
 without carrying those dependencies.
+
+The GPUI `harness_led_defaults` happy-path scenario is gated by
+`native-gpui-tests` and uses `#[serial]`, matching the native GPUI runtime
+suite. Its failing-harness error-path scenario does not require the native GPUI
+runtime and runs without the feature gate.
 
 ### Bulk-migration cookbook reference suite
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -393,6 +393,24 @@ from both `harness_led_defaults.rs` test binaries (Tokio and GPUI) to keep
 runtime-error-path assertions aligned. The guard step remains local to each
 test binary, so the `#[scenario]` macro can discover it from the test source.
 
+`rstest-bdd-harness` exposes `FailingHarness` from its crate root when its
+`testing` feature is enabled. This dependency-facing test API always returns a
+synthetic `HarnessError::RuntimeBuildFailed`, allowing adapter crates to share
+the generated scenario error-path assertions without duplicating a failing
+adapter. Enable it only for tests:
+
+```toml
+[dev-dependencies]
+rstest-bdd-harness = { workspace = true, features = ["testing"] }
+```
+
+The core macro trybuild test scopes `RUST_BACKTRACE` removal with
+`temp_env::with_var_unset`. Trybuild compares compiler diagnostics verbatim,
+and CI's inherited backtrace setting otherwise adds platform-specific output.
+Keep `temp-env` available as a dev-dependency when building this test target;
+direct environment mutation is unsafe under Rust 2024 and would violate the
+workspace's unsafe-code policy.
+
 ### Bulk-migration cookbook reference suite
 
 The user guide's "Bulk-migration cookbook" subsection is backed by a

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -386,6 +386,13 @@ The GPUI `harness_led_defaults` happy-path scenario is gated by
 suite. Its failing-harness error-path scenario does not require the native GPUI
 runtime and runs without the feature gate.
 
+The `Failing harness initialisation propagates` scenario's panic assertion is
+de-duplicated for harness integration coverage: the shared scenario assertion
+macro lives under `crates/rstest-bdd-harness/tests/support/` and is included
+from both `harness_led_defaults.rs` test binaries (Tokio and GPUI) to keep
+runtime-error-path assertions aligned. The guard step remains local to each
+test binary so the `#[scenario]` macro can discover it from the test source.
+
 ### Bulk-migration cookbook reference suite
 
 The user guide's "Bulk-migration cookbook" subsection is backed by a

--- a/docs/execplans/10-1-4-failing-gpui-scenarios-include-scenario-name-in-logs.md
+++ b/docs/execplans/10-1-4-failing-gpui-scenarios-include-scenario-name-in-logs.md
@@ -679,9 +679,9 @@ If a future refactor moves any helper into
 The change relies on the following existing public surfaces, which are not
 modified:
 
-- `gpui::run_test` — vendored shim signature unchanged.
-- `rstest_bdd_harness::ScenarioMetadata` getters — `feature_path`,
-  `scenario_name`, and `scenario_line` remain unchanged.
+- `gpui::run_test(...)` — vendored shim signature unchanged.
+- `rstest_bdd_harness::ScenarioMetadata` getter accessors remain unchanged:
+  `feature_path`, `scenario_name`, and `scenario_line`.
 - `rstest_bdd_harness::HarnessAdapter::run` — `GpuiHarness`'s
   implementation continues to return `HarnessResult<T>` for the success path
   and propagate via `panic::resume_unwind` for the failure path.

--- a/docs/execplans/9-2-2-delegate-scenario-execution-to-harness.md
+++ b/docs/execplans/9-2-2-delegate-scenario-execution-to-harness.md
@@ -298,8 +298,9 @@ The harness crate (`crates/rstest-bdd-harness/`) provides:
   `Box<dyn FnOnce() -> T + 'a>`; constructed via `ScenarioRunner::new(closure)`.
 - `ScenarioRunRequest<'a, T>` (`src/runner.rs`): bundles `ScenarioMetadata` +
   `ScenarioRunner`; constructed via `ScenarioRunRequest::new(metadata, runner)`.
-- `ScenarioMetadata` (`src/runner.rs`): `new` stores the feature path,
-  scenario name, scenario line, and tags.
+- `ScenarioMetadata` (`src/runner.rs`):
+  constructed via `ScenarioMetadata::new(...)` with feature path, scenario
+  name, scenario line, and tags.
 - `StdHarness` (`src/std_harness.rs`): `#[derive(Default)]`, implements
   `HarnessAdapter` by calling `request.run()` directly.
 

--- a/docs/execplans/9-7-3-comprehensive-test-coverage-for-harness-led-defaults.md
+++ b/docs/execplans/9-7-3-comprehensive-test-coverage-for-harness-led-defaults.md
@@ -21,13 +21,16 @@ first-party harness choices can imply their matching first-party test
 attributes when `attributes = ...` is omitted.
 
 After this work is implemented, maintainers can change the macro code with
-confidence because the test suite will prove four observable behaviours:
+confidence because the test suite will prove these observable behaviours:
 
 - harness-only Tokio and GPUI scenarios receive first-party test attributes
   when the generated function signature permits those attributes;
 - explicit `attributes = ...` overrides beat any harness-led default;
-- `attributes`-only scenarios keep their existing behaviour; and
-- unknown third-party harness paths do not infer first-party defaults.
+- `attributes`-only scenarios keep their existing behaviour;
+- unknown third-party harness paths do not infer first-party defaults;
+- harness initialisation errors propagate before any step function runs; and
+- harness-dependent steps fail loudly when a scenario supplies only an
+  attribute policy.
 
 The work is deliberately coverage-focused. The current documentation already
 describes harness-led defaults, and roadmap item 9.7.4 is the dedicated
@@ -420,7 +423,12 @@ harness-path negatives. Trybuild coverage now exercises explicit default-policy
 overrides and Tokio attributes-only expansion in the first-party harness
 crates. Behavioural coverage now proves Tokio attributes-only runtime
 availability plus explicit default-policy overrides for Tokio and GPUI
-harness-led scenarios.
+harness-led scenarios. Issue #498 follow-up coverage adds unconditional runtime
+integration binaries for Tokio and GPUI harness-led defaults: async happy-path
+steps exercise inferred first-party policy selection, failing harnesses prove
+`HarnessAdapter::run` errors surface before step execution, and a Tokio
+policy-only mismatch proves harness-dependent `spawn_local` steps fail loudly
+instead of passing silently.
 
 Focused validation passed for policy and macro unit tests, Tokio and GPUI
 trybuild suites, and Tokio and GPUI behavioural suites. Final repository gates

--- a/docs/execplans/9-7-3-comprehensive-test-coverage-for-harness-led-defaults.md
+++ b/docs/execplans/9-7-3-comprehensive-test-coverage-for-harness-led-defaults.md
@@ -28,7 +28,7 @@ confidence because the test suite will prove these observable behaviours:
 - explicit `attributes = ...` overrides beat any harness-led default;
 - `attributes`-only scenarios keep their existing behaviour;
 - unknown third-party harness paths do not infer first-party defaults;
-- harness initialisation errors propagate before any step function runs; and
+- harness initialization errors propagate before any step function runs; and
 - harness-dependent steps fail loudly when a scenario supplies only an
   attribute policy.
 

--- a/docs/execplans/9-7-3-comprehensive-test-coverage-for-harness-led-defaults.md
+++ b/docs/execplans/9-7-3-comprehensive-test-coverage-for-harness-led-defaults.md
@@ -424,8 +424,10 @@ overrides and Tokio attributes-only expansion in the first-party harness
 crates. Behavioural coverage now proves Tokio attributes-only runtime
 availability plus explicit default-policy overrides for Tokio and GPUI
 harness-led scenarios. Issue #498 follow-up coverage adds unconditional runtime
-integration binaries for Tokio and GPUI harness-led defaults: async happy-path
-steps exercise inferred first-party policy selection, failing harnesses prove
+integration binaries for Tokio and GPUI harness-led defaults: synchronous BDD
+steps exercise inferred first-party policy selection, reflecting the
+single-poll runner constraint. Standalone unit tests cover awaiting task
+completion and cancellation behaviour. Failing harnesses prove
 `HarnessAdapter::run` errors surface before step execution, and a Tokio
 policy-only mismatch proves harness-dependent `spawn_local` steps fail loudly
 instead of passing silently.

--- a/docs/execplans/adr-008-harness-led-attribute-policy-defaults.md
+++ b/docs/execplans/adr-008-harness-led-attribute-policy-defaults.md
@@ -21,15 +21,31 @@ documentation path:
 ```rust,no_run
 # use rstest_bdd_macros::scenario;
 #[scenario(
-    path = "tests/features/my_async.feature",
-    harness = rstest_bdd_harness_tokio::TokioHarness,
+    path = "tests/features/my_ui.feature",
+    harness = rstest_bdd_harness_gpui::GpuiHarness,
 )]
-fn my_tokio_scenario() {}
+fn my_gpui_scenario() {}
 ```
 
-and:
+Explicit `attributes = ...` remains authoritative, `attributes`-only
+configuration remains supported, and unknown third-party harnesses must still
+fall back to explicit policy selection rather than pretending the macro can
+infer arbitrary defaults.
 
-```rust,no_run
+Success is observable in three ways:
+
+1. Unit tests prove the exact precedence order from ADR-008:
+   explicit `attributes` override, known first-party harness defaults come
+   next, the deprecated Tokio runtime alias remains below explicit harness
+   selection, and the final fallback is the existing runtime-mode or
+   synchronous behaviour.
+2. Public-macro coverage proves the harness-only first-party forms compile and
+   run for both `#[scenario]` and `scenarios!`, while explicit override cases
+   still behave correctly.
+3. `docs/users-guide.md` clearly teaches harness-led defaults as the normal
+   first-party configuration and still documents `attributes = ...` as the
+   override and third-party escape hatch.
+
 # use rstest_bdd_macros::scenario;
 #[scenario(
     path = "tests/features/my_ui.feature",
@@ -425,11 +441,12 @@ Implementation details:
 
 Go/no-go validation:
 
-- The `trybuild_macros step_macros_compile -- --exact` suite passes with
+- `cargo test -p rstest-bdd --test trybuild_macros step_macros_compile -- --exact`
+  passes with `RUSTFLAGS="-D warnings"`.
+- `cargo test -p rstest-bdd --test scenario_harness_tokio` passes with
   `RUSTFLAGS="-D warnings"`.
-- The `scenario_harness_tokio` suite passes with `RUSTFLAGS="-D warnings"`.
-- The `scenario_harness_gpui --features gpui-harness-tests` suite passes with
-  `RUSTFLAGS="-D warnings"`.
+- `cargo test -p rstest-bdd --test scenario_harness_gpui --features gpui-harness-tests`
+  passes with `RUSTFLAGS="-D warnings"`.
 
 ### Stage D: update the user guide and design doc
 

--- a/docs/execplans/adr-008-harness-led-attribute-policy-defaults.md
+++ b/docs/execplans/adr-008-harness-led-attribute-policy-defaults.md
@@ -504,24 +504,25 @@ Goal: prove the repository is in a releasable state after the change.
 Run these commands and inspect the logs before closing the work:
 
 ```bash
-set -o pipefail; cargo test -p rstest-bdd-policy 2>&1 | tee /tmp/adr-008-policy.log
-set -o pipefail; cargo test -p rstest-bdd-macros --lib 2>&1 | tee /tmp/adr-008-macros.log
-set -o pipefail; RUSTFLAGS="-D warnings" cargo test -p rstest-bdd \
+set -euo pipefail
+cargo test -p rstest-bdd-policy 2>&1 | tee /tmp/adr-008-policy.log
+cargo test -p rstest-bdd-macros --lib 2>&1 | tee /tmp/adr-008-macros.log
+RUSTFLAGS="-D warnings" cargo test -p rstest-bdd \
   --test trybuild_macros step_macros_compile -- --exact 2>&1 | \
   tee /tmp/adr-008-trybuild.log
-set -o pipefail; RUSTFLAGS="-D warnings" cargo test \
+RUSTFLAGS="-D warnings" cargo test \
   -p rstest-bdd-harness-tokio --test harness_led_defaults 2>&1 | \
   tee /tmp/adr-008-tokio.log
-set -o pipefail; RUSTFLAGS="-D warnings" cargo test \
+RUSTFLAGS="-D warnings" cargo test \
   -p rstest-bdd-harness-gpui --test harness_led_defaults \
   --features native-gpui-tests 2>&1 | \
   tee /tmp/adr-008-gpui.log
-set -o pipefail; make fmt 2>&1 | tee /tmp/adr-008-make-fmt.log
-set -o pipefail; make markdownlint 2>&1 | tee /tmp/adr-008-make-markdownlint.log
-set -o pipefail; make nixie 2>&1 | tee /tmp/adr-008-make-nixie.log
-set -o pipefail; make check-fmt 2>&1 | tee /tmp/adr-008-make-check-fmt.log
-set -o pipefail; make lint 2>&1 | tee /tmp/adr-008-make-lint.log
-set -o pipefail; make test 2>&1 | tee /tmp/adr-008-make-test.log
+make fmt 2>&1 | tee /tmp/adr-008-make-fmt.log
+make markdownlint 2>&1 | tee /tmp/adr-008-make-markdownlint.log
+make nixie 2>&1 | tee /tmp/adr-008-make-nixie.log
+make check-fmt 2>&1 | tee /tmp/adr-008-make-check-fmt.log
+make lint 2>&1 | tee /tmp/adr-008-make-lint.log
+make test 2>&1 | tee /tmp/adr-008-make-test.log
 ```
 
 If `make fmt`, `make check-fmt`, `make lint`, or `make test` fails because

--- a/docs/execplans/adr-008-harness-led-attribute-policy-defaults.md
+++ b/docs/execplans/adr-008-harness-led-attribute-policy-defaults.md
@@ -444,10 +444,22 @@ Go/no-go validation:
 
 - `cargo test -p rstest-bdd --test trybuild_macros step_macros_compile -- --exact`
   passes with `RUSTFLAGS="-D warnings"`.
-- `cargo test -p rstest-bdd --test scenario_harness_tokio` passes with
-  `RUSTFLAGS="-D warnings"`.
-- `cargo test -p rstest-bdd --test scenario_harness_gpui --features gpui-harness-tests`
-  passes with `RUSTFLAGS="-D warnings"`.
+- The Tokio harness-led defaults test passes:
+
+  ```sh
+  RUSTFLAGS="-D warnings" cargo test \
+    -p rstest-bdd-harness-tokio \
+    --test harness_led_defaults
+  ```
+
+- The GPUI harness-led defaults test passes:
+
+  ```sh
+  RUSTFLAGS="-D warnings" cargo test \
+    -p rstest-bdd-harness-gpui \
+    --test harness_led_defaults \
+    --features native-gpui-tests
+  ```
 
 ### Stage D: update the user guide and design doc
 

--- a/docs/execplans/adr-008-harness-led-attribute-policy-defaults.md
+++ b/docs/execplans/adr-008-harness-led-attribute-policy-defaults.md
@@ -19,7 +19,7 @@ the normal emitted test attributes. These forms should work as the preferred
 documentation path:
 
 ```rust,no_run
-# use rstest_bdd_macros::scenario;
+use rstest_bdd_macros::scenario;
 #[scenario(
     path = "tests/features/my_ui.feature",
     harness = rstest_bdd_harness_gpui::GpuiHarness,
@@ -46,6 +46,7 @@ Success is observable in three ways:
    first-party configuration and still documents `attributes = ...` as the
    override and third-party escape hatch.
 
+```rust,no_run
 # use rstest_bdd_macros::scenario;
 #[scenario(
     path = "tests/features/my_ui.feature",

--- a/docs/execplans/adr-008-harness-led-attribute-policy-defaults.md
+++ b/docs/execplans/adr-008-harness-led-attribute-policy-defaults.md
@@ -503,10 +503,12 @@ set -o pipefail; cargo test -p rstest-bdd-macros --lib 2>&1 | tee /tmp/adr-008-m
 set -o pipefail; RUSTFLAGS="-D warnings" cargo test -p rstest-bdd \
   --test trybuild_macros step_macros_compile -- --exact 2>&1 | \
   tee /tmp/adr-008-trybuild.log
-set -o pipefail; RUSTFLAGS="-D warnings" cargo test -p rstest-bdd \
-  --test scenario_harness_tokio 2>&1 | tee /tmp/adr-008-tokio.log
-set -o pipefail; RUSTFLAGS="-D warnings" cargo test -p rstest-bdd \
-  --test scenario_harness_gpui --features gpui-harness-tests 2>&1 | \
+set -o pipefail; RUSTFLAGS="-D warnings" cargo test \
+  -p rstest-bdd-harness-tokio --test harness_led_defaults 2>&1 | \
+  tee /tmp/adr-008-tokio.log
+set -o pipefail; RUSTFLAGS="-D warnings" cargo test \
+  -p rstest-bdd-harness-gpui --test harness_led_defaults \
+  --features native-gpui-tests 2>&1 | \
   tee /tmp/adr-008-gpui.log
 set -o pipefail; make fmt 2>&1 | tee /tmp/adr-008-make-fmt.log
 set -o pipefail; make markdownlint 2>&1 | tee /tmp/adr-008-make-markdownlint.log

--- a/docs/execplans/adr-008-harness-led-attribute-policy-defaults.md
+++ b/docs/execplans/adr-008-harness-led-attribute-policy-defaults.md
@@ -442,8 +442,14 @@ Implementation details:
 
 Go/no-go validation:
 
-- `cargo test -p rstest-bdd --test trybuild_macros step_macros_compile -- --exact`
-  passes with `RUSTFLAGS="-D warnings"`.
+- The trybuild macro suite passes:
+
+  ```sh
+  RUSTFLAGS="-D warnings" cargo test \
+    -p rstest-bdd \
+    --test trybuild_macros step_macros_compile -- --exact
+  ```
+
 - The Tokio harness-led defaults test passes:
 
   ```sh

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -243,9 +243,8 @@ experience by introducing more powerful and intuitive APIs.
 
 - [x] 5.1.1. Implicit fixture injection: Automatically inject fixtures when a
   step function's parameter name matches a fixture name, removing the need for
-  `#[from(...)]` in most cases.
-  [user guide](users-guide.md#implicit-fixture-injection) ·
-  [trybuild](../crates/rstest-bdd-macros/tests/ui/implicit_fixture_missing.rs)
+  `#[from(...)]` in most cases. See the [user guide][implicit-fixture-guide]
+  and [trybuild][implicit-fixture-trybuild] coverage.
 - [x] 5.1.2. Inferred step patterns: Allow step definition macros (`#[given]`,
   etc.) to be used without an explicit pattern string. The pattern will be
   inferred from the function's name (e.g., `fn user_logs_in()` becomes "user
@@ -677,12 +676,14 @@ implementation commitments.
   scenarios, and unknown third-party harness paths where relevant. Finish line:
   tests prove that harness-only Tokio and GPUI scenarios receive their
   first-party test attributes when the generated signature permits it, explicit
-  overrides win, and `attributes`-only behaviour remains unchanged.
-  Prerequisite: 9.7.2. Design Doc:
-  `docs/adr-008-harness-led-attribute-policy-defaults.md`. Delivered 2026-05-21
-  with unit coverage for precedence and unknown-path negatives, trybuild
-  fixtures for first-party override and attributes-only expansion, and
-  behavioural Tokio and GPUI scenario coverage. (Buzzy Bee)
+  overrides win, `attributes`-only behaviour remains unchanged, harness
+  initialisation errors propagate before step execution, and harness-dependent
+  steps fail loudly when only an attribute policy is supplied. Prerequisite:
+  9.7.2. Design Doc: `docs/adr-008-harness-led-attribute-policy-defaults.md`.
+  Delivered 2026-05-21 with unit coverage for precedence and unknown-path
+  negatives, trybuild fixtures for first-party override and attributes-only
+  expansion, behavioural Tokio and GPUI scenario coverage, and runtime
+  error-path and mismatch coverage added for issue #498. (Buzzy Bee)
 - [x] 9.7.4. Update the user guide, design document, and first-party example
   prose to lead with harness-only configuration once the default-inference
   behaviour lands. Retain `attributes = ...` as an override pattern and keep

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -677,7 +677,7 @@ implementation commitments.
   tests prove that harness-only Tokio and GPUI scenarios receive their
   first-party test attributes when the generated signature permits it, explicit
   overrides win, `attributes`-only behaviour remains unchanged, harness
-  initialisation errors propagate before step execution, and harness-dependent
+  initialization errors propagate before step execution, and harness-dependent
   steps fail loudly when only an attribute policy is supplied. Prerequisite:
   9.7.2. Design Doc: `docs/adr-008-harness-led-attribute-policy-defaults.md`.
   Delivered 2026-05-21 with unit coverage for precedence and unknown-path
@@ -1164,3 +1164,6 @@ an assertion cannot disappear behind macro classification or generated code.
   choice is captured in an ADR and migration guidance. Finish line: the ADR,
   migration guide, and publish/package tests all reflect the same packaging
   model. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.5. (Pandalump)
+
+[implicit-fixture-guide]: users-guide.md#implicit-fixture-injection
+[implicit-fixture-trybuild]: ../crates/rstest-bdd/tests/ui_macros/implicit_fixture_missing.rs

--- a/docs/v0-5-0-migration-guide.md
+++ b/docs/v0-5-0-migration-guide.md
@@ -108,40 +108,25 @@ state to fixture-based scenario isolation.
 
 ```mermaid
 flowchart TD
-    A[Start migration] --> B{"Does the suite rely on
-shared mutable state
-across scenarios?"}
+    A["Start migration"] --> B{"Does the suite rely on<br/>shared mutable state<br/>across scenarios?"}
 
-    B -- Yes --> C["Identify global World like structures
-and cross-scenario mutation"]
-    C --> D["Move shared mutable data into
-scenario-local fixtures
-using &mut FixtureType or Slot"]
-    D --> E{"Is any expensive, mostly
-read-only infrastructure used?"}
+    B -- Yes --> C["Identify global World like structures<br/>and cross-scenario mutation"]
+    C --> D["Move shared mutable data into<br/>scenario-local fixtures<br/>using &mut FixtureType or Slot"]
+    D --> E{"Is any expensive, mostly<br/>read-only infrastructure used?"}
 
-    E -- Yes --> F["Wrap expensive, read-only infra
-in #once fixtures
-for reuse across scenarios"]
-    E -- No --> G["Keep all fixtures per-scenario
-without #once"]
+    E -- Yes --> F["Wrap expensive, read-only infra<br/>in #once fixtures<br/>for reuse across scenarios"]
+    E -- No --> G["Keep all fixtures per-scenario<br/>without #once"]
 
-    F --> H["Ensure scenario data is recreated
-per scenario and does not
-depend on execution order"]
+    F --> H["Ensure scenario data is recreated<br/>per scenario and does not<br/>depend on execution order"]
     G --> H
 
-    B -- No --> I["Keep existing fixtures
-but verify they follow
-per-scenario isolation"]
+    B -- No --> I["Keep existing fixtures<br/>but verify they follow<br/>per-scenario isolation"]
 
-    H --> J["Reserve StepContext::insert_owned
-for custom plumbing only"]
+    H --> J["Reserve StepContext::insert_owned<br/>for custom plumbing only"]
     I --> J
 
-    J --> K["Update docs and templates
-around state sharing and fixtures"]
-    K --> L[End migration]
+    J --> K["Update docs and templates<br/>around state sharing and fixtures"]
+    K --> L["End migration"]
 ```
 
 *Figure: Decision flow for migrating from shared mutable state to scenario-

--- a/docs/v0-5-0-migration-guide.md
+++ b/docs/v0-5-0-migration-guide.md
@@ -114,8 +114,8 @@ flowchart TD
     C --> D["Move shared mutable data into<br/>scenario-local fixtures<br/>using &mut FixtureType or Slot"]
     D --> E{"Is any expensive, mostly<br/>read-only infrastructure used?"}
 
-    E -- Yes --> F["Wrap expensive, read-only infra<br/>in #once fixtures<br/>for reuse across scenarios"]
-    E -- No --> G["Keep all fixtures per-scenario<br/>without #once"]
+    E -- Yes --> F["Wrap expensive, read-only infra<br/>in #[once] fixtures<br/>for reuse across scenarios"]
+    E -- No --> G["Keep all fixtures per-scenario<br/>without #[once]"]
 
     F --> H["Ensure scenario data is recreated<br/>per scenario and does not<br/>depend on execution order"]
     G --> H

--- a/docs/v0-6-0-migration-guide.md
+++ b/docs/v0-6-0-migration-guide.md
@@ -427,8 +427,13 @@ of the user guide is the in-depth reference; the steps below mirror its outline:
    `VisualTestContext` field with the durable handles, and in each subsequent
    step reconstruct the visual context with
    `gpui::VisualTestContext::from_window(window, cx)`. The return is
-   `Option<VisualTestContext>`; treat `None` as an invariant violation (for
-   example, with `let Some(visual_cx) = ... else { panic!(...) };`).
+   `Option<VisualTestContext>`; treat `None` as an invariant violation:
+
+   ```rust,ignore
+   let Some(visual_cx) = gpui::VisualTestContext::from_window(window, cx) else {
+       panic!("stored window handle should reconstruct visual context");
+   };
+   ```
 
 For a worked-out example, see the regression suite at
 `crates/rstest-bdd-harness-gpui/tests/stateful_window.rs` and the

--- a/examples/gpui-counter/Cargo.toml
+++ b/examples/gpui-counter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpui-counter"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 edition.workspace = true
 publish = false
 rust-version.workspace = true

--- a/examples/japanese-ledger/Cargo.toml
+++ b/examples/japanese-ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "japanese-ledger"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 edition.workspace = true
 publish = false
 rust-version.workspace = true

--- a/examples/todo-cli/Cargo.toml
+++ b/examples/todo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "todo-cli"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 edition.workspace = true
 publish = false
 rust-version.workspace = true

--- a/examples/tokio-reminders/Cargo.toml
+++ b/examples/tokio-reminders/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-reminders"
-version = "0.6.0-beta3"
+version = "0.6.0-beta4"
 edition.workspace = true
 publish = false
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

Closes [#498](https://github.com/leynos/rstest-bdd/issues/498)

Add `tests/harness_led_defaults.rs` to `rstest-bdd-harness-tokio` and
`rstest-bdd-harness-gpui` with runtime integration tests that run unconditionally
under `cargo test` / `nextest` (no `RSTEST_BDD_RUN_MACROTEST`, no `cargo-expand`):

- **Inferred-policy happy paths:** `harness = TokioHarness` without
  `attributes = ...` runs through the inferred `TokioAttributePolicy` with a
  live current-thread runtime + `LocalSet`; `harness = GpuiHarness` without
  `attributes = ...` runs through the inferred `GpuiAttributePolicy` and
  observes the injected `TestAppContext` (gated behind `native-gpui-tests` +
  `#[serial]`, matching the existing GPUI runtime suite).
- **Failing-harness error path (both crates):** a `FailingHarness` whose
  `HarnessAdapter::run` returns `Err` propagates the expanded macro's
  `harness failed to initialize scenario: ...` panic, pinned with
  `#[should_panic(expected = ...)]`; a guard step proves the scenario body
  never runs.
- **Policy/harness mismatch:** pairing a harness-dependent step (`spawn_local`)
  with `TokioAttributePolicy` alone fails loudly with the `LocalSet` panic
  rather than silently passing.

## Testing

- `make check-fmt`
- `make test` — 1,666 Rust passed; 69 Python passed (now including
  `step_macros_compile`, which previously self-skipped under nextest)
- `make typecheck`
- `make lint`

## References

- https://lody.ai/leynos/sessions/1829bb4e-1275-494f-8e67-44c69948b9e6
- https://lody.ai/leynos/sessions/25cdea07-586e-4e7a-bdd4-ae010eed5873

