### PR TITLE
Let Dependabot own the mutation-testing workflow pin

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -342,6 +342,41 @@ The generator has unit and property-based (`hypothesis`) tests in
 `make test` via `uv run pytest scripts/tests`. `hypothesis` is declared in
 the `python-tools` dependency group in `pyproject.toml`.
 
+## Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows,
+including calls into `leynos/shared-actions`. Contract tests that assert a
+caller's exact commit SHA create a lockstep dependency: every time Dependabot
+opens a bump PR, the test fails until a human edits the pinned constant to
+match. That defeats the purpose of automated dependency updates and turns a
+routine bump into a manual chore.
+
+Contract tests may still verify the _shape_ of a reusable-workflow caller.
+They must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it with
+  a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note, not
+as a test assertion on the SHA string.
+
 ## Test organization: harness-owned integration tests
 
 Tokio and GPUI harness integration tests are co-located with their respective

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -345,7 +345,6 @@ Link-checker and table-checker tests run with the Python suite in `make test`.
 Issue #537 tracks generating the users-guide reference block from `BASE_URL` so
 the base lives in exactly one place.
 
-
 ## Workflow pins and Dependabot
 
 Dependabot owns the upgrade of GitHub Actions and reusable workflows,

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -345,6 +345,42 @@ Link-checker and table-checker tests run with the Python suite in `make test`.
 Issue #537 tracks generating the users-guide reference block from `BASE_URL` so
 the base lives in exactly one place.
 
+
+## Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows,
+including calls into `leynos/shared-actions`. Contract tests that assert a
+caller's exact commit SHA create a lockstep dependency: every time Dependabot
+opens a bump PR, the test fails until a human edits the pinned constant to
+match. That defeats the purpose of automated dependency updates and turns a
+routine bump into a manual chore.
+
+Contract tests may still verify the _shape_ of a reusable-workflow caller.
+They must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it with
+  a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note, not
+as a test assertion on the SHA string.
+
 ## Spelling policy
 
 `make spelling` enforces en-GB-oxendict spelling over tracked text with the

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -3,16 +3,20 @@
 The executable logic lives in the ``leynos/shared-actions`` reusable
 workflow, which carries its own unit and integration tests; rstest-bdd's
 caller is declarative configuration. These tests parse the caller with
-PyYAML and pin the contract it must uphold, so drift (repointing the pin
-at a branch, widening permissions, or losing the workspace paths,
-fixture excludes, or feature arguments) fails CI on the pull request
-rather than surfacing in a scheduled or manual run.
+PyYAML and assert the contract it must uphold: the caller references the
+correct reusable workflow at a commit SHA (Dependabot owns the SHA value,
+so drift in the pinned commit is not a contract violation), and the
+caller keeps its permissions, triggers, and ``with`` inputs. Drift such as
+repointing the pin at a branch, widening permissions, or losing the
+workspace paths, fixture excludes, or feature arguments fails CI on the
+pull request rather than surfacing in a scheduled or manual run.
 
 Run via ``make test-workflow-contracts``.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -22,13 +26,11 @@ WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
 )
 
-#: The commit SHA of the shared workflow pin (the merge commit of
-#: leynos/shared-actions PR #319). Bump the workflow and this test
-#: together.
-PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
-
-EXPECTED_USES = (
-    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+#: The reusable workflow path must be pinned to a full 40-hex commit SHA
+#: (not a branch or tag). Dependabot owns the SHA value; this contract
+#: only asserts the shape of the pin.
+USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$"
 )
 
 #: The exact caller configuration: workspace source under crates/;
