### PR TITLE
Prefer owned string clones

### DIFF
--- a/crates/cargo-bdd/src/registry/tests.rs
+++ b/crates/cargo-bdd/src/registry/tests.rs
@@ -77,12 +77,12 @@ fn parses_registry_dump_with_bypassed_steps() {
         panic!("scenario entry");
     };
     assert_eq!(scenario.line, 42);
-    assert_eq!(scenario.tags, vec!["@t".to_string()]);
+    assert_eq!(scenario.tags, vec!["@t".to_owned()]);
     let Some(bypassed) = parsed.bypassed_steps.first() else {
         panic!("bypassed entry");
     };
     assert_eq!(bypassed.scenario_line, 42);
-    assert_eq!(bypassed.tags, vec!["@t".to_string()]);
+    assert_eq!(bypassed.tags, vec!["@t".to_owned()]);
     assert_eq!(bypassed.reason.as_deref(), Some("reason"));
 }
 

--- a/crates/cargo-bdd/tests/cli.rs
+++ b/crates/cargo-bdd/tests/cli.rs
@@ -80,7 +80,7 @@ fn run_cargo_bdd_captured(args: &[&str]) -> Result<(ExitStatus, String, String)>
             "`cargo bdd` emitted invalid UTF-8 to stderr (args: [{args_debug}], status: {status})"
         )
     })?;
-    Ok((status, stdout.to_string(), stderr.to_string()))
+    Ok((status, stdout.to_owned(), stderr.to_owned()))
 }
 
 fn run_cargo_bdd(args: &[&str]) -> Result<String> {
@@ -197,7 +197,7 @@ fn skipped_subcommand_emits_json() {
     assert!(fixture_entry.line > 0, "expected a 1-based line number");
     assert_eq!(
         fixture_entry.tags,
-        vec!["@allow_skipped".to_string()],
+        vec!["@allow_skipped".to_owned()],
         "expected fixture skipped scenario tags to be preserved"
     );
 }

--- a/crates/rstest-bdd-harness-gpui/src/gpui_harness/tests.rs
+++ b/crates/rstest-bdd-harness-gpui/src/gpui_harness/tests.rs
@@ -45,7 +45,7 @@ fn gpui_harness_runs_request(harness: GpuiHarness) {
             "tests/features/simple.feature",
             "Runs in GPUI",
             4,
-            vec!["@ui".to_string()],
+            vec!["@ui".to_owned()],
         ),
         ScenarioRunner::new(|_context: gpui::TestAppContext| 21 * 2),
     );
@@ -80,7 +80,7 @@ fn gpui_test_context_is_available_during_run(harness: GpuiHarness) {
 #[case::string_payload(
     "A string payload scenario",
     7,
-    Box::new("step panicked".to_string()) as Box<dyn std::any::Any + Send>,
+    Box::new("step panicked".to_owned()) as Box<dyn std::any::Any + Send>,
 )]
 #[case::str_payload(
     "A str payload scenario",

--- a/crates/rstest-bdd-harness-gpui/tests/harness_behaviour.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/harness_behaviour.rs
@@ -126,7 +126,7 @@ fn gpui_harness_passes_metadata_through() {
             "tests/features/payment.feature",
             "Payment succeeds",
             27,
-            vec!["@smoke".to_string(), "@payments".to_string()],
+            vec!["@smoke".to_owned(), "@payments".to_owned()],
         ),
         ScenarioRunner::new(|_context: gpui::TestAppContext| 200),
     );

--- a/crates/rstest-bdd-harness-gpui/tests/scenario_name_in_logs.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/scenario_name_in_logs.rs
@@ -180,7 +180,7 @@ fn scenario_metadata(name: &str) -> ScenarioMetadata {
         FEATURE_PATH,
         name,
         SCENARIO_LINE,
-        vec!["@regression".to_string()],
+        vec!["@regression".to_owned()],
     )
 }
 
@@ -264,7 +264,7 @@ fn special_characters_in_scenario_name_are_preserved_in_diagnostic() {
 #[rstest]
 #[case::string_payload(
     "String payload scenario",
-    Box::new(|| -> () { panic_any("a string panic".to_string()); }) as Box<dyn Fn() + Send + 'static>,
+    Box::new(|| -> () { panic_any("a string panic".to_owned()); }) as Box<dyn Fn() + Send + 'static>,
 )]
 #[case::str_payload(
     "&str payload scenario",

--- a/crates/rstest-bdd-harness-tokio/src/tokio_harness.rs
+++ b/crates/rstest-bdd-harness-tokio/src/tokio_harness.rs
@@ -105,7 +105,7 @@ mod tests {
                 "tests/features/simple.feature",
                 "Runs in Tokio",
                 4,
-                vec!["@async".to_string()],
+                vec!["@async".to_owned()],
             ),
             ScenarioRunner::new(|_context: TokioTestContext| 21 * 2),
         );

--- a/crates/rstest-bdd-harness-tokio/tests/harness_behaviour.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/harness_behaviour.rs
@@ -172,7 +172,7 @@ fn tokio_harness_passes_metadata_through() {
             "tests/features/payment.feature",
             "Payment succeeds",
             27,
-            vec!["@smoke".to_string(), "@payments".to_string()],
+            vec!["@smoke".to_owned(), "@payments".to_owned()],
         ),
         ScenarioRunner::new(|_context: TokioTestContext| 200),
     );

--- a/crates/rstest-bdd-harness/src/runner.rs
+++ b/crates/rstest-bdd-harness/src/runner.rs
@@ -232,7 +232,7 @@ mod tests {
                 "tests/features/auth.feature",
                 "Login succeeds",
                 17,
-                vec!["@smoke".to_string(), "@fast".to_string()],
+                vec!["@smoke".to_owned(), "@fast".to_owned()],
             ),
             || 11,
         );

--- a/crates/rstest-bdd-harness/src/std_harness.rs
+++ b/crates/rstest-bdd-harness/src/std_harness.rs
@@ -51,7 +51,7 @@ mod tests {
             "tests/features/simple.feature",
             "Runs synchronously",
             4,
-            vec!["@sync".to_string()],
+            vec!["@sync".to_owned()],
         )
     }
 

