### PR TITLE
Add scheduled mutation testing via the shared workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,10 @@ jobs:
         if: ${{ matrix.tools }}
         run: make lint
 
+      - name: Workflow contract tests
+        if: ${{ matrix.tools && matrix.features == '' }}
+        run: make test-workflow-contracts
+
       - name: Ensure async-trait is absent
         if: ${{ matrix.tools }}
         run: make forbid-async-trait

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,46 @@
+name: Mutation testing
+
+# Thin caller of the shared mutation-testing reusable workflow; caller
+# guide: leynos/shared-actions docs/mutation-cargo-workflow.md.
+# Scheduled runs mutate only files changed within the detection window;
+# manual dispatch runs mutate everything, fanned out across shards. To
+# test a branch, select it in the Actions "Run workflow" control.
+
+on:
+  schedule:
+    - cron: "35 3 * * *" # Daily, 03:35 UTC
+  workflow_dispatch:
+
+# Default the token to no scopes; the job opts in explicitly.
+permissions: {}
+
+# Serialize runs per ref: a dispatch during a scheduled run (or vice
+# versa) queues rather than racing. Runs are informational, so queued
+# runs wait instead of cancelling.
+concurrency:
+  group: mutation-testing-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mutation:
+    permissions:
+      contents: read
+      id-token: write # OIDC workflow-source resolution
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@47aea18960d24f33aedc4782ec6b73e365418313
+    with:
+      # The workspace's mutable source lives under crates/; the root
+      # Cargo.toml is a virtual manifest with no src/. The vendored
+      # gpui crates under vendor/ sit outside the workspace and are
+      # deliberately not added via extra-crate-dirs: mutants in
+      # third-party vendored code would be pure noise.
+      paths: "crates/"
+      # Example applications, test-fixture crates (cargo-bdd's minimal
+      # fixture workspace, trybuild/macrotest fixture and UI-expectation
+      # crates), and test-support modules compiled into src/ exist only
+      # to exercise the framework; their survivors are noise and UI-test
+      # expectations must never be mutated.
+      exclude-globs: "examples/**,crates/cargo-bdd/tests/fixtures/**,crates/*/tests/fixtures_macros/**,crates/rstest-bdd/tests/ui_lints/**,crates/rstest-bdd/tests/ui_macros/**,crates/rstest-bdd/src/test_support.rs,crates/rstest-bdd-server/src/test_support.rs,crates/rstest-bdd-harness/src/binary_test_support.rs,crates/rstest-bdd-harness/src/macrotest_support.rs,crates/rstest-bdd-harness/src/test_utils.rs,crates/rstest-bdd-harness/src/trybuild_staging/**"
+      # Match the repository's test baseline (`make test` runs with
+      # --workspace --all-targets --all-features) so feature-gated
+      # tests run against mutants.
+      extra-args: "--all-features"

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -41,6 +41,9 @@ jobs:
       # expectations must never be mutated.
       exclude-globs: "examples/**,crates/cargo-bdd/tests/fixtures/**,crates/*/tests/fixtures_macros/**,crates/rstest-bdd/tests/ui_lints/**,crates/rstest-bdd/tests/ui_macros/**,crates/rstest-bdd/src/test_support.rs,crates/rstest-bdd-server/src/test_support.rs,crates/rstest-bdd-harness/src/binary_test_support.rs,crates/rstest-bdd-harness/src/macrotest_support.rs,crates/rstest-bdd-harness/src/test_utils.rs,crates/rstest-bdd-harness/src/trybuild_staging/**"
       # Match the repository's test baseline (`make test` runs with
-      # --workspace --all-targets --all-features) so feature-gated
-      # tests run against mutants.
-      extra-args: "--all-features"
+      # --workspace --all-targets --all-features): feature-gated tests
+      # run against mutants, and each mutant is tested with the whole
+      # workspace's suites (macro/policy crates are covered by
+      # dependent crates' trybuild/integration tests, which
+      # cargo-mutants' per-package default would miss).
+      extra-args: "--all-features --test-workspace=true"

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VALE ?= vale
 
 .PHONY: help all clean test build build-python release lint lint-python
 .PHONY: lint-whitaker ensure-whitaker-tools typecheck fmt check-fmt markdownlint nixie publish-check
