### PR TITLE
Strengthen Rust documentation linting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,4 +104,12 @@ float_arithmetic = "deny"
 [workspace.lints.rust]
 unsafe_code = "forbid"
 missing_docs = "deny"
+
+[workspace.lints.rustdoc]
 missing_crate_level_docs = "deny"
+broken_intra_doc_links = "deny"
+private_intra_doc_links = "deny"
+bare_urls = "deny"
+invalid_html_tags = "deny"
+invalid_codeblock_attributes = "deny"
+unescaped_backticks = "deny"

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ APP ?= cargo-bdd
 CARGO ?= $(or $(shell command -v cargo 2>/dev/null),$(HOME)/.cargo/bin/cargo)
 BUILD_JOBS ?=
 RUST_FLAGS ?= -D warnings
+RUSTDOC_FLAGS ?= --cfg docsrs -D warnings
 CARGO_FLAGS ?= --workspace --all-targets --all-features
 CLIPPY_FLAGS ?= $(CARGO_FLAGS) -- $(RUST_FLAGS)
 MDLINT ?= $(or $(shell command -v markdownlint-cli2 2>/dev/null),$(HOME)/.bun/bin/markdownlint-cli2)
@@ -59,6 +60,7 @@ test: build-python ## Run tests with warnings treated as errors
 	else \
 		RUSTFLAGS="$(RUST_FLAGS)" $(CARGO) test $(CARGO_FLAGS) $(BUILD_JOBS); \
 	fi
+	RUSTFLAGS="$(RUST_FLAGS)" $(CARGO) test --doc --workspace --all-features $(BUILD_JOBS)
 	# Exercise the Python documentation helpers alongside the Rust suite.
 	$(UV_ENV) $(UV) run pytest scripts/tests
 
@@ -67,6 +69,7 @@ target/%/$(APP): ## Build binary in debug or release mode
 
 lint: ## Run Clippy and the Whitaker Dylint suite with warnings denied
 	$(CARGO) clippy $(CLIPPY_FLAGS)
+	RUSTDOCFLAGS="$(RUSTDOC_FLAGS)" $(CARGO) doc --workspace --no-deps
 	$(MAKE) lint-whitaker
 	$(MAKE) lint-python
 	python3 scripts/check_rs_file_lengths.py

--- a/crates/rstest-bdd-macros/src/lib.rs
+++ b/crates/rstest-bdd-macros/src/lib.rs
@@ -7,8 +7,6 @@
 //!   compile errors; implies `compile-time-validation`.
 //!
 //! Both features are disabled by default.
-#![cfg_attr(docsrs, feature(doc_cfg))]
-
 mod codegen;
 mod datatable;
 mod macros;
@@ -171,8 +169,9 @@ pub fn derive_scenario_state(input: TokenStream) -> TokenStream {
     scenario_state::derive(input)
 }
 
