### PR TITLE
Document mutation-testing workflow contract tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -21,8 +21,10 @@ test-group = "cargo-spawning"
 [[profile.default.overrides]]
 # trybuild-based compile tests invoke `cargo build` against a large dependency
 # tree; on cold caches this can legitimately exceed the default 60 s limit.
+# Allow the full fixture set to rebuild without treating slow, healthy compiler
+# work as a hung test.
 filter = "binary_id(rstest-bdd-harness-tokio::macro_compile) | binary_id(rstest-bdd-harness-gpui::macro_compile) | binary_id(rstest-bdd::trybuild_macros)"
-slow-timeout = { period = "300s", terminate-after = 1, grace-period = "5s" }
+slow-timeout = { period = "10m", terminate-after = 1, grace-period = "5s" }
 test-group = "cargo-spawning"
 
 [profile.long]

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -29,10 +29,8 @@ jobs:
     uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@57a33fa65e329db7edc81ece661f1a2e1d39868f
     with:
       # The workspace's mutable source lives under crates/; the root
-      # Cargo.toml is a virtual manifest with no src/. Cargo metadata includes
-      # vendor/gpui and vendor/gpui-macros as workspace members, but paths:
-      # "crates/" restricts scheduled change detection. No vendor/** exclusion
-      # is configured, so manual whole-workspace runs may process vendored code.
+      # Cargo.toml is a virtual manifest with no src/. paths: "crates/"
+      # limits scheduled change detection.
       paths: "crates/"
       # Example applications, test-fixture crates (cargo-bdd's minimal
       # fixture workspace, trybuild/macrotest fixture and UI-expectation

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -29,10 +29,10 @@ jobs:
     uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@57a33fa65e329db7edc81ece661f1a2e1d39868f
     with:
       # The workspace's mutable source lives under crates/; the root
-      # Cargo.toml is a virtual manifest with no src/. The vendored
-      # gpui crates under vendor/ sit outside the workspace and are
-      # deliberately not added via extra-crate-dirs: mutants in
-      # third-party vendored code would be pure noise.
+      # Cargo.toml is a virtual manifest with no src/. Cargo metadata includes
+      # vendor/gpui and vendor/gpui-macros as workspace members, but paths:
+      # "crates/" restricts scheduled change detection. No vendor/** exclusion
+      # is configured, so manual whole-workspace runs may process vendored code.
       paths: "crates/"
       # Example applications, test-fixture crates (cargo-bdd's minimal
       # fixture workspace, trybuild/macrotest fixture and UI-expectation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,6 +1621,7 @@ dependencies = [
  "the-newtype",
  "thiserror 2.0.20",
  "tokio",
+ "toml 0.9.12+spec-1.1.0",
  "trybuild",
  "unic-langid",
 ]

--- a/crates/rstest-bdd/Cargo.toml
+++ b/crates/rstest-bdd/Cargo.toml
@@ -49,6 +49,7 @@ serial_test.workspace = true
 temp-env.workspace = true
 the-newtype = "0.1.1"
 tempfile.workspace = true
+toml = "0.9"
 
 [features]
 default = ["diagnostics"]

