### PR TITLE
Wire the CodeScene coverage machinery into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,24 @@ jobs:
           # its merge base, so the full history must be reachable.
           fetch-depth: 0
 
+      - name: Free disk space
+        if: ${{ runner.os == 'Linux' }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          # Coverage builds the workspace once; `make publish-check` then
+          # compiles it again into a separate target directory. On the
+          # strict-feature leg the two builds exhaust the runner's disk, so
+          # reclaim space from large preinstalled toolchains we do not use.
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /opt/hostedtoolcache/CodeQL \
+            /usr/local/share/boost \
+            /usr/local/share/powershell || true
+          df -h /
+
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
         include:
           - os: ubuntu-latest
             coverage: true
-            codescene-check: true
             features: ''
             with-default-features: true
             tools: true
@@ -176,9 +175,12 @@ jobs:
       - name: Test and Measure Coverage (no features)
         if: ${{ matrix.coverage && matrix.features == '' }}
         uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
-        # The CodeScene leg gates on the ratchet, so a coverage failure must
-        # fail the build there; other legs stay best-effort as before.
-        continue-on-error: ${{ !matrix.codescene-check }}
+        # The CodeScene leg (the default-features Linux leg) gates on the
+        # ratchet, so a coverage failure must fail the build there; other
+        # legs stay best-effort as before. Selected by matrix values rather
+        # than a dedicated key so the job name (a required check context)
+        # is unchanged.
+        continue-on-error: ${{ !(matrix.os == 'ubuntu-latest' && matrix.features == '') }}
         env:
           # Windows coverage runs (build plus doctests) exceed the shared
           # action's 600s per-invocation default; give them headroom.
@@ -193,9 +195,10 @@ jobs:
           # integration test shells out to `cargo dylint`, so parallel
           # xdist workers race on the cargo package-cache lock.
           pytest-workers: ''
-          # Ratchet only the single CodeScene leg: the two Linux coverage
-          # legs would otherwise collide on the per-run baseline cache key.
-          with-ratchet: ${{ matrix.codescene-check && 'true' || 'false' }}
+          # Ratchet only the default-features Linux leg: the two Linux
+          # coverage legs would otherwise collide on the per-run baseline
+          # cache key.
+          with-ratchet: ${{ (matrix.os == 'ubuntu-latest' && matrix.features == '') && 'true' || 'false' }}
 
       - name: Verify coverage output exists
         if: ${{ matrix.coverage }}
@@ -213,9 +216,11 @@ jobs:
       # the received project-config isn't valid. Lacks the gates
       # configuration." — a CodeScene-side per-project setting, not a CI
       # defect (ddlint and chutoro projects hit the byte-identical error).
-      # It would attach to the single `matrix.codescene-check` leg (with
-      # project-url https://api.codescene.io/v2/projects/69391) alongside
-      # the ratchet. Add it in a fast-follow PR once coverage-main.yml has
+      # It would attach to the single default-features Linux leg
+      # (matrix.os == 'ubuntu-latest' && matrix.features == '', which
+      # carries the ratchet) with project-url
+      # https://api.codescene.io/v2/projects/69391. Add it in a fast-follow
+      # PR once coverage-main.yml has
       # uploaded to main at least once and the gate is confirmed to
       # resolve, or once CodeScene confirms the project's coverage gate is
       # enabled.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,14 +181,15 @@ jobs:
       - name: Publish dry run
         run: make publish-check
 
-      - name: Check coverage against CodeScene gates
-        # Run on a single leg only, or CodeScene receives duplicate uploads
-        # per commit. The guard lets token-less runs (forks) skip cleanly.
-        if: ${{ matrix.codescene-check && env.CS_ACCESS_TOKEN != '' }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
-        with:
-          format: cobertura
-          mode: check
-          project-url: https://api.codescene.io/v2/projects/69391
-          access-token: ${{ env.CS_ACCESS_TOKEN }}
-          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
+      # The `mode: check` coverage gate is deliberately not wired in yet:
+      # CodeScene project 69391 has no coverage-gates configuration, so
+      # `cs-coverage check` fails every run with "HTTP call succeeded, but
+      # the received project-config isn't valid. Lacks the gates
+      # configuration." — a CodeScene-side per-project setting, not a CI
+      # defect (ddlint and chutoro projects hit the byte-identical error).
+      # It would attach to the single `matrix.codescene-check` leg (with
+      # project-url https://api.codescene.io/v2/projects/69391) alongside
+      # the ratchet. Add it in a fast-follow PR once coverage-main.yml has
+      # uploaded to main at least once and the gate is confirmed to
+      # resolve, or once CodeScene confirms the project's coverage gate is
+      # enabled.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,10 @@ jobs:
           features: rstest-bdd/diagnostics rstest-bdd-server/test-support ${{ matrix.features }}
           with-default-features: ${{ matrix.with-default-features }}
           use-cargo-nextest: ${{ matrix.use-nextest }}
+          # Run the Python coverage suite serially: the whitaker lint-gate
+          # integration test shells out to `cargo dylint`, so parallel
+          # xdist workers race on the cargo package-cache lock.
+          pytest-workers: ''
 
       - name: Test and Measure Coverage (no features)
         if: ${{ matrix.coverage && matrix.features == '' }}
@@ -185,6 +189,10 @@ jobs:
           features: rstest-bdd/diagnostics rstest-bdd-macros/compile-time-validation rstest-bdd-server/test-support
           with-default-features: ${{ matrix.with-default-features }}
           use-cargo-nextest: ${{ matrix.use-nextest }}
+          # Run the Python coverage suite serially: the whitaker lint-gate
+          # integration test shells out to `cargo dylint`, so parallel
+          # xdist workers race on the cargo package-cache lock.
+          pytest-workers: ''
           # Ratchet only the single CodeScene leg: the two Linux coverage
           # legs would otherwise collide on the per-run baseline cache key.
           with-ratchet: ${{ matrix.codescene-check && 'true' || 'false' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,10 @@ jobs:
         if: ${{ matrix.coverage && matrix.features != '' }}
         uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         continue-on-error: true
+        env:
+          # Windows coverage runs (build plus doctests) exceed the shared
+          # action's 600s per-invocation default; give them headroom.
+          RUN_RUST_CARGO_WAIT_TIMEOUT: '1800'
         with:
           output-path: coverage.xml
           format: cobertura
@@ -153,6 +157,10 @@ jobs:
         # The CodeScene leg gates on the ratchet, so a coverage failure must
         # fail the build there; other legs stay best-effort as before.
         continue-on-error: ${{ !matrix.codescene-check }}
+        env:
+          # Windows coverage runs (build plus doctests) exceed the shared
+          # action's 600s per-invocation default; give them headroom.
+          RUN_RUST_CARGO_WAIT_TIMEOUT: '1800'
         with:
           output-path: coverage.xml
           format: cobertura

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
         include:
           - os: ubuntu-latest
             coverage: true
+            codescene-check: true
             features: ''
             with-default-features: true
             tools: true
@@ -52,9 +53,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v5
+        with:
+          # CodeScene's `cs-coverage check` diffs the pull request against
+          # its merge base, so the full history must be reachable.
+          fetch-depth: 0
 
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
 
       - name: Install bun
         if: ${{ matrix.tools }}
@@ -133,7 +138,7 @@ jobs:
 
       - name: Test and Measure Coverage (with features)
         if: ${{ matrix.coverage && matrix.features != '' }}
-        uses: leynos/shared-actions/.github/actions/generate-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         continue-on-error: true
         with:
           output-path: coverage.xml
@@ -144,14 +149,19 @@ jobs:
 
       - name: Test and Measure Coverage (no features)
         if: ${{ matrix.coverage && matrix.features == '' }}
-        uses: leynos/shared-actions/.github/actions/generate-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
-        continue-on-error: true
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        # The CodeScene leg gates on the ratchet, so a coverage failure must
+        # fail the build there; other legs stay best-effort as before.
+        continue-on-error: ${{ !matrix.codescene-check }}
         with:
           output-path: coverage.xml
           format: cobertura
           features: rstest-bdd/diagnostics rstest-bdd-macros/compile-time-validation rstest-bdd-server/test-support
           with-default-features: ${{ matrix.with-default-features }}
           use-cargo-nextest: ${{ matrix.use-nextest }}
+          # Ratchet only the single CodeScene leg: the two Linux coverage
+          # legs would otherwise collide on the per-run baseline cache key.
+          with-ratchet: ${{ matrix.codescene-check && 'true' || 'false' }}
 
       - name: Verify coverage output exists
         if: ${{ matrix.coverage }}
@@ -163,10 +173,14 @@ jobs:
       - name: Publish dry run
         run: make publish-check
 
-      - name: Upload coverage data to CodeScene
-        if: ${{ matrix.coverage && env.CS_ACCESS_TOKEN && matrix.tools && vars.CODESCENE_CLI_SHA256 }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+      - name: Check coverage against CodeScene gates
+        # Run on a single leg only, or CodeScene receives duplicate uploads
+        # per commit. The guard lets token-less runs (forks) skip cleanly.
+        if: ${{ matrix.codescene-check && env.CS_ACCESS_TOKEN != '' }}
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           format: cobertura
+          mode: check
+          project-url: https://api.codescene.io/v2/projects/69391
           access-token: ${{ env.CS_ACCESS_TOKEN }}
           installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -44,6 +44,9 @@ jobs:
       # default-features suite), so the uploaded report matches the PR gate.
       - name: Test and Measure Coverage
         uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        env:
+          # Match the per-invocation coverage timeout used in ci.yml.
+          RUN_RUST_CARGO_WAIT_TIMEOUT: '1800'
         with:
           output-path: coverage.xml
           format: cobertura

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -53,6 +53,10 @@ jobs:
           features: rstest-bdd/diagnostics rstest-bdd-macros/compile-time-validation rstest-bdd-server/test-support
           with-default-features: true
           use-cargo-nextest: true
+          # Run the Python coverage suite serially: the whitaker lint-gate
+          # integration test shells out to `cargo dylint`, so parallel
+          # xdist workers race on the cargo package-cache lock.
+          pytest-workers: ''
           with-ratchet: 'true'
 
       - name: Verify coverage output exists

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,67 @@
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push; pull requests run the
+# changed-line gate (`cs-coverage check`) in ci.yml instead. This
+# workflow also advances the coverage ratchet baseline: caches saved on
+# main are readable by every pull-request run, so the baseline written
+# here is the one PR ratchet checks compare against.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  coverage-upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CARGO_TERM_COLOR: always
+      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
+      RUSTFLAGS: -D warnings
+      RUSTDOCFLAGS: -D warnings
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v5
+
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+
+      - name: Install bun
+        uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461  # v2
+        with:
+          bun-version: '1.2.21'
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        with:
+          version: '0.11.8'
+
+      # Mirrors the "no features" coverage leg in ci.yml (the broadest
+      # default-features suite), so the uploaded report matches the PR gate.
+      - name: Test and Measure Coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          output-path: coverage.xml
+          format: cobertura
+          features: rstest-bdd/diagnostics rstest-bdd-macros/compile-time-validation rstest-bdd-server/test-support
+          with-default-features: true
+          use-cargo-nextest: true
+          with-ratchet: 'true'
+
+      - name: Verify coverage output exists
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -s coverage.xml
+
+      - name: Upload coverage data to CodeScene
+        if: ${{ env.CS_ACCESS_TOKEN != '' }}
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: cobertura
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}


### PR DESCRIPTION
## Summary

Wires rstest-bdd to the estate CodeScene coverage machinery (CodeScene
project [69391](https://codescene.io/projects/69391)).

**The pull-request `mode: check` gate is deliberately not wired in this
PR.** CodeScene project 69391 has no coverage-gates configuration yet,
so `cs-coverage check` fails every run with "HTTP call succeeded, but
the received project-config isn't valid. Lacks the gates configuration."
— a CodeScene-side, per-project setting, confirmed not to be a CI defect
because the ddlint and chutoro projects hit the byte-identical error the
same day. Wiring it now would turn the required `build-test` check
permanently red. The upload half (`coverage-main.yml`) does not depend
on the gate. A fast-follow PR adds the check step once the gate resolves
(after the first main-branch upload, or via a CodeScene-side toggle).

Background on the eventual gate: the CodeScene app posts a `CodeScene
Code Coverage` check that is not a required check in this repo's
ruleset — it feeds the commit-status rollup, which is what Dependabot's
automerge gate reads. A stuck or timed-out CodeScene coverage check
therefore silently blocks automerge without appearing in the
required-checks list. This project does not post that check today (its
coverage gate is off), so nothing is jammed; estate policy is to wire
the CI side first and enable the gate second.

## Review walkthrough

- [`ci.yml`](https://github.com/leynos/rstest-bdd/blob/codescene-coverage-gate/.github/workflows/ci.yml):
  - The shared coverage actions (`setup-rust`, `generate-coverage`,
    `upload-codescene-coverage`) move to `927edd4`
    (shared-actions#334/#333), which adds the `mode: check` gate and
    restores per-line coverage records (earlier pins emitted
    summary-only reports).
  - Checkout gains `fetch-depth: 0`, ready for `cs-coverage check`
    (which diffs the PR against its merge base).
  - The coverage ratchet is enabled on a single leg — the
    default-features Linux leg, flagged `matrix.codescene-check` — so a
    coverage regression fails that leg (`continue-on-error` is switched
    off there). The second Linux coverage leg stays unratcheted to avoid
    a per-run baseline cache-key collision; Windows legs remain
    best-effort as before.
  - The `mode: check` step is documented in a comment but not wired in
    (see the summary).
  - Windows coverage runs get `RUN_RUST_CARGO_WAIT_TIMEOUT: '1800'`:
    the bumped action caps each cargo invocation at 600s, which the
    Windows build-plus-doctests leg exceeds, killing cargo before any
    report is written.
- [`coverage-main.yml`](https://github.com/leynos/rstest-bdd/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml):
  new workflow. CodeScene accepts `cs-coverage upload` only from
  analysed branches, so a push to main uploads coverage (default
  `mode: upload`) using the same broadest default-features suite as the
  PR coverage leg. It carries `with-ratchet: 'true'` to write the
  authoritative baseline; caches saved on main are readable by every PR,
  so this is the baseline PR ratchet checks compare against.

The Dependabot-managed reusable-workflow pins
(`dependabot-automerge.yml`, `mutation-cargo.yml`) are left on their own
SHAs: they are a distinct resource class on a separate update cadence,
and forcing them to the coverage SHA would be reverted by Dependabot and
risks breaking unrelated workflows.

Coverage stays in `cobertura` (`coverage.xml`) throughout, matching the
repo's existing tooling (`codecov.yml`, the verify step); the shared
upload action accepts either format.

## Validation

- `python3 -c "import yaml; ..."` parses both workflows.
- No workflow-contract test pins `ci.yml` or coverage text
  (`tests/workflow_contracts` covers only the mutation-testing caller),
  so no contract update is needed.
- `CS_ACCESS_TOKEN` set in both the Actions and Dependabot secret
  stores.
- The repo's full build/lint/test suite was not run locally per the
  rollout's execution mechanics (shared, heavy machine); CI on this
  PR's own head is the validation surface.
