### PR TITLE
Incorporate beta3 adoption feedback

### DIFF
--- a/docs/adr-002-stable-step-return-classification.md
+++ b/docs/adr-002-stable-step-return-classification.md
@@ -68,7 +68,7 @@ and assumes `Result<..>` semantics; if the return type is not actually
   required; prose guidance alone is not an adequate guard against a false
   green.
 - The implementation must therefore make unresolved classification explicit
-  without treating every named type as fallible. Roadmap item 11.4.1 tracks
+  without treating every named type as fallible. Roadmap item 11.3.1 tracks
   the diagnostic or required-hint contract and its compile and runtime
   regression matrix. Until it lands, fallible steps must spell `Result<...>`
   or `rstest_bdd::StepResult<...>`, or use the `result` hint.

--- a/docs/adr-002-stable-step-return-classification.md
+++ b/docs/adr-002-stable-step-return-classification.md
@@ -61,6 +61,17 @@ and assumes `Result<..>` semantics; if the return type is not actually
   aliases, so callers occasionally need an explicit `result`/`value` hint.
 - The “local compromise” is explicit and limited to the affected step
   definition, rather than forcing a global nightly toolchain.
+- A downstream v0.6.0-beta3 trial exposed a correctness failure in the
+  best-effort default: a local alias of `Result<T, E>` was classified as a
+  value, so an `Err` became an opaque payload and the scenario passed. The
+  return-kind hint avoids the defect only when the caller already knows it is
+  required; prose guidance alone is not an adequate guard against a false
+  green.
+- The implementation must therefore make unresolved classification explicit
+  without treating every named type as fallible. Roadmap item 11.4.1 tracks
+  the diagnostic or required-hint contract and its compile and runtime
+  regression matrix. Until it lands, fallible steps must spell `Result<...>`
+  or `rstest_bdd::StepResult<...>`, or use the `result` hint.
 
 ## Alternatives considered
 

--- a/docs/adr-002-stable-step-return-classification.md
+++ b/docs/adr-002-stable-step-return-classification.md
@@ -49,9 +49,16 @@ explicit escape hatch on the step attribute:
 - `#[given(result)]` / `#[given(value)]` (when using the inferred pattern)
 
 The `result` hint is validated for obvious misconfigurations (for example,
-primitive return types). For type aliases, the macro cannot validate the alias
-and assumes `Result<..>` semantics; if the return type is not actually
-`Result`-like, the compiler will surface a type error.
+primitive return types). Where the hint is present but the return type is a
+type alias the macro cannot resolve, the macro trusts the hint and assumes
+`Result<..>` semantics; if the return type is not actually `Result`-like, the
+compiler will surface a type error.
+
+Without a hint, an unresolved alias is **not** assumed to be `Result`-like: it
+is classified as a value, which is the false green recorded under
+*Consequences*. An unresolved alias therefore requires explicit handling from
+the author — spell out `Result<..>` or `rstest_bdd::StepResult<..>`, or give an
+explicit `result`/`value` hint.
 
 ## Consequences
 

--- a/docs/adr-002-stable-step-return-classification.md
+++ b/docs/adr-002-stable-step-return-classification.md
@@ -57,8 +57,10 @@ compiler will surface a type error.
 Without a hint, an unresolved alias is **not** assumed to be `Result`-like: it
 is classified as a value, which is the false green recorded under
 *Consequences*. An unresolved alias therefore requires explicit handling from
-the author — spell out `Result<..>` or `rstest_bdd::StepResult<..>`, or give an
-explicit `result`/`value` hint.
+the author: a fallible alias must spell out `Result<..>` or
+`rstest_bdd::StepResult<..>`, or carry the `result` hint; `value` is only for
+an alias that deliberately returns a payload, and applying it to a genuine
+`Result` suppresses its `Err`.
 
 ## Consequences
 