--- a/crates/rstest-bdd/tests/nextest_config.rs
+++ b/crates/rstest-bdd/tests/nextest_config.rs
@@ -1,0 +1,176 @@
+//! Integration contract for the workspace's trybuild nextest override.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    error::Error,
+    io,
+    path::{Path, PathBuf},
+};
+
+use cap_std::{ambient_authority, fs::Dir};
+use toml::Value;
+
+const EXPECTED_TRYBUILD_BINARIES: [&str; 3] = [
+    "rstest-bdd-harness-tokio::macro_compile",
+    "rstest-bdd-harness-gpui::macro_compile",
+    "rstest-bdd::trybuild_macros",
+];
+
+#[test]
+fn trybuild_nextest_override_preserves_timeout_contract() -> Result<(), Box<dyn Error>> {
+    let configuration = nextest_configuration()?;
+    let overrides = default_overrides(&configuration)?;
+    let candidates = trybuild_override_candidates(overrides);
+    let binary_id_report = binary_id_report(overrides, &candidates);
+
+    assert_eq!(
+        candidates.len(),
+        1,
+        "expected exactly one trybuild nextest override, found {}. {binary_id_report}",
+        candidates.len(),
+    );
+
+    let Some(trybuild_override) = candidates.first().and_then(|index| overrides.get(*index)) else {
+        return Err(io::Error::other("expected one matching trybuild nextest override").into());
+    };
+    assert_eq!(
+        binary_id_report,
+        "missing binary IDs: <none>; duplicate binary IDs: <none>; unexpected binary IDs: <none>",
+        "trybuild nextest override must identify exactly the expected binaries. {binary_id_report}",
+    );
+
+    let slow_timeout = trybuild_override
+        .get("slow-timeout")
+        .and_then(Value::as_table)
+        .expect("trybuild nextest override must contain a slow-timeout table");
+
+    assert_eq!(
+        slow_timeout.get("period").and_then(Value::as_str),
+        Some("10m"),
+        "trybuild nextest override must allow a 10-minute slow timeout",
+    );
+    assert_eq!(
+        slow_timeout
+            .get("terminate-after")
+            .and_then(Value::as_integer),
+        Some(1),
+        "trybuild nextest override must terminate after one slow-timeout period",
+    );
+    assert_eq!(
+        slow_timeout.get("grace-period").and_then(Value::as_str),
+        Some("5s"),
+        "trybuild nextest override must retain its five-second grace period",
+    );
+    assert_eq!(
+        trybuild_override.get("test-group").and_then(Value::as_str),
+        Some("cargo-spawning"),
+        "trybuild nextest override must remain in the cargo-spawning group",
+    );
+
+    Ok(())
+}
+
+fn nextest_configuration() -> Result<Value, Box<dyn Error>> {
+    let configuration_directory = workspace_root()?.join(".config");
+    let configuration_directory =
+        Dir::open_ambient_dir(configuration_directory, ambient_authority())?;
+    let source = configuration_directory.read_to_string("nextest.toml")?;
+
+    Ok(toml::from_str(&source)?)
+}
+
+fn workspace_root() -> Result<PathBuf, io::Error> {
+    let manifest_directory = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_directory
+        .parent()
+        .and_then(Path::parent)
+        .ok_or_else(|| {
+            io::Error::other(
+                "rstest-bdd manifest directory must be nested under the workspace root",
+            )
+        })?;
+
+    Ok(workspace_root.to_path_buf())
+}
+
+fn default_overrides(configuration: &Value) -> Result<&[Value], io::Error> {
+    let overrides = configuration
+        .get("profile")
+        .and_then(Value::as_table)
+        .and_then(|profiles| profiles.get("default"))
+        .and_then(Value::as_table)
+        .and_then(|default_profile| default_profile.get("overrides"))
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            io::Error::other("nextest configuration must contain profile.default.overrides")
+        })?;
+
+    Ok(overrides)
+}
+
+fn trybuild_override_candidates(overrides: &[Value]) -> Vec<usize> {
+    overrides
+        .iter()
+        .enumerate()
+        .filter_map(|(index, override_value)| {
+            let filter = override_value.get("filter")?.as_str()?;
+            binary_ids(filter)
+                .iter()
+                .any(|binary_id| EXPECTED_TRYBUILD_BINARIES.contains(binary_id))
+                .then_some(index)
+        })
+        .collect()
+}
+
+fn binary_id_report(overrides: &[Value], candidates: &[usize]) -> String {
+    let binary_ids = candidates.iter().flat_map(|index| {
+        overrides
+            .get(*index)
+            .and_then(|override_value| override_value.get("filter"))
+            .and_then(Value::as_str)
+            .map(binary_ids)
+            .unwrap_or_default()
+    });
+    let mut occurrences = BTreeMap::new();
+    for binary_id in binary_ids {
+        *occurrences.entry(binary_id).or_insert(0_usize) += 1;
+    }
+
+    let expected = BTreeSet::from(EXPECTED_TRYBUILD_BINARIES);
+    let actual = occurrences.keys().copied().collect::<BTreeSet<_>>();
+    let missing = expected
+        .difference(&actual)
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let duplicate = occurrences
+        .iter()
+        .filter_map(|(binary_id, count)| (*count > 1).then_some(*binary_id))
+        .collect::<BTreeSet<_>>();
+    let unexpected = actual
+        .difference(&expected)
+        .copied()
+        .collect::<BTreeSet<_>>();
+
+    format!(
+        "missing binary IDs: {}; duplicate binary IDs: {}; unexpected binary IDs: {}",
+        format_binary_ids(&missing),
+        format_binary_ids(&duplicate),
+        format_binary_ids(&unexpected),
+    )
+}
+
+fn binary_ids(filter: &str) -> Vec<&str> {
+    filter
+        .split("binary_id(")
+        .skip(1)
+        .filter_map(|suffix| suffix.split_once(')').map(|(binary_id, _)| binary_id))
+        .collect()
+}
+
+fn format_binary_ids(binary_ids: &BTreeSet<&str>) -> String {
+    if binary_ids.is_empty() {
+        "<none>".to_owned()
+    } else {
+        binary_ids.iter().copied().collect::<Vec<_>>().join(", ")
+    }
+}

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -255,6 +255,73 @@ Link-checker and table-checker tests run with the Python suite in `make test`.
 Issue #537 tracks generating the users-guide reference block from `BASE_URL`
 so the base lives in exactly one place.
 