--- a/crates/rstest-bdd-harness/tests/harness_behaviour.rs
+++ b/crates/rstest-bdd-harness/tests/harness_behaviour.rs
@@ -144,7 +144,7 @@ fn std_harness_passes_metadata_through() {
         "tests/features/payment.feature",
         "Payment succeeds",
         27,
-        vec!["@smoke".to_string(), "@payments".to_string()],
+        vec!["@smoke".to_owned(), "@payments".to_owned()],
     );
     let request = StdScenarioRunRequest::new(
         expected_metadata.clone(),

--- a/crates/rstest-bdd-macros/src/codegen/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/mod.rs
@@ -226,7 +226,7 @@ mod tests {
 
     fn not_found_error(crate_name: &str) -> Error {
         Error::CrateNotFound {
-            crate_name: crate_name.to_string(),
+            crate_name: crate_name.to_owned(),
             path: PathBuf::new(),
         }
     }

--- a/crates/rstest-bdd-macros/src/codegen/scenario/runtime/tests/support.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/runtime/tests/support.rs
@@ -134,7 +134,7 @@ impl<'ast> Visit<'ast> for MethodCallFinder {
 /// Count method calls matching `method_name` within a block.
 pub(super) fn count_method_calls_in_block(block: &syn::Block, method_name: &str) -> usize {
     let mut finder = MethodCallFinder {
-        name: method_name.to_string(),
+        name: method_name.to_owned(),
         count: 0,
     };
     finder.visit_block(block);
@@ -147,7 +147,7 @@ pub(super) fn find_call_in_block(
     name: RuntimeFunction,
 ) -> Option<&syn::ExprCall> {
     let mut finder = CallFinder {
-        name: name.call_name().to_string(),
+        name: name.call_name().to_owned(),
         found: None,
     };
     finder.visit_block(block);

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/prop_tests.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/prop_tests.rs
@@ -186,7 +186,7 @@ proptest! {
     fn normalized_name_consumes_an_exactly_matching_placeholder(
         (name, ..) in prefixed_name(),
     ) {
-        let normalized = normalize_param_name(&name).to_string();
+        let normalized = normalize_param_name(&name).to_owned();
         let outcome = classify(&[], &name, HashSet::from([normalized]));
 
         prop_assert_eq!(outcome.result.as_ref().ok(), Some(&true), "{}", outcome.error());
@@ -201,7 +201,7 @@ proptest! {
         (name, ..) in prefixed_name(),
         other in ident_base(),
     ) {
-        let normalized = normalize_param_name(&name).to_string();
+        let normalized = normalize_param_name(&name).to_owned();
         prop_assume!(other != normalized);
 
         let outcome = classify(&[], &name, HashSet::from([other.clone()]));
@@ -217,7 +217,7 @@ proptest! {
     fn implicit_fixture_key_is_the_normalized_name_and_a_valid_identifier(
         (name, ..) in prefixed_name(),
     ) {
-        let normalized = normalize_param_name(&name).to_string();
+        let normalized = normalize_param_name(&name).to_owned();
         let outcome = classify(&[], &name, HashSet::new());
 
         let Some(key) = outcome.sole_fixture_name() else {
@@ -233,7 +233,7 @@ proptest! {
     fn a_single_bare_from_is_accepted_and_uses_the_normalized_name(
         (name, ..) in prefixed_name(),
     ) {
-        let normalized = normalize_param_name(&name).to_string();
+        let normalized = normalize_param_name(&name).to_owned();
         let outcome = classify(&[FromForm::Bare.tokens()], &name, HashSet::new());
 
         prop_assert_eq!(outcome.result.as_ref().ok(), Some(&true), "{}", outcome.error());

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/step_struct.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/step_struct.rs
@@ -186,7 +186,7 @@ mod tests {
     use syn::{FnArg, Ident, parse_quote};
 
     fn placeholder_set(names: &[&str]) -> HashSet<String> {
-        names.iter().map(|name| (*name).to_string()).collect()
+        names.iter().map(|name| (*name).to_owned()).collect()
     }
 
     fn pat(tokens: TokenStream2) -> syn::PatType {

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/tests.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/tests.rs
@@ -71,7 +71,7 @@ fn assert_classifies_as_step(
 #[test]
 fn context_new_links_borrows() {
     let mut extracted = ExtractedArgs::default();
-    let mut placeholders = HashSet::from(["alpha".to_string()]);
+    let mut placeholders = HashSet::from(["alpha".to_owned()]);
     {
         let ctx = ClassificationContext::new(&mut extracted, &mut placeholders);
         ctx.placeholders.clear();
@@ -89,7 +89,7 @@ fn context_new_links_borrows() {
 #[test]
 fn classify_fixture_or_step_claims_placeholder_as_step() {
     assert_classifies_as_step(
-        HashSet::from(["value".to_string()]),
+        HashSet::from(["value".to_owned()]),
         quote!(value: String),
         "value",
         quote!(String),
@@ -253,7 +253,7 @@ fn extract_step_struct_attribute_detects_marker() {
 #[test]
 fn classify_step_struct_blocks_placeholders() {
     let mut extracted = ExtractedArgs::default();
-    let mut placeholders = HashSet::from(["alpha".to_string(), "beta".to_string()]);
+    let mut placeholders = HashSet::from(["alpha".to_owned(), "beta".to_owned()]);
     let arg = pat_type(quote!(#[step_args] args: Args));
 
     match classify_step_struct(&mut extracted, &arg, &mut placeholders) {
@@ -264,7 +264,7 @@ fn classify_step_struct_blocks_placeholders() {
     assert!(placeholders.is_empty());
     assert_eq!(
         extracted.blocked_placeholders,
-        HashSet::from(["alpha".to_string(), "beta".to_string()])
+        HashSet::from(["alpha".to_owned(), "beta".to_owned()])
     );
     assert!(
         extracted
@@ -276,7 +276,7 @@ fn classify_step_struct_blocks_placeholders() {
 #[test]
 fn classify_fixture_or_step_matches_underscore_prefixed_param_to_placeholder() {
     assert_classifies_as_step(
-        HashSet::from(["value".to_string()]),
+        HashSet::from(["value".to_owned()]),
         quote!(_value: String),
         "_value",
         quote!(String),
@@ -286,7 +286,7 @@ fn classify_fixture_or_step_matches_underscore_prefixed_param_to_placeholder() {
 #[test]
 fn classify_fixture_or_step_double_underscore_matches_single_underscore_placeholder() {
     assert_classifies_as_step(
-        HashSet::from(["_value".to_string()]),
+        HashSet::from(["_value".to_owned()]),
         quote!(__value: String),
         "__value",
         quote!(String),
@@ -298,7 +298,7 @@ fn classify_fixture_or_step_double_underscore_does_not_match_plain_placeholder()
     // Placeholder set only contains "value"; "__value" should NOT be classified as a step
     // and "value" should remain in the placeholder set (it is unmatched).
     let (extracted, handled, placeholders) = execute_classify_fixture_or_step(
-        HashSet::from(["value".to_string()]),
+        HashSet::from(["value".to_owned()]),
         quote!(__value: String),
         "__value",
         quote!(String),

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/arguments/tests/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/arguments/tests/mod.rs
@@ -226,7 +226,7 @@ fn gen_step_parses_strips_quotes_for_string_hint(
     #[case] should_parse: bool,
     #[case] parse_description: &str,
 ) {
-    let code = generate_step_parse_with_hint(ty, Some("string".to_string()));
+    let code = generate_step_parse_with_hint(ty, Some("string".to_owned()));
 
     // Should contain quote stripping code
     assert!(
@@ -275,7 +275,7 @@ fn gen_step_parses_applies_hints_only_to_matching_arguments() {
     ];
 
     // Only first argument has :string hint
-    let hints: Vec<Option<String>> = vec![Some("string".to_string()), None];
+    let hints: Vec<Option<String>> = vec![Some("string".to_owned()), None];
     let tokens = gen_step_parses(&args, &captures, &hints, meta);
 
     assert_eq!(tokens.len(), 2, "expected two token streams");
@@ -309,7 +309,7 @@ fn gen_step_parses_applies_hints_only_to_matching_arguments() {
 fn gen_step_parses_string_hint_includes_parse_error_message() {
     // When :string hint is used with an owned type, the error message should still
     // reference the original type and pattern for debugging purposes
-    let code = generate_step_parse_with_hint(parse_quote!(String), Some("string".to_string()));
+    let code = generate_step_parse_with_hint(parse_quote!(String), Some("string".to_owned()));
 
     // Should contain error message with type information
     assert!(
@@ -335,7 +335,7 @@ fn gen_step_parses_non_string_hints_use_standard_parse_path(
     #[case] hint: &str,
     #[case] description: &str,
 ) {
-    let code = generate_step_parse_with_hint(parse_quote!(i32), Some(hint.to_string()));
+    let code = generate_step_parse_with_hint(parse_quote!(i32), Some(hint.to_owned()));
 
     // Non-:string hints should NOT strip quotes
     assert!(

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/emit/assembly/tests.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/emit/assembly/tests.rs
@@ -35,7 +35,7 @@ fn extract_reason_from_meta(name_value: &syn::MetaNameValue) -> Option<String> {
 }
 
 fn expected_lints(lints: &[&str]) -> HashSet<String> {
-    lints.iter().map(|lint| (*lint).to_string()).collect()
+    lints.iter().map(|lint| (*lint).to_owned()).collect()
 }
 
 /// Parse and validate the expect attribute from a wrapper function.

--- a/crates/rstest-bdd-macros/src/macros/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/mod.rs
@@ -229,27 +229,26 @@ fn keyword_name(keyword: crate::StepKeyword) -> &'static str {
 /// Produce a keyword-specific help message for a step signature diagnostic.
 fn signature_error_help(err_message: &str, keyword: crate::StepKeyword) -> String {
     if err_message.contains("duplicate `#[datatable]` attribute") {
-        return "Remove one of the duplicate `#[datatable]` attributes.".to_string();
+        return "Remove one of the duplicate `#[datatable]` attributes.".to_owned();
     }
 
     if err_message.contains("duplicate `#[from]` attribute") {
-        return "Remove one of the duplicate `#[from]` attributes.".to_string();
+        return "Remove one of the duplicate `#[from]` attributes.".to_owned();
     }
 
     if err_message.contains(crate::codegen::wrapper::args::classify::DUPLICATE_DATATABLE_ERROR) {
-        return "Remove one of the DataTable parameters.".to_string();
+        return "Remove one of the DataTable parameters.".to_owned();
     }
 
     if err_message.contains("unsupported parameter pattern") {
         return concat!(
             "Bind the parameter to a simple identifier (e.g., `tuple: (i32, i32)` or `user: User`) ",
             "and destructure it inside the step body."
-        )
-        .to_string();
+        ).to_owned();
     }
 
     if err_message.contains("methods are not supported; remove `self`") {
-        return "Remove `self` from step functions.".to_string();
+        return "Remove `self` from step functions.".to_owned();
     }
 
     let kw_name = keyword_name(keyword);

--- a/crates/rstest-bdd-macros/src/macros/scenario/selection.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenario/selection.rs
@@ -127,14 +127,14 @@ fn format_available_tags(tag_sets: &[Vec<String>]) -> String {
     // serialize each tag set separately so callers can still spot gaps without
     // losing the original grouping.
     if tag_sets.is_empty() {
-        return "available tags: <none>".to_string();
+        return "available tags: <none>".to_owned();
     }
 
     let formatted_sets: Vec<String> = tag_sets
         .iter()
         .map(|tags| {
             if tags.is_empty() {
-                "<none>".to_string()
+                "<none>".to_owned()
             } else {
                 tags.join(", ")
             }
@@ -300,7 +300,7 @@ mod tests {
 
     #[test]
     fn available_tags_serialize_each_examined_set() {
-        let tag_sets = vec![vec!["@fast".to_string(), "@ui".to_string()], Vec::new()];
+        let tag_sets = vec![vec!["@fast".to_owned(), "@ui".to_owned()], Vec::new()];
         assert_eq!(
             format_available_tags(&tag_sets),
             "available tags: @fast, @ui; <none>"

--- a/crates/rstest-bdd-macros/src/macros/scenarios/test_generation/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/test_generation/mod.rs
@@ -110,7 +110,7 @@ fn resolve_effective_runtime(
 }
 
 pub(super) fn dedupe_name(base: &str, used: &mut HashSet<String>) -> String {
-    let mut name = base.to_string();
+    let mut name = base.to_owned();
     let mut counter = 1usize;
     while used.contains(&name) {
         name = format!("{base}_{counter}");
@@ -204,7 +204,7 @@ fn normalize_type_key(ty: &syn::Type) -> String {
         .collect::<Vec<_>>()
         .join(" ")
         .trim_start_matches("::")
-        .to_string()
+        .to_owned()
 }
 
 /// Resolves a unified error type from `Result`-typed fixture specifications.

--- a/crates/rstest-bdd-macros/src/parsing/examples.rs
+++ b/crates/rstest-bdd-macros/src/parsing/examples.rs
@@ -103,7 +103,7 @@ mod tests {
     fn scenario_outline_without_examples(name: &str) -> Scenario {
         Scenario {
             keyword: "Scenario Outline".into(),
-            name: name.to_string(),
+            name: name.to_owned(),
             ..empty_scenario()
         }
     }

--- a/crates/rstest-bdd-macros/src/parsing/feature/step_extraction_tests.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/step_extraction_tests.rs
@@ -27,7 +27,7 @@ use super::support::{ExamplesBuilder, FeatureBuilder, StepBuilder, assert_featur
     vec![
         ParsedStep {
             keyword: crate::StepKeyword::Given,
-            text: "a background step".to_string(),
+            text: "a background step".to_owned(),
             docstring: None,
             table: None,
             #[cfg(feature = "compile-time-validation")]
@@ -35,7 +35,7 @@ use super::support::{ExamplesBuilder, FeatureBuilder, StepBuilder, assert_featur
         },
         ParsedStep {
             keyword: crate::StepKeyword::When,
-            text: "an action".to_string(),
+            text: "an action".to_owned(),
             docstring: None,
             table: None,
             #[cfg(feature = "compile-time-validation")]
@@ -43,7 +43,7 @@ use super::support::{ExamplesBuilder, FeatureBuilder, StepBuilder, assert_featur
         },
         ParsedStep {
             keyword: crate::StepKeyword::Then,
-            text: "a result".to_string(),
+            text: "a result".to_owned(),
             docstring: None,
             table: None,
             #[cfg(feature = "compile-time-validation")]
@@ -63,11 +63,11 @@ use super::support::{ExamplesBuilder, FeatureBuilder, StepBuilder, assert_featur
     ),
     vec![ParsedStep {
         keyword: crate::StepKeyword::Given,
-        text: "numbers".to_string(),
+        text: "numbers".to_owned(),
         docstring: None,
         table: Some(vec![
-            vec!["1".to_string(), "2".to_string()],
-            vec!["3".to_string(), "4".to_string()],
+            vec!["1".to_owned(), "2".to_owned()],
+            vec!["3".to_owned(), "4".to_owned()],
         ]),
         #[cfg(feature = "compile-time-validation")]
         span: proc_macro2::Span::call_site(),
@@ -85,8 +85,8 @@ use super::support::{ExamplesBuilder, FeatureBuilder, StepBuilder, assert_featur
     ),
     vec![ParsedStep {
         keyword: crate::StepKeyword::Given,
-        text: "text".to_string(),
-        docstring: Some("line1\nline2".to_string()),
+        text: "text".to_owned(),
+        docstring: Some("line1\nline2".to_owned()),
         table: None,
         #[cfg(feature = "compile-time-validation")]
         span: proc_macro2::Span::call_site(),
@@ -107,15 +107,15 @@ use super::support::{ExamplesBuilder, FeatureBuilder, StepBuilder, assert_featur
     vec![
         ParsedStep {
             keyword: crate::StepKeyword::Given,
-            text: "setup".to_string(),
-            docstring: Some("bg line1\nbg line2".to_string()),
+            text: "setup".to_owned(),
+            docstring: Some("bg line1\nbg line2".to_owned()),
             table: None,
             #[cfg(feature = "compile-time-validation")]
             span: proc_macro2::Span::call_site(),
         },
         ParsedStep {
             keyword: crate::StepKeyword::When,
-            text: "an action".to_string(),
+            text: "an action".to_owned(),
             docstring: None,
             table: None,
             #[cfg(feature = "compile-time-validation")]
@@ -140,7 +140,7 @@ use super::support::{ExamplesBuilder, FeatureBuilder, StepBuilder, assert_featur
     vec![
         ParsedStep {
             keyword: crate::StepKeyword::Given,
-            text: "setup".to_string(),
+            text: "setup".to_owned(),
             docstring: None,
             table: None,
             #[cfg(feature = "compile-time-validation")]
@@ -148,7 +148,7 @@ use super::support::{ExamplesBuilder, FeatureBuilder, StepBuilder, assert_featur
         },
         ParsedStep {
             keyword: crate::StepKeyword::When,
-            text: "an action".to_string(),
+            text: "an action".to_owned(),
             docstring: None,
             table: None,
             #[cfg(feature = "compile-time-validation")]
@@ -156,7 +156,7 @@ use super::support::{ExamplesBuilder, FeatureBuilder, StepBuilder, assert_featur
         },
         ParsedStep {
             keyword: crate::StepKeyword::Then,
-            text: "a result".to_string(),
+            text: "a result".to_owned(),
             docstring: None,
             table: None,
             #[cfg(feature = "compile-time-validation")]

--- a/crates/rstest-bdd-macros/src/parsing/feature/support.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/support.rs
@@ -17,7 +17,7 @@ fn kw(ty: StepType) -> String {
         StepType::Then => "Then",
         _ => unreachable!("kw() only supports Given, When, and Then"),
     }
-    .to_string()
+    .to_owned()
 }
 
 fn zero_span() -> Span {
@@ -41,7 +41,7 @@ where
     Table {
         rows: rows
             .into_iter()
-            .map(|r| r.into_iter().map(|s| s.as_ref().to_string()).collect())
+            .map(|r| r.into_iter().map(|s| s.as_ref().to_owned()).collect())
             .collect(),
         span: zero_span(),
         position: zero_pos(),
@@ -60,7 +60,7 @@ impl StepBuilder {
     pub(super) fn new(ty: StepType, value: &str) -> Self {
         Self {
             ty,
-            value: value.to_string(),
+            value: value.to_owned(),
             docstring: None,
             table: None,
             keyword: None,
@@ -68,12 +68,12 @@ impl StepBuilder {
     }
 
     pub(super) fn with_keyword(mut self, kw: &str) -> Self {
-        self.keyword = Some(kw.to_string());
+        self.keyword = Some(kw.to_owned());
         self
     }
 
     pub(super) fn with_docstring(mut self, doc: &str) -> Self {
-        self.docstring = Some(doc.to_string());
+        self.docstring = Some(doc.to_owned());
         self
     }
 
@@ -163,8 +163,8 @@ struct ScenarioData {
 impl ScenarioData {
     fn new_scenario(name: &str, steps: Vec<Step>) -> Self {
         Self {
-            keyword: "Scenario".to_string(),
-            name: name.to_string(),
+            keyword: "Scenario".to_owned(),
+            name: name.to_owned(),
             steps,
             examples: Vec::new(),
         }
@@ -172,8 +172,8 @@ impl ScenarioData {
 
     fn new_scenario_outline(name: &str, steps: Vec<Step>, examples: Examples) -> Self {
         Self {
-            keyword: "Scenario Outline".to_string(),
-            name: name.to_string(),
+            keyword: "Scenario Outline".to_owned(),
+            name: name.to_owned(),
             steps,
             examples: vec![examples],
         }
@@ -183,7 +183,7 @@ impl ScenarioData {
 impl FeatureBuilder {
     pub(super) fn new(name: &str) -> Self {
         Self {
-            name: name.to_string(),
+            name: name.to_owned(),
             background: None,
             scenarios: Vec::new(),
         }
@@ -294,7 +294,7 @@ mod tests {
         let Some(table) = step.table.as_ref() else {
             panic!("expected table on built step");
         };
-        assert_eq!(table.rows, vec![vec!["a".to_string(), "b".to_string()]],);
+        assert_eq!(table.rows, vec![vec!["a".to_owned(), "b".to_owned()]],);
     }
 
     #[test]
@@ -336,7 +336,7 @@ mod tests {
         };
         assert_eq!(
             examples_table.rows,
-            vec![vec!["x".to_string()], vec!["1".to_string()]]
+            vec![vec!["x".to_owned()], vec!["1".to_owned()]]
         );
     }
 
@@ -344,7 +344,7 @@ mod tests {
     fn assert_feature_extraction_validates_expected_steps() {
         let expected = [ParsedStep {
             keyword: crate::StepKeyword::Given,
-            text: "step".to_string(),
+            text: "step".to_owned(),
             docstring: None,
             table: None,
             #[cfg(feature = "compile-time-validation")]

--- a/crates/rstest-bdd-macros/src/parsing/placeholder.rs
+++ b/crates/rstest-bdd-macros/src/parsing/placeholder.rs
@@ -65,7 +65,7 @@ pub fn substitute_placeholders(
     headers: &[String],
     row: &[String],
 ) -> Result<String, PlaceholderError> {
-    let mut result = text.to_string();
+    let mut result = text.to_owned();
 
     for cap in PLACEHOLDER_RE.captures_iter(text) {
         // Safe: capture group 0 always exists for a successful match.
@@ -78,7 +78,7 @@ pub fn substitute_placeholders(
             .iter()
             .position(|h| h == placeholder)
             .ok_or_else(|| PlaceholderError {
-                placeholder: placeholder.to_string(),
+                placeholder: placeholder.to_owned(),
                 available_columns: headers.to_vec(),
                 available_columns_display: headers.join(", "),
             })?;
@@ -123,31 +123,31 @@ mod tests {
     #[rstest]
     #[case(
         "I have <count> items",
-        vec!["count".to_string()],
-        vec!["5".to_string()],
+        vec!["count".to_owned()],
+        vec!["5".to_owned()],
         "I have 5 items"
     )]
     #[case(
         "I have <count> <item>",
-        vec!["count".to_string(), "item".to_string()],
-        vec!["5".to_string(), "apples".to_string()],
+        vec!["count".to_owned(), "item".to_owned()],
+        vec!["5".to_owned(), "apples".to_owned()],
         "I have 5 apples"
     )]
     #[case(
         "<val> plus <val> equals double <val>",
-        vec!["val".to_string()],
-        vec!["3".to_string()],
+        vec!["val".to_owned()],
+        vec!["3".to_owned()],
         "3 plus 3 equals double 3"
     )]
     #[case(
         "I have 5 items",
-        vec!["count".to_string()],
-        vec!["10".to_string()],
+        vec!["count".to_owned()],
+        vec!["10".to_owned()],
         "I have 5 items"
     )]
     #[case(
         "I have <count> items",
-        vec!["count".to_string()],
+        vec!["count".to_owned()],
         vec![String::new()],
         "I have  items"
     )]
@@ -164,22 +164,22 @@ mod tests {
     #[test]
     fn error_on_undefined_placeholder() {
         let text = "I have <undefined> items";
-        let headers = vec!["count".to_string()];
-        let row = vec!["5".to_string()];
+        let headers = vec!["count".to_owned()];
+        let row = vec!["5".to_owned()];
 
         let result = substitute_placeholders(text, &headers, &row);
         assert!(result.is_err());
 
         let err = result.unwrap_err();
         assert_eq!(err.placeholder, "undefined");
-        assert_eq!(err.available_columns, vec!["count".to_string()]);
+        assert_eq!(err.available_columns, vec!["count".to_owned()]);
     }
 
     #[test]
     fn placeholder_with_underscores() {
         let text = "The <user_name> has <item_count> items";
-        let headers = vec!["user_name".to_string(), "item_count".to_string()];
-        let row = vec!["Alice".to_string(), "42".to_string()];
+        let headers = vec!["user_name".to_owned(), "item_count".to_owned()];
+        let row = vec!["Alice".to_owned(), "42".to_owned()];
 
         let result = substitute_placeholders(text, &headers, &row).unwrap();
         assert_eq!(result, "The Alice has 42 items");
@@ -188,8 +188,8 @@ mod tests {
     #[test]
     fn placeholder_with_spaces_and_hyphens() {
         let text = "The <start count> includes <item-id>";
-        let headers = vec!["start count".to_string(), "item-id".to_string()];
-        let row = vec!["3".to_string(), "apples".to_string()];
+        let headers = vec!["start count".to_owned(), "item-id".to_owned()];
+        let row = vec!["3".to_owned(), "apples".to_owned()];
 
         let result = substitute_placeholders(text, &headers, &row).unwrap();
         assert_eq!(result, "The 3 includes apples");

--- a/crates/rstest-bdd-macros/src/parsing/tags/lexer.rs
+++ b/crates/rstest-bdd-macros/src/parsing/tags/lexer.rs
@@ -17,12 +17,12 @@ impl Token {
     pub(super) fn describe(&self) -> String {
         match &self.kind {
             TokenKind::Tag(tag) => tag.clone(),
-            TokenKind::And => "'and'".to_string(),
-            TokenKind::Or => "'or'".to_string(),
-            TokenKind::Not => "'not'".to_string(),
-            TokenKind::LParen => "'('".to_string(),
-            TokenKind::RParen => "')'".to_string(),
-            TokenKind::End => "<end>".to_string(),
+            TokenKind::And => "'and'".to_owned(),
+            TokenKind::Or => "'or'".to_owned(),
+            TokenKind::Not => "'not'".to_owned(),
+            TokenKind::LParen => "'('".to_owned(),
+            TokenKind::RParen => "')'".to_owned(),
+            TokenKind::End => "<end>".to_owned(),
         }
     }
 }
@@ -124,7 +124,7 @@ impl<'a> Lexer<'a> {
             .input
             .get(start..self.pos)
             .ok_or_else(|| TagExprError::new(start, "invalid tag boundaries"))?
-            .to_string();
+            .to_owned();
         Ok(Token {
             kind: TokenKind::Tag(tag),
             start,

--- a/crates/rstest-bdd-macros/src/parsing/tags/sets.rs
+++ b/crates/rstest-bdd-macros/src/parsing/tags/sets.rs
@@ -11,7 +11,7 @@ use std::collections::HashSet;
 fn normalize_tag(tag: &str) -> String {
     let trimmed = tag.trim();
     if trimmed.starts_with('@') {
-        trimmed.to_string()
+        trimmed.to_owned()
     } else {
         format!("@{trimmed}")
     }

--- a/crates/rstest-bdd-macros/src/pattern.rs
+++ b/crates/rstest-bdd-macros/src/pattern.rs
@@ -82,7 +82,7 @@ mod validation {
             let Some(values) = pattern.captures(span, "I have 3") else {
                 panic!("expected captures");
             };
-            assert_eq!(values, vec!["3".to_string()]);
+            assert_eq!(values, vec!["3".to_owned()]);
         }
     }
 }

--- a/crates/rstest-bdd-macros/src/utils/pattern/mod.rs
+++ b/crates/rstest-bdd-macros/src/utils/pattern/mod.rs
@@ -96,7 +96,7 @@ fn parse_placeholder(bytes: &[u8], start: usize) -> Result<(PlaceholderInfo, usi
     validate_closing_brace(bytes, j)?;
     Ok((
         PlaceholderInfo {
-            name: name.to_string(),
+            name: name.to_owned(),
             hint,
         },
         j + 1,
@@ -198,7 +198,7 @@ fn extract_type_hint_if_present(bytes: &[u8], mut j: usize) -> Result<(Option<St
                 "type hint must be valid UTF-8",
             )
         })?
-        .to_string();
+        .to_owned();
 
     // Return None for empty hints (just a trailing colon with no content)
     let hint = if hint.is_empty() { None } else { Some(hint) };

--- a/crates/rstest-bdd-macros/src/utils/pattern/tests.rs
+++ b/crates/rstest-bdd-macros/src/utils/pattern/tests.rs
@@ -68,7 +68,7 @@ fn multiple_placeholders_with_mixed_hints() {
     assert_eq!(summary.ordered[0].name, "name");
     assert_eq!(summary.ordered[0].hint, None);
     assert_eq!(summary.ordered[1].name, "count");
-    assert_eq!(summary.ordered[1].hint, Some("u32".to_string()));
+    assert_eq!(summary.ordered[1].hint, Some("u32".to_owned()));
 }
 
 #[test]
@@ -90,11 +90,11 @@ fn placeholder_hints_align_with_names_for_wrapper_config() {
 
     // First: {name:string}
     assert_eq!(placeholder_names[0], "name");
-    assert_eq!(placeholder_hints[0], &Some("string".to_string()));
+    assert_eq!(placeholder_hints[0], &Some("string".to_owned()));
 
     // Second: {count:u32}
     assert_eq!(placeholder_names[1], "count");
-    assert_eq!(placeholder_hints[1], &Some("u32".to_string()));
+    assert_eq!(placeholder_hints[1], &Some("u32".to_owned()));
 
     // Third: {note} - no hint
     assert_eq!(placeholder_names[2], "note");

--- a/crates/rstest-bdd-macros/src/validation/placeholder.rs
+++ b/crates/rstest-bdd-macros/src/validation/placeholder.rs
@@ -172,12 +172,12 @@ mod tests {
 
     impl ParsedStepBuilder {
         fn with_text(mut self, text: &str) -> Self {
-            self.text = text.to_string();
+            self.text = text.to_owned();
             self
         }
 
         fn with_docstring(mut self, docstring: Option<&str>) -> Self {
-            self.docstring = docstring.map(ToString::to_string);
+            self.docstring = docstring.map(str::to_owned);
             self
         }
 
@@ -235,7 +235,7 @@ mod tests {
     #[case::step_text("I have <count> items", vec!["count"], None, None)]
     #[case::multiple_placeholders("I have <count> <item>", vec!["count", "item"], None, None)]
     #[case::docstring("step text", vec!["value"], Some("docstring with <value>"), None)]
-    #[case::table("step text", vec!["value"], None, Some(vec![vec!["<value>".to_string(), "static".to_string()]]))]
+    #[case::table("step text", vec!["value"], None, Some(vec![vec!["<value>".to_owned(), "static".to_owned()]]))]
     #[case::no_placeholders("I have 5 items", vec!["count"], None, None)]
     fn valid_placeholder_tests(
         #[case] text: &str,
@@ -250,7 +250,7 @@ mod tests {
                 .with_table(table)
                 .build(),
         ];
-        let headers: Vec<String> = header_strs.into_iter().map(ToString::to_string).collect();
+        let headers: Vec<String> = header_strs.into_iter().map(str::to_owned).collect();
 
         assert_valid_placeholders(&steps, &headers);
     }
@@ -258,7 +258,7 @@ mod tests {
     #[rstest]
     #[case::step_text("I have <undefined> items", vec!["count"], None, None, "<undefined>", ValidationContext::Step)]
     #[case::docstring("step text", vec!["value"], Some("docstring with <undefined>"), None, "<undefined>", ValidationContext::Docstring)]
-    #[case::table("step text", vec!["value"], None, Some(vec![vec!["<undefined>".to_string()]]), "<undefined>", ValidationContext::TableCell)]
+    #[case::table("step text", vec!["value"], None, Some(vec![vec!["<undefined>".to_owned()]]), "<undefined>", ValidationContext::TableCell)]
     fn invalid_placeholder_tests(
         #[case] text: &str,
         #[case] header_strs: Vec<&str>,
@@ -274,7 +274,7 @@ mod tests {
                 .with_table(table)
                 .build(),
         ];
-        let headers: Vec<String> = header_strs.into_iter().map(ToString::to_string).collect();
+        let headers: Vec<String> = header_strs.into_iter().map(str::to_owned).collect();
 
         assert_placeholder_error(
             &steps,
@@ -287,7 +287,7 @@ mod tests {
     #[test]
     fn empty_steps_is_valid() {
         let steps: Vec<ParsedStep> = vec![];
-        let headers = vec!["count".to_string()];
+        let headers = vec!["count".to_owned()];
 
         assert_valid_placeholders(&steps, &headers);
     }

--- a/crates/rstest-bdd-macros/src/validation/steps/messages.rs
+++ b/crates/rstest-bdd-macros/src/validation/steps/messages.rs
@@ -90,14 +90,14 @@ mod tests {
     use proc_macro2::Span;
 
     fn leak_pattern(text: &str) -> &'static MacroPattern {
-        let leaked: &'static str = Box::leak(text.to_string().into_boxed_str());
+        let leaked: &'static str = Box::leak(text.to_owned().into_boxed_str());
         Box::leak(Box::new(MacroPattern::new(leaked)))
     }
 
     fn parsed_step(text: &str) -> ParsedStep {
         ParsedStep {
             keyword: StepKeyword::Given,
-            text: text.to_string(),
+            text: text.to_owned(),
             docstring: None,
             table: None,
             #[cfg(feature = "compile-time-validation")]

--- a/crates/rstest-bdd-macros/src/validation/steps/tests/support.rs
+++ b/crates/rstest-bdd-macros/src/validation/steps/tests/support.rs
@@ -17,7 +17,7 @@ pub(super) fn clear_registry() {
 pub(super) fn create_test_step(keyword: StepKeyword, text: &str) -> ParsedStep {
     ParsedStep {
         keyword,
-        text: text.to_string(),
+        text: text.to_owned(),
         docstring: None,
         table: None,
         #[cfg(feature = "compile-time-validation")]

--- a/crates/rstest-bdd-patterns/src/capture.rs
+++ b/crates/rstest-bdd-patterns/src/capture.rs
@@ -32,7 +32,7 @@ pub fn extract_captured_values(re: &Regex, text: &str) -> Option<Vec<String>> {
     let caps = re.captures(text)?;
     let mut values = Vec::with_capacity(caps.len().saturating_sub(1));
     for capture in caps.iter().skip(1) {
-        let value = capture.map_or_else(String::new, |m| m.as_str().to_string());
+        let value = capture.map_or_else(String::new, |m| m.as_str().to_owned());
         values.push(value);
     }
 

--- a/crates/rstest-bdd-patterns/src/keyword.rs
+++ b/crates/rstest-bdd-patterns/src/keyword.rs
@@ -137,7 +137,7 @@ impl FromStr for StepKeyword {
             .iter()
             .find(|(name, _)| trimmed.eq_ignore_ascii_case(name))
             .map(|&(_, keyword)| keyword)
-            .ok_or_else(|| StepKeywordParseError(trimmed.to_string()))
+            .ok_or_else(|| StepKeywordParseError(trimmed.to_owned()))
     }
 }
 

--- a/crates/rstest-bdd-patterns/src/pattern/placeholder.rs
+++ b/crates/rstest-bdd-patterns/src/pattern/placeholder.rs
@@ -131,7 +131,7 @@ fn skip_forbidden_whitespace(
         return Err(placeholder_error(
             "invalid placeholder in step pattern",
             ctx.start,
-            Some(ctx.name.to_string()),
+            Some(ctx.name.to_owned()),
         ));
     }
 
@@ -169,12 +169,12 @@ fn parse_optional_hint(
         return Err(placeholder_error(
             "invalid placeholder in step pattern",
             ctx.start,
-            Some(ctx.name.to_string()),
+            Some(ctx.name.to_owned()),
         ));
     }
 
     *index = end;
-    Ok(Some(raw.to_string()))
+    Ok(Some(raw.to_owned()))
 }
 
 /// Determine whether a backslash escapes a brace inside a placeholder hint.
@@ -215,7 +215,7 @@ fn extract_hint_bytes<'a>(
             return Err(placeholder_error(
                 "missing closing '}' for placeholder",
                 ctx.start,
-                Some(ctx.name.to_string()),
+                Some(ctx.name.to_owned()),
             ));
         };
 
@@ -227,7 +227,7 @@ fn extract_hint_bytes<'a>(
             return Err(placeholder_error(
                 "invalid placeholder in step pattern",
                 ctx.start,
-                Some(ctx.name.to_string()),
+                Some(ctx.name.to_owned()),
             ));
         }
 
@@ -235,7 +235,7 @@ fn extract_hint_bytes<'a>(
             return Err(placeholder_error(
                 "invalid placeholder in step pattern",
                 ctx.start,
-                Some(ctx.name.to_string()),
+                Some(ctx.name.to_owned()),
             ));
         }
 
@@ -246,7 +246,7 @@ fn extract_hint_bytes<'a>(
         placeholder_error(
             "invalid placeholder in step pattern",
             ctx.start,
-            Some(ctx.name.to_string()),
+            Some(ctx.name.to_owned()),
         )
     })?;
 
@@ -276,7 +276,7 @@ fn parse_hint_text<'a>(
         placeholder_error(
             "invalid placeholder in step pattern",
             start,
-            Some(name.to_string()),
+            Some(name.to_owned()),
         )
     })
 }

--- a/crates/rstest-bdd-patterns/tests/patterns.rs
+++ b/crates/rstest-bdd-patterns/tests/patterns.rs
@@ -84,7 +84,7 @@ fn builds_regex_and_extracts_values() {
     let regex = Regex::new(&regex_src).expect("regex should compile");
     let captures = extract_captured_values(&regex, "I have 12 cukes")
         .expect("expected captures for test step");
-    assert_eq!(captures, vec!["12".to_string()]);
+    assert_eq!(captures, vec!["12".to_owned()]);
 }
 
 #[test]
@@ -178,13 +178,13 @@ fn string_hint_captures_include_quotes() {
         .expect("expected captures for quoted string");
     assert_eq!(
         captures,
-        vec![r#""hello world""#.to_string()],
+        vec![r#""hello world""#.to_owned()],
         "captured value should include quotes (stripping happens in generated code)"
     );
 
     let captures = extract_captured_values(&regex, "value is 'single quoted'")
         .expect("expected captures for single-quoted string");
-    assert_eq!(captures, vec!["'single quoted'".to_string()]);
+    assert_eq!(captures, vec!["'single quoted'".to_owned()]);
 }
 
 #[test]
@@ -233,7 +233,7 @@ fn string_hint_captures_escaped_quotes() {
         .expect("expected captures for escaped double quotes");
     assert_eq!(
         captures,
-        vec![r#""Hello \"World\"""#.to_string()],
+        vec![r#""Hello \"World\"""#.to_owned()],
         "captured value should include outer quotes and escaped internal quotes"
     );
 
@@ -242,7 +242,7 @@ fn string_hint_captures_escaped_quotes() {
         .expect("expected captures for escaped single quotes");
     assert_eq!(
         captures,
-        vec![r"'Hello \'World\''".to_string()],
+        vec![r"'Hello \'World\''".to_owned()],
         "captured value should include outer quotes and escaped internal quotes"
     );
 }

--- a/crates/rstest-bdd-server/src/config.rs
+++ b/crates/rstest-bdd-server/src/config.rs
@@ -282,8 +282,8 @@ mod tests {
     #[test]
     fn server_config_from_env_with_reads_values() {
         let config = ServerConfig::from_env_with(|key| match key {
-            "RSTEST_BDD_LSP_LOG_LEVEL" => Ok("debug".to_string()),
-            "RSTEST_BDD_LSP_DEBOUNCE_MS" => Ok("123".to_string()),
+            "RSTEST_BDD_LSP_LOG_LEVEL" => Ok("debug".to_owned()),
+            "RSTEST_BDD_LSP_DEBOUNCE_MS" => Ok("123".to_owned()),
             _ => Err(env::VarError::NotPresent),
         })
         .expect("expected parsed config");
@@ -295,7 +295,7 @@ mod tests {
     #[test]
     fn server_config_from_env_with_reads_workspace_root() {
         let config = ServerConfig::from_env_with(|key| match key {
-            "RSTEST_BDD_LSP_WORKSPACE_ROOT" => Ok("/my/workspace".to_string()),
+            "RSTEST_BDD_LSP_WORKSPACE_ROOT" => Ok("/my/workspace".to_owned()),
             _ => Err(env::VarError::NotPresent),
         })
         .expect("expected parsed config");
@@ -306,13 +306,13 @@ mod tests {
     #[test]
     fn server_config_from_env_with_rejects_invalid_values() {
         let result = ServerConfig::from_env_with(|key| match key {
-            "RSTEST_BDD_LSP_LOG_LEVEL" => Ok("invalid".to_string()),
+            "RSTEST_BDD_LSP_LOG_LEVEL" => Ok("invalid".to_owned()),
             _ => Err(env::VarError::NotPresent),
         });
         assert!(result.is_err());
 
         let result = ServerConfig::from_env_with(|key| match key {
-            "RSTEST_BDD_LSP_DEBOUNCE_MS" => Ok("invalid".to_string()),
+            "RSTEST_BDD_LSP_DEBOUNCE_MS" => Ok("invalid".to_owned()),
             _ => Err(env::VarError::NotPresent),
         });
         assert!(result.is_err());

--- a/crates/rstest-bdd-server/src/discovery/workspace.rs
+++ b/crates/rstest-bdd-server/src/discovery/workspace.rs
@@ -219,7 +219,7 @@ edition = "2024"
         assert!(result.is_ok());
         let info = result.expect("should discover workspace");
         assert_eq!(info.root, workspace.path());
-        assert!(info.packages.contains(&"test-project".to_string()));
+        assert!(info.packages.contains(&"test-project".to_owned()));
     }
 
     #[rstest]

--- a/crates/rstest-bdd-server/src/error.rs
+++ b/crates/rstest-bdd-server/src/error.rs
@@ -51,7 +51,7 @@ mod tests {
 
     #[test]
     fn workspace_discovery_error_displays_message() {
-        let error = ServerError::WorkspaceDiscovery("no Cargo.toml found".to_string());
+        let error = ServerError::WorkspaceDiscovery("no Cargo.toml found".to_owned());
         assert_eq!(
             error.to_string(),
             "workspace discovery failed: no Cargo.toml found"
@@ -72,7 +72,7 @@ mod tests {
 
     #[test]
     fn invalid_config_error_displays_message() {
-        let error = ServerError::InvalidConfig("unknown log level".to_string());
+        let error = ServerError::InvalidConfig("unknown log level".to_owned());
         assert_eq!(
             error.to_string(),
             "invalid configuration: unknown log level"

--- a/crates/rstest-bdd-server/src/handlers/lifecycle/mod.rs
+++ b/crates/rstest-bdd-server/src/handlers/lifecycle/mod.rs
@@ -100,8 +100,8 @@ pub fn initialize_result() -> InitializeResult {
     InitializeResult {
         capabilities: build_server_capabilities(),
         server_info: Some(ServerInfo {
-            name: "rstest-bdd-lsp".to_string(),
-            version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            name: "rstest-bdd-lsp".to_owned(),
+            version: Some(env!("CARGO_PKG_VERSION").to_owned()),
         }),
     }
 }

--- a/crates/rstest-bdd-server/src/handlers/lifecycle/tests.rs
+++ b/crates/rstest-bdd-server/src/handlers/lifecycle/tests.rs
@@ -113,7 +113,7 @@ fn extract_workspace_path_from_various_sources(
         (
             vec![WorkspaceFolder {
                 uri: url.clone(),
-                name: "folder".to_string(),
+                name: "folder".to_owned(),
             }],
             None,
         )
@@ -212,7 +212,7 @@ fn prepare_workspace_discovers_and_opens_capability() {
     match preparation {
         WorkspacePreparation::Discovered(info, _) => {
             assert_eq!(info.root, workspace.path());
-            assert!(info.packages.contains(&"test-project".to_string()));
+            assert!(info.packages.contains(&"test-project".to_owned()));
         }
         other => panic!("expected discovered workspace, got {other:?}"),
     }

--- a/crates/rstest-bdd-server/src/indexing/feature/tests.rs
+++ b/crates/rstest-bdd-server/src/indexing/feature/tests.rs
@@ -56,7 +56,7 @@ fn indexes_steps_tables_docstrings_and_example_columns() {
     assert!(when.table.is_some());
     let table = when.table.as_ref().expect("table present");
     let first_row = table.rows.first().expect("table should have rows");
-    assert_eq!(first_row, &vec!["a".to_string(), "b".to_string()]);
+    assert_eq!(first_row, &vec!["a".to_owned(), "b".to_owned()]);
     assert!(table.span.start < table.span.end);
 
     // Verify scenario outline indexing

--- a/crates/rstest-bdd-server/src/indexing/rust/mod.rs
+++ b/crates/rstest-bdd-server/src/indexing/rust/mod.rs
@@ -307,14 +307,14 @@ fn parse_step_pattern(
                 return Err(RustStepIndexDiagnostic::InvalidStepAttributeArguments {
                     function: function_ident.to_string(),
                     attribute,
-                    message: "expected string literal value".to_string(),
+                    message: "expected string literal value".to_owned(),
                 });
             };
             let syn::Lit::Str(lit) = &expr_lit.lit else {
                 return Err(RustStepIndexDiagnostic::InvalidStepAttributeArguments {
                     function: function_ident.to_string(),
                     attribute,
-                    message: "expected string literal value".to_string(),
+                    message: "expected string literal value".to_owned(),
                 });
             };
             Ok(interpret_pattern_literal(function_ident, lit.value()))

--- a/crates/rstest-bdd-server/src/indexing/rust/params.rs
+++ b/crates/rstest-bdd-server/src/indexing/rust/params.rs
@@ -17,8 +17,8 @@ pub(super) fn parse_function_parameters(
         .iter()
         .map(|input| match input {
             syn::FnArg::Receiver(_) => IndexedStepParameter {
-                name: Some("self".to_string()),
-                ty: "Self".to_string(),
+                name: Some("self".to_owned()),
+                ty: "Self".to_owned(),
                 is_datatable: false,
                 is_docstring: false,
                 is_step_struct: false,

--- a/crates/rstest-bdd-server/src/indexing/rust/tests.rs
+++ b/crates/rstest-bdd-server/src/indexing/rust/tests.rs
@@ -164,7 +164,7 @@ fn preserves_module_path_for_nested_definitions() {
         .expect("expected nested step");
     assert_eq!(
         step.function.module_path,
-        vec!["outer".to_string(), "inner".to_string()]
+        vec!["outer".to_owned(), "inner".to_owned()]
     );
     assert_eq!(step.function.name, "nested_step");
 }

--- a/crates/rstest-bdd-server/src/indexing/rust/type_render.rs
+++ b/crates/rstest-bdd-server/src/indexing/rust/type_render.rs
@@ -45,7 +45,7 @@ pub(super) fn render_type(ty: &Type) -> String {
             rendered
         }
         Type::TraitObject(trait_object) => render_trait_object(trait_object),
-        Type::Never(_) => "!".to_string(),
+        Type::Never(_) => "!".to_owned(),
         other => format!("{other:?}"),
     }
 }
@@ -70,7 +70,7 @@ fn render_reference(type_ref: &syn::TypeReference) -> String {
 /// `(u8,)` is a tuple, while `(u8)` is just parenthesized `u8`.
 fn render_tuple(tuple: &syn::TypeTuple) -> String {
     if tuple.elems.is_empty() {
-        return "()".to_string();
+        return "()".to_owned();
     }
 
     let elems = tuple
@@ -105,9 +105,9 @@ fn render_fn_prefix(unsafety: Option<&syn::token::Unsafe>, abi: Option<&syn::Abi
 fn render_variadic(variadic: Option<&syn::BareVariadic>, has_inputs: bool) -> String {
     if variadic.is_some() {
         if has_inputs {
-            ", ...".to_string()
+            ", ...".to_owned()
         } else {
-            "...".to_string()
+            "...".to_owned()
         }
     } else {
         String::new()
@@ -165,7 +165,7 @@ fn render_trait_object(trait_object: &syn::TypeTraitObject) -> String {
         // Defensive fallback for malformed inputs: `dyn` without bounds is not valid
         // Rust syntax, but we prefer returning a readable placeholder over a noisy
         // debug dump.
-        "dyn _".to_string()
+        "dyn _".to_owned()
     } else {
         format!("dyn {bounds}")
     }

--- a/crates/rstest-bdd-server/tests/rust_step_indexing_on_save.rs
+++ b/crates/rstest-bdd-server/tests/rust_step_indexing_on_save.rs
@@ -260,7 +260,7 @@ fn did_save_prefers_provided_text_over_filesystem_contents() {
         "#[when]\n",
         "fn I_do_the_thing() {}\n",
     )
-    .to_string();
+    .to_owned();
 
     let uri = Url::from_file_path(&path).expect("file URI");
     let params = DidSaveTextDocumentParams {

--- a/crates/rstest-bdd/src/datatable/parsers.rs
+++ b/crates/rstest-bdd/src/datatable/parsers.rs
@@ -95,7 +95,7 @@ where
     let trimmed = value.trim();
     trimmed
         .parse()
-        .map_err(|source| TrimmedParseError::new(value.to_string(), source))
+        .map_err(|source| TrimmedParseError::new(value.to_owned(), source))
 }
 
 /// Error returned when [`trimmed`] fails to parse the value.

--- a/crates/rstest-bdd/src/datatable/spec.rs
+++ b/crates/rstest-bdd/src/datatable/spec.rs
@@ -62,7 +62,7 @@ impl HeaderSpec {
             .copied()
             .ok_or_else(|| DataTableError::MissingColumn {
                 row_number,
-                column: name.to_string(),
+                column: name.to_owned(),
             })
     }
 

--- a/crates/rstest-bdd/src/datatable/tests.rs
+++ b/crates/rstest-bdd/src/datatable/tests.rs
@@ -50,17 +50,17 @@ where
 fn parses_rows_without_header() {
     let result = assert_parses_rows(
         vec![
-            vec!["alice".to_string(), "1".to_string()],
-            vec!["bob".to_string(), "2".to_string()],
+            vec!["alice".to_owned(), "1".to_owned()],
+            vec!["bob".to_owned(), "2".to_owned()],
         ],
         2,
         &[
             Pair {
-                first: "alice".to_string(),
+                first: "alice".to_owned(),
                 second: 1,
             },
             Pair {
-                first: "bob".to_string(),
+                first: "bob".to_owned(),
                 second: 2,
             },
         ],
@@ -92,18 +92,18 @@ impl DataTableRow for Named {
 fn parses_rows_with_header() {
     let result = assert_parses_rows(
         vec![
-            vec!["name".to_string(), "active".to_string()],
-            vec!["Alice".to_string(), "yes".to_string()],
-            vec!["Bob".to_string(), "no".to_string()],
+            vec!["name".to_owned(), "active".to_owned()],
+            vec!["Alice".to_owned(), "yes".to_owned()],
+            vec!["Bob".to_owned(), "no".to_owned()],
         ],
         2,
         &[
             Named {
-                name: "Alice".to_string(),
+                name: "Alice".to_owned(),
                 active: true,
             },
             Named {
-                name: "Bob".to_string(),
+                name: "Bob".to_owned(),
                 active: false,
             },
         ],
@@ -116,8 +116,8 @@ fn parses_rows_with_header() {
 #[test]
 fn header_is_required_when_flagged() {
     let rows = vec![
-        vec!["Alice".to_string(), "yes".to_string()],
-        vec!["Bob".to_string(), "no".to_string()],
+        vec!["Alice".to_owned(), "yes".to_owned()],
+        vec!["Bob".to_owned(), "no".to_owned()],
     ];
     let Err(err) = Rows::<Named>::try_from(rows) else {
         panic!("missing header");
@@ -151,8 +151,8 @@ fn uneven_rows_are_rejected() {
     }
 
     let rows = vec![
-        vec!["name".to_string()],
-        vec!["alice".to_string(), "extra".to_string()],
+        vec!["name".to_owned()],
+        vec!["alice".to_owned(), "extra".to_owned()],
     ];
     let Err(err) = Rows::<HeaderOnly>::try_from(rows) else {
         panic!("uneven rows");
@@ -270,7 +270,7 @@ fn rows_into_vec_returns_owned_elements() {
 #[test]
 fn data_table_error_messages_cover_all_variants() {
     let duplicate = DataTableError::DuplicateHeader {
-        column: "name".to_string(),
+        column: "name".to_owned(),
     };
     assert_eq!(
         duplicate.to_string(),
@@ -289,7 +289,7 @@ fn data_table_error_messages_cover_all_variants() {
 
     let missing_column = DataTableError::MissingColumn {
         row_number: 5,
-        column: "age".to_string(),
+        column: "age".to_owned(),
     };
     assert_eq!(
         missing_column.to_string(),
@@ -311,6 +311,6 @@ fn data_table_error_messages_cover_all_variants() {
     };
     assert_eq!(row_parse.to_string(), "row 4: boom");
 
-    let cell_parse = DataTableError::cell_parse(3, 1, Some("age".to_string()), FakeError);
+    let cell_parse = DataTableError::cell_parse(3, 1, Some("age".to_owned()), FakeError);
     assert_eq!(cell_parse.to_string(), "row 3, column 2 (age): boom");
 }

--- a/crates/rstest-bdd/src/execution/error/format.rs
+++ b/crates/rstest-bdd/src/execution/error/format.rs
@@ -87,19 +87,19 @@ impl ExecutionError {
         crate::localization::message_with_loader(loader, "execution-error-skip", |args| {
             args.set(
                 "has_message",
-                if message.is_some() { "yes" } else { "no" }.to_string(),
+                if message.is_some() { "yes" } else { "no" }.to_owned(),
             );
-            args.set("message", message.unwrap_or("").to_string());
+            args.set("message", message.unwrap_or("").to_owned());
         })
     }
 
     fn format_step_not_found(loader: &crate::FluentLanguageLoader, step: &StepInfo<'_>) -> String {
         crate::localization::message_with_loader(loader, "execution-error-step-not-found", |args| {
             args.set("index", step.index.to_string());
-            args.set("keyword", step.keyword.as_str().to_string());
-            args.set("text", step.text.to_string());
-            args.set("feature_path", step.feature_path.to_string());
-            args.set("scenario_name", step.scenario_name.to_string());
+            args.set("keyword", step.keyword.as_str().to_owned());
+            args.set("text", step.text.to_owned());
+            args.set("feature_path", step.feature_path.to_owned());
+            args.set("scenario_name", step.scenario_name.to_owned());
         })
     }
 
@@ -122,7 +122,7 @@ impl ExecutionError {
                 args.set("available", details.available.join(", "));
                 args.set(
                     "has_suggestion",
-                    if details.has_suggestion { "yes" } else { "no" }.to_string(),
+                    if details.has_suggestion { "yes" } else { "no" }.to_owned(),
                 );
                 args.set("feature_path", details.feature_path.clone());
                 args.set("scenario_name", details.scenario_name.clone());
@@ -137,11 +137,11 @@ impl ExecutionError {
     ) -> String {
         crate::localization::message_with_loader(loader, "execution-error-handler-failed", |args| {
             args.set("index", step.index.to_string());
-            args.set("keyword", step.keyword.as_str().to_string());
-            args.set("text", step.text.to_string());
+            args.set("keyword", step.keyword.as_str().to_owned());
+            args.set("text", step.text.to_owned());
             args.set("error", error.format_with_loader(loader));
-            args.set("feature_path", step.feature_path.to_string());
-            args.set("scenario_name", step.scenario_name.to_string());
+            args.set("feature_path", step.feature_path.to_owned());
+            args.set("scenario_name", step.scenario_name.to_owned());
         })
     }
 }

--- a/crates/rstest-bdd/src/execution/fixtures.rs
+++ b/crates/rstest-bdd/src/execution/fixtures.rs
@@ -43,15 +43,15 @@ pub(super) fn validate_required_fixtures(
 
             Err(ExecutionError::MissingFixtures(Arc::new(
                 MissingFixturesDetails {
-                    step_pattern: step.pattern.as_str().to_string(),
+                    step_pattern: step.pattern.as_str().to_owned(),
                     step_location: format!("{}:{}", step.file, step.line),
                     required: step.fixtures.to_vec(),
                     missing,
                     missing_requirements,
                     available: available_list,
                     has_suggestion,
-                    feature_path: request.feature_path.to_string(),
-                    scenario_name: request.scenario_name.to_string(),
+                    feature_path: request.feature_path.to_owned(),
+                    scenario_name: request.scenario_name.to_owned(),
                 },
             )))
         }
@@ -125,7 +125,7 @@ mod tests {
         ctx.insert("zebra", &v1);
         ctx.insert("alpha", &v2);
         let list = sorted_available(&ctx);
-        assert_eq!(list, vec!["alpha".to_string(), "zebra".to_string()]);
+        assert_eq!(list, vec!["alpha".to_owned(), "zebra".to_owned()]);
     }
 
     /// Diagnostics fall back to `<unknown>` when no typed requirements are registered.

--- a/crates/rstest-bdd/src/execution/mod.rs
+++ b/crates/rstest-bdd/src/execution/mod.rs
@@ -58,9 +58,9 @@ fn resolve_step_for_request(
         ExecutionError::StepNotFound {
             index: request.index,
             keyword: request.keyword,
-            text: request.text.to_string(),
-            feature_path: request.feature_path.to_string(),
-            scenario_name: request.scenario_name.to_string(),
+            text: request.text.to_owned(),
+            feature_path: request.feature_path.to_owned(),
+            scenario_name: request.scenario_name.to_owned(),
         }
     })
 }
@@ -75,10 +75,10 @@ fn handle_step_result(
         Err(err) => Err(ExecutionError::HandlerFailed {
             index: request.index,
             keyword: request.keyword,
-            text: request.text.to_string(),
+            text: request.text.to_owned(),
             error: Arc::new(err),
-            feature_path: request.feature_path.to_string(),
-            scenario_name: request.scenario_name.to_string(),
+            feature_path: request.feature_path.to_owned(),
+            scenario_name: request.scenario_name.to_owned(),
         }),
     }
 }
@@ -174,7 +174,7 @@ pub fn decode_skip_message(encoded: String) -> Option<String> {
         Some(c) if c == SKIP_SOME_PREFIX => {
             // Safe: prefix_len is the byte length of the first char we just matched
             let prefix_len = c.len_utf8();
-            Some(encoded.get(prefix_len..)?.to_string())
+            Some(encoded.get(prefix_len..)?.to_owned())
         }
         // Defensive fallback: preserve unexpected or malformed input rather than
         // panicking. This handles edge cases such as:

--- a/crates/rstest-bdd/src/execution/tests.rs
+++ b/crates/rstest-bdd/src/execution/tests.rs
@@ -112,16 +112,16 @@ mod deprecated_skip_encoding {
 
     #[test]
     fn encode_skip_message_some_includes_message() {
-        let encoded = encode_skip_message(Some("test message".to_string()));
+        let encoded = encode_skip_message(Some("test message".to_owned()));
         assert!(encoded.starts_with(SKIP_SOME_PREFIX));
         assert!(encoded.contains("test message"));
     }
 
     #[rstest]
     #[case::none(None)]
-    #[case::some(Some("skip reason".to_string()))]
+    #[case::some(Some("skip reason".to_owned()))]
     #[case::empty_string(Some(String::new()))]
-    #[case::unicode(Some("Unicode: 😀 🎉".to_string()))]
+    #[case::unicode(Some("Unicode: 😀 🎉".to_owned()))]
     fn decode_skip_message_round_trip(#[case] input: Option<String>) {
         let encoded = encode_skip_message(input.clone());
         let decoded = decode_skip_message(encoded);
@@ -131,7 +131,7 @@ mod deprecated_skip_encoding {
     #[test]
     fn decode_skip_message_malformed_input_preserved() {
         // Malformed input (no valid prefix) should be returned as-is
-        let malformed = "unexpected input".to_string();
+        let malformed = "unexpected input".to_owned();
         let decoded = decode_skip_message(malformed.clone());
         assert_eq!(decoded, Some(malformed));
     }
@@ -302,7 +302,7 @@ impl ExecutionErrorTestCase {
     fn expected_extract_skip_message(&self) -> Option<Option<String>> {
         match self {
             Self::SkipWithoutMessage => Some(None),
-            Self::SkipWithMessage(msg) => Some(Some((*msg).to_string())),
+            Self::SkipWithMessage(msg) => Some(Some((*msg).to_owned())),
             Self::StepNotFound | Self::HandlerFailed | Self::MissingFixtures => None,
         }
     }

--- a/crates/rstest-bdd/src/registry/diagnostics.rs
+++ b/crates/rstest-bdd/src/registry/diagnostics.rs
@@ -55,8 +55,8 @@ pub(super) fn record_bypassed_steps_impl<'a, I>(
         if let Some(step) = resolve_step(keyword, text.into()) {
             let record = BypassedStepRecord {
                 key: (step.keyword, step.pattern),
-                feature_path: feature_path.to_string(),
-                scenario_name: scenario_name.to_string(),
+                feature_path: feature_path.to_owned(),
+                scenario_name: scenario_name.to_owned(),
                 scenario_line,
                 tags: tags.to_owned(),
                 reason: reason.map(str::to_owned),

--- a/crates/rstest-bdd/src/skip.rs
+++ b/crates/rstest-bdd/src/skip.rs
@@ -257,7 +257,7 @@ mod tests {
 
     #[test]
     fn request_skip_raises_panic() {
-        let result = panic::catch_unwind(|| SkipRequest::raise(Some("skip".to_string())));
+        let result = panic::catch_unwind(|| SkipRequest::raise(Some("skip".to_owned())));
         assert!(result.is_err(), "request_skip should panic");
     }
 
@@ -296,7 +296,7 @@ mod tests {
         };
         assert_eq!(
             request.into_message(),
-            expected.map(ToString::to_string),
+            expected.map(str::to_owned),
             "skip! should produce the expected optional message",
         );
     }

--- a/crates/rstest-bdd/src/types/tests.rs
+++ b/crates/rstest-bdd/src/types/tests.rs
@@ -114,7 +114,7 @@ fn payload_from_value_returns_none_for_unit_alias() {
 
 #[test]
 fn placeholder_error_from_placeholder_syntax_returns_invalid_placeholder() {
-    let syntax_err = PlaceholderSyntaxError::new("empty type hint", 6, Some("n".to_string()));
+    let syntax_err = PlaceholderSyntaxError::new("empty type hint", 6, Some("n".to_owned()));
     let err = StepPatternError::PlaceholderSyntax(syntax_err);
     let converted: PlaceholderError = err.into();
     assert!(

--- a/crates/rstest-bdd/tests/assert_macros.rs
+++ b/crates/rstest-bdd/tests/assert_macros.rs
@@ -185,7 +185,7 @@ fn assert_step_err_unwraps_error_without_substring() {
 #[test]
 fn assert_step_err_accepts_owned_string_pattern() {
     let res: Result<(), &str> = Err("boom");
-    let pat = "boom".to_string();
+    let pat = "boom".to_owned();
     let e = assert_step_err!(res, pat);
     assert_eq!(e, "boom");
 }

--- a/crates/rstest-bdd/tests/async_semantic_behaviour.rs
+++ b/crates/rstest-bdd/tests/async_semantic_behaviour.rs
@@ -180,8 +180,8 @@ fn semantic_step_ordering_outline(
     item: String,
 ) {
     let expected = vec![
-        "fixture-created".to_string(),
-        "given".to_string(),
+        "fixture-created".to_owned(),
+        "given".to_owned(),
         format!("when:{item}"),
         format!("then:{item}"),
     ];
@@ -255,7 +255,7 @@ fn skip_propagation_preserves_message_and_bypass_metadata() {
 
     assert_eq!(
         snapshot_events(),
-        vec!["skip:given".to_string(), "skip:when".to_string()],
+        vec!["skip:given".to_owned(), "skip:when".to_owned()],
         "skip propagation should stop later steps from running",
     );
 
@@ -312,7 +312,7 @@ fn error_propagation_includes_step_and_scenario_context() {
     );
     assert_eq!(
         snapshot_events(),
-        vec!["failure:given".to_string(), "failure:when".to_string()],
+        vec!["failure:given".to_owned(), "failure:when".to_owned()],
         "failure propagation should stop later steps from running",
     );
 }

--- a/crates/rstest-bdd/tests/datatable.rs
+++ b/crates/rstest-bdd/tests/datatable.rs
@@ -8,8 +8,8 @@ fn check_table(datatable: Vec<Vec<String>>) {
     assert_eq!(
         datatable,
         vec![
-            vec!["alpha".to_string(), "beta".to_string()],
-            vec!["gamma".to_string(), "delta".to_string()],
+            vec!["alpha".to_owned(), "beta".to_owned()],
+            vec!["gamma".to_owned(), "delta".to_owned()],
         ],
     );
 }
@@ -19,10 +19,7 @@ fn datatable_scenario() {}
 
 #[given("a table then value {value}:")]
 fn table_then_value(datatable: Vec<Vec<String>>, value: String) {
-    assert_eq!(
-        datatable,
-        vec![vec!["a".to_string()], vec!["b".to_string()]],
-    );
+    assert_eq!(datatable, vec![vec!["a".to_owned()], vec!["b".to_owned()]],);
     assert_eq!(value, "beta");
 }
 
@@ -58,13 +55,13 @@ fn typed_users(#[datatable] rows: Rows<UserRow>) {
         parsed,
         vec![
             UserRow {
-                name: "Alice".to_string(),
-                email: "alice@example.com".to_string(),
+                name: "Alice".to_owned(),
+                email: "alice@example.com".to_owned(),
                 active: true,
             },
             UserRow {
-                name: "Bob".to_string(),
-                email: "bob@example.com".to_string(),
+                name: "Bob".to_owned(),
+                email: "bob@example.com".to_owned(),
                 active: false,
             },
         ]

--- a/crates/rstest-bdd/tests/execution_error.rs
+++ b/crates/rstest-bdd/tests/execution_error.rs
@@ -345,18 +345,18 @@ fn missing_fixtures_snapshot() {
         Err(e) => panic!("en-US locale should always be available: {e}"),
     };
     let details = MissingFixturesDetails {
-        step_pattern: "needs fixture".to_string(),
-        step_location: "src/steps.rs:42".to_string(),
+        step_pattern: "needs fixture".to_owned(),
+        step_location: "src/steps.rs:42".to_owned(),
         required: vec!["db"],
         missing: vec!["db"],
         missing_requirements: vec![MissingFixtureDiagnostic {
             name: "db",
             ty: "DbPool",
         }],
-        available: vec!["world".to_string()],
+        available: vec!["world".to_owned()],
         has_suggestion: true,
-        feature_path: "features/example.feature".to_string(),
-        scenario_name: "Example scenario".to_string(),
+        feature_path: "features/example.feature".to_owned(),
+        scenario_name: "Example scenario".to_owned(),
     };
     let error = rstest_bdd::execution::ExecutionError::MissingFixtures(Arc::new(details));
     insta::assert_snapshot!(format!("{error}"));

--- a/crates/rstest-bdd/tests/localization.rs
+++ b/crates/rstest-bdd/tests/localization.rs
@@ -131,8 +131,8 @@ fn message_helpers_use_active_locale() {
     let detailed = strip_directional_isolates(&message_with_args(
         "assert-step-err-missing-substring",
         |args| {
-            args.set("display", "boom".to_string());
-            args.set("expected", "snap".to_string());
+            args.set("display", "boom".to_owned());
+            args.set("expected", "snap".to_owned());
         },
     ));
     assert!(detailed.contains("boom"));

--- a/crates/rstest-bdd/tests/manual_async_scenario.rs
+++ b/crates/rstest-bdd/tests/manual_async_scenario.rs
@@ -15,7 +15,7 @@ thread_local! {
 
 #[given("the manual async step runs")]
 fn manual_async_given() {
-    MANUAL_ASYNC_STATE.with(|s| *s.borrow_mut() = "given".to_string());
+    MANUAL_ASYNC_STATE.with(|state| "given".clone_into(&mut state.borrow_mut()));
 }
 
 #[when("the manual async step continues")]

--- a/crates/rstest-bdd/tests/result_fixture.rs
+++ b/crates/rstest-bdd/tests/result_fixture.rs
@@ -26,7 +26,7 @@ impl ResultWorld {
     }
 
     fn try_new_failing() -> Result<Self, String> {
-        Err("fixture initialization failed".to_string())
+        Err("fixture initialization failed".to_owned())
     }
 }
 
@@ -146,7 +146,7 @@ fn step_result_world() -> StepResult<ResultWorld, String> {
 /// Fixture that always fails, for testing `StepResult` error propagation.
 #[fixture]
 fn failing_step_result_world() -> StepResult<ResultWorld, String> {
-    Err("step-result fixture initialization failed".to_string())
+    Err("step-result fixture initialization failed".to_owned())
 }
 
 #[given("a world initialized from a StepResult fixture")]

--- a/crates/rstest-bdd/tests/scenario_harness.rs
+++ b/crates/rstest-bdd/tests/scenario_harness.rs
@@ -139,12 +139,16 @@ impl HarnessAdapter for MetadataCapturingHarness {
 
     fn run<T>(&self, request: StdScenarioRunRequest<'_, T>) -> Result<T, HarnessError> {
         let meta = request.metadata();
-        *CAPTURED_FEATURE
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner) = meta.feature_path().to_string();
-        *CAPTURED_SCENARIO
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner) = meta.scenario_name().to_string();
+        meta.feature_path().clone_into(
+            &mut CAPTURED_FEATURE
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        );
+        meta.scenario_name().clone_into(
+            &mut CAPTURED_SCENARIO
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        );
         Ok(request.run_without_context())
     }
 }

--- a/crates/rstest-bdd/tests/step_registry/execute_step_tests.rs
+++ b/crates/rstest-bdd/tests/step_registry/execute_step_tests.rs
@@ -277,7 +277,7 @@ fn execute_step_reports_detailed_missing_harness_fixture() {
     );
     assert_eq!(
         details.available,
-        vec!["world".to_string()],
+        vec!["world".to_owned()],
         "expected inserted fixtures from StepContext::available_fixtures"
     );
     assert!(

--- a/crates/rstest-bdd/tests/string_hint.rs
+++ b/crates/rstest-bdd/tests/string_hint.rs
@@ -16,7 +16,7 @@ fn message() -> RefCell<String> {
 #[given("the message is {text:string}")]
 fn set_message(message: &RefCell<String>, text: &str) {
     // The :string hint should have stripped the surrounding quotes
-    *message.borrow_mut() = text.to_string();
+    text.clone_into(&mut message.borrow_mut());
 }
 
 /// Verify the message was captured without surrounding quotes.

--- a/examples/todo-cli/tests/todo.rs
+++ b/examples/todo-cli/tests/todo.rs
@@ -136,7 +136,7 @@ fn dedent(input: &str) -> String {
         .map(|l| if l.len() >= cut { &l[cut..] } else { "" })
         .collect::<Vec<_>>()
         .join("\n");
-    out.trim_matches('\n').to_string()
+    out.trim_matches('\n').to_owned()
 }
 
 #[given("a to-do list with {first} and {second}")]
@@ -185,7 +185,7 @@ fn completing_nonexistent_task_does_not_mutate_statuses() {
         "expected completing a missing task to fail"
     );
 
-    let expected = vec![("task 1".to_string(), false), ("task 2".to_string(), false)];
+    let expected = vec![("task 1".to_owned(), false), ("task 2".to_owned(), false)];
     assert_eq!(expected, todo_list.statuses());
 }
 

--- a/examples/tokio-reminders/src/lib.rs
+++ b/examples/tokio-reminders/src/lib.rs
@@ -306,7 +306,7 @@ mod tests {
                 assert_eq!(service.pending_reminder_count(), 2);
                 assert_eq!(
                     service.pending_recipients(),
-                    vec!["Ada".to_string(), "Grace".to_string()]
+                    vec!["Ada".to_owned(), "Grace".to_owned()]
                 );
 
                 let result = service.flush().await;
@@ -317,8 +317,8 @@ mod tests {
                 assert_eq!(
                     service.delivered_reminders(),
                     vec![
-                        "Reminder sent to Ada".to_string(),
-                        "Reminder sent to Grace".to_string(),
+                        "Reminder sent to Ada".to_owned(),
+                        "Reminder sent to Grace".to_owned(),
                     ]
                 );
                 assert_eq!(service.pending_reminder_count(), 0);
@@ -341,20 +341,20 @@ mod tests {
                 assert!(first.is_ok(), "first flush should succeed: {first:?}");
                 assert_eq!(
                     service.delivered_reminders(),
-                    vec!["Reminder sent to Ada".to_string()]
+                    vec!["Reminder sent to Ada".to_owned()]
                 );
                 assert!(service.pending_recipients().is_empty());
 
                 service.schedule_reminder("Linus");
-                assert_eq!(service.pending_recipients(), vec!["Linus".to_string()]);
+                assert_eq!(service.pending_recipients(), vec!["Linus".to_owned()]);
 
                 let second = service.flush().await;
                 assert!(second.is_ok(), "second flush should succeed: {second:?}");
                 assert_eq!(
                     service.delivered_reminders(),
                     vec![
-                        "Reminder sent to Ada".to_string(),
-                        "Reminder sent to Linus".to_string(),
+                        "Reminder sent to Ada".to_owned(),
+                        "Reminder sent to Linus".to_owned(),
                     ]
                 );
             })
@@ -376,16 +376,16 @@ mod tests {
                 let succeeding_task: ReminderTask = Box::pin(async move {
                     delivered
                         .borrow_mut()
-                        .push("Reminder sent to Grace".to_string());
+                        .push("Reminder sent to Grace".to_owned());
                 });
 
                 service.pending.borrow_mut().extend([
                     PendingReminder {
-                        recipient: "Ada".to_string(),
+                        recipient: "Ada".to_owned(),
                         task: failing_task,
                     },
                     PendingReminder {
-                        recipient: "Grace".to_string(),
+                        recipient: "Grace".to_owned(),
                         task: succeeding_task,
                     },
                 ]);
@@ -394,7 +394,7 @@ mod tests {
                 assert!(result.is_err(), "flush should report the first join error");
                 assert_eq!(
                     service.delivered_reminders(),
-                    vec!["Reminder sent to Grace".to_string()]
+                    vec!["Reminder sent to Grace".to_owned()]
                 );
                 assert_eq!(service.pending_reminder_count(), 0);
                 assert!(service.pending_recipients().is_empty());
@@ -430,7 +430,7 @@ mod tests {
                 service.flush().await.expect("flush should succeed");
                 assert_eq!(
                     service.delivered_reminders(),
-                    vec!["Reminder sent to Ada".to_string()],
+                    vec!["Reminder sent to Ada".to_owned()],
                     "delivered_reminders should contain Ada after flush"
                 );
                 assert_eq!(


### PR DESCRIPTION
Replace string-like `to_string()` calls with `to_owned()` throughout the
workspace. Use `clone_into` where the destination allocation can be reused.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

## Summary by Sourcery

Prefer idiomatic owned-string conversions throughout the workspace.

Enhancements:
- Standardize owned string creation across the workspace by replacing string-like `to_string()` conversions with `to_owned()`.
- Reuse existing destination allocations for selected string updates with `clone_into`.

## References

- [Lody session](https://lody.ai/leynos/sessions/e2e8db4e-90c2-4b90-b1b9-aae35838bb24)