### PR TITLE
Fix: satisfy no_expect_outside_tests in unit-test helpers (unblocks Lint gate)

### DIFF
--- a/crates/rstest-bdd-macros/src/codegen/wrapper/arguments/tests/helpers.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/arguments/tests/helpers.rs
@@ -37,11 +37,9 @@ pub fn generate_step_parse_with_hint(ty: syn::Type, hint: Option<String>) -> Str
 
     let tokens = gen_step_parses(&args, &captures, &hints, meta);
 
-    #[expect(
-        clippy::expect_used,
-        reason = "test helper asserts single token output"
-    )]
-    let token = tokens.first().expect("expected single token stream");
+    let Some(token) = tokens.first() else {
+        panic!("expected single token stream");
+    };
     token.to_string()
 }
 

--- a/crates/rstest-bdd-macros/src/validation/steps/tests/support.rs
+++ b/crates/rstest-bdd-macros/src/validation/steps/tests/support.rs
@@ -7,8 +7,10 @@ use rstest::fixture;
 use tempfile::tempdir;
 
 pub(super) fn clear_registry() {
-    #[expect(clippy::expect_used, reason = "registry lock must panic if poisoned")]
-    REGISTERED.lock().expect("step registry poisoned").clear();
+    let Ok(mut registry) = REGISTERED.lock() else {
+        panic!("step registry poisoned");
+    };
+    registry.clear();
 }
 
 pub(super) fn create_test_step(keyword: StepKeyword, text: &str) -> ParsedStep {

--- a/crates/rstest-bdd-server/src/handlers/diagnostics/tests/outline.rs
+++ b/crates/rstest-bdd-server/src/handlers/diagnostics/tests/outline.rs
@@ -3,15 +3,13 @@
 use super::*;
 
 /// Helper to compute scenario outline column diagnostics.
-#[expect(
-    clippy::expect_used,
-    reason = "test helper requires explicit panic for debugging failures"
-)]
 fn compute_scenario_outline_diagnostics_for_path(
     state: &ServerState,
     feature_path: &Path,
 ) -> Vec<Diagnostic> {
-    let feature_index = state.feature_index(feature_path).expect("feature index");
+    let Some(feature_index) = state.feature_index(feature_path) else {
+        panic!("feature index missing for {}", feature_path.display());
+    };
     scenario_outline::compute_scenario_outline_column_diagnostics(feature_index)
 }
 

--- a/crates/rstest-bdd-server/src/handlers/diagnostics/tests/table_docstring.rs
+++ b/crates/rstest-bdd-server/src/handlers/diagnostics/tests/table_docstring.rs
@@ -3,15 +3,13 @@
 use super::*;
 
 /// Helper to compute table/docstring mismatch diagnostics.
-#[expect(
-    clippy::expect_used,
-    reason = "test helper requires explicit panic for debugging failures"
-)]
 fn compute_table_docstring_diagnostics_for_path(
     state: &ServerState,
     feature_path: &Path,
 ) -> Vec<Diagnostic> {
-    let feature_index = state.feature_index(feature_path).expect("feature index");
+    let Some(feature_index) = state.feature_index(feature_path) else {
+        panic!("feature index missing for {}", feature_path.display());
+    };
     table_docstring::compute_table_docstring_mismatch_diagnostics(state, feature_index)
 }
 


### PR DESCRIPTION
## Summary

`make lint` currently fails on a fresh run of **`main`** (and therefore on every open PR once rebased), at the `Lint` CI step.

`make lint-whitaker` runs the full Whitaker Dylint suite (`whitaker --all`, adopted in #578), which denies `no_expect_outside_tests`. That lint permits `.expect()` only **directly inside test functions**, not in the plain helper functions that back them. Four `#[cfg(test)]` helper functions still call `.expect()` behind `#[expect(clippy::expect_used)]` — which suppresses only the *Clippy* lint, not the *Dylint* one — so the `rstest-bdd-macros` and `rstest-bdd-server` lib-test targets fail to compile under `make lint`:

- `crates/rstest-bdd-macros/src/codegen/wrapper/arguments/tests/helpers.rs`
- `crates/rstest-bdd-macros/src/validation/steps/tests/support.rs`
- `crates/rstest-bdd-server/src/handlers/diagnostics/tests/outline.rs`
- `crates/rstest-bdd-server/src/handlers/diagnostics/tests/table_docstring.rs`

## Change

Convert the four helpers to the repository's sanctioned `let Some(..) = .. else { panic!(..) }` pattern (already used by `compute_feature_diagnostics_for_path` in the same diagnostics test module) and drop the now-redundant `#[expect(clippy::expect_used)]` attributes. `.expect()` calls that live directly in `#[test]`/`#[rstest]` functions are left untouched, as the lint allows them.

## Validation

- `make lint-whitaker` — passes (previously failed with 4 `no_expect_outside_tests` errors)
- `make lint` (clippy + Whitaker) — passes
- `cargo test -p rstest-bdd-macros -p rstest-bdd-server --lib` — 394 + 164 passed

## Why a standalone PR

The break is pre-existing on `main` and unrelated to any feature PR's content, but it blocks the `Lint` gate on all of them (#524, #525, #527, #529, #530, #531, #532, #536, #541). Landing it here keeps those PRs' diffs focused; they go green on `Lint` after this merges and they rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Adopt the repository-standard let-else panic pattern in test helper functions instead of calling expect on options and locks.