--- a/docs/adr-006-fallible-scenario-functions.md
+++ b/docs/adr-006-fallible-scenario-functions.md
@@ -126,7 +126,7 @@ fn my_scenario() -> Result<(), MyError> {
 - In v0.6.0-beta3, a harness-generated test can leave the fallible scenario's
   outer `Result` unconsumed. The scenario behaves correctly at runtime, but
   rustc emits `unused_must_use`, which becomes a hard error under `-D warnings`.
-  Roadmap item 11.4.2 tracks consuming or propagating this result across the
+  Roadmap item 11.3.2 tracks consuming or propagating this result across the
   standard, Tokio, and GPUI generated-test paths.
 - A unit-returning scenario still propagates `Err` from fallible steps. Users
   only need a fallible scenario signature when the scenario body itself needs

--- a/docs/adr-006-fallible-scenario-functions.md
+++ b/docs/adr-006-fallible-scenario-functions.md
@@ -123,3 +123,11 @@ fn my_scenario() -> Result<(), MyError> {
   fail to compile and must move payloads into fixtures or state.
 - The error message is fixed to unit-return expectations; any future need for
   payloads would require a new ADR and API design.
+- In v0.6.0-beta3, a harness-generated test can leave the fallible scenario's
+  outer `Result` unconsumed. The scenario behaves correctly at runtime, but
+  rustc emits `unused_must_use`, which becomes a hard error under `-D warnings`.
+  Roadmap item 11.4.2 tracks consuming or propagating this result across the
+  standard, Tokio, and GPUI generated-test paths.
+- A unit-returning scenario still propagates `Err` from fallible steps. Users
+  only need a fallible scenario signature when the scenario body itself needs
+  to use `?`; this distinction should remain explicit in migration guidance.

--- a/docs/adr-010-feature-file-change-detection.md
+++ b/docs/adr-010-feature-file-change-detection.md
@@ -178,7 +178,7 @@ foot-gun. Recorded here to keep the analysis complete; addressed separately in
 
 Neither option is unambiguously superior across all axes. This ADR records the
 trade-offs and establishes the binding constraints; the choice of mechanism is
-deferred to the implementing ExecPlan (roadmap item 11.3.1), which has access
+deferred to the implementing ExecPlan (roadmap item 10.3.3), which has access
 to the actual call-site span data and the `scenarios!` implementation.
 
 Binding constraints for the implementing ExecPlan:
@@ -209,7 +209,7 @@ Binding constraints for the implementing ExecPlan:
 
 ## Testing strategy
 
-The implementing ExecPlan (roadmap item 11.3.1) must cover three layers, in
+The implementing ExecPlan (roadmap item 10.3.3) must cover three layers, in
 addition to the binding constraint that invalidation is a tested contract:
 
 1. **Rebuild-invalidation regression test (required).** A portability-aware
@@ -236,7 +236,7 @@ addition to the binding constraint that invalidation is a tested contract:
 
    These join the existing `rstest-bdd::trybuild_macros` / `*::macro_compile`
    suites and inherit their nextest slow-timeout override. Both fixtures are
-   required acceptance criteria for roadmap item 11.3.1.
+   required acceptance criteria for roadmap item 10.3.3.
 3. **Diagnostic snapshots (required for any touched diagnostic).** For any
    user-facing diagnostic the change touches (for example the
    missing-`.feature` error), pin the rendered message with a focused `insta`
@@ -255,7 +255,7 @@ addition to the binding constraint that invalidation is a tested contract:
 
 ## Consequences
 
-- The rebuild-invalidation foot-gun is closed once 11.3.1 lands.
+- The rebuild-invalidation foot-gun is closed once 10.3.3 lands.
 - Consumers of `#[scenario]` gain invisible rebuild tracking with no
   `build.rs` obligation (Option A path).
 - Consumers of `scenarios!` gain rebuild tracking with an opt-in `build.rs`
@@ -271,7 +271,7 @@ addition to the binding constraint that invalidation is a tested contract:
 
 ## Governs
 
-- Roadmap item: Phase 11.3.1 ("Editing only a `.feature` file triggers a
+- Roadmap item: Phase 10.3.3 ("Editing only a `.feature` file triggers a
   scenario rebuild"), targeted at v0.6.0 final.
 - Design document: new `§2.7.6.6` (feature-file rebuild invalidation) and
   updated `§3.2.2`.

--- a/docs/adr-011-first-party-scenario-state-and-cleanup.md
+++ b/docs/adr-011-first-party-scenario-state-and-cleanup.md
@@ -189,8 +189,9 @@ alternative for the thread-local interim pattern.
 `T = GpuiWorld` (or a user-supplied type parameter), shipping with:
 
 - A `ScenarioStateCleanup` type (the `Drop` guard).
-- A `#[fixture]`-generating macro (or a ready-made `#[fixture]` function)
-  that implements the two-sided reset protocol: `reset_before_assignment()` in
+- A cleanup-guard fixture-generating macro that produces
+  `ScenarioStateCleanup` and `#[fixture] fn scenario_state_cleanup()`,
+  implementing the two-sided reset protocol: `reset_before_assignment()` in
   the constructor, `reset_after_scenario()` in `Drop`.
 
 This replaces the handwritten 50-line block with an import and a one-line

--- a/docs/adr-011-first-party-scenario-state-and-cleanup.md
+++ b/docs/adr-011-first-party-scenario-state-and-cleanup.md
@@ -188,7 +188,7 @@ alternative for the thread-local interim pattern.
 `GpuiScenarioStore` is a re-export or thin wrapper of `ScenarioStore<T>` with
 `T = GpuiWorld` (or a user-supplied type parameter), shipping with:
 
-- A `ScenarioCleanupGuard` type (the `Drop` guard).
+- A `ScenarioStateCleanup` type (the `Drop` guard).
 - A `#[fixture]`-generating macro (or a ready-made `#[fixture]` function)
   that implements the two-sided reset protocol: `reset_before_assignment()` in
   the constructor, `reset_after_scenario()` in `Drop`.

--- a/docs/adr-011-first-party-scenario-state-and-cleanup.md
+++ b/docs/adr-011-first-party-scenario-state-and-cleanup.md
@@ -41,7 +41,7 @@ mechanical, and a mistake in any of the four parts (missing reset-before,
 missing `Drop`, wrong reset order, or omitting the fixture parameter) silently
 corrupts subsequent scenarios on the same test thread.
 
-Roadmap items 11.1.3 and 11.1.4 propose a generic state helper and cleanup
+Roadmap items 10.3.1 and 10.3.2 propose a generic state helper and cleanup
 registration. The first downstream adopter specifically requests a
 GPUI-specialized helper and a cleanup-guard fixture macro so the 50-line block
 is replaced with a first-party type.
@@ -228,7 +228,7 @@ migration mapping.
 `ScenarioStore<T>` is a small state machine — `set`/`with`/`with_mut`/`take`/
 `reset` plus the two-sided reset protocol — so example-based unit tests alone
 under-sample the operation orderings that matter. The implementing ExecPlan
-(roadmap items 11.1.3/11.1.4) should layer:
+(roadmap items 10.3.1/10.3.2) should layer:
 
 1. **Unit tests (required).** Exercise each of the five operations directly,
    and the three-state cleanup lifecycle (success, assertion failure, skip),
@@ -260,14 +260,14 @@ harness cost of a model checker.
 - Additive and semver-compatible change for v0.6.1.
 - GPUI adopters can replace ~50 lines of boilerplate with a single import.
 - The cleanup-ordering contract is tested and cannot silently regress.
-- The GPUI re-export depends on the generic core landing first (11.1.3 before
-  11.1.4).
+- The GPUI re-export depends on the generic core landing first (10.3.1 before
+  10.3.2).
 - `rstest-bdd`'s public API gains `ScenarioStore<T>`; naming is verified not
   to collide with existing `ScenarioState` trait and `Slot<T>`.
 
 ## Governs
 
-- Roadmap items: re-scoped 11.1.3 (`ScenarioStore<T>` generic core) and 11.1.4
+- Roadmap items: re-scoped 10.3.1 (`ScenarioStore<T>` generic core) and 10.3.2
   (`GpuiScenarioStore` + cleanup-guard fixture macro, three-state lifecycle
   test), both targeted at v0.6.0 final per the maintainer pull-forward decision.
 - Design document: `§2.7.6.4` (v0.6.1 early-life support helpers).

--- a/docs/adr-011-first-party-scenario-state-and-cleanup.md
+++ b/docs/adr-011-first-party-scenario-state-and-cleanup.md
@@ -72,7 +72,7 @@ shadow — `Slot<T>`. This ADR proposes `ScenarioStore<T>` as the generic core a
 - State clearly which API is current per v0.6.x / v0.7.0 release, so
   adopters know the thread-local interim (`§2.7.6.2`) is still supported in
   v0.6.x while `ScenarioStore<T>` is the recommended additive alternative from
-  v0.6.1 onward.
+  v0.6.0 final onward.
 
 ## Options considered
 
@@ -212,14 +212,14 @@ The ADR fixes the cleanup-ordering contract:
 
 ### Cross-version stance
 
-| Version           | Recommended pattern                      | Support status  |
-| ----------------- | ---------------------------------------- | --------------- |
-| v0.6.0 (current)  | Thread-local interim (`§2.7.6.2`)        | Supported       |
-| v0.6.1 (additive) | `ScenarioStore<T>` / `GpuiScenarioStore` | Preferred       |
-| v0.7.0 (breaking) | Guard-based borrow redesign (ADR-012)    | Supersedes both |
+| Version              | Recommended pattern                      | Support status  |
+| -------------------- | ---------------------------------------- | --------------- |
+| v0.6.0 beta          | Thread-local interim (`§2.7.6.2`)        | Supported       |
+| v0.6.0 final (addl.) | `ScenarioStore<T>` / `GpuiScenarioStore` | Preferred       |
+| v0.7.0 (breaking)    | Guard-based borrow redesign (ADR-012)    | Supersedes both |
 
-The v0.6.0 thread-local interim pattern remains supported throughout v0.6.x.
-`ScenarioStore<T>` is the recommended additive alternative from v0.6.1.
+The beta thread-local interim pattern remains supported throughout v0.6.x.
+`ScenarioStore<T>` is the recommended additive alternative from v0.6.0 final.
 ADR-012's guard-based redesign supersedes both at v0.7.0 and provides a
 migration mapping.
 
@@ -257,7 +257,8 @@ harness cost of a model checker.
 
 ## Consequences
 
-- Additive and semver-compatible change for v0.6.1.
+- Additive and semver-compatible change, scheduled as a v0.6.0 final
+  requirement.
 - GPUI adopters can replace ~50 lines of boilerplate with a single import.
 - The cleanup-ordering contract is tested and cannot silently regress.
 - The GPUI re-export depends on the generic core landing first (10.3.1 before
@@ -269,6 +270,7 @@ harness cost of a model checker.
 
 - Roadmap items: re-scoped 10.3.1 (`ScenarioStore<T>` generic core) and 10.3.2
   (`GpuiScenarioStore` + cleanup-guard fixture macro, three-state lifecycle
-  test), both preferred from v0.6.1 while the v0.6.0 thread-local pattern
+  test), both v0.6.0 final requirements under roadmap step 10.3 alongside
+  10.3.3 (the feature-file rebuild fix), while the beta thread-local pattern
   remains supported throughout v0.6.x.
-- Design document: `§2.7.6.4` (v0.6.1 early-life support helpers).
+- Design document: `§2.7.6.4`.

--- a/docs/adr-011-first-party-scenario-state-and-cleanup.md
+++ b/docs/adr-011-first-party-scenario-state-and-cleanup.md
@@ -269,5 +269,6 @@ harness cost of a model checker.
 
 - Roadmap items: re-scoped 10.3.1 (`ScenarioStore<T>` generic core) and 10.3.2
   (`GpuiScenarioStore` + cleanup-guard fixture macro, three-state lifecycle
-  test), both targeted at v0.6.0 final per the maintainer pull-forward decision.
+  test), both preferred from v0.6.1 while the v0.6.0 thread-local pattern
+  remains supported throughout v0.6.x.
 - Design document: `§2.7.6.4` (v0.6.1 early-life support helpers).

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -979,8 +979,8 @@ Contributors touching the borrow machinery should expect:
   it.
 - `FixtureRefMut` exposes a stable, opaque accessor API (12.1.2), and a
   first-class world lifecycle contract (12.1.3) supersedes the thread-local
-  reset protocol and the v0.6.1 `ScenarioStore<T>` helper. The ADR carries the
-  v0.6→v0.7 migration mapping.
+  reset protocol and the v0.6.0 final `ScenarioStore<T>` helper. The ADR carries
+  the v0.6→v0.7 migration mapping.
 - Borrow-state invariants are the highest-risk part of the surface and must be
   covered by generated-wrapper, property-based (`proptest`), and lifecycle
   tests — see the ADR's _Testing strategy_.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -932,11 +932,11 @@ bookkeeping exactly once and applies the caller's projection to the resolved
 ## Planned internal APIs and tooling (ADR-010 to ADR-013)
 
 Three accepted-as-`Proposed` ADRs schedule internal-API and build-tooling
-changes that contributors will encounter as the v0.6.1 and v0.7.0 work lands.
-ADR-013 is already accepted and governs the current Whitaker lint gate. They
-are summarized here, so the decisions are discoverable from the developer
-guide; the ADRs remain the authoritative source, and the planning rationale
-lives in
+changes that contributors will encounter as the v0.6.0 final and v0.7.0 work
+lands. ADR-013 is already accepted and governs the current Whitaker lint
+gate. They are summarized here, so the decisions are discoverable from the
+developer guide; the ADRs remain the authoritative source, and the planning
+rationale lives in
 [`docs/execplans/adopt-v0-6-0-beta2-feedback.md`](execplans/adopt-v0-6-0-beta2-feedback.md).
 
 ### Scenario-state helpers and per-scenario cleanup (ADR-011)

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -959,7 +959,7 @@ cleanup guard that stateful GPUI scenarios use today:
   by unit, property-based (`proptest`), and `serial_test`-guarded
   thread-isolation tests — see the ADR's _Testing strategy_.
 
-Tracked by roadmap items 11.1.3 and 11.1.4 (pulled forward to v0.6.0 final);
+Tracked by roadmap items 10.3.1 and 10.3.2 (pulled forward to v0.6.0 final);
 design coverage is in `rstest-bdd-design.md` §2.7.6.4.
 
 ### Guard-based `StepContext` borrowing and `FixtureBorrowError` (ADR-012)
@@ -1011,7 +1011,7 @@ foot-gun: `#[scenario(path = …)]` and `scenarios!` read `.feature` files with
   _Testing strategy_. This is distinct from the OUT_DIR AST _caching_
   performance idea in `rstest-bdd-design.md` §3.2.2.
 
-Tracked by roadmap item 11.3.1 (pulled forward to v0.6.0 final); design
+Tracked by roadmap item 10.3.3 (pulled forward to v0.6.0 final); design
 coverage is in `rstest-bdd-design.md` §2.7.6.6. Until it lands,
 `v0-6-0-migration-guide.md` carries a caveat that `.feature`-only edits do not
 trigger a rebuild.

--- a/docs/execplans/10-2-7-gpui-bulk-migration-cookbook.md
+++ b/docs/execplans/10-2-7-gpui-bulk-migration-cookbook.md
@@ -41,7 +41,8 @@ You can see success four ways:
 
 1. `docs/users-guide.md` contains an expanded "Bulk-migration cookbook"
    subsection that documents sharing the *step library* (not only the state
-   scaffolding), is framed as the v0.6.0 shape that v0.6.1 shrinks, bridges the
+   scaffolding), is framed as the beta shape that v0.6.0 final shrinks, bridges
+   the
    GPUI specifics to published `gpui 0.2.2`, and points at the executable
    reference.
 2. A new executable reference suite proves one shared step library is reused by
@@ -115,8 +116,9 @@ the executable *sharing* reference.
 
 The rejected alternative — a second feature-gated GPUI suite with two
 window-opening binaries — was declined because it re-proves the
-harness-agnostic sharing mechanism at high cost, hand-builds boilerplate
-scheduled for deletion in v0.6.1, trips the dead-code lint, and would be built
+harness-agnostic sharing mechanism at high cost, hand-builds boilerplate that
+roadmap items 10.3.1/10.3.2 replace as v0.6.0 final work, trips the dead-code
+lint, and would be built
 by copying `stateful_window.rs` wholesale (Constraint 2 forbids refactoring
 it), i.e. the anti-duplication exemplar would itself be duplication.
 
@@ -396,7 +398,7 @@ Stop and escalate (document in Decision Log, await direction) when:
 Delivered against all four success criteria in "Purpose":
 
 1. `docs/users-guide.md` "Bulk-migration cookbook" now documents sharing the
-   step library (not only scaffolding), framed v0.6.0→v0.6.1, bridged to
+   step library (not only scaffolding), framed beta→v0.6.0 final, bridged to
    published `gpui 0.2.2`, and pointing at the executable references.
 2. The harness-agnostic reference suite proves one shared step library serves
    two scenarios across two feature files, with zero step definitions in the

--- a/docs/execplans/10-2-7-gpui-bulk-migration-cookbook.md
+++ b/docs/execplans/10-2-7-gpui-bulk-migration-cookbook.md
@@ -467,7 +467,7 @@ Key terms:
 
 1. `docs/roadmap.md` around lines 866-870 — the 10.2.7 item and finish line;
    lines 907-933 — items 10.3.1/10.3.2 (`ScenarioStore<T>` and the
-   cleanup-guard macro) that shrink this boilerplate in v0.6.1.
+   cleanup-guard macro) that shrink this boilerplate in v0.6.0 final.
 2. `docs/rstest-bdd-design.md` §2.7.6.2 (lines ~1947-2058) — the interim GPUI
    state pattern and the vendored-vs-published mapping table.
 3. `docs/users-guide.md`: "Stateful GPUI scenarios with durable handles"

--- a/docs/execplans/10-2-7-gpui-bulk-migration-cookbook.md
+++ b/docs/execplans/10-2-7-gpui-bulk-migration-cookbook.md
@@ -101,8 +101,8 @@ primitives without gpui and without thread-locals). This is:
 
 - cheaper and lint-clean (no dead-code from per-feature-unused helpers);
 - not obsolescence-bound (it uses the `Slot<T>`/`ScenarioState` primitives that
-  roadmap 11.1.3's `ScenarioStore<T>` builds on, rather than the thread-local
-  boilerplate 11.1.3/11.1.4 will delete);
+  roadmap 10.3.1's `ScenarioStore<T>` builds on, rather than the thread-local
+  boilerplate 10.3.1/10.3.2 will delete);
 - free of the vendored-vs-published gpui mismatch (see Decision 2); and
 - free of the cross-binary GPUI concerns the review examined and dismissed.
 
@@ -314,7 +314,7 @@ Stop and escalate (document in Decision Log, await direction) when:
 - Observation: `crates/rstest-bdd/tests/scenario_state.rs` demonstrates durable
   scenario state via `#[derive(ScenarioState)]` + `Slot<T>` + `#[fixture]`,
   with no gpui and no thread-local. Impact: the recommended suite builds on
-  shipped primitives and is not obsoleted by 11.1.3.
+  shipped primitives and is not obsoleted by 10.3.1.
 - Observation: `make test` uses `--workspace --all-targets --all-features`
   (Makefile line 13). Impact: the recommended (non-gated) suite runs in the
   standard gate; whether `--all-features` also flips
@@ -351,7 +351,7 @@ Stop and escalate (document in Decision Log, await direction) when:
   proof in `rstest-bdd`, not a new feature-gated GPUI suite. Rationale: the
   reuse property is harness-agnostic and already precedented by
   `noop_steps.rs`; a GPUI suite re-proves it at high cost, hand-builds