-/// Derive [`StepArgs`](rstest_bdd::step_args::StepArgs) for a struct whose
-/// fields map to pattern placeholders.
+/// Derive
+/// [`rstest_bdd::StepArgs`](https://docs.rs/rstest-bdd/latest/rstest_bdd/trait.StepArgs.html)
+/// for a struct whose fields map to pattern placeholders.
 #[proc_macro_error]
 #[proc_macro_derive(StepArgs)]
 pub fn derive_step_args(input: TokenStream) -> TokenStream {

--- a/crates/rstest-bdd-macros/src/macros/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/mod.rs
@@ -303,7 +303,6 @@ fn step_attr(attr: TokenStream, item: TokenStream, keyword: crate::StepKeyword) 
     };
     let pattern = determine_step_pattern(attr_args.pattern, &func.sig.ident);
     #[cfg(feature = "compile-time-validation")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "compile-time-validation")))]
     crate::validation::steps::register_step(keyword, &pattern);
     let mut placeholder_summary = match placeholder_names(&pattern.value()) {
         Ok(set) => set,

--- a/crates/rstest-bdd-macros/src/macros/scenario/paths.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenario/paths.rs
@@ -53,6 +53,11 @@ fn normalize(path: &Path) -> PathBuf {
 
 #[cfg(all(test, windows))]
 mod windows_paths {
+    //! Exercises Windows-specific normalization of scenario feature paths.
+    //!
+    //! These tests complement the surrounding platform-independent path logic
+    //! with drive-relative and UNC paths that cannot be represented on Unix.
+
     use super::normalize;
     use std::path::Path;
 

--- a/crates/rstest-bdd-macros/src/macros/scenarios/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/mod.rs
@@ -303,6 +303,11 @@ mod tests {
 #[cfg(not(unix))]
 #[cfg(test)]
 mod tests {
+    //! Covers the non-Unix scenario-discovery test configuration.
+    //!
+    //! This portability guard complements the Unix-only symlink-discovery test
+    //! above when Unix symlink APIs and directory-loop semantics are absent.
+
     #[test]
     fn collects_symlinked_feature_files_without_following_directory_loops() {
         assert!(cfg!(not(unix)));

--- a/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
@@ -24,7 +24,6 @@ pub(crate) struct ParsedStep {
     pub docstring: Option<String>,
     pub table: Option<Vec<Vec<String>>>,
     #[cfg(feature = "compile-time-validation")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "compile-time-validation")))]
     /// Approximate span for diagnostics.
     pub(crate) span: proc_macro2::Span,
 }

--- a/crates/rstest-bdd-macros/src/validation/mod.rs
+++ b/crates/rstest-bdd-macros/src/validation/mod.rs
@@ -4,5 +4,4 @@ pub(crate) mod examples;
 pub(crate) mod parameters;
 pub(crate) mod placeholder;
 #[cfg(feature = "compile-time-validation")]
-#[cfg_attr(docsrs, doc(cfg(feature = "compile-time-validation")))]
 pub(crate) mod steps;

--- a/crates/rstest-bdd-patterns/src/hint.rs
+++ b/crates/rstest-bdd-patterns/src/hint.rs
@@ -3,10 +3,14 @@
 /// Translate a placeholder type hint into a regular-expression fragment.
 ///
 /// # Examples
-/// ```ignore
+/// ```
 /// use rstest_bdd_patterns::get_type_pattern;
-/// assert_eq!(get_type_pattern(Some("u32")), "\\d+");
-/// assert_eq!(get_type_pattern(Some("f64")), "(?i:(?:[+-]?(?:\d+\.\d*|\.\d+|\d+)(?:[eE][+-]?\d+)?|nan|inf|infinity))");
+///
+/// assert_eq!(get_type_pattern(Some("u32")), r"\d+");
+/// assert_eq!(
+///     get_type_pattern(Some("f64")),
+///     r"(?i:(?:[+-]?(?:\d+\.\d*|\.\d+|\d+)(?:[eE][+-]?\d+)?|nan|inf|infinity))",
+/// );
 /// assert_eq!(get_type_pattern(None), ".+?");
 /// ```
 #[must_use]

--- a/crates/rstest-bdd-patterns/src/keyword.rs
+++ b/crates/rstest-bdd-patterns/src/keyword.rs
@@ -53,8 +53,7 @@ macro_rules! keyword_table {
         impl StepKeyword {
             /// Return the keyword as a string slice.
             ///
-            /// The rendering derives from the canonical [`keyword_table!`]
-            /// entries.
+            /// The rendering derives from the canonical keyword table entries.
             ///
             /// # Examples
             ///
@@ -130,8 +129,8 @@ impl std::error::Error for StepKeywordParseError {}
 impl FromStr for StepKeyword {
     type Err = StepKeywordParseError;
 
-    /// Parse a keyword case-insensitively via the canonical [`KEYWORDS`]
-    /// table, trimming surrounding whitespace first.
+    /// Parse a keyword case-insensitively via the canonical keyword table,
+    /// trimming surrounding whitespace first.
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         let trimmed = value.trim();
         KEYWORDS

--- a/crates/rstest-bdd-server/src/handlers/util.rs
+++ b/crates/rstest-bdd-server/src/handlers/util.rs
@@ -111,7 +111,7 @@ fn clamp_final_offset(
 
 /// Convert an LSP Position to a byte offset in the source text.
 ///
-/// This is the inverse of [`byte_offset_to_position`]. It scans the source text
+/// This is the inverse of `byte_offset_to_position`. It scans the source text
 /// to find the byte offset corresponding to the given line and character position.
 ///
 /// The LSP specification defines character positions as UTF-16 code unit offsets.

--- a/crates/rstest-bdd/src/context/insert_outcome.rs
+++ b/crates/rstest-bdd/src/context/insert_outcome.rs
@@ -6,7 +6,7 @@
 
 use std::any::Any;
 
-/// Outcome of [`StepContext::insert_value`].
+/// Outcome of [`crate::StepContext::insert_value`].
 ///
 /// Distinguishes a recorded override from the two cases where the value is
 /// dropped, which a bare `Option` return previously conflated.

--- a/crates/rstest-bdd/src/datatable/parsers.rs
+++ b/crates/rstest-bdd/src/datatable/parsers.rs
@@ -74,8 +74,8 @@ impl TruthyBoolError {
 
 /// Trims leading and trailing whitespace before parsing a value.
 ///
-/// `trimmed` delegates to [`FromStr`] implementations after normalizing the
-/// input. Errors from the inner parser are preserved.
+/// `trimmed` delegates to [`std::str::FromStr`] implementations after
+/// normalizing the input. Errors from the inner parser are preserved.
 ///
 /// # Examples
 /// ```

--- a/crates/rstest-bdd/src/execution/mod.rs
+++ b/crates/rstest-bdd/src/execution/mod.rs
@@ -101,8 +101,8 @@ fn handle_step_result(
 ///
 /// # Returns
 ///
-/// An encoded string starting with [`SKIP_NONE_PREFIX`] (no message) or
-/// [`SKIP_SOME_PREFIX`] followed by the message content.
+/// An encoded string starting with `SKIP_NONE_PREFIX` (no message) or
+/// `SKIP_SOME_PREFIX` followed by the message content.
 ///
 /// # Examples
 ///

--- a/crates/rstest-bdd/src/panic_support.rs
+++ b/crates/rstest-bdd/src/panic_support.rs
@@ -10,7 +10,7 @@ use crate::localization;
 /// Extracts a panic payload into a human-readable message.
 ///
 /// Attempts to downcast common primitives before falling back to an opaque
-/// description that includes the payload [`TypeId`].
+/// description that includes the payload [`std::any::TypeId`].
 ///
 /// # Examples
 /// ```

--- a/crates/rstest-bdd/src/reporting/mod.rs
+++ b/crates/rstest-bdd/src/reporting/mod.rs
@@ -9,10 +9,10 @@
 //!
 //! The collector is intentionally global so that generated tests and external
 //! binaries can publish their outcomes without plumbing additional context.
-//! Behavioural tests that assert on the stored records must execute
-//! serially (for example via [`serial_test::serial`]) to avoid cross-test
-//! contamination. The API does not reset records automatically; callers
-//! remain responsible for draining the collector between assertions.
+//! Behavioural tests that assert on the stored records must execute serially
+//! (for example via `#[serial_test::serial]`) to avoid cross-test contamination.
+//! The API does not reset records automatically; callers remain responsible for
+//! draining the collector between assertions.
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
 #[cfg(feature = "diagnostics")]

--- a/crates/rstest-bdd/src/types.rs
+++ b/crates/rstest-bdd/src/types.rs
@@ -160,7 +160,7 @@ impl fmt::Display for PlaceholderSyntaxError {
 
 impl std::error::Error for PlaceholderSyntaxError {}
 
-/// Errors that may occur when compiling a [`StepPattern`].
+/// Errors that may occur when compiling a [`crate::StepPattern`].
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum StepPatternError {

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -105,6 +105,41 @@ trybuild scratch directory by querying `cargo metadata` for the workspace
 `Result<PathBuf, Box<dyn Error>>` and is consumed by
 `stage_trybuild_support_files` in each harness crate's `macro_compile.rs` test.
 
+## Rust documentation policy and gates
+
+The workspace denies missing documentation on Rust items and crate roots. It
+also denies broken or private intra-doc links, bare URLs, invalid HTML tags,
+invalid code-block attributes, and unescaped backticks through the
+`[workspace.lints.rust]` and `[workspace.lints.rustdoc]` tables in
+`Cargo.toml`. Workspace crates inherit these lints with
+`lints.workspace = true`; keep new modules and public APIs documented instead
+of suppressing a lint.
+
+`make lint` builds the workspace documentation after Clippy with:
+
+```makefile
+RUSTDOCFLAGS="$(RUSTDOC_FLAGS)" $(CARGO) doc --workspace --no-deps
+```
+
+The Makefile exposes the flag value as
+`RUSTDOC_FLAGS ?= --cfg docsrs -D warnings`, so callers may override it for
+diagnostics. The committed default enables `docsrs`-conditional documentation
+and promotes every Rustdoc warning to an error. `--workspace` checks every
+member crate, while `--no-deps` keeps the gate focused on documentation owned
+by this repository.
+
+`make test` separately compiles and runs documentation examples across every
+workspace crate and feature combination with:
+
+```makefile
+RUSTFLAGS="$(RUST_FLAGS)" $(CARGO) test --doc --workspace --all-features $(BUILD_JOBS)
+```
+
+Keep the documentation build and all-feature doctest commands distinct: the
+former validates generated documentation and links under the docs.rs
+configuration, while the latter verifies that executable examples compile and
+behave as documented.
+
 ## nextest configuration (`.config/nextest.toml`)
 
 cargo-nextest reads its configuration from `.config/nextest.toml` at the


### PR DESCRIPTION
## Summary

This branch strengthens workspace Rust and Rustdoc documentation policy, makes workspace documentation and doctests part of the standard gates, and repairs every documentation defect exposed by those settings. It is stacked on formatter-only draft PR #623 so this PR's diff remains limited to Rust documentation and gate configuration.

## Review walkthrough

- Start with [Cargo.toml](https://github.com/leynos/rstest-bdd/blob/strengthen-rustdoc-lints/Cargo.toml) for the workspace `missing_docs` policy and the denied Rustdoc lint set.
- Then review the [Makefile](https://github.com/leynos/rstest-bdd/blob/strengthen-rustdoc-lints/Makefile) for workspace-wide `cargo doc` in `lint` and all-feature workspace doctests in `test`.
- Review the public documentation repairs in [rstest-bdd-patterns](https://github.com/leynos/rstest-bdd/blob/strengthen-rustdoc-lints/crates/rstest-bdd-patterns/src/keyword.rs), [rstest-bdd](https://github.com/leynos/rstest-bdd/blob/strengthen-rustdoc-lints/crates/rstest-bdd/src/types.rs), [rstest-bdd-macros](https://github.com/leynos/rstest-bdd/blob/strengthen-rustdoc-lints/crates/rstest-bdd-macros/src/lib.rs), and [rstest-bdd-server](https://github.com/leynos/rstest-bdd/blob/strengthen-rustdoc-lints/crates/rstest-bdd-server/src/handlers/util.rs).
- Finish with the stable docs.rs compatibility cleanup in the [macro crate](https://github.com/leynos/rstest-bdd/blob/strengthen-rustdoc-lints/crates/rstest-bdd-macros/src/validation/mod.rs), which removes nightly-only `doc(cfg)` annotations from private items without changing feature gating or public behaviour.

## Validation

- `make check-fmt`: passed.
- `make lint`: passed, including `RUSTDOCFLAGS="--cfg docsrs -D warnings" cargo doc --workspace --no-deps` for all workspace members.
- `make typecheck`: passed.
- Rust test phase: Nextest passed 1,506 tests with 7 skipped.
- `RUSTFLAGS="-D warnings" cargo test --doc --workspace --all-features`: passed, including the repaired runnable regex doctest.
- Python helper tests: the aggregate process reproducibly deadlocks in the pre-existing `test_check_users_guide_links_cli.py` subprocess suite; the two Whitaker integration cases pass individually. The full `make test` command therefore did not return success and is not represented as green.
- `make markdownlint`: passed; 99 Markdown files, zero errors.
- `mbake validate Makefile`: passed.
- `git diff --check format-markdown-docs`: passed.
- `make nixie`: blocked by a 30-second renderer timeout in the untouched `docs/v0-5-0-migration-guide.md` diagram at lines 110–145.

## References

- Base formatter PR: [#623](https://github.com/leynos/rstest-bdd/pull/623)
- [Lody session](https://lody.ai/leynos/sessions/41f4c800-d0b5-4c00-a806-0f8ba4d20836)

## Summary by Sourcery

Strengthen workspace Rust documentation policy, enforce Rustdoc linting in standard workflows, and update documentation to comply with stricter rules.

Bug Fixes:
- Repair doctest for type hint regex patterns so it runs successfully under strict Rustdoc settings.

Enhancements:
- Tighten workspace Rustdoc lint configuration to deny missing crate-level docs, broken or private intra-doc links, bare URLs, invalid HTML tags and code block attributes, and unescaped backticks.
- Improve public Rust API documentation across crates to use fully qualified references and clearer wording, ensuring compatibility with docs.rs in stable Rust.
- Remove nightly-only doc configuration attributes from private macro-validation code without changing feature gating or runtime behaviour.

Tests:
- Include workspace doctests with all features in the standard test target so documentation examples are exercised under warnings-as-errors.
- Run workspace documentation generation with Rustdoc warnings denied as part of the lint target.