+## Mutation-testing workflow contract tests
+
+This repository runs scheduled, informational mutation testing through a thin
+caller workflow, [`.github/workflows/mutation-testing.yml`](../.github/workflows/mutation-testing.yml),
+which delegates to the shared reusable workflow
+`leynos/shared-actions/.github/workflows/mutation-cargo.yml`. The heavy lifting
+— running `cargo-mutants`, sharding, and summarizing survivors — lives in
+`shared-actions`; this repository carries only declarative configuration. The
+run is **informational only**: it never gates a pull request. Survivors are
+reported through the job summary and downloadable artefacts so they can be
+triaged into tests, not enforced as a blocking check.
+
+The workflow runs in two modes. A **daily schedule** fires a change-scoped run
+that mutates only the source files touched within the detection window, so
+quiet days are cheap no-ops. A **manual dispatch** (the Actions "Run workflow"
+control) mutates the whole workspace, fanned out across shards; select a
+branch in that control to exercise a feature branch.
+
+The caller passes a small set of configuration inputs, each carrying intent:
+
+- `paths` — the change-detection globs (`crates/`) that decide whether a
+  scheduled run has anything to mutate, bounding the scheduled run to the
+  workspace's mutable source. The root `Cargo.toml` is a virtual manifest with
+  no `src/`, and the vendored `gpui` crates under `vendor/` sit outside the
+  workspace and are deliberately excluded.
+- `exclude-globs` — example applications, test-fixture crates
+  (`cargo-bdd`'s minimal fixture workspace, and the trybuild/macrotest fixture
+  and UI-expectation crates), and test-support modules compiled into `src/`,
+  whose surviving mutants are noise rather than genuine test gaps. UI-test
+  expectation crates must never be mutated.
+- `extra-args` — `--all-features --test-workspace=true`, so feature-gated
+  tests run against mutants and each mutant is tested with the whole
+  workspace's suites, matching the repository's `make test` baseline
+  (`--workspace --all-targets --all-features`). `--test-workspace=true` in
+  particular avoids `cargo-mutants`' per-package default, which would miss
+  coverage that the macro and policy crates receive only through dependent
+  crates' trybuild and integration tests.
+
+The `uses:` reference pins the shared workflow to a full 40-character commit
+SHA rather than a branch or tag, so a force-push upstream cannot silently
+change what runs here. The contract test hard-codes the expected SHA in a
+`PINNED_SHA` constant and asserts the `uses:` line matches it, so bumping the
+pin means editing the workflow's `uses:` line and that constant together in
+the same change.
+
+Because the caller is configuration rather than code, a contract test pins the
+shape it must uphold, failing the pull request when the caller drifts —
+repointing the pin at a branch, widening the token scope, or dropping a
+configuration input — rather than letting the breakage surface only in a
+scheduled run. Run it locally with `make test-workflow-contracts` (which
+invokes `uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest
+tests/workflow_contracts -q`, covering both this contract and the CodeScene
+coverage-caller contract in the same directory). The test module
+`tests/workflow_contracts/mutation_testing_test.py` validates:
+
+- the `uses:` reference targets `mutation-cargo.yml` pinned to the documented
+  full commit SHA;
+- job permissions are exactly least-privilege (`contents: read`,
+  `id-token: write`);
+- the workflow-level default token scope is an empty mapping;
+- `concurrency` serializes runs per ref (`mutation-testing-${{ github.ref
+  }}`) without cancelling one in progress;
+- the triggers keep the daily 03:35 UTC schedule and a plain
+  `workflow_dispatch` with no legacy branch input; and
+- the `with:` block carries exactly the expected `paths`, `exclude-globs`,
+  and `extra-args` shown above.
+
 ## Spelling policy
 
 `make spelling` enforces en-GB-oxendict spelling over tracked text with the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -262,9 +262,9 @@ Mitigation:
   nextest like any other test.
 - `.config/nextest.toml` raises the `slow-timeout` for the trybuild
   compile-test binaries (including both `macro_compile` binaries and
-  `rstest-bdd::trybuild_macros`) to 300 s as a local-development safety net.
-  This does not fix the deadlock; it only delays termination to allow the build
-  to complete on fast machines.
+  `rstest-bdd::trybuild_macros`) to 10 minutes as a local-development safety
+  net. This does not fix the deadlock; it only delays termination to allow the
+  build to complete on fast machines.
 - `.config/nextest.toml` also places the `cargo-bdd::cli` and trybuild
   binaries in a `cargo-spawning` test group with `max-threads = 1`, so these
   cargo-spawning tests run one at a time rather than contending for the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -197,13 +197,15 @@ The file sets the timeout policy for the test suite:
 - A `[[profile.default.overrides]]` entry raises the `slow-timeout` to 180 s
   for `cargo-bdd::cli`, whose smoke tests spawn `cargo` to build fixture crates
   and can legitimately exceed 60 s on cold caches.