-  thread-local boilerplate that 11.1.3/11.1.4 delete in v0.6.1, trips the
+  thread-local boilerplate that 10.3.1/10.3.2 delete for v0.6.0 final, trips the
   dead-code lint, targets vendored gpui for a published-gpui audience, and
   would be built by copying `stateful_window.rs` (which Constraint 2 forbids
   refactoring), making the anti-duplication exemplar out of duplication. The
@@ -410,7 +410,7 @@ Delivered against all four success criteria in "Purpose":
 
 What went well: the six-lens design review caught, before any code was written,
 that the originally planned feature-gated GPUI suite was the wrong vehicle
-(obsolescence against 11.1.3/11.1.4, dead-code lint, vendored-vs-published
+(obsolescence against 10.3.1/10.3.2, dead-code lint, vendored-vs-published
 mismatch, and duplication of `stateful_window.rs`). Switching to a
 harness-agnostic proof built on the shipped `Slot<T>`/`ScenarioState`
 primitives made the suite lint-clean, cheap, and durable.
@@ -466,7 +466,7 @@ Key terms:
 ### Files to read first
 
 1. `docs/roadmap.md` around lines 866-870 — the 10.2.7 item and finish line;
-   lines 907-933 — items 11.1.3/11.1.4 (`ScenarioStore<T>` and the
+   lines 907-933 — items 10.3.1/10.3.2 (`ScenarioStore<T>` and the
    cleanup-guard macro) that shrink this boilerplate in v0.6.1.
 2. `docs/rstest-bdd-design.md` §2.7.6.2 (lines ~1947-2058) — the interim GPUI
    state pattern and the vendored-vs-published mapping table.
@@ -571,8 +571,8 @@ the presence of the shared *steps*.
 ### Stage B-docs — documentation
 
 1. Expand `docs/users-guide.md` "Bulk-migration cookbook":
-   - Open with the frame: this is the v0.6.0 shape; v0.6.1 (roadmap
-     11.1.3/11.1.4,
+   - Open with the frame: this is the beta shape; v0.6.0 final (roadmap
+     10.3.1/10.3.2,
      `ScenarioStore<T>` + cleanup-guard macro) collapses the shared block to an
      import and generates the cleanup parameter — adopt now, expect to shrink.
    - State that the shared module holds the **step library** (the

--- a/docs/execplans/adopt-v0-6-0-beta2-feedback.md
+++ b/docs/execplans/adopt-v0-6-0-beta2-feedback.md
@@ -198,25 +198,24 @@ Thresholds that trigger escalation when breached.
   `make nixie`), and cleared a `coderabbit review --agent` pass (0 findings).
 - [x] (2026-06-09) Community-of-experts (Logisphere) panel reviewed the plan;
   revised in response — renamed the helper to `ScenarioStore<T>` (collision
-  fix), made ADR-010 even-handed and rejected absolute-path embedding, moved
-  the rebuild item to Phase 11.3, elevated the pull-forward recommendation,
-  added the tested cleanup lifecycle, the v0.6→v0.7 mapping sketch, the gpui
+  fix), made ADR-010 even-handed and rejected absolute-path embedding, moved the
+  rebuild item to step 10.3, elevated the pull-forward recommendation, added
+  the tested cleanup lifecycle, the v0.6→v0.7 mapping sketch, the gpui
   maintenance-tax note, and the open scheduling/divergence decisions.
 - [x] (2026-06-10) Maintainer approval received. Open decisions resolved:
   (a) pull-forward recommendation accepted — 10.3.1/10.3.2 (`ScenarioStore`/
   cleanup helper) and 10.3.3 (rebuild-invalidation fix) will be scheduled in
   v0.6.0 final; (b) Stage E code fix deferred — to be added as a roadmap item
   and implemented under its own ExecPlan rather than in this branch.
-- [x] (2026-06-10) Stage B complete: wrote
-      `adr-010-feature-file-change-detection.md`,
+- [x] (2026-06-10) Stage B complete: wrote `adr-010-feature-file-change-detection.md`,
   `adr-011-first-party-scenario-state-and-cleanup.md`, and
   `adr-012-guard-based-stepcontext-borrowing.md`; `make markdownlint` clean.
 - [x] (2026-06-10) Stage C complete: applied roadmap edits — clarified
   10.1.4 (affirmative outcome + test reference), added 10.2.4–10.2.7
-  (documentation items) with dual-track maintenance note, re-scoped 10.3.1 and
-  10.3.2 (ScenarioStore naming + pull-forward notes), added Phase 11.3 (rebuild
-  gap + ADR-008 follow-up note), and amended Phase 12 heading and 12.1.1 to
-  reference ADR-012; `make markdownlint` clean.
+  (documentation items) with dual-track maintenance note, re-scoped 10.3.1
+  and 10.3.2 (ScenarioStore naming + pull-forward notes), added 10.3.3
+  (rebuild gap + ADR-008 follow-up note), and amended Phase 12 heading and
+  12.1.1 to reference ADR-012; `make markdownlint` clean.
 - [x] (2026-06-10) Stage D complete: applied design-document and adoption-guide
   edits — added which-gpui banner + mapping table in §2.7.6.2, added ADR-011
   reference in §2.7.6.4, updated §2.7.6.5 to committed direction + ADR-012
@@ -242,8 +241,8 @@ Thresholds that trigger escalation when breached.
   alongside the portability-aware rebuild regression test.
 - [x] (2026-06-13) Follow-up review warning: elevated ADR-010's `trybuild`
   compile-pass and compile-fail fixtures from *recommended* to *required*
-  acceptance criteria, and strengthened the snapshot guidance to require focused
-  `insta` snapshots backed by semantic/substring assertions on the
+  acceptance criteria, and strengthened the snapshot guidance to require
+  focused `insta` snapshots backed by semantic/substring assertions on the
   load-bearing diagnostic fragments. Mirrored the requirement in roadmap item
   10.3.3's finish line.
 
@@ -330,25 +329,25 @@ Thresholds that trigger escalation when breached.
 ## Decision log
 
 - Decision: assign the three new ADRs the next free numbers — `adr-010`
-  (feature-file change detection), `adr-011` (first-party scenario-state
-  helpers and cleanup), `adr-012` (guard-based `StepContext` borrowing
-  committed for v0.7.0). Rationale: the highest existing ADR is 009; sequential
-  numbering matches the established convention. Date/Author: 2026-06-09 /
-  Claude (plan author).
+  (feature-file change detection), `adr-011` (first-party scenario-state helpers
+  and cleanup), `adr-012` (guard-based `StepContext` borrowing committed for
+  v0.7.0). Rationale: the highest existing ADR is 009; sequential numbering
+  matches the established convention. Date/Author: 2026-06-09 / Claude (plan
+  author).
 
 - Decision: document the gpui API divergence with a banner plus a mapping table
   rather than rewriting the snippets to a single API. Rationale: the regression
-  suite compiles against the vendored gpui; a one-API rewrite would either
-  break the suite's mirroring contract or misrepresent what adopters compile
-  against. Date/Author: 2026-06-09 / Claude.
+  suite compiles against the vendored gpui; a one-API rewrite would either break
+  the suite's mirroring contract or misrepresent what adopters compile against.
+  Date/Author: 2026-06-09 / Claude.
 
 - Decision: recommend macro-emitted `include_str!` as the preferred
-  rebuild-invalidation mechanism, with the build-script
-  (`cargo::rerun-if-changed`) route as a documented fallback for the
-  directory-glob `scenarios!` case. Rationale: `include_str!` closes the loop
-  invisibly to consumers and cannot be forgotten per call site; the
-  build-script route is proven by `theoremc` but reintroduces the "emit one
-  rerun-if line per file or regress" trap. Date/Author: 2026-06-09 / Claude.
+  rebuild-invalidation mechanism, with the build-script (`cargo::rerun-if-changed`)
+  route as a documented fallback for the directory-glob `scenarios!` case.
+  Rationale: `include_str!` closes the loop invisibly to consumers and cannot be
+  forgotten per call site; the build-script route is proven by `theoremc` but
+  reintroduces the "emit one rerun-if line per file or regress" trap. Date/Author:
+  2026-06-09 / Claude.
 
 - Decision: keep ADR-008's `Proposed`→`Accepted` resolution as a separable,
   clearly-labelled roadmap follow-up, not a dependency of this feedback work.
@@ -379,11 +378,10 @@ Doggylump, Dinolump):
   build-script route avoids embedding entirely and fits `scenarios!` globs.
   Date/Author: 2026-06-09 / Claude (panel: Doggylump, Wafflecat, Buzzy Bee).
 
-- Decision: place the rebuild-invalidation item in Phase 11 (`11.3`), not a new
-  subsection of the delivered Phase 10. Rationale: Phase 10 is delivered;
-  adding work to it muddies phase semantics. The pull-forward-to-v0.6.0-final
-  recommendation is recorded separately. Date/Author: 2026-06-09 / Claude
-  (panel: Pandalump).
+- Decision: place the rebuild-invalidation item in step 10.3 as item 10.3.3.
+  Rationale: the maintainer accepted the pull-forward-to-v0.6.0-final
+  recommendation, and the roadmap now collects all final-release requirements
+  under one step. Date/Author: 2026-06-10 / maintainer.
 
 - Decision (2026-06-10, maintainer): pull 10.3.1/10.3.2 (the
   `ScenarioStore`/cleanup helper) and 10.3.3 (the rebuild fix) forward into
@@ -405,14 +403,13 @@ Doggylump, Dinolump):
 
 All four observable outcomes from `Purpose / big picture` are met:
 
-1. **Roadmap records every new or re-scoped work item.** Added items
-   10.2.4–10.2.7 (gpui-version banner + mapping table, lint-clean playbook
-   variant, nextest interaction note, bulk-migration cookbook), re-scoped
-   10.3.1/10.3.2 (naming the correct `ScenarioStore<T>` / `GpuiScenarioStore`
-   types and cleanup-guard fixture macro, with pull-forward scheduling notes),
-   added Phase 11.3 with item 10.3.3 (feature-file rebuild fix), and amended
-   Phase 12 intro and 12.1.1 to record the committed direction and reference
-   ADR-012.
+1. **Roadmap records every new or re-scoped work item.** Added items 10.2.4–10.2.7
+   (gpui-version banner + mapping table, lint-clean playbook variant, nextest
+   interaction note, bulk-migration cookbook), re-scoped 10.3.1/10.3.2 (naming
+   the correct `ScenarioStore<T>` / `GpuiScenarioStore` types and cleanup-guard
+   fixture macro, with pull-forward scheduling notes), added item 10.3.3 to
+   step 10.3 (feature-file rebuild fix), and amended Phase 12 intro and 12.1.1
+   to record the committed direction and reference ADR-012.
 
 2. **Design document `§2.7.6.x` corrected and extended.** Added a which-gpui
    banner and vendored-to-published mapping table in `§2.7.6.2`, ADR references
@@ -426,11 +423,11 @@ All four observable outcomes from `Purpose / big picture` are met:
    cross-referencing the roadmap items and design subsections they govern.
 
 4. **Adoption guides carry the corrections.** `docs/users-guide.md` carries the
-   gpui-version banner + mapping table, nextest/`serial_test` caveat,
-   lint-clean variant, bulk-migration cookbook, and design-doc cross-links.
-   `docs/v0-6-0-migration-guide.md` carries a "Feature-file edits do not
-   trigger a rebuild" caveat under "Common errors and fixes", marked removable
-   once 10.3.3 lands.
+   gpui-version banner + mapping table, nextest/`serial_test` caveat, lint-clean
+   variant, bulk-migration cookbook, and design-doc cross-links.
+   `docs/v0-6-0-migration-guide.md` carries a "Feature-file edits do not trigger
+   a rebuild" caveat under "Common errors and fixes", marked removable once
+   10.3.3 lands.
 
 No feedback item was left unscheduled. Stage E (rebuild-invalidation code fix)
 was deferred to a separate ExecPlan and roadmap item (10.3.3) per explicit
