### PR TITLE
Add crates.io badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # rstest-bdd
 
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](
-https://deepwiki.com/leynos/rstest-bdd)
-[![Crates.io Version](https://img.shields.io/crates/v/rstest-bdd)](
-https://crates.io/crates/rstest-bdd)
+[![Ask DeepWiki][dw]][deepwiki] [![Crates.io Version][crates]][package]
+
+[dw]: https://deepwiki.com/badge.svg
+[deepwiki]: https://deepwiki.com/leynos/rstest-bdd
+[crates]: https://img.shields.io/crates/v/rstest-bdd "crates.io package"
+[package]: https://crates.io/crates/rstest-bdd
 
 *Where Rustaceans come for their gourd‑related puns.*
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](
 https://deepwiki.com/leynos/rstest-bdd)
+[![Crates.io Version](https://img.shields.io/crates/v/rstest-bdd)](
+https://crates.io/crates/rstest-bdd)
 
 *Where Rustaceans come for their gourd‑related puns.*
 


### PR DESCRIPTION
## Summary

This branch adds a crates.io version badge beside the DeepWiki badge so readers
can see the latest published `rstest-bdd` version and navigate directly to the
crate page. The badge image also exposes the title `crates.io package`.

**Stack:** 2/2 — depends on #622.

## Review walkthrough

- Review [README.md](https://github.com/leynos/rstest-bdd/blob/0f83a94167925b8e9a9fcf7dd994ec375ebeef88/README.md#L3-L8) for the adjacent linked badges, the crates.io image title, and the short references that remain stable across repeated formatter passes.

## Validation

- `make fmt`: two consecutive passes produced an identical README hash
- `make check-fmt`: passed
- `make test`: 1,506 Rust tests and 69 Python tests passed
- `make typecheck`: passed
- `make lint`: passed, including Clippy, Whitaker and Python linting
- `make markdownlint`: passed, including the spelling gate
- `make nixie`: passed
- `mbake validate Makefile`: passed
- `git diff --check`: passed

## Notes

This branch is stacked on the formatter-only change in #622. Its diff against
that base is limited to `README.md`. It is not linked to a roadmap task, issue
or execplan.

## Summary by Sourcery

Documentation:
- Update README to include a crates.io version badge that links to the rstest-bdd crate on crates.io.