-- A second override raises the `slow-timeout` further, to 300 s, for the
+- A second override raises the `slow-timeout` further, to 10 minutes, for the
   trybuild-based compile-test binaries:
   `rstest-bdd-harness-tokio::macro_compile`,
   `rstest-bdd-harness-gpui::macro_compile`, and `rstest-bdd::trybuild_macros`.
-  These tests invoke `cargo build` against a large dependency tree, so a cold
-  cache (or CPU contention when several compile tests run concurrently) can
-  push a single test well past the default limit even though nothing is wrong.
+  These tests invoke `cargo build` against a large dependency tree. The
+  10-minute allowance permits the full fixture set to rebuild on a cold cache
+  without treating slow, healthy compiler work as a hung test. The strict 60 s
+  default remains in force elsewhere, and these tests stay in the
+  `cargo-spawning` group so they run serially.
 - Both overrides also place their binaries in a `cargo-spawning` test group
   (`max-threads = 1`), so `cargo-bdd::cli` and the three trybuild binaries run
   one at a time instead of contending for CPU with concurrent `cargo` builds.
@@ -457,7 +459,6 @@ Link-checker and table-checker tests run with the Python suite in `make test`.
 Issue #537 tracks generating the users-guide reference block from `BASE_URL` so
 the base lives in exactly one place.
 
-
 ## Mutation-testing workflow contract tests
 
 This repository runs scheduled, informational mutation testing through a thin
@@ -479,16 +480,16 @@ contains an applicable mutation-testing entry.
 The workflow runs in two modes. A **daily schedule** fires a change-scoped run
 that mutates only the source files touched within the detection window, so
 quiet days are cheap no-ops. A **manual dispatch** (the Actions "Run workflow"
-control) mutates the whole workspace, fanned out across shards; select a
-branch in that control to exercise a feature branch.
+control) mutates the whole workspace, fanned out across shards; select a branch
+in that control to exercise a feature branch.
 
 The caller passes a small set of configuration inputs, each carrying intent:
 
 - `paths` — the change-detection globs (`crates/`) that decide whether a
   scheduled run has anything to mutate, bounding the scheduled run to the
   workspace's mutable source. The root `Cargo.toml` is a virtual manifest with