@@ -438,9 +435,8 @@ maintainer decision; it is not unscheduled, just not implemented in this
 documentation branch.
 
 Open items remaining after this plan: (a) the ADR-008 Proposed→Accepted
-advancement (separately gated, orthogonal); (b) the
-retarget-onto-published-gpui architectural decision (Wafflecat's alternative,
-deferred).
+advancement (separately gated, orthogonal); (b) the retarget-onto-published-gpui
+architectural decision (Wafflecat's alternative, deferred).
 
 ## Context and orientation
 
@@ -798,7 +794,8 @@ the tolerance bound and must be re-approved.
 - Consequences: closes the foot-gun; the chosen mechanism must be covered by a
   portability-aware regression test; no absolute path is embedded into the
   artefact.
-- Governs roadmap item: new Phase 11.3 rebuild item. Design Doc: new `§2.7.6.6`.
+- Governs roadmap item: 10.3.3 in the v0.6.0 final requirements step. Design
+  Doc: new `§2.7.6.6`.
 
 ### ADR-011 — First-party scenario-state helpers and per-scenario cleanup
 
@@ -879,15 +876,15 @@ the tolerance bound and must be re-approved.
 Prescriptive list (apply in document order, matching existing item style — each
 new item carries a finish line and a `Design Doc:` / ADR reference):
 
-- New subsection `### 11.3. Close the feature-file rebuild gap` with item
-  `10.3.3`: "Editing only a `.feature` file triggers a scenario rebuild."
-  Finish line: the `#[scenario]`/`scenarios!` expansion registers each bound
-  feature file as a Cargo rebuild dependency (per ADR-010, without embedding an
-  absolute path into the artefact), and a portability-aware regression test
-  proves a `.feature`-only edit forces recompilation and a fresh failure. The
-  item lives in Phase 11 (the open v0.6.x line) rather than the delivered Phase
-  10, and carries a recommendation to pull it forward to v0.6.0 final.
-  Non-breaking. Design Doc: `§2.7.6.6`; ADR-010.
+- Add item `10.3.3` to `### 10.3. v0.6.0 final requirements`: "Editing only a
+  `.feature` file triggers a scenario rebuild." Finish
+  line: the `#[scenario]`/`scenarios!` expansion registers each bound feature
+  file as a Cargo rebuild dependency (per ADR-010, without embedding an absolute
+  path into the artefact), and a portability-aware regression test proves a
+  `.feature`-only edit forces recompilation and a fresh failure. The item lives
+  in Phase 11 (the open v0.6.x line) rather than the delivered Phase 10, and
+  carries a recommendation to pull it forward to v0.6.0 final. Non-breaking.
+  Design Doc: `§2.7.6.6`; ADR-010.
 - Clarify delivered `10.1.4`: append that the affirmative branch shipped — the
   scenario name is embedded in the augmented panic message and tracing events
   (`crates/rstest-bdd-harness-gpui/src/gpui_harness.rs`), with regression tests
@@ -918,8 +915,8 @@ new item carries a finish line and a `Design Doc:` / ADR reference):
     library across many GPUI scenarios in a single consuming crate. Finish line:
     a cookbook subsection in the user guide. Design Doc: `§2.7.6.2`.
 - Re-scope `10.3.1` to name the generic `ScenarioStore<T>` core in `rstest-bdd`
-  (named to avoid colliding with the shipped `ScenarioState` trait and
-  `Slot<T>` in `crates/rstest-bdd/src/state.rs`) *and* the GPUI-specialized
+  (named to avoid colliding with the shipped `ScenarioState` trait and `Slot<T>`
+  in `crates/rstest-bdd/src/state.rs`) *and* the GPUI-specialized
   `GpuiScenarioStore` re-export in `rstest-bdd-harness-gpui`; re-scope `10.3.2`
   to add a cleanup-guard fixture-generating macro with a tested three-state
   lifecycle (success, failure, skip). Reference ADR-011.
@@ -945,8 +942,8 @@ new item carries a finish line and a `Design Doc:` / ADR reference):
   (a) compile-testing the playbook snippets (a doc-test or a tiny example crate
   that the gate builds) so staleness fails CI, and (b) recording the larger
   alternative of retargeting the regression suite and docs onto the published
-  `gpui` so the mapping table can eventually be retired — deferred as a
-  separate architectural decision outwith this plan (see Decision Log).
+  `gpui` so the mapping table can eventually be retired — deferred as a separate
+  architectural decision outwith this plan (see Decision Log).
 
 ### Design-document edits (`docs/rstest-bdd-design.md`)
 
@@ -984,8 +981,8 @@ review: renamed the proposed helper from `ScenarioState<T>` to
 `ScenarioStore<T>`/`GpuiScenarioStore` to avoid a verified collision with the
 shipped `ScenarioState` trait and `Slot<T>`; rewrote ADR-010 to weigh the
 mechanisms even-handedly and reject absolute-path `include_str!` embedding for
-build reproducibility; relocated the rebuild item from `10.3` to `11.3` to
-respect the delivered Phase 10 boundary; surfaced the pull-forward scheduling
+build reproducibility; placed the rebuild item at `10.3.3` under the consolidated
+v0.6.0 final requirements; surfaced the pull-forward scheduling
 recommendation as an explicit open maintainer decision; added a tested
 three-state cleanup lifecycle to ADR-011, a concrete v0.6→v0.7
 migration-mapping sketch to ADR-012, a gpui dual-track maintenance-tax note

--- a/docs/execplans/adopt-v0-6-0-beta2-feedback.md
+++ b/docs/execplans/adopt-v0-6-0-beta2-feedback.md
@@ -460,8 +460,8 @@ Key files this plan touches or references:
 - `docs/rstest-bdd-design.md` — `§2.7` harness adapters; `§2.7.6.1` borrow
   constraint (E0499/E0502); `§2.7.6.2` interim GPUI state pattern (lines
   1947–2021, contains the divergent snippet); `§2.7.6.3` v0.6.0-beta2 quick
-  wins; `§2.7.6.4` v0.6.1 helpers; `§2.7.6.5` v0.7.0 redesign (lines 2058–2067);
-  `§3.2.2` OUT_DIR AST-caching aspiration (lines ~1277–1282).
+  wins; `§2.7.6.4` state helpers; `§2.7.6.5` v0.7.0 redesign (lines
+  2058–2067); `§3.2.2` OUT_DIR AST-caching aspiration (lines ~1277–1282).
 - `docs/users-guide.md` — "Stateful GPUI scenarios with durable handles"
   playbook (lines ~1088–1360), including "Reset protocol" (~1131) which mentions
   `#[serial]` (~1159) and the durable-handle snippets (~1264–1316).
@@ -836,13 +836,15 @@ the tolerance bound and must be re-approved.
   failure, skip) rather than leaving the contract as advisory prose.
 - Cross-version stance: the v0.6.x thread-local interim pattern (`§2.7.6.2`)
   remains supported throughout v0.6.x; `ScenarioStore<T>` is the preferred
-  additive alternative from v0.6.1; the v0.7.0 guard-based borrow redesign
-  (ADR-012) supersedes both, with a migration mapping. The ADR states this
-  explicitly so adopters know which pattern is current per release.
-- Consequences: additive and semver-compatible (v0.6.1); the GPUI re-export
-  depends on the generic core landing first.
-- Governs roadmap items: re-scoped 10.3.1/10.3.2 and a new cleanup-guard-macro
-  item. Design Doc: `§2.7.6.4`.
+  additive alternative from v0.6.0 final; the v0.7.0 guard-based borrow
+  redesign (ADR-012) supersedes both, with a migration mapping. The ADR
+  states this explicitly so adopters know which pattern is current per
+  release.
+- Consequences: additive and semver-compatible (v0.6.0 final); the GPUI
+  re-export depends on the generic core landing first.
+- Governs roadmap items: re-scoped 10.3.1 (the generic `ScenarioStore<T>`
+  core) and 10.3.2 (`GpuiScenarioStore`, the cleanup-guard fixture macro, and
+  its three-state lifecycle test). Design Doc: `§2.7.6.4`.
 
 ### ADR-012 — Guard-based `StepContext` borrowing committed for v0.7.0
 
@@ -867,8 +869,8 @@ the tolerance bound and must be re-approved.
   requesting `&mut World` directly alongside `&mut TestAppContext`, now legal
   because guard-based borrowing permits concurrent distinct-key mutable borrows.
 - Consequences: a breaking change reserved for v0.7.0 with a migration guide;
-  it supersedes the interim pattern of `§2.7.6.2`. Pairs with the v0.6.1
-  additive helper (`adr-011`) as the stepping stone.
+  it supersedes the interim pattern of `§2.7.6.2`. Pairs with the v0.6.0
+  final additive helper (`adr-011`) as the stepping stone.
 - Governs roadmap items: amended Phase 12 intro and 12.1.1. Design Doc:
   `§2.7.6.5`.
 
@@ -882,9 +884,7 @@ new item carries a finish line and a `Design Doc:` / ADR reference):
   line: the `#[scenario]`/`scenarios!` expansion registers each bound feature
   file as a Cargo rebuild dependency (per ADR-010, without embedding an absolute
   path into the artefact), and a portability-aware regression test proves a
-  `.feature`-only edit forces recompilation and a fresh failure. The item lives
-  in Phase 11 (the open v0.6.x line) rather than the delivered Phase 10, and
-  carries a recommendation to pull it forward to v0.6.0 final. Non-breaking.
+  `.feature`-only edit forces recompilation and a fresh failure. Non-breaking.
   Design Doc: `§2.7.6.6`; ADR-010.
 - Clarify delivered `10.1.4`: append that the affirmative branch shipped — the
   scenario name is embedded in the augmented panic message and tracing events

--- a/docs/execplans/adopt-v0-6-0-beta2-feedback.md
+++ b/docs/execplans/adopt-v0-6-0-beta2-feedback.md
@@ -100,7 +100,7 @@ Thresholds that trigger escalation when breached.
   `docs/rstest-bdd-design.md`, `docs/users-guide.md`,
   `docs/v0-6-0-migration-guide.md`, and this plan), stop and escalate.
 - Roadmap scheduling: this plan *recommends* pulling the scenario-state helper
-  (11.1.3/11.1.4) and the rebuild-invalidation fix forward to v0.6.0 final, but
+  (10.3.1/10.3.2) and the rebuild-invalidation fix forward to v0.6.0 final, but
   the actual release-train placement is a maintainer decision. If executing the
   plan would require committing to a release schedule not yet agreed, stop and
   present the trade-off rather than choosing unilaterally.
@@ -203,8 +203,8 @@ Thresholds that trigger escalation when breached.
   added the tested cleanup lifecycle, the v0.6→v0.7 mapping sketch, the gpui
   maintenance-tax note, and the open scheduling/divergence decisions.
 - [x] (2026-06-10) Maintainer approval received. Open decisions resolved:
-  (a) pull-forward recommendation accepted — 11.1.3/11.1.4 (`ScenarioStore`/
-  cleanup helper) and 11.3.1 (rebuild-invalidation fix) will be scheduled in
+  (a) pull-forward recommendation accepted — 10.3.1/10.3.2 (`ScenarioStore`/
+  cleanup helper) and 10.3.3 (rebuild-invalidation fix) will be scheduled in
   v0.6.0 final; (b) Stage E code fix deferred — to be added as a roadmap item
   and implemented under its own ExecPlan rather than in this branch.
 - [x] (2026-06-10) Stage B complete: wrote
@@ -213,8 +213,8 @@ Thresholds that trigger escalation when breached.
   `adr-012-guard-based-stepcontext-borrowing.md`; `make markdownlint` clean.
 - [x] (2026-06-10) Stage C complete: applied roadmap edits — clarified
   10.1.4 (affirmative outcome + test reference), added 10.2.4–10.2.7