-.PHONY: forbid-async-trait vale update-ui-lints-lock
+.PHONY: forbid-async-trait vale update-ui-lints-lock test-workflow-contracts
 
 SHELL := bash
 export PATH := $(HOME)/.cargo/bin:$(HOME)/.bun/bin:$(HOME)/.local/bin:$(PATH)
@@ -146,6 +146,9 @@ nixie:
 
 publish-check: build-python ## Package crates in release order to validate publish readiness
 	$(UV_ENV) $(UV) run --with "$(LADING_SPEC)" lading publish --workspace-root . --allow-unpublished-workspace-deps
+
+test-workflow-contracts: ## Validate the mutation-testing caller contract
+	$(UV_ENV) $(UV) run --with 'pytest>=8' --with 'pyyaml>=6' pytest tests/workflow_contracts -q
 
 update-ui-lints-lock: ## Refresh ui_lints trybuild lockfile for `--locked` CI
 	$(CARGO) generate-lockfile --manifest-path crates/rstest-bdd/tests/ui_lints/Cargo.toml

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -1,0 +1,156 @@
+"""Contract tests for the mutation-testing caller workflow.
+
+The executable logic lives in the ``leynos/shared-actions`` reusable
+workflow, which carries its own unit and integration tests; rstest-bdd's
+caller is declarative configuration. These tests parse the caller with
+PyYAML and pin the contract it must uphold, so drift (repointing the pin
+at a branch, widening permissions, or losing the workspace paths,
+fixture excludes, or feature arguments) fails CI on the pull request
+rather than surfacing in a scheduled or manual run.
+
+Run via ``make test-workflow-contracts``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
+)
+
+#: The commit SHA of the shared workflow pin (the merge commit of
+#: leynos/shared-actions PR #319). Bump the workflow and this test
+#: together.
+PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
+
+EXPECTED_USES = (
+    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+)
+
+#: The exact caller configuration: workspace source under crates/;
+#: example applications, test-fixture crates, and test-support modules
+#: excluded as noise; feature-gated tests enabled to match `make test`.
+EXPECTED_WITH = {
+    "paths": "crates/",
+    "exclude-globs": (
+        "examples/**,"
+        "crates/cargo-bdd/tests/fixtures/**,"
+        "crates/*/tests/fixtures_macros/**,"
+        "crates/rstest-bdd/tests/ui_lints/**,"
+        "crates/rstest-bdd/tests/ui_macros/**,"
+        "crates/rstest-bdd/src/test_support.rs,"
+        "crates/rstest-bdd-server/src/test_support.rs,"
+        "crates/rstest-bdd-harness/src/binary_test_support.rs,"
+        "crates/rstest-bdd-harness/src/macrotest_support.rs,"
+        "crates/rstest-bdd-harness/src/test_utils.rs,"
+        "crates/rstest-bdd-harness/src/trybuild_staging/**"
+    ),
+    "extra-args": "--all-features",
+}
+
+
+def _load() -> dict[str, object]:
+    """Parse the workflow file."""
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the ``on:`` mapping (PyYAML parses the bare key as True)."""
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict), "the workflow must declare an on: mapping"
+    return triggers
+
+
+def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the single calling job."""
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "the workflow must declare a jobs mapping"
+    assert jobs, "the workflow must declare at least one job"
+    assert list(jobs) == ["mutation"], (
+        f"expected a single job named 'mutation', found {sorted(jobs)}"
+    )
+    return jobs["mutation"]
+
+
+def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
+    """The job must call the shared workflow at the exact documented SHA."""
+    uses = _mutation_job(_load()).get("uses")
+    assert uses is not None, "jobs.mutation.uses is missing"
+    path, _, ref = uses.partition("@")
+    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
+        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
+    )
+    assert len(ref) == 40, (
+        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert all(c in "0123456789abcdef" for c in ref), (
+        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert uses == EXPECTED_USES, (
+        f"jobs.mutation.uses pins {ref!r}; this contract documents {PINNED_SHA!r} — "
+        "bump the workflow and this test together"
+    )
+
+
+def test_job_permissions_are_exactly_least_privilege() -> None:
+    """The job grants contents: read and id-token: write, nothing broader."""
+    permissions = _mutation_job(_load()).get("permissions")
+    assert permissions == {"contents": "read", "id-token": "write"}, (
+        "jobs.mutation.permissions must be exactly "
+        f"{{'contents': 'read', 'id-token': 'write'}}, got {permissions!r}"
+    )
+
+
+def test_workflow_default_permissions_are_empty() -> None:
+    """The workflow-level default token scope is empty."""
+    workflow = _load()
+    assert workflow.get("permissions") == {}, (
+        f"top-level permissions must be an empty mapping, got "
+        f"{workflow.get('permissions')!r}"
+    )
+
+
+def test_concurrency_serializes_per_ref_without_cancelling() -> None:
+    """Runs queue per ref instead of cancelling one another."""
+    concurrency = _load().get("concurrency")
+    assert isinstance(concurrency, dict), "the workflow must declare concurrency"
+    assert concurrency.get("group") == "mutation-testing-${{ github.ref }}", (
+        f"concurrency.group must key on the triggering ref, got "
+        f"{concurrency.get('group')!r}"
+    )
+    assert concurrency.get("cancel-in-progress") is False, (
+        f"concurrency.cancel-in-progress must be false, got "
+        f"{concurrency.get('cancel-in-progress')!r}"
+    )
+
+
+def test_triggers_keep_schedule_and_plain_dispatch() -> None:
+    """The daily schedule stays; dispatch has no legacy branch input."""
+    triggers = _triggers(_load())
+    schedule = triggers.get("schedule")
+    assert schedule == [{"cron": "35 3 * * *"}], (
+        f"on.schedule must be the daily 03:35 UTC cron, got {schedule!r}"
+    )
+    assert "workflow_dispatch" in triggers, "on.workflow_dispatch is missing"
+    dispatch = triggers.get("workflow_dispatch") or {}
+    inputs = dispatch.get("inputs") or {}
+    assert "branch" not in inputs, (
+        "on.workflow_dispatch must not declare a branch input; the Actions "
+        "run-workflow control selects the ref"
+    )
+
+
+def test_with_block_carries_the_caller_configuration() -> None:
+    """The caller passes exactly the paths, excludes, and feature args."""
+    with_block = _mutation_job(_load()).get("with")
+    assert isinstance(with_block, dict), "jobs.mutation.with is missing"
+    assert with_block == EXPECTED_WITH, (
+        "jobs.mutation.with must configure exactly the workspace paths, the "
+        "example/fixture/test-support excludes, and --all-features; got "
+        f"{with_block!r}, expected {EXPECTED_WITH!r}"
+    )

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 import yaml
 
 WORKFLOW_PATH = (
@@ -48,7 +49,7 @@ EXPECTED_WITH = {
         "crates/rstest-bdd-harness/src/test_utils.rs,"
         "crates/rstest-bdd-harness/src/trybuild_staging/**"
     ),
-    "extra-args": "--all-features",
+    "extra-args": "--all-features --test-workspace=true",
 }
 
 
@@ -75,9 +76,23 @@ def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
     return jobs["mutation"]
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
+@pytest.fixture(scope="module")
+def workflow() -> dict[str, object]:
+    """Parse the workflow file once for the module."""
+    return _load()
+
+
+@pytest.fixture(scope="module")
+def mutation_job(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the single calling job."""
+    return _mutation_job(workflow)
+
+
+def test_uses_reference_is_pinned_to_the_documented_sha(
+    mutation_job: dict[str, object],
+) -> None:
     """The job must call the shared workflow at the exact documented SHA."""