-  no `src/`. Cargo metadata lists both `vendor/gpui` and `vendor/gpui-macros` as
-  workspace members, but `paths: "crates/"` restricts scheduled change
+  no `src/`. Cargo metadata lists both `vendor/gpui` and `vendor/gpui-macros`
+  as workspace members, but `paths: "crates/"` restricts scheduled change
   detection; because no `vendor/**` exclusion is configured, a manual
   whole-workspace run may process vendored code.
 - `exclude-globs` — example applications, test-fixture crates
@@ -514,10 +515,11 @@ Because the caller is configuration rather than code, a contract test pins the
 shape it must uphold, failing the pull request when the caller drifts —
 repointing the pin at a branch, widening the token scope, or dropping a
 configuration input — rather than letting the breakage surface only in a
-scheduled run. Run it locally with `make test-workflow-contracts` (which
-invokes `uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest
-tests/workflow_contracts -q`, covering both this contract and the CodeScene
-coverage-caller contract in the same directory). The test module
+scheduled run. Run it locally with `make test-workflow-contracts` (which invokes
+`uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest
+tests/workflow_contracts -q`,
+covering both this contract and the CodeScene coverage-caller contract in the
+same directory). The test module
 `tests/workflow_contracts/mutation_testing_test.py` validates:
 
 - the `uses:` reference targets the correct `mutation-cargo.yml` path and has
@@ -525,8 +527,8 @@ coverage-caller contract in the same directory). The test module
 - job permissions are exactly least-privilege (`contents: read`,
   `id-token: write`);
 - the workflow-level default token scope is an empty mapping;
-- `concurrency` serializes runs per ref (`mutation-testing-${{ github.ref
-  }}`) without cancelling one in progress;
+- `concurrency` serializes runs per ref (`mutation-testing-${{ github.ref }}`)
+  without cancelling one in progress;
 - the triggers keep the daily 03:35 UTC schedule and a plain
   `workflow_dispatch` with no legacy branch input; and
 - the `with:` block carries exactly the expected `paths`, `exclude-globs`,

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -457,6 +457,74 @@ Link-checker and table-checker tests run with the Python suite in `make test`.
 Issue #537 tracks generating the users-guide reference block from `BASE_URL` so
 the base lives in exactly one place.
 