-  (documentation items) with dual-track maintenance note, re-scoped 11.1.3 and
-  11.1.4 (ScenarioStore naming + pull-forward notes), added Phase 11.3 (rebuild
+  (documentation items) with dual-track maintenance note, re-scoped 10.3.1 and
+  10.3.2 (ScenarioStore naming + pull-forward notes), added Phase 11.3 (rebuild
   gap + ADR-008 follow-up note), and amended Phase 12 heading and 12.1.1 to
   reference ADR-012; `make markdownlint` clean.
 - [x] (2026-06-10) Stage D complete: applied design-document and adoption-guide
@@ -245,7 +245,7 @@ Thresholds that trigger escalation when breached.
   acceptance criteria, and strengthened the snapshot guidance to require focused
   `insta` snapshots backed by semantic/substring assertions on the
   load-bearing diagnostic fragments. Mirrored the requirement in roadmap item
-  11.3.1's finish line.
+  10.3.3's finish line.
 
 ## Surprises & discoveries
 
@@ -313,7 +313,7 @@ Thresholds that trigger escalation when breached.
   the test reference, removing the "or documented limitation" ambiguity.
 
 - Observation: a generic helper named `ScenarioState<T>` (as loosely implied by
-  roadmap 11.1.3) would collide with an already-shipped public surface.
+  roadmap 10.3.1) would collide with an already-shipped public surface.
   Evidence: `crates/rstest-bdd/src/state.rs` defines
   `pub trait ScenarioState: Default` (line 136) and `pub struct Slot<T>` (line
   30), both re-exported from the crate root. Impact: the new helper is named
@@ -385,14 +385,14 @@ Doggylump, Dinolump):
   recommendation is recorded separately. Date/Author: 2026-06-09 / Claude
   (panel: Pandalump).
 
-- Decision (2026-06-10, maintainer): pull 11.1.3/11.1.4 (the
-  `ScenarioStore`/cleanup helper) and 11.3.1 (the rebuild fix) forward into
+- Decision (2026-06-10, maintainer): pull 10.3.1/10.3.2 (the
+  `ScenarioStore`/cleanup helper) and 10.3.3 (the rebuild fix) forward into
   v0.6.0 final. Rationale: the pull-forward recommendation was accepted; the
   thread-local tax will not persist across the v0.6.x line.
 
 - Decision (2026-06-10, maintainer): Stage E code change is deferred to its own
   ExecPlan and roadmap item rather than being landed in this documentation
-  branch. The rebuild-invalidation fix is added to the roadmap as 11.3.1 with a
+  branch. The rebuild-invalidation fix is added to the roadmap as 10.3.3 with a
   v0.6.0 final target and will be implemented under a separate ExecPlan.
 
 - Open decision (deferred, separate architectural call): whether to retire the
@@ -408,9 +408,9 @@ All four observable outcomes from `Purpose / big picture` are met:
 1. **Roadmap records every new or re-scoped work item.** Added items
    10.2.4–10.2.7 (gpui-version banner + mapping table, lint-clean playbook
    variant, nextest interaction note, bulk-migration cookbook), re-scoped
-   11.1.3/11.1.4 (naming the correct `ScenarioStore<T>` / `GpuiScenarioStore`
+   10.3.1/10.3.2 (naming the correct `ScenarioStore<T>` / `GpuiScenarioStore`
    types and cleanup-guard fixture macro, with pull-forward scheduling notes),
-   added Phase 11.3 with item 11.3.1 (feature-file rebuild fix), and amended
+   added Phase 11.3 with item 10.3.3 (feature-file rebuild fix), and amended
    Phase 12 intro and 12.1.1 to record the committed direction and reference
    ADR-012.
 
@@ -430,10 +430,10 @@ All four observable outcomes from `Purpose / big picture` are met:
    lint-clean variant, bulk-migration cookbook, and design-doc cross-links.
    `docs/v0-6-0-migration-guide.md` carries a "Feature-file edits do not
    trigger a rebuild" caveat under "Common errors and fixes", marked removable
-   once 11.3.1 lands.
+   once 10.3.3 lands.
 
 No feedback item was left unscheduled. Stage E (rebuild-invalidation code fix)
-was deferred to a separate ExecPlan and roadmap item (11.3.1) per explicit
+was deferred to a separate ExecPlan and roadmap item (10.3.3) per explicit
 maintainer decision; it is not unscheduled, just not implemented in this
 documentation branch.
 
@@ -531,7 +531,7 @@ Apply, in document order, the additions and clarifications specified in
 3. Add new Phase 10.2 documentation items for: the gpui-version banner and
    mapping table; the lint-clean playbook variant; the nextest/`serial_test`
    interaction note; and the bulk-migration cookbook.
-4. Re-scope Phase 11 items 11.1.3 and 11.1.4 to name the GPUI-specialized
+4. Re-scope Phase 11 items 10.3.1 and 10.3.2 to name the GPUI-specialized
    `GpuiScenarioState` helper and the cleanup-guard fixture macro, referencing
    `adr-011`; add a priority note recommending they (and the rebuild fix) be
    pulled forward to v0.6.0 final, flagged as a maintainer scheduling decision.
@@ -654,7 +654,7 @@ Acceptance is observable in the repository:
   and design subsection.
 - `docs/roadmap.md` contains: the new feature-file rebuild item referencing
   `adr-010`; a clarified 10.1.4 naming the `scenario_name_in_logs.rs` evidence;
-  the four new documentation items; re-scoped 11.1.3/11.1.4 referencing
+  the four new documentation items; re-scoped 10.3.1/10.3.2 referencing
   `adr-011`; an amended 12.1.1 referencing `adr-012`; and the labelled ADR-008
   follow-up note.
 - `docs/rstest-bdd-design.md` contains the which-gpui banner and mapping table
@@ -807,7 +807,7 @@ the tolerance bound and must be re-approved.
   plus a `Drop` cleanup guard and a two-sided reset protocol (see
   `crates/rstest-bdd-harness-gpui/tests/stateful_window.rs`, ~50 lines of
   scaffolding per consuming crate per the adopter report — the largest single
-  source of handwritten boilerplate the migration hit). Roadmap 11.1.3/11.1.4
+  source of handwritten boilerplate the migration hit). Roadmap 10.3.1/10.3.2
   propose a generic helper and cleanup registration; the adopter asks
   specifically for a GPUI-shaped helper and a cleanup-guard fixture macro.
 - Naming constraint (verified): `rstest-bdd` already ships
@@ -843,7 +843,7 @@ the tolerance bound and must be re-approved.
   explicitly so adopters know which pattern is current per release.
 - Consequences: additive and semver-compatible (v0.6.1); the GPUI re-export
   depends on the generic core landing first.
-- Governs roadmap items: re-scoped 11.1.3/11.1.4 and a new cleanup-guard-macro
+- Governs roadmap items: re-scoped 10.3.1/10.3.2 and a new cleanup-guard-macro
   item. Design Doc: `§2.7.6.4`.
 
 ### ADR-012 — Guard-based `StepContext` borrowing committed for v0.7.0
@@ -880,7 +880,7 @@ Prescriptive list (apply in document order, matching existing item style — eac
 new item carries a finish line and a `Design Doc:` / ADR reference):
 
 - New subsection `### 11.3. Close the feature-file rebuild gap` with item
-  `11.3.1`: "Editing only a `.feature` file triggers a scenario rebuild."
+  `10.3.3`: "Editing only a `.feature` file triggers a scenario rebuild."
   Finish line: the `#[scenario]`/`scenarios!` expansion registers each bound
   feature file as a Cargo rebuild dependency (per ADR-010, without embedding an
   absolute path into the artefact), and a portability-aware regression test
@@ -917,17 +917,17 @@ new item carries a finish line and a `Design Doc:` / ADR reference):
   - `10.2.7`: a bulk-migration cookbook shows sharing one durable-handle step
     library across many GPUI scenarios in a single consuming crate. Finish line:
     a cookbook subsection in the user guide. Design Doc: `§2.7.6.2`.
-- Re-scope `11.1.3` to name the generic `ScenarioStore<T>` core in `rstest-bdd`
+- Re-scope `10.3.1` to name the generic `ScenarioStore<T>` core in `rstest-bdd`
   (named to avoid colliding with the shipped `ScenarioState` trait and
   `Slot<T>` in `crates/rstest-bdd/src/state.rs`) *and* the GPUI-specialized
-  `GpuiScenarioStore` re-export in `rstest-bdd-harness-gpui`; re-scope `11.1.4`
+  `GpuiScenarioStore` re-export in `rstest-bdd-harness-gpui`; re-scope `10.3.2`
   to add a cleanup-guard fixture-generating macro with a tested three-state
   lifecycle (success, failure, skip). Reference ADR-011.
 - **Recommended scheduling decision (maintainer call, surfaced prominently):**
   the adopter report identifies the thread-local boilerplate as the single
   largest adoption cost, so the next adopter keeps paying it for the whole
-  v0.6.x line unless 11.1.3/11.1.4 (the `ScenarioStore`/cleanup helper) and
-  11.3.1 (the rebuild fix) ship in v0.6.0 final rather than v0.6.1. This plan
+  v0.6.x line unless 10.3.1/10.3.2 (the `ScenarioStore`/cleanup helper) and
+  10.3.3 (the rebuild fix) ship in v0.6.0 final rather than v0.6.1. This plan
   recommends pulling all three forward but does not reschedule them
   unilaterally; the maintainer must confirm the release-train placement. This
   decision is logged as open in the Decision Log.

--- a/docs/execplans/adopt-v0-6-0-beta2-feedback.md
+++ b/docs/execplans/adopt-v0-6-0-beta2-feedback.md
@@ -99,11 +99,11 @@ Thresholds that trigger escalation when breached.
   in `Interfaces and dependencies` (three new ADRs, `docs/roadmap.md`,
   `docs/rstest-bdd-design.md`, `docs/users-guide.md`,
   `docs/v0-6-0-migration-guide.md`, and this plan), stop and escalate.
-- Roadmap scheduling: this plan *recommends* pulling the scenario-state helper
-  (10.3.1/10.3.2) and the rebuild-invalidation fix forward to v0.6.0 final, but
-  the actual release-train placement is a maintainer decision. If executing the
-  plan would require committing to a release schedule not yet agreed, stop and
-  present the trade-off rather than choosing unilaterally.
+- Roadmap scheduling: the maintainer approved pulling the scenario-state helper
+  (10.3.1/10.3.2) and the rebuild-invalidation fix forward to v0.6.0 final, so
+  that placement is settled. If executing the plan would require committing to
+  any further release schedule not yet agreed, stop and present the trade-off
+  rather than choosing unilaterally.
 - Code change: if the optional Stage E rebuild-invalidation fix cannot be made
   non-breaking and confined to the macro crate plus one regression test, stop
   and escalate; do not expand it into a build-script redesign within this plan.
@@ -838,7 +838,7 @@ the tolerance bound and must be re-approved.
   remains supported throughout v0.6.x; `ScenarioStore<T>` is the preferred
   additive alternative from v0.6.0 final; the v0.7.0 guard-based borrow
   redesign (ADR-012) supersedes both, with a migration mapping. The ADR
-  states this explicitly so adopters know which pattern is current per
+  states this explicitly, so adopters know which pattern is current per
   release.
 - Consequences: additive and semver-compatible (v0.6.0 final); the GPUI
   re-export depends on the generic core landing first.
@@ -921,14 +921,13 @@ new item carries a finish line and a `Design Doc:` / ADR reference):
   `GpuiScenarioStore` re-export in `rstest-bdd-harness-gpui`; re-scope `10.3.2`
   to add a cleanup-guard fixture-generating macro with a tested three-state
   lifecycle (success, failure, skip). Reference ADR-011.
