### PR TITLE
Bump whitaker-installer to 0.2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       RUSTDOCFLAGS: -D warnings
       LADING_REF: d3217a599ea34adad6a6e3845845fff2fe923758
       MERMAN_CLI_VERSION: '0.7.0'
-      WHITAKER_INSTALLER_VERSION: '0.2.5'
+      WHITAKER_INSTALLER_VERSION: '0.2.6'
     strategy:
       fail-fast: false
       matrix:

--- a/crates/rstest-bdd/src/datatable/parsers.rs
+++ b/crates/rstest-bdd/src/datatable/parsers.rs
@@ -122,7 +122,6 @@ where
         }
     }
 
-    #[must_use]
     /// Return the original, untrimmed string that failed to parse.
     ///
     /// # Examples
@@ -131,6 +130,7 @@ where
     /// let err: TrimmedParseError<_> = trimmed::<u8>(" not a number ").unwrap_err();
     /// assert_eq!(err.original_input(), " not a number ");
     /// ```
+    #[must_use]
     pub fn original_input(&self) -> &str {
         &self.original_input
     }

--- a/crates/rstest-bdd/src/localization.rs
+++ b/crates/rstest-bdd/src/localization.rs
@@ -137,7 +137,6 @@ pub fn current_languages() -> Result<Vec<LanguageIdentifier>, LocalizationError>
     })
 }
 
-#[must_use]
 /// Retrieve a localized string without interpolation arguments.
 ///
 /// # Examples
@@ -148,11 +147,11 @@ pub fn current_languages() -> Result<Vec<LanguageIdentifier>, LocalizationError>
 ///     "pattern mismatch"
 /// );
 /// ```
+#[must_use]
 pub fn message(id: &str) -> String {
     with_loader(|loader| loader.get(id))
 }
 
-#[must_use]
 /// Retrieve a localized string with Fluent arguments supplied via a closure.
 ///
 /// # Examples
@@ -163,6 +162,7 @@ pub fn message(id: &str) -> String {
 /// });
 /// assert!(rendered.contains("Example"));
 /// ```
+#[must_use]
 pub fn message_with_args<F>(id: &str, configure: F) -> String
 where
     F: FnOnce(&mut FluentArgs<'static>),

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -966,7 +966,7 @@ Local setup installs the `whitaker` wrapper and its pinned Dylint driver
 toolchain via the installer:
 
 ```bash
-cargo install --locked whitaker-installer --version 0.2.5
+cargo install --locked whitaker-installer --version 0.2.6
 whitaker-installer
 ```
 


### PR DESCRIPTION
## Summary

This pull request bumps the pinned `whitaker-installer` version from 0.2.5 to 0.2.6 in CI and the developers' guide. The Whitaker Dylint suite's rolling release now pins toolchain `nightly-2026-05-28`, which requires `cargo-dylint` 6.0.1. Installer 0.2.5 provisions `cargo-dylint` 4.1.0, whose driver cannot compile on that nightly, leaving the repository's CI lint step red. Installer 0.2.6 provisions `cargo-dylint` 6.0.1 and its prebuilt dependency binaries are now published, so the bump unblocks the lint gate.

## Changes

- [`.github/workflows/ci.yml`](https://github.com/leynos/rstest-bdd/blob/bump-whitaker-installer-0.2.6/.github/workflows/ci.yml) — bumps `WHITAKER_INSTALLER_VERSION` from `0.2.5` to `0.2.6`.
- [`docs/developers-guide.md`](https://github.com/leynos/rstest-bdd/blob/bump-whitaker-installer-0.2.6/docs/developers-guide.md) — bumps the documented `whitaker-installer` install version from 0.2.5 to 0.2.6.

Other `0.2.5` strings in the repository (e.g. Whitaker's own `v0.2.5` tag references in execplans, ADR-013, and roadmap item 10.2.5) are unrelated to the installer pin and were left untouched.

## Test plan

- [ ] CI lint step (`make lint-whitaker` via GitHub Actions) passes on `nightly-2026-05-28` with the new pin.