+
+## Mutation-testing workflow contract tests
+
+This repository runs scheduled, informational mutation testing through a thin
+caller workflow, [`.github/workflows/mutation-testing.yml`](../.github/workflows/mutation-testing.yml),
+which delegates to the shared reusable workflow
+`leynos/shared-actions/.github/workflows/mutation-cargo.yml`. The heavy lifting
+— running `cargo-mutants`, sharding, and summarizing survivors — lives in
+`shared-actions`; this repository carries only declarative configuration. The
+run is **informational only**: it never gates a pull request. Survivors are
+reported through the job summary and downloadable artefacts so they can be
+triaged into tests, not enforced as a blocking check.
+
+The workflow runs in two modes. A **daily schedule** fires a change-scoped run
+that mutates only the source files touched within the detection window, so
+quiet days are cheap no-ops. A **manual dispatch** (the Actions "Run workflow"
+control) mutates the whole workspace, fanned out across shards; select a
+branch in that control to exercise a feature branch.
+
+The caller passes a small set of configuration inputs, each carrying intent:
+
+- `paths` — the change-detection globs (`crates/`) that decide whether a
+  scheduled run has anything to mutate, bounding the scheduled run to the
+  workspace's mutable source. The root `Cargo.toml` is a virtual manifest with
+  no `src/`, and the vendored `gpui` crates under `vendor/` sit outside the
+  workspace and are deliberately excluded.
+- `exclude-globs` — example applications, test-fixture crates
+  (`cargo-bdd`'s minimal fixture workspace, and the trybuild/macrotest fixture
+  and UI-expectation crates), and test-support modules compiled into `src/`,
+  whose surviving mutants are noise rather than genuine test gaps. UI-test
+  expectation crates must never be mutated.
+- `extra-args` — `--all-features --test-workspace=true`, so feature-gated
+  tests run against mutants and each mutant is tested with the whole
+  workspace's suites, matching the repository's `make test` baseline
+  (`--workspace --all-targets --all-features`). `--test-workspace=true` in
+  particular avoids `cargo-mutants`' per-package default, which would miss
+  coverage that the macro and policy crates receive only through dependent
+  crates' trybuild and integration tests.
+
+The `uses:` reference pins the shared workflow to a full 40-character commit
+SHA rather than a branch or tag, so a force-push upstream cannot silently
+change what runs here. The contract test hard-codes the expected SHA in a
+`PINNED_SHA` constant and asserts the `uses:` line matches it, so bumping the
+pin means editing the workflow's `uses:` line and that constant together in
+the same change.
+
+Because the caller is configuration rather than code, a contract test pins the
+shape it must uphold, failing the pull request when the caller drifts —
+repointing the pin at a branch, widening the token scope, or dropping a
+configuration input — rather than letting the breakage surface only in a
+scheduled run. Run it locally with `make test-workflow-contracts` (which
+invokes `uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest
+tests/workflow_contracts -q`, covering both this contract and the CodeScene
+coverage-caller contract in the same directory). The test module
+`tests/workflow_contracts/mutation_testing_test.py` validates:
+
+- the `uses:` reference targets `mutation-cargo.yml` pinned to the documented
+  full commit SHA;
+- job permissions are exactly least-privilege (`contents: read`,
+  `id-token: write`);
+- the workflow-level default token scope is an empty mapping;
+- `concurrency` serializes runs per ref (`mutation-testing-${{ github.ref
+  }}`) without cancelling one in progress;
+- the triggers keep the daily 03:35 UTC schedule and a plain
+  `workflow_dispatch` with no legacy branch input; and
+- the `with:` block carries exactly the expected `paths`, `exclude-globs`,
+  and `extra-args` shown above.
+
 ## Workflow pins and Dependabot
 
 Dependabot owns the upgrade of GitHub Actions and reusable workflows, including

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -461,7 +461,7 @@ the base lives in exactly one place.
 ## Mutation-testing workflow contract tests
 
 This repository runs scheduled, informational mutation testing through a thin
-caller workflow, [`.github/workflows/mutation-testing.yml`](../.github/workflows/mutation-testing.yml),
+caller workflow, [`.github/workflows/mutation-testing.yml`][mutation-workflow],
 which delegates to the shared reusable workflow
 `leynos/shared-actions/.github/workflows/mutation-cargo.yml`. The heavy lifting
 — running `cargo-mutants`, sharding, and summarizing survivors — lives in
@@ -469,6 +469,12 @@ which delegates to the shared reusable workflow
 run is **informational only**: it never gates a pull request. Survivors are
 reported through the job summary and downloadable artefacts so they can be
 triaged into tests, not enforced as a blocking check.
+
+This repository contains only the Cargo mutation-testing caller: no `mutmut`
+caller or workflow exists, and neither `docs/roadmap.md` nor `docs/execplans/`
+contains an applicable mutation-testing entry.
+
+[mutation-workflow]: ../.github/workflows/mutation-testing.yml
 
 The workflow runs in two modes. A **daily schedule** fires a change-scoped run
 that mutates only the source files touched within the detection window, so
@@ -481,8 +487,10 @@ The caller passes a small set of configuration inputs, each carrying intent:
 - `paths` — the change-detection globs (`crates/`) that decide whether a
   scheduled run has anything to mutate, bounding the scheduled run to the
   workspace's mutable source. The root `Cargo.toml` is a virtual manifest with