-- **Recommended scheduling decision (maintainer call, surfaced prominently):**
-  the adopter report identifies the thread-local boilerplate as the single
-  largest adoption cost, so the next adopter keeps paying it for the whole
-  v0.6.x line unless 10.3.1/10.3.2 (the `ScenarioStore`/cleanup helper) and
-  10.3.3 (the rebuild fix) ship in v0.6.0 final rather than v0.6.1. This plan
-  recommends pulling all three forward but does not reschedule them
-  unilaterally; the maintainer must confirm the release-train placement. This
-  decision is logged as open in the Decision Log.
+- **Approved scheduling decision:** the adopter report identifies the
+  thread-local boilerplate as the single largest adoption cost, so the next
+  adopter would keep paying it for the whole v0.6.x line unless 10.3.1/10.3.2
+  (the `ScenarioStore`/cleanup helper) and 10.3.3 (the rebuild fix) ship in
+  v0.6.0 final rather than v0.6.1. The maintainer approved pulling all three
+  forward, so they are placed under roadmap step 10.3, "v0.6.0 final
+  requirements". This decision is recorded in the Decision Log.
 - Amend the Phase 12 introduction and item `12.1.1` to reference ADR-012 and
   state the guard-based borrow redesign is a committed v0.7.0 direction.
 - Add a labelled follow-up note (separate from the GPUI feedback) recommending

--- a/docs/execplans/adopt-v0-6-0-beta2-feedback.md
+++ b/docs/execplans/adopt-v0-6-0-beta2-feedback.md
@@ -51,7 +51,7 @@ the branch returns no unresolved concerns.
 
 This is a planning-and-documentation deliverable. It does **not** implement any
 of the code work items it schedules (the `include_str!` emission, the
-`GpuiScenarioState` helper, the guard-based `StepContext`); those remain
+`ScenarioStore<T>` helper, the guard-based `StepContext`); those remain
 roadmap items delivered under their own ExecPlans. The single exception, if the
 maintainer approves it, is the optional code change in Stage E (the
 rebuild-invalidation fix), which is small, non-breaking, and closes an active
@@ -527,10 +527,11 @@ Apply, in document order, the additions and clarifications specified in
 3. Add new Phase 10.2 documentation items for: the gpui-version banner and
    mapping table; the lint-clean playbook variant; the nextest/`serial_test`
    interaction note; and the bulk-migration cookbook.
-4. Re-scope Phase 11 items 10.3.1 and 10.3.2 to name the GPUI-specialized
-   `GpuiScenarioState` helper and the cleanup-guard fixture macro, referencing
-   `adr-011`; add a priority note recommending they (and the rebuild fix) be
-   pulled forward to v0.6.0 final, flagged as a maintainer scheduling decision.
+4. Re-scope items 10.3.1 and 10.3.2 to name the generic `ScenarioStore<T>` core
+   and its GPUI-specialized `GpuiScenarioStore` re-export (10.3.1), with the
+   cleanup-guard fixture macro owned by 10.3.2, referencing `adr-011`; add a
+   priority note recommending they (and the rebuild fix) be pulled forward to
+   v0.6.0 final, flagged as a maintainer scheduling decision.
 5. Amend the Phase 12 intro and item 12.1.1 to reference `adr-012` and state the
    borrow redesign is a committed direction.
 6. Add a separable follow-up note recommending ADR-008 be moved from `Proposed`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1118,23 +1118,43 @@ a committed direction (ADR-012).
   `docs/rstest-bdd-design.md` §§2.7.3, 2.7.6.5. (Pandalump)
 - [ ] 12.2.3. A declarative extension model lets first-party and third-party
   harness crates participate through one explicit metadata mechanism instead of
-  macro-local path tables. Finish line: one first-party and one example
-  third-party harness use the metadata mechanism in tests, and docs describe
-  the extension contract. Design Doc: `docs/rstest-bdd-design.md`
-  §§2.7.3-2.7.6.5. (Telefono)
-- [ ] 12.2.4. The generated-test model gives each `#[scenario]`, `scenarios!`,
+  macro-local path tables. Before implementation, an ADR chooses between this
+  proc-macro-readable model and an explicitly closed first-party inference
+  facility in which custom harnesses supply test attributes directly. The ADR
+  must make the public `AttributePolicy` contract match the selected scope and
+  reject runtime plug-in discovery as unnecessary for compile-time attribute
+  generation. Finish line: the ADR records the decision and migration impact;
+  if the declarative model is selected, one first-party and one example
+  third-party harness use it in compile and runtime tests; if closed inference
+  is selected, unknown policy paths produce an actionable diagnostic rather
+  than silently falling back to plain `#[rstest::rstest]`. Documentation must
+  describe the selected extension contract without presenting marker policies
+  as executable when the macro cannot read them. Design Doc:
+  `docs/rstest-bdd-design.md` §§2.7.3-2.7.6.5. (Telefono)
+- [ ] 12.2.4. Ratify `HarnessAdapter::Context: Any` as an explicit owned
+  `'static` context invariant, or replace it deliberately before v1 if borrowed
+  harness contexts are required. The decision records the supported lifecycle,
+  ownership, and downcasting model; explains that process handles,
+  `Rc<RefCell<App>>`, and owned client contexts fit the boundary; and states
+  whether contexts may borrow from a harness or surrounding fixtures. Finish
+  line: an ADR updates the harness contract and migration guidance; compile
+  tests accept representative owned contexts and either reject a borrowed
+  context with a documented diagnostic or prove the selected borrowing design.
+  ADR: `docs/adr-007-harness-context-injection.md`. Design Doc:
+  `docs/rstest-bdd-design.md` §§2.7.2-2.7.6.5. (Pandalump, Telefono)
+- [ ] 12.2.5. The generated-test model gives each `#[scenario]`, `scenarios!`,
   scenario, and outline row a readable Rust test name, isolated lifecycle, and
   failure reports that no longer depend on hidden loops over unrelated
   scenarios. Finish line: integration tests assert generated names, lifecycle
   isolation, and per-row failure reporting for `#[scenario]` and `scenarios!`.
   Design Doc: `docs/rstest-bdd-design.md` §2.7.6.5. (Doggylump)
-- [ ] 12.2.5. The recorded async harness trait surface gives Tokio and future
+- [ ] 12.2.6. The recorded async harness trait surface gives Tokio and future
   async adapters coherent migration, multi-poll, cancellation, and runtime
   ownership semantics, whether the v1 contract remains synchronous or moves to
   an async harness trait. Finish line: an ADR records the decision, Tokio tests
   cover the selected semantics, and migration docs explain the rejected path.
   Design Doc: `docs/rstest-bdd-design.md` §§2.5, 2.7.6.5. (Buzzy Bee)
-- [ ] 12.2.6. The v1 packaging model records whether first-party integrations
+- [ ] 12.2.7. The v1 packaging model records whether first-party integrations
   are feature-gated on `rstest-bdd` or remain explicit adapter crates, and the
   choice is captured in an ADR and migration guidance. Finish line: the ADR,
   migration guide, and publish/package tests all reflect the same packaging

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -881,6 +881,16 @@ changing the public trait contracts.
   `make nixie`, and
   `cargo test -p rstest-bdd --test trybuild_macros step_macros_compile` passed;
   CodeRabbit `review --agent` completed with zero findings.
+- [ ] 10.2.8. The stateful GPUI playbook includes compile-checked
+  published-`gpui 0.2.2` `given` and `when` variants, so adopters do not have
+  to translate the vendored-only worked example from the mapping table alone.
+  The guide also states that step functions and their helpers are ordinary
+  functions for Clippy's `allow-expect-in-tests` policy, and recommends the
+  lint-clean `let ... else { panic!(...) }` invariant form. Finish line: the
+  published snippets compile against crates.io `gpui 0.2.2`, the vendored and
+  published variants are visibly paired, and a drift gate covers both. Design
+  Doc: `docs/rstest-bdd-design.md` §2.7.6.2. Origin:
+  `leynos/rstest-bdd#575` and the gauss v0.6.0-beta3 adoption report.
 
 > **Note (dual-track maintenance):** items 10.2.4 and 10.2.5 introduce a
 > vendored-to-published mapping table that must be kept in sync with any
@@ -1014,6 +1024,37 @@ remove the existing `StepContext`, harness, or macro surfaces.
   maintainer has approved pulling this item forward to v0.6.0 final. Until it
   lands, a caveat in `docs/v0-6-0-migration-guide.md` alerts adopters that
   `.feature`-only edits do not trigger a rebuild.
+  The gauss v0.6.0-beta3 migration independently reproduced this failure mode
+  and had to falsify a scenario by editing its Rust step file instead.
+
+### 11.4. Prevent beta3 false greens and generated-result warnings
+
+This hardening step closes two failure modes found by the gauss beta trial. It
+asks whether every fallible step and scenario result is observably consumed, so
+an assertion cannot disappear behind macro classification or generated code.
+
+- [ ] 11.4.1. A step returning a local alias of `Result<T, E>` cannot silently
+  pass when it returns `Err`. Adopt an explicit, stable classification contract
+  for syntactically unresolved return types, with a migration diagnostic or
+  required `result`/`value` hint where the macro cannot prove the return kind.
+  Preserve ordinary value-returning steps without guessing that every alias is
+  fallible. Finish line: compile and runtime regressions cover an alias that
+  returns `Err`, spelled `Result`, `StepResult`, an alias explicitly marked
+  `result`, and a genuine value alias; no `Err` case is boxed and discarded as
+  an opaque payload. ADR: `docs/adr-002-stable-step-return-classification.md`.
+  Design Doc: `docs/rstest-bdd-design.md` §2.1. Origin:
+  `leynos/rstest-bdd#573` and the gauss v0.6.0-beta3 validation matrix.
+- [ ] 11.4.2. Harness-generated tests consume the result of fallible scenario
+  functions, including under `GpuiHarness`, without triggering
+  `unused_must_use` under `-D warnings`. Unit-returning scenarios continue to
+  propagate fallible step errors, and the guide makes clear that a fallible
+  scenario signature is only needed when the scenario body itself uses `?`.
+  Finish line: compile-pass tests exercise standard, Tokio, and GPUI harnesses
+  with `Result<(), E>` scenario bodies under denied warnings; runtime tests
+  prove scenario-body and step errors both fail the test. ADR:
+  `docs/adr-006-fallible-scenario-functions.md`. Design Doc:
+  `docs/rstest-bdd-design.md` §§2.7.2-2.7.4. Origin:
+  `leynos/rstest-bdd#574` and the gauss v0.6.0-beta3 validation matrix.
 
 > **Note (ADR-008 follow-up):** roadmap items 9.7.1–9.7.4 shipped the
 > harness-led attribute defaults under maintainer authorization, but

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -864,8 +864,8 @@ changing the public trait contracts.
   `docs/users-guide.md`. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.2.
   Delivered 2026-07-06: expanded the user-guide "Bulk-migration cookbook" to
   share the whole step library (given/when/then plus the state scaffolding) in
-  one `#[path]`-included module per crate, framed as the v0.6.0 shape that
-  v0.6.1 (11.1.3/11.1.4) shrinks, with inventory-per-binary and `pub`/
+  one `#[path]`-included module per crate, framed as the beta shape that
+  v0.6.0 final (10.3.1/10.3.2) shrinks, with inventory-per-binary and `pub`/
   subdirectory rationale, the module-qualified `#[from(...)]` form, and the
   GPUI specialization bridged to published `gpui 0.2.2` via the mapping table
   and cross-linked to `stateful_window.rs`. Backed by a harness-agnostic
@@ -903,6 +903,54 @@ changing the public trait contracts.
 > `docs/execplans/adopt-v0-6-0-beta2-feedback.md` and is out of scope for
 > this phase.
 
