### PR TITLE
Apply Markdown formatter

### DIFF
--- a/docs/adr-007-harness-context-injection.md
+++ b/docs/adr-007-harness-context-injection.md
@@ -175,26 +175,25 @@ indirection.
 
 ### Harness-context wrapper contract
 
-`StepContext` exposes a fixed set of thin wrappers that hard-code the
-reserved `RSTEST_BDD_HARNESS_CONTEXT_FIXTURE` key over the generic fixture
-API. They are deliberate API surface, not dead code, and divide into two
-roles:
+`StepContext` exposes a fixed set of thin wrappers that hard-code the reserved
+`RSTEST_BDD_HARNESS_CONTEXT_FIXTURE` key over the generic fixture API. They are
+deliberate API surface, not dead code, and divide into two roles:
 
-| Wrapper | Role |
-| --- | --- |
-| `insert_owned_harness_context` | **Required by codegen.** Emitted by macro-generated harness scenarios (`codegen/scenario/runtime/harness.rs`), which wrap `HarnessAdapter::Context` in an owned cell, so steps can borrow it mutably. |
-| `insert_harness_context` | Insert-side counterpart for adapters that keep ownership of their context and share it by reference. |
-| `borrow_harness_context` / `borrow_harness_context_mut` | The supported typed read/write accessors for context stored by the owned insert path. |
-| `harness_context` | Typed accessor for the shared-reference insert path (returns `None` for owned entries). |
+| Wrapper                                                 | Role                                                                                                                                                                                                  |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `insert_owned_harness_context`                          | **Required by codegen.** Emitted by macro-generated harness scenarios (`codegen/scenario/runtime/harness.rs`), which wrap `HarnessAdapter::Context` in an owned cell, so steps can borrow it mutably. |
+| `insert_harness_context`                                | Insert-side counterpart for adapters that keep ownership of their context and share it by reference.                                                                                                  |
+| `borrow_harness_context` / `borrow_harness_context_mut` | The supported typed read/write accessors for context stored by the owned insert path.                                                                                                                 |
+| `harness_context`                                       | Typed accessor for the shared-reference insert path (returns `None` for owned entries).                                                                                                               |
 
 Collapsing these onto the generic API
-(`ctx.get(RSTEST_BDD_HARNESS_CONTEXT_FIXTURE)` and friends) was considered
-and rejected: the reserved key would then be repeated at every call-site,
-including inside generated code, and the typed pairing between the insert
-and borrow sides would no longer be discoverable from the API surface.
+(`ctx.get(RSTEST_BDD_HARNESS_CONTEXT_FIXTURE)` and friends) was considered and
+rejected: the reserved key would then be repeated at every call-site, including
+inside generated code, and the typed pairing between the insert and borrow
+sides would no longer be discoverable from the API surface.
 
-The wrapper set is intentionally closed. New generic fixture-access patterns
-on `StepContext` must **not** gain a matching `*_harness_context` wrapper by
+The wrapper set is intentionally closed. New generic fixture-access patterns on
+`StepContext` must **not** gain a matching `*_harness_context` wrapper by
 default; add one only when macro-generated code or the documented
 step-authoring path needs it, and record the addition here.
 

--- a/docs/adr-014-retain-users-guide-link-validator.md
+++ b/docs/adr-014-retain-users-guide-link-validator.md
@@ -66,8 +66,8 @@ remain outside its remit.
 
 The vendored guide is the one document in this repository whose links are
 consumed outside it, so it is the one document where link rot escapes the
-normal feedback loop. That asymmetry — not link hygiene in general — justifies a
-dedicated check. Restricting the validator to that document keeps the cost
+normal feedback loop. That asymmetry — not link hygiene in general — justifies
+a dedicated check. Restricting the validator to that document keeps the cost
 proportionate to the risk it addresses, and keeps the failure mode legible:
 when the gate fails, it names the offending definition and why.
 
@@ -95,8 +95,8 @@ Cons:
 - Detection moves downstream, where it is slowest and most expensive.
 - The maintenance saved is small — the script's contract is narrow and stable.
 
-Rejected: the saving is marginal, and it is paid for with the only deterministic
-detection mechanism available.
+Rejected: the saving is marginal, and it is paid for with the only
+deterministic detection mechanism available.
 
 ### Option B: expand the validator to all documentation links
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -220,8 +220,8 @@ normal default root, so the gate always covers the working repository.
 - Unit and Hypothesis property tests live in
   `scripts/tests/test_check_users_guide_links.py`. Hypothesis exercises the
   slug-generation invariants (anchors stay lowercase, contain no spaces, use
-  only word characters and hyphens, and are idempotent) and fenced-code
-  heading handling, where generated headings expose parser edge cases that
+  only word characters and hyphens, and are idempotent) and fenced-code heading
+  handling, where generated headings expose parser edge cases that
   example-based cases miss.
 - Cuprum subprocess/CLI integration tests live in
   `scripts/tests/test_check_users_guide_links_cli.py`. They verify
