### PR TITLE
Require panic documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ option_if_let_else = "deny"
 use_self = "deny"
 string_lit_as_bytes = "deny"
 float_arithmetic = "deny"
+missing_panics_doc = "deny"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/rstest-bdd-server/src/discovery/workspace.rs
+++ b/crates/rstest-bdd-server/src/discovery/workspace.rs
@@ -183,14 +183,6 @@ fn collect_feature_files_recursive(dir: &Path, features: &mut Vec<PathBuf>) {
     reason = "tests require explicit panic messages for debugging failures"
 )]
 mod tests {
-    //! Unit tests for workspace discovery.
-
-    use super::*;
-    use rstest::{fixture, rstest};
-    use std::fs;
-    use std::io;
-    use tempfile::TempDir;
-
     #[fixture]
     fn create_test_workspace() -> io::Result<TempDir> {
         let dir = TempDir::new()?;

--- a/crates/rstest-bdd-server/src/discovery/workspace.rs
+++ b/crates/rstest-bdd-server/src/discovery/workspace.rs
@@ -183,6 +183,14 @@ fn collect_feature_files_recursive(dir: &Path, features: &mut Vec<PathBuf>) {
     reason = "tests require explicit panic messages for debugging failures"
 )]
 mod tests {
+    //! Unit tests for workspace discovery.
+
+    use super::*;
+    use rstest::{fixture, rstest};
+    use std::fs;
+    use std::io;
+    use tempfile::TempDir;
+
     #[fixture]
     fn create_test_workspace() -> io::Result<TempDir> {
         let dir = TempDir::new()?;

--- a/examples/gpui-counter/Cargo.toml
+++ b/examples/gpui-counter/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 publish = false
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 
 [dev-dependencies]

--- a/examples/japanese-ledger/Cargo.toml
+++ b/examples/japanese-ledger/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 publish = false
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 
 [dev-dependencies]

--- a/examples/todo-cli/Cargo.toml
+++ b/examples/todo-cli/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 publish = false
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 eyre = "0.6"

--- a/examples/todo-cli/src/main.rs
+++ b/examples/todo-cli/src/main.rs
@@ -3,7 +3,8 @@
 
 use clap::builder::ValueParser;
 use clap::{Parser, Subcommand};
-use eyre::Result;
+use eyre::{Result, WrapErr};
+use std::io::Write;
 use todo_cli::TodoList;
 
 /// Trim and reject blank-only task descriptions.
@@ -42,7 +43,8 @@ fn main() -> Result<()> {
     let mut list = TodoList::new();
     match cli.command {
         Command::Add { description } => list.add(description),
-        Command::List => println!("{}", list.display()),
+        Command::List => writeln!(std::io::stdout().lock(), "{}", list.display())
+            .wrap_err("write task list to stdout")?,
     }
     Ok(())
 }

--- a/examples/todo-cli/tests/todo.rs
+++ b/examples/todo-cli/tests/todo.rs
@@ -38,7 +38,12 @@ impl TryFrom<Vec<Vec<String>>> for TaskEntries {
         for (index, row) in rows.into_iter().enumerate() {
             expect_column_count(&row, 1, index, "exactly one column (task description)")?;
             let mut cells = row.into_iter();
-            let task = cells.next().expect("row.len() == 1 just asserted");
+            let task = cells.next().ok_or_else(|| {
+                format!(
+                    "datatable row {} must contain a task description",
+                    index + 1
+                )
+            })?;
             tasks.push(task);
         }
         Ok(Self(tasks))
@@ -65,8 +70,18 @@ impl TryFrom<Vec<Vec<String>>> for StatusEntries {
         for (index, row) in rows.into_iter().enumerate() {
             expect_column_count(&row, 2, index, "exactly two columns: <task> | <yes/no>")?;
             let mut cells = row.into_iter();
-            let task = cells.next().expect("row.len() == 2 just asserted");
-            let done_cell = cells.next().expect("row.len() == 2 just asserted");
+            let task = cells.next().ok_or_else(|| {
+                format!(
+                    "datatable row {} must contain a task description",
+                    index + 1
+                )
+            })?;
+            let done_cell = cells.next().ok_or_else(|| {
+                format!(
+                    "datatable row {} must contain a completion value",
+                    index + 1
+                )
+            })?;
             let normalized = done_cell.trim().to_ascii_lowercase();
             let done = match normalized.as_str() {
                 "yes" | "y" | "true" => true,
@@ -133,7 +148,11 @@ fn dedent(input: &str) -> String {
     let cut = min_indent.unwrap_or(0);
     let out = s
         .lines()
-        .map(|l| if l.len() >= cut { &l[cut..] } else { "" })
+        .map(|line| {
+            line.char_indices().nth(cut).map_or("", |(byte_index, _)| {
+                line.get(byte_index..).unwrap_or_default()
+            })
+        })
         .collect::<Vec<_>>()
         .join("\n");
     out.trim_matches('\n').to_owned()
@@ -197,6 +216,10 @@ fn dedent_handles_edge_cases() {
         (
             concat!("    line1", "\n", "  line2", "\n", "        line3"),
             concat!("  line1", "\n", "line2", "\n", "      line3"),
+        ),
+        (
+            concat!("  café", "\n", "  crème"),
+            concat!("café", "\n", "crème"),
         ),
     ];
 

--- a/examples/tokio-reminders/Cargo.toml
+++ b/examples/tokio-reminders/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 publish = false
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 thiserror.workspace = true
 tokio.workspace = true

--- a/examples/tokio-reminders/src/lib.rs
+++ b/examples/tokio-reminders/src/lib.rs
@@ -131,6 +131,11 @@ impl ReminderService {
     /// [`LocalSet::run_until`](tokio::task::LocalSet::run_until) or
     /// [`LocalSet::block_on`](tokio::task::LocalSet::block_on)).
     ///
+    /// # Errors
+    ///
+    /// Returns [`ReminderServiceError::Join`] if a scheduled reminder task
+    /// cannot be joined.
+    ///
     /// # Examples
     ///
     /// ```
@@ -165,11 +170,7 @@ impl ReminderService {
             }
         }
 
-        if let Some(error) = first_error {
-            Err(error)
-        } else {
-            Ok(())
-        }
+        first_error.map_or_else(|| Ok(()), Err)
     }
 
     /// Returns the delivered reminder messages in delivery order.


### PR DESCRIPTION
Deny `missing_panics_doc` across the workspace so public APIs document
their panicking contracts alongside the existing rustdoc policy.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

## References

- [Lody session](https://lody.ai/leynos/sessions/0f081bb7-3692-4199-a18e-9319ad8b6909)

## Summary by Sourcery

Enforce panic documentation across the workspace while removing avoidable panics and improving example error handling.

Bug Fixes:
- Replace panic-prone CLI test parsing with descriptive validation errors.
- Preserve Unicode correctness when dedenting test input.

Enhancements:
- Require workspace-wide documentation of panicking public APIs.
- Apply workspace lint settings to all example crates and document reminder task join errors.
- Improve CLI stdout error reporting when displaying tasks.

Documentation:
- Document the error contract of reminder shutdown operations.

Tests:
- Add coverage for dedenting Unicode text.