-  no `src/`, and the vendored `gpui` crates under `vendor/` sit outside the
-  workspace and are deliberately excluded.
+  no `src/`. Cargo metadata lists both `vendor/gpui` and `vendor/gpui-macros` as
+  workspace members, but `paths: "crates/"` restricts scheduled change
+  detection; because no `vendor/**` exclusion is configured, a manual
+  whole-workspace run may process vendored code.
 - `exclude-globs` — example applications, test-fixture crates
   (`cargo-bdd`'s minimal fixture workspace, and the trybuild/macrotest fixture
   and UI-expectation crates), and test-support modules compiled into `src/`,
@@ -498,10 +506,9 @@ The caller passes a small set of configuration inputs, each carrying intent:
 
 The `uses:` reference pins the shared workflow to a full 40-character commit
 SHA rather than a branch or tag, so a force-push upstream cannot silently
-change what runs here. The contract test hard-codes the expected SHA in a
-`PINNED_SHA` constant and asserts the `uses:` line matches it, so bumping the
-pin means editing the workflow's `uses:` line and that constant together in
-the same change.
+change what runs here. The contract test checks the reusable-workflow path and
+the full 40-hex SHA shape, without asserting a specific SHA value, so
+Dependabot can update the pin without a lockstep test edit.
 
 Because the caller is configuration rather than code, a contract test pins the
 shape it must uphold, failing the pull request when the caller drifts —
@@ -513,8 +520,8 @@ tests/workflow_contracts -q`, covering both this contract and the CodeScene
 coverage-caller contract in the same directory). The test module
 `tests/workflow_contracts/mutation_testing_test.py` validates:
 
-- the `uses:` reference targets `mutation-cargo.yml` pinned to the documented
-  full commit SHA;
+- the `uses:` reference targets the correct `mutation-cargo.yml` path and has
+  a full 40-character lowercase-hex commit SHA;
 - job permissions are exactly least-privilege (`contents: read`,
   `id-token: write`);
 - the workflow-level default token scope is an empty mapping;


### PR DESCRIPTION
## Summary

- Adds a `## Mutation-testing workflow contract tests` section to
  `docs/developers-guide.md`, covering the caller workflow
  (`.github/workflows/mutation-testing.yml`), its shared
  `mutation-cargo.yml` reusable workflow, and the contract test that checks
  the caller's shape.
- Documents the Rust-workspace permutation: scheduled detection is scoped to
  `crates/`, while manual whole-workspace runs may process the vendored GPUI
  crates because Cargo includes them as workspace members and no `vendor/**`
  exclusion is configured. Examples, fixture crates, and test-support modules
  remain excluded through `exclude-globs`; the caller passes
  `--all-features --test-workspace=true` to match `make test`.
- States that this repository has only the Cargo mutation-testing caller—no
  `mutmut` workflow—and no applicable roadmap or execplan entry. Mutation
  testing remains informational and non-blocking.
- The workflow contract verifies the shared workflow path and a full
  40-character lowercase-hex SHA shape, without tying Dependabot updates to a
  particular SHA. Run it locally with `make test-workflow-contracts`.
- Raises the serialized trybuild test override to 10 minutes, allowing a
  healthy cold-cache fixture rebuild without weakening the strict default
  timeout.

## Validation

- `make check-fmt`
- `make test-workflow-contracts` (11 passed)
- `make test` (1,685 passed; 7 skipped)
- `make typecheck`
- `make lint`
- `make markdownlint`

## References

- [Lody session](https://lody.ai/leynos/sessions/0c7b603e-bdd8-488e-a045-93ff38420c0e)

## Summary by Sourcery

Document and enforce the mutation-testing workflow and trybuild timeout contracts.

New Features:
- Document the mutation-testing workflow contract, including its triggers, scope, exclusions, permissions, pinning, and non-blocking behavior.

Enhancements:
- Increase the trybuild nextest slow-timeout to 10 minutes for cold-cache fixture rebuilds while retaining serialized execution.
- Add an integration contract test that validates the trybuild nextest override and its expected binaries and timeout settings.

CI:
- Clarify the mutation-testing caller's scheduled and manual workspace behavior and constrain scheduled change detection to the crates directory.

Documentation:
- Add developer-guide documentation for mutation-testing workflow behavior, contract validation, and local execution.

Tests:
- Add coverage for the trybuild nextest configuration contract and expected timeout policy.