+### 10.3. v0.6.0 final requirements
+
+This step collects the remaining non-breaking work approved as release
+requirements after downstream beta adoption. The release is ready when its
+state helpers remove the largest GPUI migration tax and feature-file edits
+cannot leave users running stale scenarios.
+
+- [ ] 10.3.1. A generic `ScenarioStore<T>` core (in `rstest-bdd`) replaces
+  per-scenario thread-local `RefCell` boilerplate; it exposes `set`, `with`,
+  `with_mut`, `take`, and `reset` operations and wraps the two-sided reset
+  protocol. Naming note: the name `ScenarioStore<T>` is chosen to avoid
+  colliding with the already-shipped `pub trait ScenarioState: Default` and
+  `pub struct Slot<T>` in `crates/rstest-bdd/src/state.rs`. A GPUI-specific
+  `GpuiScenarioStore` re-export ships in `rstest-bdd-harness-gpui`. Finish
+  line: unit tests exercise all five operations; a GPUI integration test uses
+  `GpuiScenarioStore` and the cleanup fixture macro without handwritten
+  `thread_local!` boilerplate; docs present it as the supported v0.6.0 final
+  alternative to the beta thread-local interim pattern. ADR:
+  `docs/adr-011-first-party-scenario-state-and-cleanup.md`. Design Doc:
+  `docs/rstest-bdd-design.md` §2.7.6.4. (Dinolump)
+- [ ] 10.3.2. A cleanup-guard fixture-generating macro in
+  `rstest-bdd-harness-gpui` produces the `ScenarioStateCleanup` `Drop` guard
+  and the `#[fixture] fn scenario_state_cleanup()` function, so GPUI scenarios
+  can adopt the two-sided reset protocol with a single macro call. A regression
+  test proves the three-state lifecycle (success, assertion failure, skip) each
+  leave the store in the default state. Requires 10.3.1. ADR:
+  `docs/adr-011-first-party-scenario-state-and-cleanup.md`. Design Doc:
+  `docs/rstest-bdd-design.md` §2.7.6.4. Finish line: an integration test shows
+  cleanup running after success, failure, and skip; the docs state the required
+  registration order. (Doggylump)
+- [ ] 10.3.3. Editing only a `.feature` file triggers a rebuild of the scenario
+  binary. The `#[scenario]`/`scenarios!` expansion registers each bound feature
+  file as a Cargo rebuild dependency without embedding an absolute path into the
+  compiled artefact, and a portability-aware regression test proves a
+  `.feature`-only edit forces recompilation and a fresh test failure. The fix is
+  non-breaking: no existing call site changes. Finish line: the regression test
+  fails against the current `std::fs`-read macro and passes after the fix;
+  required `trybuild` compile-pass and compile-fail fixtures pin the emitted
+  binding and the missing-`.feature` diagnostic; a redacted `insta` snapshot
+  with semantic assertions pins any touched diagnostic wording; no absolute
+  `CARGO_MANIFEST_DIR` path appears in the artefact; `make test` is green. ADR:
+  `docs/adr-010-feature-file-change-detection.md` (see its *Testing strategy*).
+  Design Doc: `docs/rstest-bdd-design.md` §2.7.6.6. Until this requirement
+  lands, a caveat in `docs/v0-6-0-migration-guide.md` alerts adopters that
+  `.feature`-only edits do not trigger a rebuild. The gauss v0.6.0-beta3
+  migration independently reproduced this failure mode and had to falsify a
+  scenario by editing its Rust step file instead.
+
 ## 11. Early life support: v0.6.1 additive hardening
 
 The v0.6.1 line should stay semver-compatible. It can add helper APIs,
@@ -927,33 +975,6 @@ remove the existing `StepContext`, harness, or macro surfaces.
   helper without breaking the existing `borrow_mut` API, or the documented
   deferral includes a failing-shape test. Design Doc:
   `docs/rstest-bdd-design.md` §2.7.6.4. (Pandalump)
-- [ ] 11.1.3. A generic `ScenarioStore<T>` core (in `rstest-bdd`) replaces
-  per-scenario thread-local `RefCell` boilerplate; it exposes `set`, `with`,
-  `with_mut`, `take`, and `reset` operations and wraps the two-sided reset
-  protocol. Naming note: the name `ScenarioStore<T>` is chosen to avoid
-  colliding with the already-shipped `pub trait ScenarioState: Default` and
-  `pub struct Slot<T>` in `crates/rstest-bdd/src/state.rs`. A GPUI-specific
-  `GpuiScenarioStore` re-export ships in `rstest-bdd-harness-gpui`. Finish
-  line: unit tests exercise all five operations; a GPUI integration test uses
-  `GpuiScenarioStore` and the cleanup fixture macro without handwritten
-  `thread_local!` boilerplate; docs present it as the additive v0.6.1
-  alternative to the v0.6.0 thread-local interim pattern. ADR:
-  `docs/adr-011-first-party-scenario-state-and-cleanup.md`. Design Doc:
-  `docs/rstest-bdd-design.md` §2.7.6.4. (Dinolump) **Scheduling note:** the
-  maintainer has approved pulling this item forward to v0.6.0 final, as the
-  thread-local boilerplate is the largest adoption friction in the v0.6.x line
-  (per the first downstream GPUI adopter report).
-- [ ] 11.1.4. A cleanup-guard fixture-generating macro in
-  `rstest-bdd-harness-gpui` produces the `ScenarioStateCleanup` `Drop` guard
-  and the `#[fixture] fn scenario_state_cleanup()` function, so GPUI scenarios
-  can adopt the two-sided reset protocol with a single macro call. A regression
-  test proves the three-state lifecycle (success, assertion failure, skip) each
-  leave the store in the default state. Prerequisite: 11.1.3. ADR:
-  `docs/adr-011-first-party-scenario-state-and-cleanup.md`. Design Doc:
-  `docs/rstest-bdd-design.md` §2.7.6.4. Finish line: an integration test shows
-  cleanup running after success, failure, and skip; the docs state the required
-  registration order. (Doggylump) **Scheduling note:** pull-forward approved
-  alongside 11.1.3.
 
 ### 11.2. Smooth integration ergonomics
 
@@ -1006,34 +1027,13 @@ remove the existing `StepContext`, harness, or macro surfaces.
   `whitaker-installer` flow (CI pins `WHITAKER_INSTALLER_VERSION` at `0.2.6`)
   rather than building a pinned Whitaker tag. See leynos/rstest-bdd#597.
 
-### 11.3. Close the feature-file rebuild gap
-
-- [ ] 11.3.1. Editing only a `.feature` file triggers a rebuild of the scenario
-  binary. The `#[scenario]`/`scenarios!` expansion registers each bound feature
-  file as a Cargo rebuild dependency without embedding an absolute path into
-  the compiled artefact, and a portability-aware regression test proves a
-  `.feature`-only edit forces recompilation and a fresh test failure. The fix
-  is non-breaking: no existing call site changes. Finish line: the regression
-  test fails against the current `std::fs`-read macro and passes after the fix;
-  required `trybuild` compile-pass and compile-fail fixtures pin the emitted
-  binding and the missing-`.feature` diagnostic; a redacted `insta` snapshot
-  with semantic assertions pins any touched diagnostic wording; no absolute
-  `CARGO_MANIFEST_DIR` path appears in the artefact; `make test` is green. ADR:
-  `docs/adr-010-feature-file-change-detection.md` (see its *Testing strategy*).
-  Design Doc: `docs/rstest-bdd-design.md` §2.7.6.6. **Scheduling note:** the
-  maintainer has approved pulling this item forward to v0.6.0 final. Until it
-  lands, a caveat in `docs/v0-6-0-migration-guide.md` alerts adopters that
-  `.feature`-only edits do not trigger a rebuild.
-  The gauss v0.6.0-beta3 migration independently reproduced this failure mode
-  and had to falsify a scenario by editing its Rust step file instead.
-
-### 11.4. Prevent beta3 false greens and generated-result warnings
+### 11.3. Prevent beta3 false greens and generated-result warnings
 
 This hardening step closes two failure modes found by the gauss beta trial. It
 asks whether every fallible step and scenario result is observably consumed, so
 an assertion cannot disappear behind macro classification or generated code.
 
-- [ ] 11.4.1. A step returning a local alias of `Result<T, E>` cannot silently
+- [ ] 11.3.1. A step returning a local alias of `Result<T, E>` cannot silently
   pass when it returns `Err`. Adopt an explicit, stable classification contract
   for syntactically unresolved return types, with a migration diagnostic or
   required `result`/`value` hint where the macro cannot prove the return kind.
@@ -1044,7 +1044,7 @@ an assertion cannot disappear behind macro classification or generated code.
   an opaque payload. ADR: `docs/adr-002-stable-step-return-classification.md`.
   Design Doc: `docs/rstest-bdd-design.md` §2.1. Origin:
   `leynos/rstest-bdd#573` and the gauss v0.6.0-beta3 validation matrix.
-- [ ] 11.4.2. Harness-generated tests consume the result of fallible scenario
+- [ ] 11.3.2. Harness-generated tests consume the result of fallible scenario
   functions, including under `GpuiHarness`, without triggering
   `unused_must_use` under `-D warnings`. Unit-returning scenarios continue to
   propagate fallible step errors, and the guide makes clear that a fallible

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -2090,7 +2090,7 @@ compile-pass mirror,
 the GPUI durable-handle specialization remains proven by `stateful_window.rs`.
 The user guide's "Bulk-migration cookbook" subsection documents the shape and
 bridges its GPUI snippets to published `gpui 0.2.2` through the vendored-to-
-published mapping table. This handwritten shared block is superseded in v0.6.1
+published mapping table. This handwritten shared block is superseded in v0.6.0 final
 by `ScenarioStore<T>` and the cleanup-guard fixture macro (roadmap 10.3.1 and
 10.3.2).
 

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1612,6 +1612,14 @@ boundary, preserving scenario-level `Result<(), E>` behaviour while surfacing
 harness initialization failures as fatal test infrastructure errors with the
 underlying `HarnessError` detail.
 
+A gauss migration on v0.6.0-beta3 showed that the outer generated GPUI test
+body did not consume a fallible scenario's `Result`, producing
+`unused_must_use` under `-D warnings`. This is a generated-wrapper defect, not a
+reason to weaken the fallible-scenario contract: every harness path must
+consume or propagate the scenario result. Unit-returning scenario functions
+already propagate fallible step errors and remain the simpler shape when the
+user body does not itself need `?` (ADR-006; roadmap 11.4.2).
+
 **Context handoff (Phase 9.4.1 / ADR-007).** The harness contract now includes
 an associated context type:
 
@@ -1998,6 +2006,15 @@ interaction.
 > `unwrap_or_else(|| panic!(…))`. ADR-013 records the `make lint` Whitaker gate
 > that enforces `no_unwrap_or_else_panic`, and the user guide carries the
 > executable `let … else { panic!(…) }` shape mirrored by the regression suite.
+
+The mapping table is necessary but not sufficient for downstream adoption.
+The gauss v0.6.0-beta3 trial confirmed that the harness and published
+`gpui 0.2.2` share one compatible `TestAppContext` type, while translating the
+vendored-only `given` and `when` snippets still imposed avoidable work.
+Roadmap 10.2.8 therefore adds compile-checked published variants for those
+steps. It also records that Clippy treats step functions and helpers as
+ordinary functions, so `allow-expect-in-tests` does not exempt them from
+`expect_used`; the lint-clean invariant form remains `let … else { panic!(…) }`.
 
 The recommended v0.6-compatible shape keeps only durable handles in resettable
 scenario state. In schematic form (vendored gpui API):
@@ -2806,6 +2823,18 @@ classify common `Result` shapes during expansion (`Result`,
 `rstest_bdd::StepResult`). For other cases (for example, a user-defined type
 alias), step definitions can opt into explicit classification via
 `#[when("...", result)]` or `#[when("...", value)]`.