@@ -241,8 +241,7 @@ absolute link can ship downstream undetected; manual review does not give
 deterministic drift detection. Its scope is limited to repository-reference
 link definitions in `docs/users-guide.md`, rather than expanding to every
 documentation cross-reference in the repository. See
-[ADR-014](adr-014-retain-users-guide-link-validator.md) for the decision
-record.
+[ADR-014](adr-014-retain-users-guide-link-validator.md) for the decision record.
 
 ## GPUI mapping-table validation (`scripts/check_gpui_mapping_table.py`)
 
@@ -899,16 +898,15 @@ policy `P`:
 3. **rstest is first** — the first attribute path is `rstest::rstest`, so
    fixture expansion precedes the runtime-specific test macro.
 
-Harness adapter crates (`rstest-bdd-harness-tokio`,
-`rstest-bdd-harness-gpui`, and any future adapter) must exercise their policy
-through this helper, supplying only the crate-specific expected rendered
-attributes; do not re-implement the emit/render/ordering assertions per
-crate. New harness crates get the policy contract for free by calling the
-helper from one `#[test]`.
+Harness adapter crates (`rstest-bdd-harness-tokio`, `rstest-bdd-harness-gpui`,
+and any future adapter) must exercise their policy through this helper,
+supplying only the crate-specific expected rendered attributes; do not
+re-implement the emit/render/ordering assertions per crate. New harness crates
+get the policy contract for free by calling the helper from one `#[test]`.
 
 The GPUI adapter's library target sets `test = false`, so an in-module
-`#[cfg(test)]` block there would never be compiled or run. Its conformance
-test therefore lives in the `tests/attribute_policy_behaviour.rs` integration
+`#[cfg(test)]` block there would never be compiled or run. Its conformance test
+therefore lives in the `tests/attribute_policy_behaviour.rs` integration
 target, exercised under `--all-features` (which enables the crate's
 `native-gpui-tests` feature) — the arrangement `make test` uses.
 
@@ -917,9 +915,9 @@ target, exercised under `--all-features` (which enables the crate's
 `crates/rstest-bdd-patterns/src/keyword.rs` drives the string ↔ `StepKeyword`
 correspondence from a single `keyword_table![...]` invocation — the list of
 `(rendering, variant)` pairs and the true source of truth. That macro generates
-the `KEYWORDS` const table consumed by `StepKeyword::from_str` (case-insensitive,
-whitespace-trimming parsing) and the match inside `StepKeyword::as_str`
-(rendering), so neither side carries its own literal list.
+the `KEYWORDS` const table consumed by `StepKeyword::from_str`
+(case-insensitive, whitespace-trimming parsing) and the match inside
+`StepKeyword::as_str` (rendering), so neither side carries its own literal list.
 
 - **Adding or renaming a keyword:** edit the `keyword_table![...]` invocation
   (and the enum variant) only — not the generated `KEYWORDS` const. Do not add

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -2067,8 +2067,8 @@ assert_attribute_policy_conformance::<DefaultAttributePolicy>(
 );
 ```
 
-It pins three invariants, panicking with a descriptive message when any of
-them is violated:
+It pins three invariants, panicking with a descriptive message when any of them
+is violated:
 
 - **Emit** — the policy returns exactly as many attributes as expected.
 - **Render** — each attribute renders to the corresponding expected string, in


### PR DESCRIPTION
## Summary

This branch applies the repository Markdown formatter to four files that had
drifted from its current wrapping and table-layout rules. It keeps the
formatter-only changes separate so the dependent crates.io badge pull request
remains focused.

**Stack:** 1/2 — prerequisite for #619.

## Review walkthrough

- Start with [ADR-007](https://github.com/leynos/rstest-bdd/blob/441ce02a99a1926030668098ab210eef4e683051/docs/adr-007-harness-context-injection.md) to review the table normalization and paragraph wrapping.
- Then review [ADR-014](https://github.com/leynos/rstest-bdd/blob/441ce02a99a1926030668098ab210eef4e683051/docs/adr-014-retain-users-guide-link-validator.md), the [developers' guide](https://github.com/leynos/rstest-bdd/blob/441ce02a99a1926030668098ab210eef4e683051/docs/developers-guide.md), and the [users' guide](https://github.com/leynos/rstest-bdd/blob/441ce02a99a1926030668098ab210eef4e683051/docs/users-guide.md) for wrapping-only changes.

## Validation

- `make fmt`: passed
- `make check-fmt`: passed
- `make test`: 1,506 Rust tests and 69 Python tests passed
- `make typecheck`: passed
- `make lint`: passed
- `make markdownlint`: passed
- `make nixie`: passed
- `mbake validate Makefile`: passed
- `git diff --check`: passed

## Summary by Sourcery

Documentation:
- Normalize Markdown tables and wrapping in ADR-007, ADR-014, developers' guide, and users' guide to match repository formatting rules.