@@ -88,27 +90,21 @@ def mutation_job(workflow: dict[str, object]) -> dict[str, object]:
     return _mutation_job(workflow)
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha(
+def test_uses_reference_is_pinned_to_a_commit_sha(
     mutation_job: dict[str, object],
 ) -> None:
-    """The job must call the shared workflow at the exact documented SHA."""
+    """The job must call the shared workflow pinned to a commit SHA.
+
+    Dependabot owns the SHA value, so this asserts the shape of the pin
+    (correct reusable-workflow path, full 40-hex commit SHA) rather than
+    a specific commit.
+    """
     uses = mutation_job.get("uses")
     assert uses is not None, "jobs.mutation.uses is missing"
-    path, _, ref = uses.partition("@")
-    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
-        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
-    )
-    assert len(ref) == 40, (
-        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert all(c in "0123456789abcdef" for c in ref), (
-        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert uses == EXPECTED_USES, (
-        f"jobs.mutation.uses pins {ref!r}; this contract documents {PINNED_SHA!r} — "
-        "bump the workflow and this test together"
+    assert USES_RE.match(uses), (
+        f"jobs.mutation.uses must reference mutation-cargo.yml pinned to a "
+        f"full 40-character lowercase-hex commit SHA, not a branch or tag: "
+        f"{uses!r}"
     )
 
 

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -3,18 +3,20 @@
 The executable logic lives in the ``leynos/shared-actions`` reusable
 workflow, which carries its own unit and integration tests; rstest-bdd's
 caller is declarative configuration. These tests parse the caller with
-PyYAML and assert the contract it must uphold, so drift (repointing the
-pin at a branch, widening permissions, or losing the workspace paths,
-fixture excludes, or feature arguments) fails CI on the pull request
-rather than surfacing in a scheduled or manual run. The reference must
-be a full commit SHA; the SHA value itself is owned by Dependabot and
-is deliberately not asserted.
+PyYAML and assert the contract it must uphold: the caller references the
+correct reusable workflow at a commit SHA (Dependabot owns the SHA value,
+so drift in the pinned commit is not a contract violation), and the
+caller keeps its permissions, triggers, and ``with`` inputs. Drift such as
+repointing the pin at a branch, widening permissions, or losing the
+workspace paths, fixture excludes, or feature arguments fails CI on the
+pull request rather than surfacing in a scheduled or manual run.
 
 Run via ``make test-workflow-contracts``.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -22,6 +24,13 @@ import yaml
 
 WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
+)
+
+#: The reusable workflow path must be pinned to a full 40-hex commit SHA
+#: (not a branch or tag). Dependabot owns the SHA value; this contract
+#: only asserts the shape of the pin.
+USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$"
 )
 
 #: The exact caller configuration: workspace source under crates/;
@@ -84,20 +93,18 @@ def mutation_job(workflow: dict[str, object]) -> dict[str, object]:
 def test_uses_reference_is_pinned_to_a_commit_sha(
     mutation_job: dict[str, object],
 ) -> None:
-    """The job must call the shared workflow at a full commit SHA."""
+    """The job must call the shared workflow pinned to a commit SHA.
+
+    Dependabot owns the SHA value, so this asserts the shape of the pin
+    (correct reusable-workflow path, full 40-hex commit SHA) rather than
+    a specific commit.
+    """
     uses = mutation_job.get("uses")
     assert uses is not None, "jobs.mutation.uses is missing"
-    path, _, ref = uses.partition("@")
-    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
-        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
-    )
-    assert len(ref) == 40, (
-        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert all(c in "0123456789abcdef" for c in ref), (
-        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
-        f"not a branch or tag: {ref!r}"
+    assert USES_RE.match(uses), (
+        f"jobs.mutation.uses must reference mutation-cargo.yml pinned to a "
+        f"full 40-character lowercase-hex commit SHA, not a branch or tag: "
+        f"{uses!r}"
     )
 
 


### PR DESCRIPTION
## Summary

- The mutation-testing workflow contract test pinned the caller's exact
  `leynos/shared-actions` commit SHA, so every Dependabot bump PR failed
  CI until a human hand-edited the pinned constant to match.
- Replace the exact-SHA equality assertion with a regex that still
  requires the correct reusable-workflow path
  (`leynos/shared-actions/.github/workflows/mutation-cargo.yml`) pinned
  to a full 40-hex commit SHA, but no longer checks which SHA. This
  keeps the guard against repointing at a mutable branch such as `main`
  while handing SHA ownership to Dependabot.
- Document the policy in `docs/developers-guide.md` under a new
  "Workflow pins and Dependabot" section so future contract tests follow
  the same shape.

## Review walkthrough

- `tests/workflow_contracts/mutation_testing_test.py`: dropped
  `PINNED_SHA`/`EXPECTED_USES` and the "bump the workflow and this test
  together" doc-comment; added `USES_RE` and a single
  `test_uses_reference_is_pinned_to_a_commit_sha` test that matches the
  `uses:` value against the path-plus-40-hex-SHA pattern. All other
  assertions (permissions, top-level permissions, concurrency, triggers,
  `with` block) are unchanged. Module docstring updated to describe the
  shape contract instead of the pinned-SHA contract.
- `docs/developers-guide.md`: new section documenting that Dependabot
  owns workflow-pin upgrades and that contract tests must assert shape,
  not a specific SHA value.
- No workflow files changed — the actual `leynos/shared-actions` pin in
  `.github/workflows/mutation-testing.yml` is untouched; Dependabot
  continues to move it.
- `.github/dependabot.yml` already has a `github-actions` ecosystem
  entry with `directory: "/"` (weekly schedule), so no change needed
  there.

## Validation

- `make test-workflow-contracts` — 6 passed, confirming the regex
  matches the currently pinned SHA.
- Reasoned through the regex against a hypothetical different 40-hex
  SHA: `^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$`
  matches any lowercase-hex 40-character ref on that exact path, and
  still rejects a branch/tag ref or a different reusable workflow path.
- `make markdownlint` and `make spellcheck` pass against the updated
  developer guide.

## References

- [Lody session](https://lody.ai/leynos/sessions/d7be4ecf-63b5-4334-850a-68aa945e5230)