+
+Syntactic classification must never turn a fallible step into a false green.
+The gauss v0.6.0-beta3 trial demonstrated the unsafe case: a local
+`TestSupportResult<()>` alias returned `Err`, the macro classified it as a
+value, and the scenario passed after boxing the error as an unused payload.
+Spelling `Result<(), E>` or using `StepResult` failed correctly, independent
+of whether the scenario function returned `()` or `Result<(), E>`. Because a
+named return type can also be a legitimate value alias, the macro cannot
+simply classify every unresolved path as a result. The stable contract must
+instead require or diagnose an explicit `result`/`value` choice where
+classification is unresolved, with regression coverage for both fallible and
+genuine-value aliases (ADR-002; roadmap 11.4.1).
 
 The following diagrams illustrate how the wrapper captures step outputs and how
 later steps consume overrides from the context.

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1618,7 +1618,7 @@ body did not consume a fallible scenario's `Result`, producing
 reason to weaken the fallible-scenario contract: every harness path must
 consume or propagate the scenario result. Unit-returning scenario functions
 already propagate fallible step errors and remain the simpler shape when the
-user body does not itself need `?` (ADR-006; roadmap 11.4.2).
+user body does not itself need `?` (ADR-006; roadmap 11.3.2).
 
 **Context handoff (Phase 9.4.1 / ADR-007).** The harness contract now includes
 an associated context type:
@@ -2091,8 +2091,8 @@ the GPUI durable-handle specialization remains proven by `stateful_window.rs`.
 The user guide's "Bulk-migration cookbook" subsection documents the shape and
 bridges its GPUI snippets to published `gpui 0.2.2` through the vendored-to-
 published mapping table. This handwritten shared block is superseded in v0.6.1
-by `ScenarioStore<T>` and the cleanup-guard fixture macro (roadmap 11.1.3 and
-11.1.4).
+by `ScenarioStore<T>` and the cleanup-guard fixture macro (roadmap 10.3.1 and
+10.3.2).
 
 ##### 2.7.6.3 v0.6.0-beta2 quick wins
 
@@ -2187,7 +2187,7 @@ is usable behind a `nightly` feature gate pending stabilization.
 OUT_DIR AST caching (noted in `§3.2.2` below) is a *performance* optimization,
 not an invalidation mechanism; it does not close this gap.
 
-Until roadmap item 11.3.1 lands, a caveat in the adoption guide notes that
+Until roadmap item 10.3.3 lands, a caveat in the adoption guide notes that
 `.feature`-only edits do not trigger a rebuild, and users should `touch` an
 affected `.rs` file or `cargo clean` when an updated expectation is not picked
 up.
@@ -2834,7 +2834,7 @@ named return type can also be a legitimate value alias, the macro cannot
 simply classify every unresolved path as a result. The stable contract must
 instead require or diagnose an explicit `result`/`value` choice where
 classification is unresolved, with regression coverage for both fallible and
-genuine-value aliases (ADR-002; roadmap 11.4.1).
+genuine-value aliases (ADR-002; roadmap 11.3.1).
 
 The following diagrams illustrate how the wrapper captures step outputs and how
 later steps consume overrides from the context.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -318,8 +318,14 @@ Alternatively, add an explicit return-kind hint: `#[when(result)]` /
 `#[when(value)]`.
 
 The `result`/`value` hints are validated for obvious misconfigurations.
-`result` is rejected for primitive return types. For aliases, the macro cannot
-validate the underlying definition and assumes `Result<..>` semantics.
+`result` is rejected for primitive return types. Where `result` is given for an
+alias, the macro cannot validate the underlying definition and trusts the hint,
+assuming `Result<..>` semantics.
+
+Without a hint, an unresolved alias is **not** assumed to be `Result`-like: it
+is classified as a value, so an `Err` is stored as a payload and the step
+passes. Always give an unresolved alias explicit handling — spell out
+`Result<..>` or `rstest_bdd::StepResult<..>`, or add a `result`/`value` hint.
 
 Use `#[when("...", value)]` (or `#[when(value)]` when using the inferred
 pattern) to force treating the return value as a payload even when it is

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1410,7 +1410,7 @@ single Whitaker lint now while deferring the full Whitaker suite.
 When migrating a large test suite, factor the whole durable-handle **step
 library** — the `#[given]`/`#[when]`/`#[then]` steps together with the state
 scaffolding — into one shared module per consuming crate, rather than copying
-it into every test file. This is the v0.6.0 shape, and it is deliberately
+it into every test file. This is the beta shape, and it is deliberately
 explicit. Once roadmap items 10.3.1 and 10.3.2 ship (`ScenarioStore<T>` and the
 cleanup-guard fixture macro), the shared block shrinks to a single import and
 the `#[scenario]` cleanup parameter is generated for you. Adopt the pattern now

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1372,7 +1372,7 @@ binding name is part of the contract.
   walks readers through moving an existing scenario to the playbook.
 - Design-document §2.7.6.6 documents the feature-file rebuild-invalidation
   foot-gun (`.feature`-only edits do not trigger a rebuild until roadmap item
-  11.3.1 lands).
+  10.3.3 lands).
 - Design-document §2.7.6.7 documents the full cargo test versus nextest matrix
   for `#[serial]` and thread-local state.
 
@@ -1405,7 +1405,7 @@ When migrating a large test suite, factor the whole durable-handle **step
 library** — the `#[given]`/`#[when]`/`#[then]` steps together with the state
 scaffolding — into one shared module per consuming crate, rather than copying
 it into every test file. This is the v0.6.0 shape, and it is deliberately
-explicit. Once roadmap items 11.1.3 and 11.1.4 ship (`ScenarioStore<T>` and the
+explicit. Once roadmap items 10.3.1 and 10.3.2 ship (`ScenarioStore<T>` and the
 cleanup-guard fixture macro), the shared block shrinks to a single import and
 the `#[scenario]` cleanup parameter is generated for you. Adopt the pattern now
 and expect to shrink it then.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -324,8 +324,10 @@ assuming `Result<..>` semantics.
 
 Without a hint, an unresolved alias is **not** assumed to be `Result`-like: it
 is classified as a value, so an `Err` is stored as a payload and the step
-passes. Always give an unresolved alias explicit handling — spell out
-`Result<..>` or `rstest_bdd::StepResult<..>`, or add a `result`/`value` hint.
+passes. Always give an unresolved alias explicit handling: if the alias is
+fallible, spell out `Result<..>` or `rstest_bdd::StepResult<..>`, or add the
+`result` hint. Reserve the `value` hint for an alias that deliberately
+returns a payload — applying it to a real `Result` suppresses its `Err`.
 
 Use `#[when("...", value)]` (or `#[when(value)]` when using the inferred
 pattern) to force treating the return value as a payload even when it is

--- a/docs/v0-6-0-migration-guide.md
+++ b/docs/v0-6-0-migration-guide.md
@@ -574,7 +574,7 @@ the playbook redirect instead.
 
 ### Feature-file edits do not trigger a rebuild
 
-> **This caveat applies until roadmap item 11.3.1 lands.** Once the
+> **This caveat applies until roadmap item 10.3.3 lands.** Once the
 > rebuild-invalidation fix ships, this section can be removed.
 
 `#[scenario(path = "...")]` and `scenarios!` read `.feature` files with
@@ -598,7 +598,7 @@ editing any `.rs` file.
 **Root cause and roadmap:** see design-document
 [§2.7.6.6](rstest-bdd-design.md#2766-feature-file-rebuild-invalidation) and
 [ADR-010](adr-010-feature-file-change-detection.md) for the analysis and the
-chosen fix mechanism. Roadmap item 11.3.1 tracks the implementation, approved
+chosen fix mechanism. Roadmap item 10.3.3 tracks the implementation, approved
 for v0.6.0 final.
 
 ## Further reading


### PR DESCRIPTION
## Summary

This branch incorporates gauss's v0.6.0-beta3 adoption evidence so the
remaining release and pre-1.0 work reflects observed downstream behaviour,
rather than assumptions from the in-tree GPUI shim.

It records the aliased-`Result` false green reported in
[#573](https://github.com/leynos/rstest-bdd/issues/573), the fallible-scenario
`unused_must_use` failure reported in
[#574](https://github.com/leynos/rstest-bdd/issues/574), and the
published-GPUI documentation gap reported in
[#575](https://github.com/leynos/rstest-bdd/issues/575). It also consolidates
the remaining v0.6.0 final requirements under roadmap step 10.3 and makes the
attribute-policy and `Context: Any` decisions explicit pre-1.0 work.

This is a documentation and planning change. It does not close #573, #574, or
#575; their implementation work remains open. There is no beta3-specific
ExecPlan on this branch. The existing
[beta2 adoption ExecPlan](https://github.com/leynos/rstest-bdd/blob/ea7d6bedb3ae541324dbd4e7972f35d6506d32d2/docs/execplans/adopt-v0-6-0-beta2-feedback.md)
is updated only to keep its roadmap references current.

## Review walkthrough

- Start with the
  [roadmap](https://github.com/leynos/rstest-bdd/blob/ea7d6bedb3ae541324dbd4e7972f35d6506d32d2/docs/roadmap.md)
  to review the new beta3 hardening work, the consolidated v0.6.0 final
  requirements, and the tightened pre-1.0 harness decisions.
- Then review
  [ADR-002](https://github.com/leynos/rstest-bdd/blob/ea7d6bedb3ae541324dbd4e7972f35d6506d32d2/docs/adr-002-stable-step-return-classification.md)
  and
  [ADR-006](https://github.com/leynos/rstest-bdd/blob/ea7d6bedb3ae541324dbd4e7972f35d6506d32d2/docs/adr-006-fallible-scenario-functions.md)
  for the two correctness findings and their interim safe usage.
- Continue with the
  [main design document](https://github.com/leynos/rstest-bdd/blob/ea7d6bedb3ae541324dbd4e7972f35d6506d32d2/docs/rstest-bdd-design.md)
  for the validation matrix, published-GPUI evidence, and generated-wrapper
  invariants.
- Finish with
  [ADR-010](https://github.com/leynos/rstest-bdd/blob/ea7d6bedb3ae541324dbd4e7972f35d6506d32d2/docs/adr-010-feature-file-change-detection.md),
  [ADR-011](https://github.com/leynos/rstest-bdd/blob/ea7d6bedb3ae541324dbd4e7972f35d6506d32d2/docs/adr-011-first-party-scenario-state-and-cleanup.md),
  and the
  [users' guide](https://github.com/leynos/rstest-bdd/blob/ea7d6bedb3ae541324dbd4e7972f35d6506d32d2/docs/users-guide.md)
  to verify that moved roadmap identifiers remain consistent across the
  documentation set.

## Validation

Re-run after rebasing onto `origin/main` (`cf8d0fd`):

- `make check-fmt`: passed.
- `make lint`: passed, including Clippy, Whitaker, Ruff, Pylint, and the
  repository policy checks (users-guide link checker, GPUI mapping-table and
  serial/nextest matrix parity gates).
- `make typecheck`: passed, both `cargo check` and `ty`.
- `make test`: passed; 1,507 Rust tests passed, 7 were skipped, and 69 Python
  tests passed.
- Scoped `markdownlint-cli2` validation for all changed Markdown files:
  passed.
- `git diff --check`: passed.

## Notes

- Unknown third-party attribute-policy resolution remains deliberately
  unresolved until the ADR required by roadmap task 12.2.3 chooses an honest
  extension contract.
- The roadmap edit exposed unrelated whole-document indentation churn in
  `mapsplice 0.1.0`; the minimal reproduction is tracked in
  [mapsplice #42](https://github.com/leynos/mapsplice/issues/42). That churn
  has been resolved out of this branch during the rebase, so the roadmap diff
  against `main` is now additions only.
- The rebase resolved nine Markdown conflicts. In each case `main`'s
  re-wrapping was kept and this branch's roadmap renumbering was re-applied on
  top. Two entity-merge artefacts needed manual repair: a duplicated
  `### 11.3` roadmap section, and a typed-data-table code block relocated into
  an unrelated GPUI code fence in `docs/users-guide.md`.

## References

- [Lody session](https://lody.ai/leynos/sessions/1f7e67c0-2072-4df9-b59c-880f64d8a719)