-    uses = _mutation_job(_load()).get("uses")
+    uses = mutation_job.get("uses")
     assert uses is not None, "jobs.mutation.uses is missing"
     path, _, ref = uses.partition("@")
     assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
@@ -97,27 +112,32 @@ def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
     )
 
 
-def test_job_permissions_are_exactly_least_privilege() -> None:
+def test_job_permissions_are_exactly_least_privilege(
+    mutation_job: dict[str, object],
+) -> None:
     """The job grants contents: read and id-token: write, nothing broader."""
-    permissions = _mutation_job(_load()).get("permissions")
+    permissions = mutation_job.get("permissions")
     assert permissions == {"contents": "read", "id-token": "write"}, (
         "jobs.mutation.permissions must be exactly "
         f"{{'contents': 'read', 'id-token': 'write'}}, got {permissions!r}"
     )
 
 
-def test_workflow_default_permissions_are_empty() -> None:
+def test_workflow_default_permissions_are_empty(
+    workflow: dict[str, object],
+) -> None:
     """The workflow-level default token scope is empty."""
-    workflow = _load()
     assert workflow.get("permissions") == {}, (
         f"top-level permissions must be an empty mapping, got "
         f"{workflow.get('permissions')!r}"
     )
 
 
-def test_concurrency_serializes_per_ref_without_cancelling() -> None:
+def test_concurrency_serializes_per_ref_without_cancelling(
+    workflow: dict[str, object],
+) -> None:
     """Runs queue per ref instead of cancelling one another."""
-    concurrency = _load().get("concurrency")
+    concurrency = workflow.get("concurrency")
     assert isinstance(concurrency, dict), "the workflow must declare concurrency"
     assert concurrency.get("group") == "mutation-testing-${{ github.ref }}", (
         f"concurrency.group must key on the triggering ref, got "
@@ -129,9 +149,11 @@ def test_concurrency_serializes_per_ref_without_cancelling() -> None:
     )
 
 
-def test_triggers_keep_schedule_and_plain_dispatch() -> None:
+def test_triggers_keep_schedule_and_plain_dispatch(
+    workflow: dict[str, object],
+) -> None:
     """The daily schedule stays; dispatch has no legacy branch input."""
-    triggers = _triggers(_load())
+    triggers = _triggers(workflow)
     schedule = triggers.get("schedule")
     assert schedule == [{"cron": "35 3 * * *"}], (
         f"on.schedule must be the daily 03:35 UTC cron, got {schedule!r}"
@@ -145,9 +167,11 @@ def test_triggers_keep_schedule_and_plain_dispatch() -> None:
     )
 
 
-def test_with_block_carries_the_caller_configuration() -> None:
+def test_with_block_carries_the_caller_configuration(
+    mutation_job: dict[str, object],
+) -> None:
     """The caller passes exactly the paths, excludes, and feature args."""
-    with_block = _mutation_job(_load()).get("with")
+    with_block = mutation_job.get("with")
     assert isinstance(with_block, dict), "jobs.mutation.with is missing"
     assert with_block == EXPECTED_WITH, (
         "jobs.mutation.with must configure exactly the workspace paths, the "


### PR DESCRIPTION
## Summary

This change adopts the shared mutation-testing reusable workflow as a thin caller of `leynos/shared-actions` `mutation-cargo.yml`, pinned to `47aea18960d24f33aedc4782ec6b73e365418313`. Runs are informational only: a daily 03:35 UTC schedule mutates files changed within the detection window, and manual dispatch fans a full workspace run out across shards.

## Configuration for this repository

- `paths: "crates/"` — the root `Cargo.toml` is a virtual manifest with no `src/`; all workspace source lives under `crates/`. The vendored gpui crates under `vendor/` sit outside the workspace and are deliberately not added via `extra-crate-dirs`, as mutants in third-party vendored code would be pure noise.
- `exclude-globs` covers the example applications (`examples/**`), the test-fixture crates (cargo-bdd's minimal fixture workspace, the `fixtures_macros` crates, and the `ui_lints`/`ui_macros` trybuild crates, whose UI-test expectations must never be mutated), and the test-support modules compiled into `src/` (`test_support.rs`, `binary_test_support.rs`, `macrotest_support.rs`, `test_utils.rs`, `trybuild_staging/`), whose survivors would be noise.
- `extra-args: "--all-features"` mirrors the repository's `make test` baseline (`--workspace --all-targets --all-features`) so feature-gated tests run against mutants.

A contract test suite at `tests/workflow_contracts/mutation_testing_test.py` pins the shared workflow SHA, least-privilege permissions, per-ref non-cancelling concurrency, the daily schedule, and the exact `with:` block. It runs via a new `make test-workflow-contracts` target, wired into CI on the Linux default-features matrix leg after linting (uv is already set up in that job).

## Validation

- Both workflows parse with PyYAML and pass actionlint.
- `make test-workflow-contracts`: 6 passed.
- Negative test: repointing the pin at `@v1` fails the SHA contract test; restoring the pin returns the suite to green.

References: [caller guide](https://github.com/leynos/shared-actions/blob/main/docs/mutation-cargo-workflow.md), [estate template PR leynos/wireframe#572](https://github.com/leynos/wireframe/pull/572).
