### PR TITLE
Standardize Rust formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,12 @@ jobs:
         with:
           version: '0.11.8'
 
+      # `.rustfmt.toml` uses unstable options, so `make check-fmt` shells out
+      # to the pinned nightly rustfmt named by the Makefile's FMT_TOOLCHAIN.
+      - name: Install nightly rustfmt
+        if: ${{ matrix.tools }}
+        run: rustup toolchain install nightly-2026-08-07 --profile minimal --component rustfmt
+
       - name: Check formatting
         if: ${{ matrix.tools }}
         run: make check-fmt

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,14 @@
+unstable_features = true
+comment_width = 100
+format_code_in_doc_comments = true
+imports_granularity = "Crate"
+imports_layout = "HorizontalVertical"
+wrap_comments = true
+group_imports = "StdExternalCrate"
+use_try_shorthand = true
+hex_literal_case = "Lower"
+format_strings = true
+format_macro_matchers = true
+fn_single_line = true
+condense_wildcard_suffixes = true
+use_field_init_shorthand = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,7 @@ dependencies = [
  "rstest",
  "rstest-bdd",
  "rstest-bdd-harness",
+ "rstest-bdd-test-macros",
  "serde",
  "serde_json",
  "serial_test 2.0.0",
@@ -765,6 +766,7 @@ dependencies = [
  "rstest-bdd",
  "rstest-bdd-harness-gpui",
  "rstest-bdd-macros",
+ "rstest-bdd-test-macros",
 ]
 
 [[package]]
@@ -1076,6 +1078,7 @@ dependencies = [
  "rstest",
  "rstest-bdd",
  "rstest-bdd-macros",
+ "rstest-bdd-test-macros",
 ]
 
 [[package]]
@@ -1569,6 +1572,7 @@ dependencies = [
  "rstest-bdd-macros",
  "rstest-bdd-patterns",
  "rstest-bdd-policy",
+ "rstest-bdd-test-macros",
  "rust-embed",
  "serde",
  "serde_json",
@@ -1591,6 +1595,7 @@ dependencies = [
  "proptest",
  "rstest",
  "rstest-bdd-harness",
+ "rstest-bdd-test-macros",
  "temp-env",
  "tempfile",
  "thiserror 2.0.18",
@@ -1611,6 +1616,7 @@ dependencies = [
  "rstest-bdd",
  "rstest-bdd-harness",
  "rstest-bdd-macros",
+ "rstest-bdd-test-macros",
  "serial_test 2.0.0",
  "tokio",
  "tracing",
@@ -1629,6 +1635,7 @@ dependencies = [
  "rstest-bdd",
  "rstest-bdd-harness",
  "rstest-bdd-macros",
+ "rstest-bdd-test-macros",
  "serial_test 3.5.0",
  "tokio",
  "trybuild",
@@ -1654,6 +1661,7 @@ dependencies = [
  "rstest-bdd-harness",
  "rstest-bdd-patterns",
  "rstest-bdd-policy",
+ "rstest-bdd-test-macros",
  "serial_test 2.0.0",
  "syn 2.0.117",
  "tempfile",
@@ -1698,6 +1706,7 @@ dependencies = [
  "rstest",
  "rstest-bdd-patterns",
  "rstest-bdd-server",
+ "rstest-bdd-test-macros",
  "serde",
  "serde_json",
  "syn 2.0.117",
@@ -1708,6 +1717,15 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "rstest-bdd-test-macros"
+version = "0.6.0-beta4"
+dependencies = [
+ "quote",
+ "rstest",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2222,6 +2240,7 @@ dependencies = [
  "rstest-bdd",
  "rstest-bdd-harness",
  "rstest-bdd-macros",
+ "rstest-bdd-test-macros",
  "toml 0.9.12+spec-1.1.0",
 ]
 
@@ -2259,6 +2278,7 @@ dependencies = [
  "rstest-bdd",
  "rstest-bdd-harness-tokio",
  "rstest-bdd-macros",
+ "rstest-bdd-test-macros",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,10 @@ float_arithmetic = "deny"
 missing_panics_doc = "deny"
 
 [workspace.lints.rust]
+# `rstest` fixtures are re-emitted as nested blocks. Combined with
+# `fn_single_line` in `.rustfmt.toml`, rustc sees an inner block whose braces
+# cannot be scoped away from macro expansion diagnostics.
+unused_braces = "allow"
 unsafe_code = "forbid"
 missing_docs = "deny"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/rstest-bdd-policy",
     "crates/rstest-bdd-patterns",
     "crates/rstest-bdd-server",
+    "crates/rstest-bdd-test-macros",
     "crates/cargo-bdd",
     "examples/todo-cli",
     "examples/japanese-ledger",
@@ -61,6 +62,7 @@ rstest-bdd-harness-tokio = { version = "0.6.0-beta4", path = "crates/rstest-bdd-
 rstest-bdd-macros = { version = "0.6.0-beta4", path = "crates/rstest-bdd-macros" }
 rstest-bdd-policy = { version = "0.6.0-beta4", path = "crates/rstest-bdd-policy" }
 rstest-bdd-patterns = { version = "0.6.0-beta4", path = "crates/rstest-bdd-patterns" }
+rstest-bdd-test-macros = { version = "0.6.0-beta4", path = "crates/rstest-bdd-test-macros" }
 log = "0.4"
 temp-env = "0.3.6"
 tempfile = "3.23"
@@ -104,10 +106,6 @@ float_arithmetic = "deny"
 missing_panics_doc = "deny"
 
 [workspace.lints.rust]
-# `rstest` fixtures are re-emitted as nested blocks. Combined with
-# `fn_single_line` in `.rustfmt.toml`, rustc sees an inner block whose braces
-# cannot be scoped away from macro expansion diagnostics.
-unused_braces = "allow"
 unsafe_code = "forbid"
 missing_docs = "deny"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ rstest-bdd-harness-tokio = { version = "0.6.0-beta4", path = "crates/rstest-bdd-
 rstest-bdd-macros = { version = "0.6.0-beta4", path = "crates/rstest-bdd-macros" }
 rstest-bdd-policy = { version = "0.6.0-beta4", path = "crates/rstest-bdd-policy" }
 rstest-bdd-patterns = { version = "0.6.0-beta4", path = "crates/rstest-bdd-patterns" }
-rstest-bdd-test-macros = { version = "0.6.0-beta4", path = "crates/rstest-bdd-test-macros" }
+rstest-bdd-test-macros = { path = "crates/rstest-bdd-test-macros" }
 log = "0.4"
 temp-env = "0.3.6"
 tempfile = "3.23"

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,13 @@ SHELL := bash
 export PATH := $(HOME)/.cargo/bin:$(HOME)/.bun/bin:$(HOME)/.local/bin:$(PATH)
 APP ?= cargo-bdd
 CARGO ?= $(or $(shell command -v cargo 2>/dev/null),$(HOME)/.cargo/bin/cargo)
+# `.rustfmt.toml` enables unstable rustfmt options, which only a nightly
+# rustfmt understands. Formatting therefore runs on nightly while every other
+# Cargo invocation stays on the pinned stable toolchain. The nightly is pinned
+# to a date so that an upstream rustfmt change cannot reformat the tree out
+# from under unrelated pull requests.
+FMT_TOOLCHAIN ?= nightly-2026-08-07
+CARGO_FMT ?= $(CARGO) +$(FMT_TOOLCHAIN) fmt
 BUILD_JOBS ?=
 RUST_FLAGS ?= -D warnings
 RUSTDOC_FLAGS ?= --cfg docsrs -D warnings
@@ -92,13 +99,13 @@ forbid-async-trait: ## Ensure the async-trait crate and macro remain absent
 	python3 scripts/check_forbidden_async_trait.py
 
 fmt: build-python ## Format Rust and Markdown sources
-	$(CARGO) fmt --all
+	$(CARGO_FMT) --all
 	$(UV_ENV) $(UV) run ruff format $(PYTHON_TARGETS)
 	$(UV_ENV) $(UV) run ruff check --select I --fix $(PYTHON_TARGETS)
 	mdformat-all
 
 check-fmt: build-python ## Verify formatting
-	$(CARGO) fmt --all -- --check
+	$(CARGO_FMT) --all -- --check
 	$(UV_ENV) $(UV) run ruff format --check $(PYTHON_TARGETS)
 
 markdownlint: spelling ## Lint Markdown files and enforce en-GB-oxendict spelling

--- a/crates/cargo-bdd/Cargo.toml
+++ b/crates/cargo-bdd/Cargo.toml
@@ -29,6 +29,7 @@ assert_cmd = "2"
 insta.workspace = true
 proptest.workspace = true
 rstest.workspace = true
+rstest-bdd-test-macros.workspace = true
 rstest-bdd-harness.workspace = true
 serial_test = "2"
 tempfile.workspace = true

--- a/crates/cargo-bdd/src/cli.rs
+++ b/crates/cargo-bdd/src/cli.rs
@@ -1,17 +1,24 @@
 //! Command dispatch and formatting for the `cargo bdd` entrypoint.
 
-use std::collections::HashMap;
-use std::io::{self, Write};
+use std::{
+    collections::HashMap,
+    io::{self, Write},
+};
 
 use clap::{Args, Parser, Subcommand};
 use eyre::{Context, Result, bail};
 use serde::Serialize;
 
-use crate::output::{
-    ScenarioDisplayOptions, write_bypassed_steps, write_group_separator, write_scenarios,
-    write_step,
+use crate::{
+    output::{
+        ScenarioDisplayOptions,
+        write_bypassed_steps,
+        write_group_separator,
+        write_scenarios,
+        write_step,
+    },
+    registry::{BypassedStep, Scenario, ScenarioOutcome, Step, collect_registry},
 };
-use crate::registry::{BypassedStep, Scenario, ScenarioOutcome, Step, collect_registry};
 
 /// Cargo subcommand providing diagnostics for rstest-bdd.
 #[derive(Parser)]
@@ -128,9 +135,7 @@ fn handle_steps(args: &StepsArgs) -> Result<()> {
     )
 }
 
-fn handle_unused() -> Result<()> {
-    write_filtered_steps(|step| !step.used, None)
-}
+fn handle_unused() -> Result<()> { write_filtered_steps(|step| !step.used, None) }
 
 fn handle_duplicates() -> Result<()> {
     let mut groups: HashMap<(String, String), Vec<Step>> = HashMap::new();

--- a/crates/cargo-bdd/src/main.rs
+++ b/crates/cargo-bdd/src/main.rs
@@ -4,6 +4,4 @@ mod cli;
 mod output;
 mod registry;
 
-fn main() -> eyre::Result<()> {
-    cli::run()
-}
+fn main() -> eyre::Result<()> { cli::run() }

--- a/crates/cargo-bdd/src/output/tests.rs
+++ b/crates/cargo-bdd/src/output/tests.rs
@@ -6,6 +6,7 @@ use rstest::{fixture, rstest};
 use super::*;
 use crate::registry::ScenarioOutcome;
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn sample_scenario() -> Scenario {
     Scenario {
@@ -43,6 +44,7 @@ fn render_scenarios(scenarios: &[Scenario], options: ScenarioDisplayOptions) -> 
 /// exercise `append_scenario_annotations`; this one forces the
 /// `[forced failure]` marker so a regression in that fragment (or its
 /// ordering relative to tags and the reason) is caught.
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn annotated_scenario() -> Scenario {
     Scenario {
@@ -56,6 +58,7 @@ fn annotated_scenario() -> Scenario {
 /// false so `append_scenario_annotations` takes its second branch: the
 /// `[forced failure]` marker suppresses `[skip disallowed]`, so only this
 /// combination renders it.
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn skip_disallowed_scenario() -> Scenario {
     Scenario {

--- a/crates/cargo-bdd/src/registry/mod.rs
+++ b/crates/cargo-bdd/src/registry/mod.rs
@@ -1,9 +1,11 @@
 //! Registry collection helpers shared by the CLI subcommands.
 
-use std::collections::HashSet;
-use std::io::{self, BufReader, Read, Write};
-use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
+use std::{
+    collections::HashSet,
+    io::{self, BufReader, Read, Write},
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+};
 
 use cargo_metadata::{Message, Package, PackageId, Target};
 use eyre::{Context, Result, bail, eyre};
@@ -159,7 +161,8 @@ fn parse_cargo_messages(
                 let _ = child.wait();
                 return Err(eyre!(err)).wrap_err_with(|| {
                     format!(
-                        "failed to parse cargo metadata message for target {target_name} in package {package_name}",
+                        "failed to parse cargo metadata message for target {target_name} in \
+                         package {package_name}",
                     )
                 });
             }

--- a/crates/cargo-bdd/src/registry/tests.rs
+++ b/crates/cargo-bdd/src/registry/tests.rs
@@ -1,8 +1,9 @@
 //! Unit tests for registry collection and parsing.
 
-use super::*;
 use cargo_metadata::Message as MetadataMessage;
 use rstest::rstest;
+
+use super::*;
 
 #[test]
 fn detects_unrecognized_flag_from_libtest_getopts() {
@@ -86,9 +87,7 @@ fn parses_registry_dump_with_bypassed_steps() {
     assert_eq!(bypassed.reason.as_deref(), Some("reason"));
 }
 
-fn parse_message(json: &str) -> serde_json::Result<MetadataMessage> {
-    serde_json::from_str(json)
-}
+fn parse_message(json: &str) -> serde_json::Result<MetadataMessage> { serde_json::from_str(json) }
 
 /// Assert that `extract_test_executable` maps a cargo JSON message to the
 /// expected executable path.

--- a/crates/cargo-bdd/tests/cli.rs
+++ b/crates/cargo-bdd/tests/cli.rs
@@ -1,15 +1,12 @@
 //! Basic smoke tests for the cargo-bdd subcommand.
 
+use std::{env, fs, path::PathBuf, process::ExitStatus, str};
+
 use assert_cmd::Command;
 use eyre::{Context, Result};
 use rstest_bdd_harness::binary_test_support::{BinaryName, locate_or_build_binary};
 use serde::Deserialize;
 use serial_test::serial;
-use std::env;
-use std::fs;
-use std::path::PathBuf;
-use std::process::ExitStatus;
-use std::str;
 
 #[derive(Debug, Deserialize)]
 struct SkippedDefinition {
@@ -62,9 +59,7 @@ fn locate_or_build_cargo_bdd_command() -> Result<Command> {
     .map_err(|e| eyre::eyre!(e))
 }
 
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
-}
+fn workspace_root() -> PathBuf { PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..") }
 
 fn run_cargo_bdd_captured(args: &[&str]) -> Result<(ExitStatus, String, String)> {
     let output = run_cargo_bdd_raw(args)?;
@@ -103,9 +98,7 @@ fn run_cargo_bdd_failure(args: &[&str]) -> Result<String> {
     Ok(stderr)
 }
 
-fn run_cargo_bdd_steps() -> Result<String> {
-    run_cargo_bdd(&["steps"])
-}
+fn run_cargo_bdd_steps() -> Result<String> { run_cargo_bdd(&["steps"]) }
 
 #[test]
 #[serial]

--- a/crates/rstest-bdd-harness-gpui/Cargo.toml
+++ b/crates/rstest-bdd-harness-gpui/Cargo.toml
@@ -30,6 +30,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
+rstest-bdd-test-macros.workspace = true
 rstest-bdd.workspace = true
 rstest-bdd-harness = { workspace = true, features = ["testing"] }
 rstest-bdd-macros.workspace = true

--- a/crates/rstest-bdd-harness-gpui/src/gpui_harness/mod.rs
+++ b/crates/rstest-bdd-harness-gpui/src/gpui_harness/mod.rs
@@ -28,16 +28,23 @@
 //! `GpuiHarness::run`-driving test with `#[serial_test::serial]` so
 //! libtest cannot interleave them on the same process.
 
+use std::{
+    any::Any,
+    cell::RefCell,
+    io::{self, Write},
+    panic::{self, AssertUnwindSafe},
+    sync::{Mutex, PoisonError},
+};
+
 use gpui::TestAppContext;
 use rstest_bdd::panic_message;
 use rstest_bdd_harness::{
-    HarnessAdapter, HarnessResult, ScenarioMetadata, ScenarioRunRequest, ScenarioRunner,
+    HarnessAdapter,
+    HarnessResult,
+    ScenarioMetadata,
+    ScenarioRunRequest,
+    ScenarioRunner,
 };
-use std::any::Any;
-use std::cell::RefCell;
-use std::io::{self, Write};
-use std::panic::{self, AssertUnwindSafe};
-use std::sync::{Mutex, PoisonError};
 
 /// Executes scenario runners inside the GPUI test harness.
 ///
@@ -49,16 +56,16 @@ use std::sync::{Mutex, PoisonError};
 /// # Examples
 ///
 /// ```
-/// use rstest_bdd_harness::{HarnessAdapter, ScenarioMetadata, ScenarioRunRequest, ScenarioRunner};
+/// use rstest_bdd_harness::{
+///     HarnessAdapter,
+///     ScenarioMetadata,
+///     ScenarioRunRequest,
+///     ScenarioRunner,
+/// };
 /// use rstest_bdd_harness_gpui::GpuiHarness;
 ///
 /// let request = ScenarioRunRequest::new(
-///     ScenarioMetadata::new(
-///         "tests/features/demo.feature",
-///         "GPUI scenario",
-///         5,
-///         vec![],
-///     ),
+///     ScenarioMetadata::new("tests/features/demo.feature", "GPUI scenario", 5, vec![]),
 ///     ScenarioRunner::new(|cx: gpui::TestAppContext| cx.test_function_name().is_none()),
 /// );
 ///
@@ -83,17 +90,13 @@ struct ContextCleanup<'a> {
 }
 
 impl Drop for ContextCleanup<'_> {
-    fn drop(&mut self) {
-        GpuiHarness::finish_context(self.dispatcher, self.context);
-    }
+    fn drop(&mut self) { GpuiHarness::finish_context(self.dispatcher, self.context); }
 }
 
 impl GpuiHarness {
     /// Creates a new GPUI harness instance.
     #[must_use]
-    pub const fn new() -> Self {
-        Self
-    }
+    pub const fn new() -> Self { Self }
 
     /// Runs a single GPUI scenario request, dispatching through `gpui::run_test`.
     ///
@@ -185,8 +188,7 @@ impl GpuiHarness {
             .take();
         let Some(runner) = runner else {
             panic!(
-                "rstest-bdd-harness-gpui: scenario runner invoked more than once: \
-                 {scenario_name}"
+                "rstest-bdd-harness-gpui: scenario runner invoked more than once: {scenario_name}"
             );
         };
         runner.run(context)
@@ -223,7 +225,7 @@ impl GpuiHarness {
         let Some(output) = output else {
             panic!(
                 "rstest-bdd-harness-gpui: test harness produced no scenario result: \
-                {scenario_name}"
+                 {scenario_name}"
             );
         };
         output

--- a/crates/rstest-bdd-harness-gpui/src/gpui_harness/tests.rs
+++ b/crates/rstest-bdd-harness-gpui/src/gpui_harness/tests.rs
@@ -28,6 +28,7 @@ use rstest_bdd_harness::{HarnessAdapter, ScenarioMetadata, ScenarioRunRequest, S
 
 use super::GpuiHarness;
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn harness() -> GpuiHarness { GpuiHarness::new() }
 

--- a/crates/rstest-bdd-harness-gpui/src/gpui_harness/tests.rs
+++ b/crates/rstest-bdd-harness-gpui/src/gpui_harness/tests.rs
@@ -7,35 +7,29 @@
 //! into two strands:
 //!
 //! - **Adapter behaviour:** [`gpui_harness_runs_request`] and
-//!   [`gpui_test_context_is_available_during_run`] drive
-//!   [`super::GpuiHarness::run`] end-to-end against `gpui::run_test`, so
-//!   they take a `#[serial_test::serial]` guard to honour the GPUI
-//!   single-thread requirement (see the parent module docs for the full
-//!   constraint).
-//! - **Panic-path helpers:**
-//!   [`augmented_panic_message_includes_scenario_name_for_payload_type`]
-//!   is an `rstest`-parametrized test that covers all three downcast arms
-//!   of [`super::GpuiHarness::augmented_panic_message`] (owned `String`,
-//!   `&'static str`, and an opaque `Debug`-only payload).
-//!   [`write_stderr_diagnostic_to_returns_err_on_broken_pipe`] asserts
-//!   that [`super::GpuiHarness::write_stderr_diagnostic_to`] surfaces an
-//!   `Err` rather than panicking when the writer reports `BrokenPipe`.
-//!   Neither helper test touches GPUI runtime state, so they run in
-//!   parallel without serialization.
+//!   [`gpui_test_context_is_available_during_run`] drive [`super::GpuiHarness::run`] end-to-end
+//!   against `gpui::run_test`, so they take a `#[serial_test::serial]` guard to honour the GPUI
+//!   single-thread requirement (see the parent module docs for the full constraint).
+//! - **Panic-path helpers:** [`augmented_panic_message_includes_scenario_name_for_payload_type`] is
+//!   an `rstest`-parametrized test that covers all three downcast arms of
+//!   [`super::GpuiHarness::augmented_panic_message`] (owned `String`, `&'static str`, and an opaque
+//!   `Debug`-only payload). [`write_stderr_diagnostic_to_returns_err_on_broken_pipe`] asserts that
+//!   [`super::GpuiHarness::write_stderr_diagnostic_to`] surfaces an `Err` rather than panicking
+//!   when the writer reports `BrokenPipe`. Neither helper test touches GPUI runtime state, so they
+//!   run in parallel without serialization.
 
 /// An opaque panic-payload type that is neither `String` nor `&str`, used to
 /// exercise the fallback downcast arm of `augmented_panic_message`.
 #[derive(Debug)]
 struct OpaquePayload;
 
-use super::GpuiHarness;
 use rstest::{fixture, rstest};
 use rstest_bdd_harness::{HarnessAdapter, ScenarioMetadata, ScenarioRunRequest, ScenarioRunner};
 
+use super::GpuiHarness;
+
 #[fixture]
-fn harness() -> GpuiHarness {
-    GpuiHarness::new()
-}
+fn harness() -> GpuiHarness { GpuiHarness::new() }
 
 #[rstest]
 #[serial_test::serial]
@@ -126,9 +120,7 @@ fn write_stderr_diagnostic_to_returns_err_on_broken_pipe() {
             Err(io::Error::from(io::ErrorKind::BrokenPipe))
         }
         /// Succeeds without flushing because no bytes were written.
-        fn flush(&mut self) -> io::Result<()> {
-            Ok(())
-        }
+        fn flush(&mut self) -> io::Result<()> { Ok(()) }
     }
 
     let result = GpuiHarness::write_stderr_diagnostic_to(&mut BrokenPipeWriter, "test message");

--- a/crates/rstest-bdd-harness-gpui/src/lib.rs
+++ b/crates/rstest-bdd-harness-gpui/src/lib.rs
@@ -10,7 +10,15 @@ mod policy;
 pub use gpui_harness::GpuiHarness;
 pub use policy::GpuiAttributePolicy;
 pub use rstest_bdd_harness::{
-    AttributePolicy, HarnessAdapter, HarnessError, HarnessResult, ScenarioMetadata,
-    ScenarioRunRequest, ScenarioRunner, StdScenarioRunRequest, StdScenarioRunner, TestAttribute,
+    AttributePolicy,
+    HarnessAdapter,
+    HarnessError,
+    HarnessResult,
+    ScenarioMetadata,
+    ScenarioRunRequest,
+    ScenarioRunner,
+    StdScenarioRunRequest,
+    StdScenarioRunner,
+    TestAttribute,
     tracing,
 };

--- a/crates/rstest-bdd-harness-gpui/src/policy.rs
+++ b/crates/rstest-bdd-harness-gpui/src/policy.rs
@@ -25,9 +25,7 @@ const GPUI_TEST_ATTRIBUTES: [TestAttribute; 2] = [
 ];
 
 impl AttributePolicy for GpuiAttributePolicy {
-    fn test_attributes() -> &'static [TestAttribute] {
-        &GPUI_TEST_ATTRIBUTES
-    }
+    fn test_attributes() -> &'static [TestAttribute] { &GPUI_TEST_ATTRIBUTES }
 }
 
 // The attribute-policy conformance check lives in

--- a/crates/rstest-bdd-harness-gpui/tests/harness_behaviour.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/harness_behaviour.rs
@@ -28,6 +28,7 @@ fn run_gpui_harness<T>(request: ScenarioRunRequest<'_, gpui::TestAppContext, T>)
     }
 }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn default_metadata() -> ScenarioMetadata { ScenarioMetadata::default() }
 

--- a/crates/rstest-bdd-harness-gpui/tests/harness_behaviour.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/harness_behaviour.rs
@@ -1,15 +1,20 @@
 //! Behavioural tests for GPUI harness adapter execution semantics.
 #![cfg(feature = "native-gpui-tests")]
 
+use std::{cell::Cell, io, rc::Rc};
+
 use rstest::{fixture, rstest};
 use rstest_bdd_harness::{
-    HarnessAdapter, HarnessError, HarnessResult, ScenarioMetadata, ScenarioRunRequest,
-    ScenarioRunner, StdScenarioRunRequest, StdScenarioRunner,
+    HarnessAdapter,
+    HarnessError,
+    HarnessResult,
+    ScenarioMetadata,
+    ScenarioRunRequest,
+    ScenarioRunner,
+    StdScenarioRunRequest,
+    StdScenarioRunner,
 };
 use rstest_bdd_harness_gpui::GpuiHarness;
-use std::cell::Cell;
-use std::io;
-use std::rc::Rc;
 
 /// Runs a [`GpuiHarness`] with `request`, returning the runner's output.
 ///
@@ -24,9 +29,7 @@ fn run_gpui_harness<T>(request: ScenarioRunRequest<'_, gpui::TestAppContext, T>)
 }
 
 #[fixture]
-fn default_metadata() -> ScenarioMetadata {
-    ScenarioMetadata::default()
-}
+fn default_metadata() -> ScenarioMetadata { ScenarioMetadata::default() }
 
 #[rstest]
 fn gpui_harness_executes_runner_once(default_metadata: ScenarioMetadata) {

--- a/crates/rstest-bdd-harness-gpui/tests/harness_led_defaults.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/harness_led_defaults.rs
@@ -69,6 +69,7 @@ mod native {
         fn drop(&mut self) { reset_context_pointer(); }
     }
 
+    #[rstest_bdd_test_macros::allow_fixture_expansion_lints]
     #[fixture]
     fn context_pointer_cleanup() -> ContextPointerCleanup {
         // Reset before the scenario assigns its own address so a reused serial

--- a/crates/rstest-bdd-harness-gpui/tests/harness_led_defaults.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/harness_led_defaults.rs
@@ -5,18 +5,16 @@
 //! these run unconditionally under `cargo test` / `nextest` and assert
 //! observable runtime behaviour:
 //!
-//! - A harness whose `HarnessAdapter::run` returns `Err` propagates the
-//!   `harness failed to initialize scenario: ...` panic emitted by the
-//!   expanded macro, and the scenario body never runs. This path needs no
-//!   native GPUI runtime, so it is not feature-gated.
-//! - `harness = GpuiHarness` without `attributes = ...` runs through the
-//!   inferred `GpuiAttributePolicy` path with a live `TestAppContext`. This
-//!   requires the native GPUI test runtime, so it shares the
-//!   `native-gpui-tests` gate (and `#[serial]` discipline) with the rest of
-//!   the GPUI scenario suite. Cross-step context identity is proved through a
-//!   single recorded address whose lifetime is owned by a fixture guard, so
-//!   success, failure, and skip paths all clear it before the next serial
-//!   scenario runs — the same reset protocol as `tests/stateful_window.rs`.
+//! - A harness whose `HarnessAdapter::run` returns `Err` propagates the `harness failed to
+//!   initialize scenario: ...` panic emitted by the expanded macro, and the scenario body never
+//!   runs. This path needs no native GPUI runtime, so it is not feature-gated.
+//! - `harness = GpuiHarness` without `attributes = ...` runs through the inferred
+//!   `GpuiAttributePolicy` path with a live `TestAppContext`. This requires the native GPUI test
+//!   runtime, so it shares the `native-gpui-tests` gate (and `#[serial]` discipline) with the rest
+//!   of the GPUI scenario suite. Cross-step context identity is proved through a single recorded
+//!   address whose lifetime is owned by a fixture guard, so success, failure, and skip paths all
+//!   clear it before the next serial scenario runs — the same reset protocol as
+//!   `tests/stateful_window.rs`.
 
 use rstest_bdd_macros::{given, scenario};
 
@@ -39,10 +37,11 @@ failing_harness_error_path_scenario!();
 mod native {
     //! Inferred-policy coverage that drives the real GPUI test runtime.
 
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use rstest::fixture;
     use rstest_bdd_macros::{given, scenario, then, when};
     use serial_test::serial;
-    use std::sync::atomic::{AtomicUsize, Ordering};
 
     /// Address of the `TestAppContext` the harness injected into the current
     /// scenario, recorded solely so later steps can assert pointer identity.
@@ -60,18 +59,14 @@ mod native {
 
     const UNSET_CONTEXT_POINTER: usize = 0;
 
-    fn reset_context_pointer() {
-        CONTEXT_POINTER.store(UNSET_CONTEXT_POINTER, Ordering::SeqCst);
-    }
+    fn reset_context_pointer() { CONTEXT_POINTER.store(UNSET_CONTEXT_POINTER, Ordering::SeqCst); }
 
     /// Fixture guard that resets [`CONTEXT_POINTER`] around each scenario.
     #[derive(Clone, Debug)]
     struct ContextPointerCleanup;
 
     impl Drop for ContextPointerCleanup {
-        fn drop(&mut self) {
-            reset_context_pointer();
-        }
+        fn drop(&mut self) { reset_context_pointer(); }
     }
 
     #[fixture]

--- a/crates/rstest-bdd-harness-gpui/tests/macro_compile.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/macro_compile.rs
@@ -4,23 +4,22 @@
 //! package can be published without resolving GPUI-specific dev-dependencies.
 #![cfg(feature = "native-gpui-tests")]
 
-use std::fs;
-use std::path::PathBuf;
+use std::{fs, path::PathBuf};
 
-use rstest_bdd_harness::macrotest_support::{
-    assert_snapshot_contains, assert_snapshot_omits, snapshot_refresh_is_enabled,
-    trybuild_crate_root,
+use rstest_bdd_harness::{
+    macrotest_support::{
+        assert_snapshot_contains,
+        assert_snapshot_omits,
+        snapshot_refresh_is_enabled,
+        trybuild_crate_root,
+    },
+    trybuild_staging::{copy_dir_tree, copy_file},
 };
-use rstest_bdd_harness::trybuild_staging::{copy_dir_tree, copy_file};
 use serial_test::serial;
 
-fn crate_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-}
+fn crate_root() -> PathBuf { PathBuf::from(env!("CARGO_MANIFEST_DIR")) }
 
-fn fixture_path(relative: &str) -> PathBuf {
-    crate_root().join(relative)
-}
+fn fixture_path(relative: &str) -> PathBuf { crate_root().join(relative) }
 
 #[test]
 #[serial]

--- a/crates/rstest-bdd-harness-gpui/tests/scenario_macros.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/scenario_macros.rs
@@ -2,9 +2,10 @@
 //! harness adapter and attribute policy.
 #![cfg(feature = "native-gpui-tests")]
 
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
 use rstest_bdd_macros::{given, scenario, scenarios, then, when};
 use serial_test::serial;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 static CONTEXT_POINTER: AtomicUsize = AtomicUsize::new(0);
 static CONTEXT_MUTATED: AtomicBool = AtomicBool::new(false);
@@ -73,9 +74,7 @@ fn gpui_context_was_harness_provided_not_attribute_provided(
 }
 
 #[given("a plain GPUI policy scenario runs")]
-fn plain_gpui_policy_scenario_runs() {
-    GPUI_POLICY_RAN.store(true, Ordering::SeqCst);
-}
+fn plain_gpui_policy_scenario_runs() { GPUI_POLICY_RAN.store(true, Ordering::SeqCst); }
 
 #[then("the plain GPUI policy scenario completed")]
 fn plain_gpui_policy_scenario_completed() {

--- a/crates/rstest-bdd-harness-gpui/tests/scenario_name_in_logs.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/scenario_name_in_logs.rs
@@ -5,23 +5,30 @@
 //! feature-file line number so developers can orientate failures quickly.
 #![cfg(feature = "native-gpui-tests")]
 
+use std::{
+    fmt,
+    panic::{AssertUnwindSafe, catch_unwind, panic_any},
+    process::Command,
+    sync::{Arc, Mutex},
+};
+
 use rstest::rstest;
 use rstest_bdd::panic_message;
 use rstest_bdd_harness::{
-    HarnessAdapter, HarnessResult, ScenarioMetadata, ScenarioRunRequest, ScenarioRunner,
+    HarnessAdapter,
+    HarnessResult,
+    ScenarioMetadata,
+    ScenarioRunRequest,
+    ScenarioRunner,
 };
 use rstest_bdd_harness_gpui::GpuiHarness;
 use serial_test::serial;
-use std::fmt;
-use std::panic::{AssertUnwindSafe, catch_unwind, panic_any};
-use std::process::Command;
-use std::sync::{Arc, Mutex};
-use tracing::field::{Field, Visit};
-use tracing::{Event, Subscriber};
-use tracing_subscriber::layer::Context;
-use tracing_subscriber::prelude::*;
-use tracing_subscriber::{Layer, Registry};
-
+use tracing::{
+    Event,
+    Subscriber,
+    field::{Field, Visit},
+};
+use tracing_subscriber::{Layer, Registry, layer::Context, prelude::*};
 const FEATURE_PATH: &str = "tests/features/scenario_name_in_logs.feature";
 const FAILING_SCENARIO: &str = "Step panics with augmented diagnostic";
 const SCENARIO_LINE: u32 = 7;
@@ -298,8 +305,7 @@ fn augmented_message_includes_scenario_name_for_opaque_any_payload() {
     #[derive(Debug)]
     #[expect(
         dead_code,
-        reason = "field only exists to produce an opaque Any payload; \
-                  see ExecPlan 10.1.4"
+        reason = "field only exists to produce an opaque Any payload; see ExecPlan 10.1.4"
     )]
     struct CustomPayload(u32);
 

--- a/crates/rstest-bdd-harness-gpui/tests/stateful_window.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/stateful_window.rs
@@ -11,11 +11,12 @@
 //! not leak stale handles into the next serial GPUI scenario.
 #![cfg(feature = "native-gpui-tests")]
 
+use std::cell::RefCell;
+
 use proptest::prelude::*;
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 use serial_test::serial;
-use std::cell::RefCell;
 
 #[derive(Clone, Debug, Default)]
 struct CounterView {
@@ -48,9 +49,7 @@ fn reset_state_after_scenario() {
 struct ScenarioStateCleanup;
 
 impl Drop for ScenarioStateCleanup {
-    fn drop(&mut self) {
-        reset_state_after_scenario();
-    }
+    fn drop(&mut self) { reset_state_after_scenario(); }
 }
 
 #[fixture]

--- a/crates/rstest-bdd-harness-gpui/tests/stateful_window.rs
+++ b/crates/rstest-bdd-harness-gpui/tests/stateful_window.rs
@@ -52,6 +52,7 @@ impl Drop for ScenarioStateCleanup {
     fn drop(&mut self) { reset_state_after_scenario(); }
 }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn scenario_state_cleanup() -> ScenarioStateCleanup {
     reset_state_before_assignment();

--- a/crates/rstest-bdd-harness-tokio/Cargo.toml
+++ b/crates/rstest-bdd-harness-tokio/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { version = "1", features = ["rt"] }
 
 [dev-dependencies]
 rstest.workspace = true
+rstest-bdd-test-macros.workspace = true
 rstest-bdd.workspace = true
 rstest-bdd-harness = { workspace = true, features = ["testing"] }
 rstest-bdd-macros.workspace = true

--- a/crates/rstest-bdd-harness-tokio/src/lib.rs
+++ b/crates/rstest-bdd-harness-tokio/src/lib.rs
@@ -10,8 +10,16 @@ mod tokio_harness;
 
 pub use policy::TokioAttributePolicy;
 pub use rstest_bdd_harness::{
-    AttributePolicy, HarnessAdapter, HarnessError, HarnessResult, ScenarioMetadata,
-    ScenarioRunRequest, ScenarioRunner, StdScenarioRunRequest, StdScenarioRunner, TestAttribute,
+    AttributePolicy,
+    HarnessAdapter,
+    HarnessError,
+    HarnessResult,
+    ScenarioMetadata,
+    ScenarioRunRequest,
+    ScenarioRunner,
+    StdScenarioRunRequest,
+    StdScenarioRunner,
+    TestAttribute,
     tracing,
 };
 pub use tokio_context::TokioTestContext;

--- a/crates/rstest-bdd-harness-tokio/src/policy.rs
+++ b/crates/rstest-bdd-harness-tokio/src/policy.rs
@@ -30,9 +30,7 @@ const TOKIO_TEST_ATTRIBUTES: [TestAttribute; 2] = [
 ];
 
 impl AttributePolicy for TokioAttributePolicy {
-    fn test_attributes() -> &'static [TestAttribute] {
-        &TOKIO_TEST_ATTRIBUTES
-    }
+    fn test_attributes() -> &'static [TestAttribute] { &TOKIO_TEST_ATTRIBUTES }
 }
 
 #[cfg(test)]
@@ -43,8 +41,9 @@ mod tests {
     //! shared conformance check in `rstest-bdd-harness`; only the expected
     //! rendered attributes are crate-specific.
 
-    use super::TokioAttributePolicy;
     use rstest_bdd_harness::policy_conformance::assert_attribute_policy_conformance;
+
+    use super::TokioAttributePolicy;
 
     #[test]
     fn tokio_policy_conforms_to_attribute_policy_contract() {

--- a/crates/rstest-bdd-harness-tokio/src/tokio_context.rs
+++ b/crates/rstest-bdd-harness-tokio/src/tokio_context.rs
@@ -10,13 +10,11 @@ use tokio::runtime::Handle;
 /// # Examples
 ///
 /// ```
-/// use rstest_bdd_macros::given;
 /// use rstest_bdd_harness_tokio::TokioTestContext;
+/// use rstest_bdd_macros::given;
 ///
 /// #[given("a background task is spawned")]
-/// async fn spawn_background_task(
-///     #[from(rstest_bdd_harness_context)] context: &TokioTestContext,
-/// ) {
+/// async fn spawn_background_task(#[from(rstest_bdd_harness_context)] context: &TokioTestContext) {
 ///     let task = context.handle().spawn(async { 2 + 2 });
 ///     assert_eq!(task.await.expect("background task should complete"), 4);
 /// }
@@ -41,9 +39,7 @@ impl TokioTestContext {
 
     /// Returns a reference to the Tokio runtime handle.
     #[must_use]
-    pub const fn handle(&self) -> &Handle {
-        &self.handle
-    }
+    pub const fn handle(&self) -> &Handle { &self.handle }
 }
 
 #[cfg(test)]

--- a/crates/rstest-bdd-harness-tokio/src/tokio_harness.rs
+++ b/crates/rstest-bdd-harness-tokio/src/tokio_harness.rs
@@ -87,6 +87,7 @@ mod tests {
 
     use super::{TokioHarness, TokioTestContext};
 
+    #[rstest_bdd_test_macros::allow_fixture_expansion_lints]
     #[fixture]
     fn harness() -> TokioHarness { TokioHarness::new() }
 

--- a/crates/rstest-bdd-harness-tokio/src/tokio_harness.rs
+++ b/crates/rstest-bdd-harness-tokio/src/tokio_harness.rs
@@ -1,7 +1,8 @@
 //! Tokio current-thread harness adapter for scenario execution.
 
-use crate::tokio_context::TokioTestContext;
 use rstest_bdd_harness::{HarnessAdapter, HarnessError, HarnessResult, ScenarioRunRequest};
+
+use crate::tokio_context::TokioTestContext;
 
 /// Executes scenario runners inside a Tokio current-thread runtime with a
 /// [`LocalSet`](tokio::task::LocalSet).
@@ -25,21 +26,22 @@ use rstest_bdd_harness::{HarnessAdapter, HarnessError, HarnessResult, ScenarioRu
 ///
 /// ```
 /// use rstest_bdd_harness::{
-///     HarnessAdapter, ScenarioMetadata, ScenarioRunRequest, ScenarioRunner,
+///     HarnessAdapter,
+///     ScenarioMetadata,
+///     ScenarioRunRequest,
+///     ScenarioRunner,
 /// };
 /// use rstest_bdd_harness_tokio::{TokioHarness, TokioTestContext};
 ///
 /// let request = ScenarioRunRequest::new(
-///     ScenarioMetadata::new(
-///         "tests/features/demo.feature",
-///         "Async scenario",
-///         5,
-///         vec![],
-///     ),
+///     ScenarioMetadata::new("tests/features/demo.feature", "Async scenario", 5, vec![]),
 ///     ScenarioRunner::new(|_context: TokioTestContext| 2 + 2),
 /// );
 /// let harness = TokioHarness::new();
-/// assert_eq!(harness.run(request).expect("tokio harness should not fail"), 4);
+/// assert_eq!(
+///     harness.run(request).expect("tokio harness should not fail"),
+///     4
+/// );
 /// ```
 #[derive(Debug, Clone, Copy, Default)]
 pub struct TokioHarness;
@@ -47,9 +49,7 @@ pub struct TokioHarness;
 impl TokioHarness {
     /// Creates a new Tokio harness instance.
     #[must_use]
-    pub const fn new() -> Self {
-        Self
-    }
+    pub const fn new() -> Self { Self }
 }
 
 impl HarnessAdapter for TokioHarness {
@@ -77,16 +77,18 @@ impl HarnessAdapter for TokioHarness {
 mod tests {
     //! Unit tests for the Tokio current-thread harness.
 
-    use super::{TokioHarness, TokioTestContext};
     use rstest::{fixture, rstest};
     use rstest_bdd_harness::{
-        HarnessAdapter, ScenarioMetadata, ScenarioRunRequest, ScenarioRunner,
+        HarnessAdapter,
+        ScenarioMetadata,
+        ScenarioRunRequest,
+        ScenarioRunner,
     };
 
+    use super::{TokioHarness, TokioTestContext};
+
     #[fixture]
-    fn harness() -> TokioHarness {
-        TokioHarness::new()
-    }
+    fn harness() -> TokioHarness { TokioHarness::new() }
 
     fn run_expecting_ok<T>(
         harness: TokioHarness,

--- a/crates/rstest-bdd-harness-tokio/tests/harness_behaviour.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/harness_behaviour.rs
@@ -1,19 +1,20 @@
 //! Behavioural tests for Tokio harness adapter execution semantics.
 
+use std::{cell::Cell, io, rc::Rc};
+
 use rstest::{fixture, rstest};
 use rstest_bdd_harness::{
-    HarnessAdapter, HarnessError, HarnessResult, ScenarioMetadata, ScenarioRunRequest,
+    HarnessAdapter,
+    HarnessError,
+    HarnessResult,
+    ScenarioMetadata,
+    ScenarioRunRequest,
     ScenarioRunner,
 };
 use rstest_bdd_harness_tokio::{TokioHarness, TokioTestContext};
-use std::cell::Cell;
-use std::io;
-use std::rc::Rc;
 
 #[fixture]
-fn default_metadata() -> ScenarioMetadata {
-    ScenarioMetadata::default()
-}
+fn default_metadata() -> ScenarioMetadata { ScenarioMetadata::default() }
 
 /// Runs `request` through a freshly-constructed [`TokioHarness`] and returns
 /// the value on success, or panics with a diagnostic message on failure.
@@ -45,9 +46,7 @@ fn tokio_harness_executes_runner_once(default_metadata: ScenarioMetadata) {
 struct RuntimeBuildFailureProbeHarness;
 
 impl RuntimeBuildFailureProbeHarness {
-    fn new(_inner: TokioHarness) -> Self {
-        Self
-    }
+    fn new(_inner: TokioHarness) -> Self { Self }
 }
 
 impl HarnessAdapter for RuntimeBuildFailureProbeHarness {

--- a/crates/rstest-bdd-harness-tokio/tests/harness_behaviour.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/harness_behaviour.rs
@@ -13,6 +13,7 @@ use rstest_bdd_harness::{
 };
 use rstest_bdd_harness_tokio::{TokioHarness, TokioTestContext};
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn default_metadata() -> ScenarioMetadata { ScenarioMetadata::default() }
 

--- a/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
@@ -5,15 +5,13 @@
 //! these run unconditionally under `cargo test` / `nextest` and assert
 //! observable runtime behaviour:
 //!
-//! - `harness = TokioHarness` without `attributes = ...` runs through the
-//!   inferred `TokioAttributePolicy` path with a live current-thread runtime
-//!   and `LocalSet`.
-//! - A harness whose `HarnessAdapter::run` returns `Err` propagates the
-//!   `harness failed to initialize scenario: ...` panic emitted by the
-//!   expanded macro, and the scenario body never runs.
-//! - Pairing steps that rely on the harness contract with an attribute
-//!   policy alone fails loudly (a `LocalSet` panic from `spawn_local`), not
-//!   silently.
+//! - `harness = TokioHarness` without `attributes = ...` runs through the inferred
+//!   `TokioAttributePolicy` path with a live current-thread runtime and `LocalSet`.
+//! - A harness whose `HarnessAdapter::run` returns `Err` propagates the `harness failed to
+//!   initialize scenario: ...` panic emitted by the expanded macro, and the scenario body never
+//!   runs.
+//! - Pairing steps that rely on the harness contract with an attribute policy alone fails loudly (a
+//!   `LocalSet` panic from `spawn_local`), not silently.
 
 use std::sync::Arc;
 
@@ -35,9 +33,7 @@ struct LocalTaskState {
 }
 
 #[fixture]
-fn local_task_state() -> LocalTaskState {
-    LocalTaskState::default()
-}
+fn local_task_state() -> LocalTaskState { LocalTaskState::default() }
 
 #[given("the inferred Tokio runtime is active")]
 fn inferred_runtime_is_active(#[from(rstest_bdd_harness_context)] context: &TokioTestContext) {

--- a/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/harness_led_defaults.rs
@@ -32,6 +32,7 @@ struct LocalTaskState {
     handle: Slot<tokio::task::JoinHandle<u32>>,
 }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn local_task_state() -> LocalTaskState { LocalTaskState::default() }
 

--- a/crates/rstest-bdd-harness-tokio/tests/macro_compile.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/macro_compile.rs
@@ -5,20 +5,20 @@
 
 use std::path::PathBuf;
 
-use rstest_bdd_harness::macrotest_support::{
-    assert_snapshot_contains, assert_snapshot_omits, snapshot_refresh_is_enabled,
-    trybuild_crate_root,
+use rstest_bdd_harness::{
+    macrotest_support::{
+        assert_snapshot_contains,
+        assert_snapshot_omits,
+        snapshot_refresh_is_enabled,
+        trybuild_crate_root,
+    },
+    trybuild_staging::copy_file,
 };
-use rstest_bdd_harness::trybuild_staging::copy_file;
 use serial_test::serial;
 
-fn crate_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-}
+fn crate_root() -> PathBuf { PathBuf::from(env!("CARGO_MANIFEST_DIR")) }
 
-fn fixture_path(relative: &str) -> PathBuf {
-    crate_root().join(relative)
-}
+fn fixture_path(relative: &str) -> PathBuf { crate_root().join(relative) }
 
 #[test]
 #[serial]

--- a/crates/rstest-bdd-harness-tokio/tests/runtime_compat_alias.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/runtime_compat_alias.rs
@@ -12,14 +12,10 @@ use rstest_bdd_macros::{given, scenarios, then, when};
 static RUNTIME_ALIAS_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 #[given("a runtime alias counter initialized to 0")]
-fn runtime_alias_counter_init() {
-    RUNTIME_ALIAS_COUNTER.store(0, Ordering::SeqCst);
-}
+fn runtime_alias_counter_init() { RUNTIME_ALIAS_COUNTER.store(0, Ordering::SeqCst); }
 
 #[when("the runtime alias counter is incremented synchronously")]
-fn runtime_alias_counter_increment() {
-    RUNTIME_ALIAS_COUNTER.fetch_add(1, Ordering::SeqCst);
-}
+fn runtime_alias_counter_increment() { RUNTIME_ALIAS_COUNTER.fetch_add(1, Ordering::SeqCst); }
 
 #[then(expr = "the runtime alias counter value is {n}")]
 fn runtime_alias_counter_value(n: usize) {

--- a/crates/rstest-bdd-harness-tokio/tests/scenario_macros.rs
+++ b/crates/rstest-bdd-harness-tokio/tests/scenario_macros.rs
@@ -2,11 +2,9 @@
 //! Tokio harness adapter and attribute policy.
 //!
 //! These tests prove end-to-end that:
-//! - `TokioHarness` provides an active Tokio current-thread runtime during
-//!   step execution.
+//! - `TokioHarness` provides an active Tokio current-thread runtime during step execution.
 //! - `TokioAttributePolicy` can be combined with `TokioHarness`.
-//! - `spawn_local` succeeds in step functions, confirming the `LocalSet` +
-//!   `current_thread` wiring.
+//! - `spawn_local` succeeds in step functions, confirming the `LocalSet` + `current_thread` wiring.
 
 use rstest_bdd_harness_tokio::TokioTestContext;
 use rstest_bdd_macros::{given, scenario, scenarios, then, when};
@@ -18,9 +16,7 @@ fn tokio_runtime_is_active() {
 }
 
 #[when("a Tokio handle is obtained")]
-fn tokio_handle_is_obtained() {
-    let _handle = tokio::runtime::Handle::current();
-}
+fn tokio_handle_is_obtained() { let _handle = tokio::runtime::Handle::current(); }
 
 #[then("the handle confirms current-thread execution")]
 fn handle_confirms_current_thread() {
@@ -64,9 +60,7 @@ fn injected_tokio_context_proves_harness_ownership(
 }
 
 #[then("the Tokio runtime remains available")]
-fn tokio_runtime_remains_available() {
-    let _handle = tokio::runtime::Handle::current();
-}
+fn tokio_runtime_remains_available() { let _handle = tokio::runtime::Handle::current(); }
 
 /// Tests `#[scenario]` with `harness = TokioHarness` only.
 ///

--- a/crates/rstest-bdd-harness/Cargo.toml
+++ b/crates/rstest-bdd-harness/Cargo.toml
@@ -31,5 +31,6 @@ rstest-bdd-harness = { path = ".", features = ["testing"] }
 insta.workspace = true
 proptest.workspace = true
 rstest.workspace = true
+rstest-bdd-test-macros.workspace = true
 temp-env.workspace = true
 tempfile.workspace = true

--- a/crates/rstest-bdd-harness/src/binary_test_support.rs
+++ b/crates/rstest-bdd-harness/src/binary_test_support.rs
@@ -4,10 +4,12 @@
 //! These utilities are exposed as a hidden module for test use only and are
 //! not part of the supported public API.
 
-use std::env;
-use std::fmt;
-use std::path::{Path, PathBuf};
-use std::process::{Command, ExitStatus, Output};
+use std::{
+    env,
+    fmt,
+    path::{Path, PathBuf},
+    process::{Command, ExitStatus, Output},
+};
 
 use thiserror::Error;
 
@@ -21,27 +23,19 @@ pub struct BinaryName<'a>(&'a str);
 impl<'a> BinaryName<'a> {
     /// Creates a `BinaryName` from the given string slice.
     #[must_use]
-    pub const fn new(name: &'a str) -> Self {
-        Self(name)
-    }
+    pub const fn new(name: &'a str) -> Self { Self(name) }
 
     /// Returns the binary name as a string slice.
     #[must_use]
-    pub const fn as_str(self) -> &'a str {
-        self.0
-    }
+    pub const fn as_str(self) -> &'a str { self.0 }
 }
 
 impl<'a> From<&'a str> for BinaryName<'a> {
-    fn from(s: &'a str) -> Self {
-        Self(s)
-    }
+    fn from(s: &'a str) -> Self { Self(s) }
 }
 
 impl std::fmt::Display for BinaryName<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.0)
-    }
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { f.write_str(self.0) }
 }
 
 /// Captured output from `cargo build --bin` when it exits unsuccessfully.
@@ -123,7 +117,8 @@ fn try_command_from_cargo_test_bin_layout(binary_name: BinaryName<'_>) -> Option
 ///
 /// ```
 /// use std::path::Path;
-/// use rstest_bdd_harness::binary_test_support::{binary_path_in_target_dir, BinaryName};
+///
+/// use rstest_bdd_harness::binary_test_support::{BinaryName, binary_path_in_target_dir};
 ///
 /// let path = binary_path_in_target_dir(Path::new("/tmp/ws/target"), BinaryName::new("my-bin"));
 /// let suffix = std::env::consts::EXE_SUFFIX;
@@ -148,6 +143,7 @@ pub fn binary_path_in_target_dir(target_directory: &Path, binary_name: BinaryNam
 ///
 /// ```no_run
 /// use std::path::Path;
+///
 /// use rstest_bdd_harness::binary_test_support::target_directory_for_manifest;
 ///
 /// let target = target_directory_for_manifest(Path::new("Cargo.toml")).expect("metadata");
@@ -170,20 +166,23 @@ pub fn target_directory_for_manifest(
 ///
 /// ```no_run
 /// use std::path::Path;
-/// use rstest_bdd_harness::binary_test_support::{locate_or_build_binary, BinaryName};
 ///
-/// let cmd = locate_or_build_binary(Path::new("Cargo.toml"), Path::new("."), BinaryName::new("my-bin"))
-///     .expect("locate binary");
+/// use rstest_bdd_harness::binary_test_support::{BinaryName, locate_or_build_binary};
+///
+/// let cmd = locate_or_build_binary(
+///     Path::new("Cargo.toml"),
+///     Path::new("."),
+///     BinaryName::new("my-bin"),
+/// )
+/// .expect("locate binary");
 /// let _ = cmd;
 /// ```
 ///
 /// Strategy:
-/// 1. Try the path implied by `CARGO_BIN_EXE_<binary_name>` (and the same
-///    `current_exe` fallback used by `assert_cmd`'s `cargo_bin` helper).
-/// 2. On failure, resolve the expected debug binary path via
-///    `target_directory_for_manifest`.
-/// 3. If the binary is absent, invoke `build_binary` and surface stdout/stderr
-///    on failure.
+/// 1. Try the path implied by `CARGO_BIN_EXE_<binary_name>` (and the same `current_exe` fallback
+///    used by `assert_cmd`'s `cargo_bin` helper).
+/// 2. On failure, resolve the expected debug binary path via `target_directory_for_manifest`.
+/// 3. If the binary is absent, invoke `build_binary` and surface stdout/stderr on failure.
 /// 4. Return `Command::new(binary)` when the binary is present.
 pub fn locate_or_build_binary(
     manifest_path: &Path,
@@ -222,7 +221,8 @@ pub fn locate_or_build_binary(
 ///
 /// ```no_run
 /// use std::path::Path;
-/// use rstest_bdd_harness::binary_test_support::{build_binary, BinaryName};
+///
+/// use rstest_bdd_harness::binary_test_support::{BinaryName, build_binary};
 ///
 /// let output = build_binary(Path::new("."), BinaryName::new("some-bin")).expect("spawn cargo");
 /// assert!(output.status.success() || !output.stderr.is_empty());

--- a/crates/rstest-bdd-harness/src/error.rs
+++ b/crates/rstest-bdd-harness/src/error.rs
@@ -47,27 +47,19 @@ impl HarnessErrorContext {
 
     /// Returns the original typed harness error.
     #[must_use]
-    pub const fn error(&self) -> &HarnessError {
-        &self.error
-    }
+    pub const fn error(&self) -> &HarnessError { &self.error }
 
     /// Returns the feature path for the scenario that failed to initialize.
     #[must_use]
-    pub fn feature_path(&self) -> &str {
-        &self.feature_path
-    }
+    pub fn feature_path(&self) -> &str { &self.feature_path }
 
     /// Returns the scenario name that failed to initialize.
     #[must_use]
-    pub fn scenario_name(&self) -> &str {
-        &self.scenario_name
-    }
+    pub fn scenario_name(&self) -> &str { &self.scenario_name }
 
     /// Consumes this wrapper and returns the original typed error.
     #[must_use]
-    pub fn into_error(self) -> HarnessError {
-        self.error
-    }
+    pub fn into_error(self) -> HarnessError { self.error }
 }
 
 impl fmt::Display for HarnessErrorContext {
@@ -81,9 +73,7 @@ impl fmt::Display for HarnessErrorContext {
 }
 
 impl std::error::Error for HarnessErrorContext {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(&self.error)
-    }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.error) }
 }
 
 impl HarnessError {
@@ -102,9 +92,9 @@ impl HarnessError {
 mod tests {
     //! Unit tests for harness error formatting and source chaining.
 
+    use std::{error::Error, io};
+
     use super::HarnessError;
-    use std::error::Error;
-    use std::io;
 
     #[test]
     fn runtime_build_failed_display_includes_io_error_message() {

--- a/crates/rstest-bdd-harness/src/lib.rs
+++ b/crates/rstest-bdd-harness/src/lib.rs
@@ -24,7 +24,11 @@ pub use adapter::HarnessAdapter;
 pub use error::{HarnessError, HarnessResult};
 pub use policy::{AttributePolicy, DefaultAttributePolicy, TestAttribute};
 pub use runner::{
-    ScenarioMetadata, ScenarioRunRequest, ScenarioRunner, StdScenarioRunRequest, StdScenarioRunner,
+    ScenarioMetadata,
+    ScenarioRunRequest,
+    ScenarioRunner,
+    StdScenarioRunRequest,
+    StdScenarioRunner,
 };
 pub use std_harness::StdHarness;
 #[cfg(feature = "testing")]

--- a/crates/rstest-bdd-harness/src/macrotest_support.rs
+++ b/crates/rstest-bdd-harness/src/macrotest_support.rs
@@ -12,10 +12,12 @@
 //! `CARGO_MANIFEST_DIR` resolves at compile time inside the caller crate;
 //! sharing the helpers via this module avoids that per-crate coupling.
 
-use std::error::Error;
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::{
+    error::Error,
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 /// Returns `true` when the macrotest refresh workflow is enabled.
 ///

--- a/crates/rstest-bdd-harness/src/policy.rs
+++ b/crates/rstest-bdd-harness/src/policy.rs
@@ -14,7 +14,10 @@
 /// assert_eq!(rstest.render(), "#[rstest::rstest]");
 ///
 /// let tokio = TestAttribute::with_arguments("tokio::test", "flavor = \"current_thread\"");
-/// assert_eq!(tokio.render(), "#[tokio::test(flavor = \"current_thread\")]");
+/// assert_eq!(
+///     tokio.render(),
+///     "#[tokio::test(flavor = \"current_thread\")]"
+/// );
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TestAttribute {
@@ -43,15 +46,11 @@ impl TestAttribute {
 
     /// Returns the attribute path.
     #[must_use]
-    pub const fn path(self) -> &'static str {
-        self.path
-    }
+    pub const fn path(self) -> &'static str { self.path }
 
     /// Returns optional argument payload.
     #[must_use]
-    pub const fn arguments(self) -> Option<&'static str> {
-        self.arguments
-    }
+    pub const fn arguments(self) -> Option<&'static str> { self.arguments }
 
     /// Renders the attribute as text for diagnostics and tests.
     #[must_use]
@@ -87,9 +86,7 @@ pub struct DefaultAttributePolicy;
 const DEFAULT_TEST_ATTRIBUTES: [TestAttribute; 1] = [TestAttribute::new("rstest::rstest")];
 
 impl AttributePolicy for DefaultAttributePolicy {
-    fn test_attributes() -> &'static [TestAttribute] {
-        &DEFAULT_TEST_ATTRIBUTES
-    }
+    fn test_attributes() -> &'static [TestAttribute] { &DEFAULT_TEST_ATTRIBUTES }
 }
 
 #[cfg(test)]

--- a/crates/rstest-bdd-harness/src/policy_conformance.rs
+++ b/crates/rstest-bdd-harness/src/policy_conformance.rs
@@ -16,12 +16,11 @@ const RSTEST_ATTRIBUTE_PATH: &str = "rstest::rstest";
 ///
 /// The check pins three invariants shared by every first-party policy:
 ///
-/// 1. **Emit** — the policy emits exactly `expected_rendered.len()`
-///    attributes.
-/// 2. **Render** — each attribute renders to the corresponding entry of
-///    `expected_rendered`, in order.
-/// 3. **rstest is first** — the first attribute path is `rstest::rstest`, so
-///    fixture expansion precedes the runtime-specific test macro.
+/// 1. **Emit** — the policy emits exactly `expected_rendered.len()` attributes.
+/// 2. **Render** — each attribute renders to the corresponding entry of `expected_rendered`, in
+///    order.
+/// 3. **rstest is first** — the first attribute path is `rstest::rstest`, so fixture expansion
+///    precedes the runtime-specific test macro.
 ///
 /// # Panics
 ///
@@ -31,8 +30,10 @@ const RSTEST_ATTRIBUTE_PATH: &str = "rstest::rstest";
 /// # Examples
 ///
 /// ```
-/// use rstest_bdd_harness::DefaultAttributePolicy;
-/// use rstest_bdd_harness::policy_conformance::assert_attribute_policy_conformance;
+/// use rstest_bdd_harness::{
+///     DefaultAttributePolicy,
+///     policy_conformance::assert_attribute_policy_conformance,
+/// };
 ///
 /// assert_attribute_policy_conformance::<DefaultAttributePolicy>(&["#[rstest::rstest]"]);
 /// ```
@@ -93,30 +94,22 @@ mod tests {
 
     struct GoodPolicy;
     impl AttributePolicy for GoodPolicy {
-        fn test_attributes() -> &'static [TestAttribute] {
-            &GOOD
-        }
+        fn test_attributes() -> &'static [TestAttribute] { &GOOD }
     }
 
     struct WrongCountPolicy;
     impl AttributePolicy for WrongCountPolicy {
-        fn test_attributes() -> &'static [TestAttribute] {
-            &WRONG_COUNT
-        }
+        fn test_attributes() -> &'static [TestAttribute] { &WRONG_COUNT }
     }
 
     struct WrongRenderPolicy;
     impl AttributePolicy for WrongRenderPolicy {
-        fn test_attributes() -> &'static [TestAttribute] {
-            &WRONG_RENDER
-        }
+        fn test_attributes() -> &'static [TestAttribute] { &WRONG_RENDER }
     }
 
     struct RstestNotFirstPolicy;
     impl AttributePolicy for RstestNotFirstPolicy {
-        fn test_attributes() -> &'static [TestAttribute] {
-            &RSTEST_NOT_FIRST
-        }
+        fn test_attributes() -> &'static [TestAttribute] { &RSTEST_NOT_FIRST }
     }
 
     #[test]

--- a/crates/rstest-bdd-harness/src/runner.rs
+++ b/crates/rstest-bdd-harness/src/runner.rs
@@ -43,33 +43,23 @@ impl ScenarioMetadata {
 
     /// Returns the feature path.
     #[must_use]
-    pub fn feature_path(&self) -> &str {
-        &self.feature_path
-    }
+    pub fn feature_path(&self) -> &str { &self.feature_path }
 
     /// Returns the scenario name.
     #[must_use]
-    pub fn scenario_name(&self) -> &str {
-        &self.scenario_name
-    }
+    pub fn scenario_name(&self) -> &str { &self.scenario_name }
 
     /// Returns the one-based line number in the feature file.
     #[must_use]
-    pub const fn scenario_line(&self) -> u32 {
-        self.scenario_line
-    }
+    pub const fn scenario_line(&self) -> u32 { self.scenario_line }
 
     /// Returns the scenario tags.
     #[must_use]
-    pub fn tags(&self) -> &[String] {
-        &self.tags
-    }
+    pub fn tags(&self) -> &[String] { &self.tags }
 }
 
 impl Default for ScenarioMetadata {
-    fn default() -> Self {
-        Self::new("<unknown>", "<unknown>", 1, Vec::new())
-    }
+    fn default() -> Self { Self::new("<unknown>", "<unknown>", 1, Vec::new()) }
 }
 
 /// A callable scenario runner closure owned by a harness.
@@ -97,9 +87,7 @@ impl<'a, C, T> ScenarioRunner<'a, C, T> {
 
     /// Executes the wrapped closure.
     #[must_use]
-    pub fn run(self, context: C) -> T {
-        (self.inner)(context)
-    }
+    pub fn run(self, context: C) -> T { (self.inner)(context) }
 }
 
 impl<'a, T> ScenarioRunner<'a, (), T> {
@@ -111,9 +99,7 @@ impl<'a, T> ScenarioRunner<'a, (), T> {
 
     /// Executes a unit-context runner without explicitly passing `()`.
     #[must_use]
-    pub fn run_without_context(self) -> T {
-        self.run(())
-    }
+    pub fn run_without_context(self) -> T { self.run(()) }
 }
 
 /// A harness execution request for one scenario.
@@ -143,9 +129,7 @@ impl<'a, C, T> ScenarioRunRequest<'a, C, T> {
 
     /// Returns immutable metadata for diagnostics or harness setup.
     #[must_use]
-    pub fn metadata(&self) -> &ScenarioMetadata {
-        &self.metadata
-    }
+    pub fn metadata(&self) -> &ScenarioMetadata { &self.metadata }
 
     /// Consumes the request and returns metadata and runner separately.
     #[must_use]
@@ -155,9 +139,7 @@ impl<'a, C, T> ScenarioRunRequest<'a, C, T> {
 
     /// Executes the runner with harness-provided context.
     #[must_use]
-    pub fn run(self, context: C) -> T {
-        self.runner.run(context)
-    }
+    pub fn run(self, context: C) -> T { self.runner.run(context) }
 }
 
 impl<'a, T> ScenarioRunRequest<'a, (), T> {
@@ -172,9 +154,7 @@ impl<'a, T> ScenarioRunRequest<'a, (), T> {
 
     /// Executes a unit-context request without explicitly passing `()`.
     #[must_use]
-    pub fn run_without_context(self) -> T {
-        self.run(())
-    }
+    pub fn run_without_context(self) -> T { self.run(()) }
 }
 
 /// Type alias for the common unit-context runner case.
@@ -187,9 +167,9 @@ pub type StdScenarioRunRequest<'a, T> = ScenarioRunRequest<'a, (), T>;
 mod tests {
     //! Unit tests for scenario metadata and runner primitives.
 
+    use std::{cell::Cell, rc::Rc};
+
     use super::{ScenarioMetadata, ScenarioRunRequest, ScenarioRunner};
-    use std::cell::Cell;
-    use std::rc::Rc;
 
     #[test]
     fn metadata_default_is_unknown() {

--- a/crates/rstest-bdd-harness/src/std_harness.rs
+++ b/crates/rstest-bdd-harness/src/std_harness.rs
@@ -1,7 +1,6 @@
 //! Default synchronous harness implementation.
 
-use crate::runner::StdScenarioRunRequest;
-use crate::{HarnessAdapter, HarnessResult};
+use crate::{HarnessAdapter, HarnessResult, runner::StdScenarioRunRequest};
 
 /// Framework-agnostic synchronous harness.
 ///
@@ -13,9 +12,7 @@ pub struct StdHarness;
 impl StdHarness {
     /// Creates a new synchronous harness instance.
     #[must_use]
-    pub const fn new() -> Self {
-        Self
-    }
+    pub const fn new() -> Self { Self }
 }
 
 impl HarnessAdapter for StdHarness {
@@ -35,15 +32,17 @@ mod tests {
     use rstest::{fixture, rstest};
 
     use super::StdHarness;
-    use crate::test_utils::{STD_HARNESS_PANIC_MESSAGE, panic_payload_matches};
     use crate::{
-        HarnessAdapter, ScenarioMetadata, ScenarioRunner, StdScenarioRunRequest, StdScenarioRunner,
+        HarnessAdapter,
+        ScenarioMetadata,
+        ScenarioRunner,
+        StdScenarioRunRequest,
+        StdScenarioRunner,
+        test_utils::{STD_HARNESS_PANIC_MESSAGE, panic_payload_matches},
     };
 
     #[fixture]
-    fn harness() -> StdHarness {
-        StdHarness::new()
-    }
+    fn harness() -> StdHarness { StdHarness::new() }
 
     #[fixture]
     fn metadata() -> ScenarioMetadata {

--- a/crates/rstest-bdd-harness/src/std_harness.rs
+++ b/crates/rstest-bdd-harness/src/std_harness.rs
@@ -41,9 +41,11 @@ mod tests {
         test_utils::{STD_HARNESS_PANIC_MESSAGE, panic_payload_matches},
     };
 
+    #[rstest_bdd_test_macros::allow_fixture_expansion_lints]
     #[fixture]
     fn harness() -> StdHarness { StdHarness::new() }
 
+    #[rstest_bdd_test_macros::allow_fixture_expansion_lints]
     #[fixture]
     fn metadata() -> ScenarioMetadata {
         ScenarioMetadata::new(

--- a/crates/rstest-bdd-harness/src/trybuild_staging/mod.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/mod.rs
@@ -5,9 +5,11 @@
 //! behaviour. They are exposed as a hidden module for those tests only and are
 //! not part of the supported public API.
 
-use std::fs;
-use std::io;
-use std::path::{Path, PathBuf};
+use std::{
+    fs,
+    io,
+    path::{Path, PathBuf},
+};
 
 #[cfg(test)]
 mod tests;
@@ -18,14 +20,19 @@ mod prop_tests;
 /// Copies a single file, creating parent directories as needed.
 ///
 /// ```
-/// use std::fs;
-/// use std::time::{SystemTime, UNIX_EPOCH};
+/// use std::{
+///     fs,
+///     time::{SystemTime, UNIX_EPOCH},
+/// };
 ///
 /// use rstest_bdd_harness::trybuild_staging::copy_file;
 ///
 /// let root = std::env::temp_dir().join(format!(
 ///     "{}_{}_{}",
-///     concat!("rstest_bdd_trybuild_staging_copy_file_doc_", env!("CARGO_PKG_NAME")),
+///     concat!(
+///         "rstest_bdd_trybuild_staging_copy_file_doc_",
+///         env!("CARGO_PKG_NAME")
+///     ),
 ///     std::process::id(),
 ///     SystemTime::now()
 ///         .duration_since(UNIX_EPOCH)
@@ -125,9 +132,7 @@ fn canonical_missing_destination(destination: &Path) -> io::Result<PathBuf> {
     Ok(apply_missing_tail(base, destination))
 }
 
-fn paths_overlap(a: &Path, b: &Path) -> bool {
-    a == b || a.starts_with(b) || b.starts_with(a)
-}
+fn paths_overlap(a: &Path, b: &Path) -> bool { a == b || a.starts_with(b) || b.starts_with(a) }
 
 /// Rejects paths where `copy_dir_tree` would call `remove_destination` on a tree
 /// that still contains (or equals) the source directory.
@@ -154,14 +159,19 @@ fn reject_overlapping_copy_dir_tree_paths(source: &Path, destination: &Path) -> 
 /// malicious or accidental link cannot escape the tree or create copy loops.
 ///
 /// ```
-/// use std::fs;
-/// use std::time::{SystemTime, UNIX_EPOCH};
+/// use std::{
+///     fs,
+///     time::{SystemTime, UNIX_EPOCH},
+/// };
 ///
 /// use rstest_bdd_harness::trybuild_staging::copy_dir_tree;
 ///
 /// let root = std::env::temp_dir().join(format!(
 ///     "{}_{}_{}",
-///     concat!("rstest_bdd_trybuild_staging_copy_dir_doc_", env!("CARGO_PKG_NAME")),
+///     concat!(
+///         "rstest_bdd_trybuild_staging_copy_dir_doc_",
+///         env!("CARGO_PKG_NAME")
+///     ),
 ///     std::process::id(),
 ///     SystemTime::now()
 ///         .duration_since(UNIX_EPOCH)
@@ -176,10 +186,7 @@ fn reject_overlapping_copy_dir_tree_paths(source: &Path, destination: &Path) -> 
 /// copy_dir_tree(&src, &dst).expect("failed to copy dir tree");
 /// let out = dst.join("inner").join("note.txt");
 /// assert!(out.exists());
-/// assert_eq!(
-///     fs::read(&out).expect("failed to read destination"),
-///     b"tree"
-/// );
+/// assert_eq!(fs::read(&out).expect("failed to read destination"), b"tree");
 /// let _ = fs::remove_dir_all(&root);
 /// ```
 ///
@@ -188,8 +195,10 @@ fn reject_overlapping_copy_dir_tree_paths(source: &Path, destination: &Path) -> 
 /// ```
 /// # #[cfg(unix)]
 /// # {
-/// use std::fs;
-/// use std::time::{SystemTime, UNIX_EPOCH};
+/// use std::{
+///     fs,
+///     time::{SystemTime, UNIX_EPOCH},
+/// };
 ///
 /// use rstest_bdd_harness::trybuild_staging::copy_dir_tree;
 ///
@@ -211,8 +220,7 @@ fn reject_overlapping_copy_dir_tree_paths(source: &Path, destination: &Path) -> 
 /// let target = root.join("escape.txt");
 /// fs::create_dir_all(&src).expect("failed to create src");
 /// fs::write(&target, b"secret").expect("failed to write target");
-/// std::os::unix::fs::symlink(&target, src.join("link.txt"))
-///     .expect("failed to create symlink");
+/// std::os::unix::fs::symlink(&target, src.join("link.txt")).expect("failed to create symlink");
 /// let err = copy_dir_tree(&src, &dst).expect_err("copy_dir_tree should reject symlink");
 /// assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
 /// let _ = fs::remove_dir_all(&root);

--- a/crates/rstest-bdd-harness/src/trybuild_staging/prop_tests.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/prop_tests.rs
@@ -4,10 +4,12 @@
 //! destination paths are canonicalized and destination overlaps are detected
 //! before a copy can create or remove the wrong tree.
 
-use std::fs;
-use std::os::unix::fs::symlink;
-use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    fs,
+    os::unix::fs::symlink,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use proptest::prelude::*;
 

--- a/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
@@ -13,6 +13,7 @@ struct CopyFileStaging {
     dst: PathBuf,
 }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn copy_file_staging() -> io::Result<CopyFileStaging> {
     let root = TempDir::new()?;
@@ -53,6 +54,7 @@ struct OverlapCheckStaging {
     src: PathBuf,
 }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn overlap_check_staging() -> io::Result<OverlapCheckStaging> {
     let (root, src, _dst) = make_src_dst_scaffold()?;
@@ -61,6 +63,7 @@ fn overlap_check_staging() -> io::Result<OverlapCheckStaging> {
     Ok(OverlapCheckStaging { root, src })
 }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn replace_dir_staging() -> io::Result<ReplaceDstStaging> {
     let (root, src, dst) = make_src_dst_scaffold()?;
@@ -97,6 +100,7 @@ fn copy_dir_tree_creates_missing_destination_parents(
     assert!(nested_dst.join("sub").join("a.txt").exists());
 }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn replace_file_dest_staging() -> io::Result<ReplaceDstStaging> {
     let (root, src, dst) = make_src_dst_scaffold()?;
@@ -181,6 +185,7 @@ struct SymlinkInSourceStaging {
 }
 
 #[cfg(unix)]
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn symlink_in_source_staging() -> io::Result<SymlinkInSourceStaging> {
     use std::os::unix::fs::symlink;

--- a/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
+++ b/crates/rstest-bdd-harness/src/trybuild_staging/tests.rs
@@ -1,11 +1,8 @@
 //! Unit tests for [`super::copy_file`] and [`super::copy_dir_tree`] staging helpers.
 
-use std::fs;
-use std::io;
-use std::path::PathBuf;
+use std::{fs, io, path::PathBuf};
 
-use rstest::fixture;
-use rstest::rstest;
+use rstest::{fixture, rstest};
 use tempfile::TempDir;
 
 use super::{copy_dir_tree, copy_file};

--- a/crates/rstest-bdd-harness/tests/binary_test_support_cargo.rs
+++ b/crates/rstest-bdd-harness/tests/binary_test_support_cargo.rs
@@ -8,12 +8,17 @@
 
 #![cfg(unix)]
 
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use rstest_bdd_harness::binary_test_support::{
-    BinaryLocateError, BinaryName, build_binary, locate_or_build_binary,
+    BinaryLocateError,
+    BinaryName,
+    build_binary,
+    locate_or_build_binary,
     target_directory_for_manifest,
 };
 
@@ -80,7 +85,8 @@ fn build_binary_returns_err_for_nonexistent_workspace() {
     let result = build_binary(&workspace, BinaryName::new("nonexistent-binary"));
     assert!(
         result.is_err(),
-        "expected build_binary to fail when the workspace directory does not exist, got: {result:?}"
+        "expected build_binary to fail when the workspace directory does not exist, got: \
+         {result:?}"
     );
 }
 

--- a/crates/rstest-bdd-harness/tests/harness_behaviour.rs
+++ b/crates/rstest-bdd-harness/tests/harness_behaviour.rs
@@ -1,14 +1,25 @@
 //! Behavioural tests for harness adapter execution semantics.
 
+use std::{
+    cell::Cell,
+    io,
+    panic::{AssertUnwindSafe, catch_unwind},
+    rc::Rc,
+};
+
 use rstest::{fixture, rstest};
 use rstest_bdd_harness::{
-    FailingHarness, HarnessAdapter, HarnessError, HarnessResult, ScenarioMetadata,
-    ScenarioRunRequest, ScenarioRunner, StdHarness, StdScenarioRunRequest, StdScenarioRunner,
+    FailingHarness,
+    HarnessAdapter,
+    HarnessError,
+    HarnessResult,
+    ScenarioMetadata,
+    ScenarioRunRequest,
+    ScenarioRunner,
+    StdHarness,
+    StdScenarioRunRequest,
+    StdScenarioRunner,
 };
-use std::cell::Cell;
-use std::io;
-use std::panic::{AssertUnwindSafe, catch_unwind};
-use std::rc::Rc;
 
 #[path = "../src/test_utils.rs"]
 mod test_utils;
@@ -16,9 +27,7 @@ mod test_utils;
 use test_utils::{STD_HARNESS_PANIC_MESSAGE, panic_payload_matches};
 
 #[fixture]
-fn default_metadata() -> ScenarioMetadata {
-    ScenarioMetadata::default()
-}
+fn default_metadata() -> ScenarioMetadata { ScenarioMetadata::default() }
 
 #[derive(Debug)]
 struct MetadataProbeHarness {

--- a/crates/rstest-bdd-harness/tests/harness_behaviour.rs
+++ b/crates/rstest-bdd-harness/tests/harness_behaviour.rs
@@ -26,6 +26,7 @@ mod test_utils;
 
 use test_utils::{STD_HARNESS_PANIC_MESSAGE, panic_payload_matches};
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn default_metadata() -> ScenarioMetadata { ScenarioMetadata::default() }
 

--- a/crates/rstest-bdd-harness/tests/support/failing_harness_error_path.rs
+++ b/crates/rstest-bdd-harness/tests/support/failing_harness_error_path.rs
@@ -8,24 +8,22 @@ macro_rules! failing_harness_error_path_scenario {
         /// `harness failed to initialize scenario: ...` panic, carrying the
         /// underlying error and scenario context, and must not execute any step.
         #[scenario(
-            path = "tests/features/harness_led_defaults.feature",
-            name = "Failing harness initialization propagates",
-            harness = rstest_bdd_harness::FailingHarness,
-        )]
-        #[should_panic(
-            expected = "harness failed to initialize scenario: failed to build runtime: synthetic harness initialization failure"
-        )]
+                                            path = "tests/features/harness_led_defaults.feature",
+                                            name = "Failing harness initialization propagates",
+                                            harness = rstest_bdd_harness::FailingHarness,
+                                        )]
+        #[should_panic(expected = "harness failed to initialize scenario: failed to build \
+                                   runtime: synthetic harness initialization failure")]
         fn failing_harness_panics_with_meaningful_message() {}
 
         /// The wrapped harness error must retain feature and scenario context.
         #[scenario(
-            path = "tests/features/harness_led_defaults.feature",
-            name = "Failing harness initialization propagates",
-            harness = rstest_bdd_harness::FailingHarness,
-        )]
-        #[should_panic(
-            expected = "harness_led_defaults.feature, scenario: Failing harness initialization propagates)"
-        )]
+                                            path = "tests/features/harness_led_defaults.feature",
+                                            name = "Failing harness initialization propagates",
+                                            harness = rstest_bdd_harness::FailingHarness,
+                                        )]
+        #[should_panic(expected = "harness_led_defaults.feature, scenario: Failing harness \
+                                   initialization propagates)")]
         fn failing_harness_panic_includes_scenario_context() {}
     };
 }

--- a/crates/rstest-bdd-macros/Cargo.toml
+++ b/crates/rstest-bdd-macros/Cargo.toml
@@ -46,6 +46,7 @@ thiserror.workspace = true
 [dev-dependencies]
 proptest.workspace = true
 rstest.workspace = true
+rstest-bdd-test-macros.workspace = true
 serial_test.workspace = true
 tempfile.workspace = true
 

--- a/crates/rstest-bdd-macros/src/codegen/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/mod.rs
@@ -41,15 +41,11 @@ const GPUI_HARNESS: CrateSpec = CrateSpec {
 };
 
 /// Return a token stream pointing to the `rstest_bdd` crate or its renamed form.
-pub(crate) fn rstest_bdd_path() -> TokenStream2 {
-    resolve_crate_path(&RSTEST_BDD)
-}
+pub(crate) fn rstest_bdd_path() -> TokenStream2 { resolve_crate_path(&RSTEST_BDD) }
 
 /// Return a token stream pointing to the `rstest_bdd_harness` crate or its
 /// renamed form.
-pub(crate) fn rstest_bdd_harness_path() -> TokenStream2 {
-    resolve_crate_path(&RSTEST_BDD_HARNESS)
-}
+pub(crate) fn rstest_bdd_harness_path() -> TokenStream2 { resolve_crate_path(&RSTEST_BDD_HARNESS) }
 
 /// Try to return a token stream pointing to the requested crate or renamed
 /// dependency without panicking when the consumer does not depend on it.
@@ -65,9 +61,7 @@ fn try_resolve_crate_path(spec: &CrateSpec) -> Option<TokenStream2> {
 /// Used by the `runtime = "tokio-current-thread"` compatibility alias to
 /// resolve `TokioHarness` via proper crate lookup, supporting downstream
 /// crates that rename the dependency in their `Cargo.toml`.
-pub(crate) fn rstest_bdd_harness_tokio_path() -> TokenStream2 {
-    resolve_crate_path(&TOKIO_HARNESS)
-}
+pub(crate) fn rstest_bdd_harness_tokio_path() -> TokenStream2 { resolve_crate_path(&TOKIO_HARNESS) }
 
 /// Return the crate root that provides base harness API for the given harness
 /// or attribute-policy path.
@@ -124,7 +118,8 @@ fn emit_first_party_adapter_fallback_warning(adapter_path: &syn::Path) {
     emit_warning!(
         span,
         concat!(
-            "rstest-bdd could not identify this harness or attribute-policy path as a first-party adapter; ",
+            "rstest-bdd could not identify this harness or attribute-policy path as a first-party \
+             adapter; ",
             "falling back to `rstest-bdd-harness` for base harness API types. ",
             "Use the canonical crate-root path, ensure `{}` is directly resolvable as `{}`, ",
             "or add `rstest-bdd-harness` as a direct dev-dependency."
@@ -216,13 +211,19 @@ fn handle_missing_crate(spec: &CrateSpec, err: &proc_macro_crate::Error) -> Toke
 mod tests {
     //! Unit tests for shared code generation utilities.
 
-    use super::{
-        GPUI_HARNESS, RSTEST_BDD, RSTEST_BDD_HARNESS, TOKIO_HARNESS, handle_missing_crate,
-    };
+    use std::path::PathBuf;
+
     use proc_macro_crate::Error;
     use proptest::prelude::*;
     use rstest::rstest;
-    use std::path::PathBuf;
+
+    use super::{
+        GPUI_HARNESS,
+        RSTEST_BDD,
+        RSTEST_BDD_HARNESS,
+        TOKIO_HARNESS,
+        handle_missing_crate,
+    };
 
     fn not_found_error(crate_name: &str) -> Error {
         Error::CrateNotFound {

--- a/crates/rstest-bdd-macros/src/codegen/scenario/assertions.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/assertions.rs
@@ -1,0 +1,38 @@
+//! Compile-time contract assertions emitted beside generated scenarios.
+
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+
+/// Generate sibling assertions for configured harness and attribute-policy types.
+pub(super) fn generate_trait_assertions(
+    harness: Option<&syn::Path>,
+    attributes: Option<&syn::Path>,
+) -> TokenStream2 {
+    if harness.is_none() && attributes.is_none() {
+        return TokenStream2::new();
+    }
+
+    let harness_assertion = harness.map(|harness_path| {
+        let harness_crate = crate::codegen::rstest_bdd_harness_api_path_for(harness_path);
+        quote! {
+            const _: () = {
+                fn __assert_harness<T: #harness_crate::HarnessAdapter + Default>() {}
+                fn __call() { __assert_harness::<#harness_path>(); }
+            };
+        }
+    });
+    let attributes_assertion = attributes.map(|policy_path| {
+        let harness_crate = crate::codegen::rstest_bdd_harness_api_path_for(policy_path);
+        quote! {
+            const _: () = {
+                fn __assert_attr_policy<T: #harness_crate::AttributePolicy>() {}
+                fn __call() { __assert_attr_policy::<#policy_path>(); }
+            };
+        }
+    });
+
+    quote! {
+        #harness_assertion
+        #attributes_assertion
+    }
+}

--- a/crates/rstest-bdd-macros/src/codegen/scenario/helpers.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/helpers.rs
@@ -38,9 +38,7 @@ fn cell_to_lit(value: &str) -> syn::LitStr {
 }
 
 /// Returns true when an Examples row contains at least one non-empty cell.
-pub(crate) fn row_has_values(row: &[String]) -> bool {
-    row.iter().any(|cell| !cell.is_empty())
-}
+pub(crate) fn row_has_values(row: &[String]) -> bool { row.iter().any(|cell| !cell.is_empty()) }
 
 /// Returns true when any parameter uses an underscore-prefixed identifier.
 ///
@@ -358,9 +356,10 @@ pub(crate) fn process_steps_substituted(
 mod tests {
     //! Unit tests for scenario code generation helpers.
 
-    use super::*;
     use rstest::rstest;
     use syn::parse_quote;
+
+    use super::*;
 
     #[rstest]
     #[case(parse_quote! { fn test(_state: State) }, true)]

--- a/crates/rstest-bdd-macros/src/codegen/scenario/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/mod.rs
@@ -4,50 +4,61 @@
 //! BDD scenario or scenario outline. The pipeline is partitioned across
 //! five focused sub-modules:
 //!
-//! - [`domain`] — domain types shared across the pipeline (`StepText`,
-//!   `ExampleHeaders`, `ExampleRow`, and `Docstring`).
+//! - [`domain`] — domain types shared across the pipeline (`StepText`, `ExampleHeaders`,
+//!   `ExampleRow`, and `Docstring`).
 //! - [`helpers`] — step-processing utilities and case-attribute generators.
-//! - [`metadata`] — strongly-typed wrappers for feature-path and
-//!   scenario-name values used in generated code.
-//! - [`runtime`] — token generation for the async runtime wrapper and the
-//!   harness-orchestrated `ScenarioRunRequest`.
-//! - [`test_attrs`] — ADR-008 attribute-policy resolution, translating
-//!   harness and runtime-mode hints into the correct set of test attributes
-//!   (`#[rstest::rstest]`, `#[tokio::test]`, `#[gpui::test]`).
+//! - [`metadata`] — strongly-typed wrappers for feature-path and scenario-name values used in
+//!   generated code.
+//! - [`runtime`] — token generation for the async runtime wrapper and the harness-orchestrated
+//!   `ScenarioRunRequest`.
+//! - [`test_attrs`] — ADR-008 attribute-policy resolution, translating harness and runtime-mode
+//!   hints into the correct set of test attributes (`#[rstest::rstest]`, `#[tokio::test]`,
+//!   `#[gpui::test]`).
 //!
 //! Public entry points are [`generate_scenario`] and
 //! [`generate_scenario_outline`], which delegate to the internal helpers
 //! after resolving compile-time trait assertions via
 //! [`crate::codegen::rstest_bdd_harness_api_path_for`].
 
+use std::borrow::Cow;
+
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use std::borrow::Cow;
 
+mod assertions;
 mod domain;
 mod helpers;
 mod metadata;
 mod runtime;
 mod test_attrs;
 
+use assertions::generate_trait_assertions;
 pub(crate) use domain::*;
 pub(crate) use helpers::process_steps;
 use helpers::{
-    generate_case_attrs, generate_indexed_case_attrs, generate_underscore_expect,
-    process_steps_substituted, row_has_values,
+    generate_case_attrs,
+    generate_indexed_case_attrs,
+    generate_underscore_expect,
+    process_steps_substituted,
+    row_has_values,
 };
 pub(crate) use metadata::{FeaturePath, ScenarioName};
 use runtime::{
-    OutlineTestTokensConfig, ProcessedSteps, ScenarioMetadata, TestTokensConfig,
-    generate_test_tokens, generate_test_tokens_outline,
+    OutlineTestTokensConfig,
+    ProcessedSteps,
+    ScenarioMetadata,
+    TestTokensConfig,
+    generate_test_tokens,
+    generate_test_tokens_outline,
 };
+use test_attrs::{TestAttrPolicy, generate_test_attrs_with_boundary};
 
 pub(crate) use crate::macros::scenarios::ScenariosRuntimeMode as RuntimeMode;
-use crate::macros::scenarios::ScenariosTestAttributeHint as TestAttributeHint;
-
-use crate::parsing::placeholder::contains_placeholders;
-use test_attrs::{TestAttrPolicy, generate_test_attrs_with_boundary};
+use crate::{
+    macros::scenarios::ScenariosTestAttributeHint as TestAttributeHint,
+    parsing::placeholder::contains_placeholders,
+};
 
 /// Return kinds supported by scenario bodies.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -57,9 +68,7 @@ pub(crate) enum ScenarioReturnKind {
 }
 
 impl ScenarioReturnKind {
-    pub(crate) fn is_fallible(self) -> bool {
-        matches!(self, Self::ResultUnit)
-    }
+    pub(crate) fn is_fallible(self) -> bool { matches!(self, Self::ResultUnit) }
 }
 
 /// Configuration for generating code for a single scenario test.
@@ -107,43 +116,6 @@ pub(crate) struct ContextConfig<P, I, Q> {
 
 pub(crate) fn scenario_allows_skip(tags: &[String]) -> bool {
     tags.iter().any(|tag| tag == "@allow_skipped")
-}
-
-/// Generate compile-time trait-bound const assertions for harness and attribute
-/// policy types. These are emitted as sibling items alongside the test function
-/// so they produce clear compiler errors when a type does not implement the
-/// required trait.
-fn generate_trait_assertions(
-    harness: Option<&syn::Path>,
-    attributes: Option<&syn::Path>,
-) -> TokenStream2 {
-    if harness.is_none() && attributes.is_none() {
-        return TokenStream2::new();
-    }
-
-    let harness_assertion = harness.map(|harness_path| {
-        let harness_crate = crate::codegen::rstest_bdd_harness_api_path_for(harness_path);
-        quote! {
-            const _: () = {
-                fn __assert_harness<T: #harness_crate::HarnessAdapter + Default>() {}
-                fn __call() { __assert_harness::<#harness_path>(); }
-            };
-        }
-    });
-    let attributes_assertion = attributes.map(|policy_path| {
-        let harness_crate = crate::codegen::rstest_bdd_harness_api_path_for(policy_path);
-        quote! {
-            const _: () = {
-                fn __assert_attr_policy<T: #harness_crate::AttributePolicy>() {}
-                fn __call() { __assert_attr_policy::<#policy_path>(); }
-            };
-        }
-    });
-
-    quote! {
-        #harness_assertion
-        #attributes_assertion
-    }
 }
 
 /// Checks if any step in the scenario contains placeholder tokens.
@@ -249,9 +221,9 @@ fn reject_async_harness(config: &ScenarioConfig<'_>) -> Option<TokenStream> {
 
     let err = syn::Error::new(
         proc_macro2::Span::call_site(),
-        "combining `harness` with `async fn` scenarios is not supported; \
-         use a synchronous scenario function with `TokioHarness` instead \
-         (the harness provides the Tokio runtime for step functions)",
+        "combining `harness` with `async fn` scenarios is not supported; use a synchronous \
+         scenario function with `TokioHarness` instead (the harness provides the Tokio runtime \
+         for step functions)",
     );
     Some(TokenStream::from(err.into_compile_error()))
 }

--- a/crates/rstest-bdd-macros/src/codegen/scenario/runtime/generators/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/runtime/generators/mod.rs
@@ -14,10 +14,13 @@ mod step;
 mod step_loop;
 
 pub(super) use outline::{
-    generate_async_step_executor_loop_outline, generate_step_executor_loop_outline,
+    generate_async_step_executor_loop_outline,
+    generate_step_executor_loop_outline,
 };
 pub(super) use scenario::{generate_scenario_guard, generate_skip_handler};
 pub(super) use step::{
-    generate_async_step_executor, generate_skip_extractor, generate_step_executor,
+    generate_async_step_executor,
+    generate_skip_extractor,
+    generate_step_executor,
 };
 pub(super) use step_loop::{generate_async_step_executor_loop, generate_step_executor_loop};

--- a/crates/rstest-bdd-macros/src/codegen/scenario/runtime/generators/outline.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/runtime/generators/outline.rs
@@ -8,9 +8,8 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 
-use crate::codegen::scenario::helpers::ProcessedStepTokens;
-
 use super::step_loop::generate_step_result_handler;
+use crate::codegen::scenario::helpers::ProcessedStepTokens;
 
 /// Generates a step executor loop for scenario outlines with placeholder substitution.
 ///
@@ -58,8 +57,8 @@ fn generate_step_executor_loop_outline_impl(
 ///
 /// # Arguments
 ///
-/// * `all_rows_steps` - A vector where each element contains the processed steps for
-///   one Examples row. Each inner tuple contains (keywords, values, docstrings, tables).
+/// * `all_rows_steps` - A vector where each element contains the processed steps for one Examples
+///   row. Each inner tuple contains (keywords, values, docstrings, tables).
 ///
 /// # Generated code
 ///
@@ -96,8 +95,8 @@ pub(in crate::codegen::scenario::runtime) fn generate_step_executor_loop_outline
 ///
 /// # Arguments
 ///
-/// * `all_rows_steps` - A vector where each element contains the processed steps for
-///   one Examples row. Each inner tuple contains (keywords, values, docstrings, tables).
+/// * `all_rows_steps` - A vector where each element contains the processed steps for one Examples
+///   row. Each inner tuple contains (keywords, values, docstrings, tables).
 ///
 /// # Generated code
 ///

--- a/crates/rstest-bdd-macros/src/codegen/scenario/runtime/generators/step.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/runtime/generators/step.rs
@@ -68,8 +68,9 @@ pub(in crate::codegen::scenario::runtime) fn generate_step_executor() -> TokenSt
 
 /// Generates the `__rstest_bdd_extract_skip_message` function.
 ///
-/// The generated function extracts the skip message from an [`rstest_bdd::execution::ExecutionError::Skip`]
-/// variant, returning `Some(Option<String>)` for skips and `None` for other errors.
+/// The generated function extracts the skip message from an
+/// [`rstest_bdd::execution::ExecutionError::Skip`] variant, returning `Some(Option<String>)` for
+/// skips and `None` for other errors.
 ///
 /// # Generated code
 ///

--- a/crates/rstest-bdd-macros/src/codegen/scenario/runtime/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/runtime/mod.rs
@@ -45,29 +45,19 @@ trait ScenarioTestConfig {
     fn metadata(&self) -> ScenarioMetadata<'_>;
 
     /// Extracts the common scenario metadata fields.
-    fn literals_input(&self) -> ScenarioLiteralsInput<'_> {
-        self.metadata().literals_input()
-    }
+    fn literals_input(&self) -> ScenarioLiteralsInput<'_> { self.metadata().literals_input() }
 
     /// Returns the test function block.
-    fn block(&self) -> &syn::Block {
-        self.metadata().block
-    }
+    fn block(&self) -> &syn::Block { self.metadata().block }
 
     /// Returns the return kind for the scenario body.
-    fn return_kind(&self) -> ScenarioReturnKind {
-        self.metadata().return_kind
-    }
+    fn return_kind(&self) -> ScenarioReturnKind { self.metadata().return_kind }
 
     /// Whether the scenario runs asynchronously.
-    fn is_async(&self) -> bool {
-        self.metadata().is_async
-    }
+    fn is_async(&self) -> bool { self.metadata().is_async }
 
     /// Returns the optional harness adapter type path for execution delegation.
-    fn harness(&self) -> Option<&syn::Path> {
-        self.metadata().harness
-    }
+    fn harness(&self) -> Option<&syn::Path> { self.metadata().harness }
 }
 
 impl ScenarioTestConfig for TestTokensConfig<'_> {
@@ -79,9 +69,7 @@ impl ScenarioTestConfig for TestTokensConfig<'_> {
         )
     }
 
-    fn metadata(&self) -> ScenarioMetadata<'_> {
-        self.metadata
-    }
+    fn metadata(&self) -> ScenarioMetadata<'_> { self.metadata }
 
     fn literals_input(&self) -> ScenarioLiteralsInput<'_> { self.metadata.literals_input() }
 
@@ -103,9 +91,7 @@ impl ScenarioTestConfig for OutlineTestTokensConfig<'_> {
         )
     }
 
-    fn metadata(&self) -> ScenarioMetadata<'_> {
-        self.metadata
-    }
+    fn metadata(&self) -> ScenarioMetadata<'_> { self.metadata }
 
     fn literals_input(&self) -> ScenarioLiteralsInput<'_> { self.metadata.literals_input() }
 

--- a/crates/rstest-bdd-macros/src/codegen/scenario/runtime/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/runtime/mod.rs
@@ -7,22 +7,26 @@ mod harness;
 mod tests;
 mod types;
 
-use proc_macro2::TokenStream as TokenStream2;
-use quote::quote;
-
-use crate::codegen::scenario::ScenarioReturnKind;
-
-use super::helpers::ProcessedStepTokens;
 use body::wrap_scenario_block;
 use generators::{
-    generate_async_step_executor, generate_async_step_executor_loop,
-    generate_async_step_executor_loop_outline, generate_scenario_guard, generate_skip_extractor,
-    generate_skip_handler, generate_step_executor, generate_step_executor_loop,
+    generate_async_step_executor,
+    generate_async_step_executor_loop,
+    generate_async_step_executor_loop_outline,
+    generate_scenario_guard,
+    generate_skip_extractor,
+    generate_skip_handler,
+    generate_step_executor,
+    generate_step_executor_loop,
     generate_step_executor_loop_outline,
 };
 use harness::assemble_test_tokens_with_harness;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
 use types::{CodeComponents, ScenarioLiterals, ScenarioLiteralsInput, TokenAssemblyContext};
 pub(crate) use types::{ProcessedSteps, ScenarioMetadata, TestTokensConfig};
+
+use super::helpers::ProcessedStepTokens;
+use crate::codegen::scenario::ScenarioReturnKind;
 
 /// Configuration for generating test tokens for scenario outlines.
 #[derive(Debug)]
@@ -78,6 +82,16 @@ impl ScenarioTestConfig for TestTokensConfig<'_> {
     fn metadata(&self) -> ScenarioMetadata<'_> {
         self.metadata
     }
+
+    fn literals_input(&self) -> ScenarioLiteralsInput<'_> { self.metadata.literals_input() }
+
+    fn block(&self) -> &syn::Block { self.metadata.block }
+
+    fn return_kind(&self) -> ScenarioReturnKind { self.metadata.return_kind }
+
+    fn is_async(&self) -> bool { self.metadata.is_async }
+
+    fn harness(&self) -> Option<&syn::Path> { self.metadata.harness }
 }
 
 impl ScenarioTestConfig for OutlineTestTokensConfig<'_> {
@@ -92,6 +106,16 @@ impl ScenarioTestConfig for OutlineTestTokensConfig<'_> {
     fn metadata(&self) -> ScenarioMetadata<'_> {
         self.metadata
     }
+
+    fn literals_input(&self) -> ScenarioLiteralsInput<'_> { self.metadata.literals_input() }
+
+    fn block(&self) -> &syn::Block { self.metadata.block }
+
+    fn return_kind(&self) -> ScenarioReturnKind { self.metadata.return_kind }
+
+    fn is_async(&self) -> bool { self.metadata.is_async }
+
+    fn harness(&self) -> Option<&syn::Path> { self.metadata.harness }
 }
 
 /// Context token stream iterators for test generation.

--- a/crates/rstest-bdd-macros/src/codegen/scenario/runtime/tests/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/runtime/tests/mod.rs
@@ -68,8 +68,8 @@ impl<'a> StepExecutorExpectation<'a> {
 /// # Arguments
 ///
 /// * `tokens` - The generated token stream to parse.
-/// * `expectation` - The expected runtime delegation; it provides the function
-///   name to find and a human-readable description for error messages.
+/// * `expectation` - The expected runtime delegation; it provides the function name to find and a
+///   human-readable description for error messages.
 fn assert_step_executor_delegates_to_runtime(
     tokens: proc_macro2::TokenStream,
     expectation: StepExecutorExpectation<'_>,

--- a/crates/rstest-bdd-macros/src/codegen/scenario/runtime/tests/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/runtime/tests/mod.rs
@@ -1,10 +1,13 @@
 //! Tests for runtime scaffolding code generation.
 
+use rstest::rstest;
+
 use super::generators::{
-    generate_async_step_executor, generate_skip_extractor, generate_step_executor,
+    generate_async_step_executor,
+    generate_skip_extractor,
+    generate_step_executor,
 };
 use crate::codegen::scenario::ScenarioReturnKind;
-use rstest::rstest;
 
 mod support;
 

--- a/crates/rstest-bdd-macros/src/codegen/scenario/runtime/tests/support.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/runtime/tests/support.rs
@@ -1,10 +1,9 @@
 //! Test support helpers for scenario runtime code generation.
 
-use crate::codegen::scenario::ScenarioReturnKind;
 use syn::visit::Visit;
 
-use super::super::generators::generate_skip_handler;
-use super::RuntimeFunction;
+use super::{super::generators::generate_skip_handler, RuntimeFunction};
+use crate::codegen::scenario::ScenarioReturnKind;
 
 /// Return the identifier of the final segment in a `syn::Path`.
 ///
@@ -177,9 +176,7 @@ struct ReturnFinder<'ast> {
 }
 
 impl<'ast> Visit<'ast> for ReturnFinder<'ast> {
-    fn visit_expr_return(&mut self, node: &'ast syn::ExprReturn) {
-        self.returns.push(node);
-    }
+    fn visit_expr_return(&mut self, node: &'ast syn::ExprReturn) { self.returns.push(node); }
 }
 
 /// Collect return expressions within a block.

--- a/crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/test_attrs.rs
@@ -4,13 +4,12 @@
 //! framework test attributes are emitted alongside `#[rstest::rstest]` for
 //! each generated test function:
 //!
-//! 1. An explicit `attributes = …` path supplied to the `#[scenario]` or
-//!    `#[scenarios]` macro takes highest precedence.
-//! 2. A `harness = …` path is consulted next; first-party adapter types
-//!    (`TokioHarness`, `GpuiHarness`) are recognized via
-//!    [`crate::codegen::first_party_adapter_attribute_hint`].
-//! 3. The `RuntimeMode` derived from `runtime = …` or the macro's defaults
-//!    provides the final fallback.
+//! 1. An explicit `attributes = …` path supplied to the `#[scenario]` or `#[scenarios]` macro takes
+//!    highest precedence.
+//! 2. A `harness = …` path is consulted next; first-party adapter types (`TokioHarness`,
+//!    `GpuiHarness`) are recognized via [`crate::codegen::first_party_adapter_attribute_hint`].
+//! 3. The `RuntimeMode` derived from `runtime = …` or the macro's defaults provides the final
+//!    fallback.
 //!
 //! The production surface is [`generate_test_attrs_with_boundary`] and
 //! [`TestAttrPolicy`].
@@ -20,12 +19,12 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use rstest_bdd_policy::{
-    resolve_test_attribute_hint_for_harness_path, resolve_test_attribute_hint_for_policy_path,
+    resolve_test_attribute_hint_for_harness_path,
+    resolve_test_attribute_hint_for_policy_path,
 };
 
-use crate::codegen::first_party_adapter_attribute_hint;
-
 use super::{RuntimeMode, TestAttributeHint};
+use crate::codegen::first_party_adapter_attribute_hint;
 
 /// Returns `true` when `attr` is exactly `<crate_name>::<fn_name>`.
 fn is_two_segment_attr(attr: &syn::Attribute, crate_name: &str, fn_name: &str) -> bool {
@@ -39,13 +38,9 @@ fn is_two_segment_attr(attr: &syn::Attribute, crate_name: &str, fn_name: &str) -
     segments.next().is_none() && first.ident == crate_name && second.ident == fn_name
 }
 
-fn is_tokio_test_attr(attr: &syn::Attribute) -> bool {
-    is_two_segment_attr(attr, "tokio", "test")
-}
+fn is_tokio_test_attr(attr: &syn::Attribute) -> bool { is_two_segment_attr(attr, "tokio", "test") }
 
-fn is_gpui_test_attr(attr: &syn::Attribute) -> bool {
-    is_two_segment_attr(attr, "gpui", "test")
-}
+fn is_gpui_test_attr(attr: &syn::Attribute) -> bool { is_two_segment_attr(attr, "gpui", "test") }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum PolicyAttribute {

--- a/crates/rstest-bdd-macros/src/codegen/scenario/tests/gpui_policy.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/tests/gpui_policy.rs
@@ -1,7 +1,10 @@
 //! GPUI-specific attribute policy tests for scenario test-attribute generation.
 
 use super::{
-    RuntimeMode, ScenarioReturnKind, TestAttrPolicy, adapt_fallible_gpui_boundary,
+    RuntimeMode,
+    ScenarioReturnKind,
+    TestAttrPolicy,
+    adapt_fallible_gpui_boundary,
     generate_test_attrs,
 };
 use crate::codegen::scenario::test_attrs::generate_test_attrs_with_boundary;
@@ -95,7 +98,8 @@ fn generate_test_attrs_dedupes_gpui_policy_and_user_attribute() {
     let gpui_count = output.match_indices("gpui :: test").count();
     assert_eq!(
         gpui_count, 1,
-        "expected exactly one gpui::test when both user attribute and policy are present, got {gpui_count}: {output}"
+        "expected exactly one gpui::test when both user attribute and policy are present, got \
+         {gpui_count}: {output}"
     );
 }
 

--- a/crates/rstest-bdd-macros/src/codegen/scenario/tests/harness_defaults.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/tests/harness_defaults.rs
@@ -1,17 +1,18 @@
 //! Tests for harness-led default attribute-policy precedence.
 
-use super::{RuntimeMode, TestAttrPolicy, generate_test_attrs};
 use quote::quote;
+
+use super::{RuntimeMode, TestAttrPolicy, generate_test_attrs};
 
 #[rstest::rstest]
 // This table protects the ADR-008 precedence order:
 //
-// 1. explicit `attributes = ...` wins, even when it names another first-party
-//    policy or an unknown policy;
+// 1. explicit `attributes = ...` wins, even when it names another first-party policy or an unknown
+//    policy;
 // 2. fully qualified first-party harness paths imply their matching defaults;
 // 3. unresolved or third-party-like harness paths fall back to the runtime; and
-// 4. `attributes = ...` without `harness = ...` keeps the attributes-only
-//    behaviour that existed before harness-led defaults.
+// 4. `attributes = ...` without `harness = ...` keeps the attributes-only behaviour that existed
+//    before harness-led defaults.
 #[case::tokio_harness_beats_sync_runtime(
     RuntimeMode::Sync,
     Some(parse_path!("rstest_bdd_harness_tokio::TokioHarness")),
@@ -137,12 +138,14 @@ fn generate_test_attrs_honours_harness_precedence(
     assert_eq!(
         output.contains("tokio :: test"),
         expect_tokio_test,
-        "tokio::test presence mismatch for runtime={runtime:?}, harness={harness_path:?}, policy={policy_path:?}: {output}"
+        "tokio::test presence mismatch for runtime={runtime:?}, harness={harness_path:?}, \
+         policy={policy_path:?}: {output}"
     );
     assert_eq!(
         output.contains("gpui :: test"),
         expect_gpui_test,
-        "gpui::test presence mismatch for runtime={runtime:?}, harness={harness_path:?}, policy={policy_path:?}: {output}"
+        "gpui::test presence mismatch for runtime={runtime:?}, harness={harness_path:?}, \
+         policy={policy_path:?}: {output}"
     );
 }
 

--- a/crates/rstest-bdd-macros/src/codegen/scenario/tests/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/tests/mod.rs
@@ -1,6 +1,8 @@
 //! Tests exercising scenario code-generation utilities.
-use super::test_attrs::{TestAttrPolicy, generate_test_attrs};
-use super::*;
+use super::{
+    test_attrs::{TestAttrPolicy, generate_test_attrs},
+    *,
+};
 use crate::parsing::feature::ParsedStep;
 
 /// Parse a `syn::Path` from a string literal.
@@ -86,7 +88,7 @@ fn normalizes_sequences(
             ..blank()
         })
         .collect();
-    let (keyword_tokens, _, _, _) = process_steps(&steps);
+    let (keyword_tokens, ..) = process_steps(&steps);
     let collected: syn::Result<Vec<_>> = keyword_tokens.iter().map(kw).collect();
     let parsed = match collected {
         Ok(parsed) => parsed,
@@ -95,9 +97,7 @@ fn normalizes_sequences(
     assert_eq!(parsed, expect);
 }
 
-fn tags(list: &[&str]) -> Vec<String> {
-    list.iter().map(|tag| (*tag).to_owned()).collect()
-}
+fn tags(list: &[&str]) -> Vec<String> { list.iter().map(|tag| (*tag).to_owned()).collect() }
 
 #[rstest::rstest]
 #[case::present(tags(&["@allow_skipped", "@other"]), true)]
@@ -295,6 +295,7 @@ fn generate_test_attrs_dedupes_tokio_policy_and_user_attribute() {
     let tokio_count = output.match_indices("tokio :: test").count();
     assert_eq!(
         tokio_count, 1,
-        "expected exactly one tokio::test when both user attribute and policy are present, got {tokio_count}: {output}"
+        "expected exactly one tokio::test when both user attribute and policy are present, got \
+         {tokio_count}: {output}"
     );
 }

--- a/crates/rstest-bdd-macros/src/codegen/scenario/tests/runtime_split.rs
+++ b/crates/rstest-bdd-macros/src/codegen/scenario/tests/runtime_split.rs
@@ -1,8 +1,14 @@
 //! Tests covering the `ScenarioConfig` execution-runtime split.
 
 use super::{
-    FeaturePath, RuntimeMode, ScenarioConfig, ScenarioName, ScenarioReturnKind, TestAttrPolicy,
-    blank, generate_test_attrs,
+    FeaturePath,
+    RuntimeMode,
+    ScenarioConfig,
+    ScenarioName,
+    ScenarioReturnKind,
+    TestAttrPolicy,
+    blank,
+    generate_test_attrs,
 };
 
 #[test]
@@ -52,6 +58,7 @@ fn scenario_config_keeps_attribute_runtime_separate_from_execution_runtime() {
     );
     assert!(
         !output.contains("tokio :: test"),
-        "expected generated attributes to follow attribute_runtime instead of execution runtime, got: {output}"
+        "expected generated attributes to follow attribute_runtime instead of execution runtime, \
+         got: {output}"
     );
 }

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/fixture_or_step.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/fixture_or_step.rs
@@ -5,8 +5,7 @@
 //! name, claims a matching step-pattern placeholder where possible, and
 //! otherwise records the parameter as a fixture injection.
 
-use super::ClassificationContext;
-use super::{Arg, normalize_param_name};
+use super::{Arg, ClassificationContext, normalize_param_name};
 
 /// Extract the fixture name from a `#[from(...)]` attribute, if present.
 ///
@@ -162,7 +161,8 @@ fn resolve_fixture_name(
         syn::Error::new(
             pat.span(),
             format!(
-                "normalized fixture name `{normalized}` is not a valid identifier; use #[from(...)] to specify the fixture name explicitly"
+                "normalized fixture name `{normalized}` is not a valid identifier; use \
+                 #[from(...)] to specify the fixture name explicitly"
             ),
         )
     })?;
@@ -233,12 +233,11 @@ fn classify_by_placeholder_match(
 ///
 /// Mutates both `arg` and `ctx`:
 ///
-/// - Any `#[from]` attribute is removed from [`syn::PatType::attrs`] in place
-///   via [`parse_from_attribute`], including on the error paths.
-/// - A matched placeholder is removed from `ctx.placeholders`, so it cannot bind
-///   a second parameter.
-/// - The resulting [`Arg::Step`] or [`Arg::Fixture`] is appended to
-///   `ctx.extracted`.
+/// - Any `#[from]` attribute is removed from [`syn::PatType::attrs`] in place via
+///   [`parse_from_attribute`], including on the error paths.
+/// - A matched placeholder is removed from `ctx.placeholders`, so it cannot bind a second
+///   parameter.
+/// - The resulting [`Arg::Step`] or [`Arg::Fixture`] is appended to `ctx.extracted`.
 ///
 /// # Errors
 ///
@@ -278,15 +277,14 @@ mod tests {
     //! collapse by accident — that an explicit name is matched and guarded
     //! verbatim, while only an implicit one is normalized.
 
-    use super::super::ExtractedArgs;
-    use super::*;
-    use proc_macro2::Span;
     use std::collections::HashSet;
+
+    use proc_macro2::Span;
     use syn::parse_quote;
 
-    fn ident(name: &str) -> syn::Ident {
-        syn::Ident::new(name, Span::call_site())
-    }
+    use super::{super::ExtractedArgs, *};
+
+    fn ident(name: &str) -> syn::Ident { syn::Ident::new(name, Span::call_site()) }
 
     /// Classify `#[from(<from_name>)] state: usize` against the given state.
     fn classify_explicit_from(

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/mod.rs
@@ -23,9 +23,7 @@ use type_shape::{is_docstring_canonical, is_type_seq, should_classify_as_datatab
 /// must distinguish a `CachedTable` parameter from a raw `Vec<Vec<String>>` one.
 /// It lives here rather than alongside the other shape predicates in
 /// [`type_shape`] so that `classify::is_cached_table` remains its path.
-pub(crate) fn is_cached_table(ty: &syn::Type) -> bool {
-    is_type_seq(ty, &["CachedTable"])
-}
+pub(crate) fn is_cached_table(ty: &syn::Type) -> bool { is_type_seq(ty, &["CachedTable"]) }
 
 /// Diagnostic for a `datatable` parameter declared with an unsupported type.
 const DATATABLE_TYPE_ERROR: &str = concat!(
@@ -249,10 +247,9 @@ where
 /// via [`extract_flag_attribute`].
 ///
 /// - `st` — classification accumulator, mutated on success.
-/// - `arg` — the parameter being classified; its attribute list is mutated
-///   in place even when validation subsequently fails.
-/// - `pat` / `ty` — the parameter's identifier and type, pre-extracted by
-///   the caller.
+/// - `arg` — the parameter being classified; its attribute list is mutated in place even when
+///   validation subsequently fails.
+/// - `pat` / `ty` — the parameter's identifier and type, pre-extracted by the caller.
 ///
 /// Returns `Ok(true)` when the parameter was claimed, `Ok(false)` to let the
 /// next classifier try.

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/prop_tests.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/prop_tests.rs
@@ -123,9 +123,7 @@ impl Outcome {
     }
 
     /// Whether exactly one step argument was recorded.
-    fn is_sole_step(&self) -> bool {
-        matches!(self.extracted.args.as_slice(), [Arg::Step { .. }])
-    }
+    fn is_sole_step(&self) -> bool { matches!(self.extracted.args.as_slice(), [Arg::Step { .. }]) }
 
     /// Whether any `#[from]` attribute survived the run.
     ///

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/step_struct.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/step_struct.rs
@@ -131,13 +131,11 @@ fn validate_owned_type(ty: &syn::Type) -> syn::Result<()> {
 ///
 /// On success, and only on success:
 ///
-/// - [`Arg::StepStruct`] is appended to `st` and `st.step_struct_idx` is set to
-///   its index.
-/// - `st.blocked_placeholders` is overwritten with a clone of `placeholders`,
-///   recording the names the struct now owns so a later parameter cannot rebind
-///   one. [`super::fixture_or_step`] consults this set.
-/// - `placeholders` is then **cleared**, since the struct consumes every
-///   placeholder at once.
+/// - [`Arg::StepStruct`] is appended to `st` and `st.step_struct_idx` is set to its index.
+/// - `st.blocked_placeholders` is overwritten with a clone of `placeholders`, recording the names
+///   the struct now owns so a later parameter cannot rebind one. [`super::fixture_or_step`]
+///   consults this set.
+/// - `placeholders` is then **cleared**, since the struct consumes every placeholder at once.
 ///
 /// `arg` is not mutated; the marker was already removed by the caller.
 ///
@@ -180,10 +178,11 @@ pub(crate) fn classify_step_struct(
 mod tests {
     //! Unit tests for classifying step struct parameters.
 
-    use super::*;
     use proc_macro2::{Span, TokenStream as TokenStream2};
     use quote::quote;
     use syn::{FnArg, Ident, parse_quote};
+
+    use super::*;
 
     fn placeholder_set(names: &[&str]) -> HashSet<String> {
         names.iter().map(|name| (*name).to_owned()).collect()

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/tests.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/tests.rs
@@ -113,6 +113,7 @@ fn classify_fixture_or_step_falls_back_to_fixture() {
 
 /// Accumulator holding a `#[step_args]` struct that owns the `blocked`
 /// placeholder, for the conflict-guard cases.
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn step_struct_extracted() -> ExtractedArgs {
     let mut extracted = ExtractedArgs::default();

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/tests.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/tests.rs
@@ -1,15 +1,15 @@
 //! Unit tests for the argument classifier helpers.
 
-use super::*;
+use std::collections::HashSet;
+
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
 use rstest::{fixture, rstest};
-use std::collections::HashSet;
 use syn::{FnArg, parse_quote};
 
-fn ident(name: &str) -> syn::Ident {
-    syn::Ident::new(name, Span::call_site())
-}
+use super::*;
+
+fn ident(name: &str) -> syn::Ident { syn::Ident::new(name, Span::call_site()) }
 
 fn pat_type(tokens: TokenStream2) -> syn::PatType {
     match syn::parse2::<FnArg>(tokens) {

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/type_shape.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/classify/type_shape.rs
@@ -104,14 +104,10 @@ fn has_unfollowable_generic(segment: &syn::PathSegment) -> bool {
 }
 
 /// Test whether `ty` is `String`, the only type a `DocString` parameter accepts.
-pub(super) fn is_string(ty: &syn::Type) -> bool {
-    is_type_seq(ty, &["String"])
-}
+pub(super) fn is_string(ty: &syn::Type) -> bool { is_type_seq(ty, &["String"]) }
 
 /// Test whether `ty` is the raw `Vec<Vec<String>>` table representation.
-pub(super) fn is_datatable(ty: &syn::Type) -> bool {
-    is_type_seq(ty, &["Vec", "Vec", "String"])
-}
+pub(super) fn is_datatable(ty: &syn::Type) -> bool { is_type_seq(ty, &["Vec", "Vec", "String"]) }
 
 /// Test whether a parameter is the canonical `DataTable` shape.
 ///
@@ -144,8 +140,9 @@ mod tests {
     //! guard, a wrong leaf at depth, a non-path type at depth, and a
     //! non-type first generic argument were all unpinned.
 
-    use super::*;
     use rstest::rstest;
+
+    use super::*;
 
     /// Parse a type from source, failing loudly when a test input is malformed.
     ///

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/extract.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/extract.rs
@@ -13,8 +13,12 @@ use quote::ToTokens;
 use super::{
     ExtractedArgs,
     classify::{
-        ClassificationContext, classify_datatable, classify_docstring, classify_fixture_or_step,
-        classify_step_struct, extract_step_struct_attribute,
+        ClassificationContext,
+        classify_datatable,
+        classify_docstring,
+        classify_fixture_or_step,
+        classify_step_struct,
+        extract_step_struct_attribute,
     },
 };
 
@@ -73,7 +77,8 @@ fn next_typed_argument(
             return Err(syn::Error::new(
                 span_for_pattern(other),
                 format!(
-                    "unsupported parameter pattern `{pattern}`; use a simple identifier (e.g., `arg: T`)"
+                    "unsupported parameter pattern `{pattern}`; use a simple identifier (e.g., \
+                     `arg: T`)"
                 ),
             ));
         }
@@ -113,7 +118,8 @@ fn classify_step_or_fixture(
             return Err(syn::Error::new(
                 span_for_pattern(other),
                 format!(
-                    "unsupported parameter pattern `{pattern}`; use a simple identifier (e.g., `arg: T`)"
+                    "unsupported parameter pattern `{pattern}`; use a simple identifier (e.g., \
+                     `arg: T`)"
                 ),
             ));
         }
@@ -148,8 +154,8 @@ fn classify_step_or_fixture(
 /// ```
 ///
 /// Note: special arguments must use the canonical names:
-/// - data table parameter must be annotated with `#[datatable]` or be named
-///   `datatable` and have type `Vec<Vec<String>>`
+/// - data table parameter must be annotated with `#[datatable]` or be named `datatable` and have
+///   type `Vec<Vec<String>>`
 /// - doc string parameter must be named `docstring` and have type `String`
 ///
 /// At most one `datatable` and one `docstring` parameter are permitted.
@@ -191,8 +197,9 @@ pub fn extract_args(
 mod tests {
     //! Unit tests for extracting wrapper argument metadata.
 
-    use super::*;
     use syn::parse_quote;
+
+    use super::*;
 
     fn parse_fn(src: &str) -> syn::ItemFn {
         match syn::parse_str(src) {

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/args/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/args/mod.rs
@@ -18,9 +18,7 @@ pub use extract::extract_args;
 pub(super) use crate::utils::pattern::normalize_param_name;
 
 #[cfg(test)]
-pub(super) fn normalize_param_name(name: &str) -> &str {
-    name.strip_prefix('_').unwrap_or(name)
-}
+pub(super) fn normalize_param_name(name: &str) -> &str { name.strip_prefix('_').unwrap_or(name) }
 
 /// Everything required to describe a single step-function argument.
 #[derive(Clone)]

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/arguments/bindings.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/arguments/bindings.rs
@@ -5,8 +5,9 @@
 //! This module centralizes the `rstest_bdd_arg_{n}` naming scheme and keeps the
 //! binding metadata next to each extracted argument.
 
-use super::super::args::{Arg, DataTableArg, StepStructArg};
 use quote::format_ident;
+
+use super::super::args::{Arg, DataTableArg, StepStructArg};
 
 /// Wrapper-local argument bindings avoid leading underscores to keep Clippy happy.
 #[derive(Copy, Clone)]

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/arguments/datatable.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/arguments/datatable.rs
@@ -3,25 +3,28 @@
 //! This module emits the per-wrapper snippets that pull the incoming
 //! `Option<&[&[&str]]>` docstring/table arguments into concrete, typed values
 //! expected by the step function. When a step declares a data table, we emit:
-//! - Access to a wrapper-scoped table cache (see `emit::datatable_cache`) keyed
-//!   by pointer identity plus an FNV-1a hash of contents. The cache is emitted
-//!   as a `OnceLock<Mutex<HashMap<key, Arc<Vec<Vec<String>>>>>>` referenced via
-//!   the supplied `cache_idents.cache` identifier.
-//! - Conversion of the cached rows into the concrete type requested by the
-//!   step signature.
-//! - Diagnostics for cache misses to aid tests and telemetry.
-//!   The `CacheIdents` passed in are the identifiers produced by the emitter
-//!   for the key type and the cache `OnceLock<HashMap<...>>`, so we can
-//!   reference them while generating argument initialization code.
+//! - Access to a wrapper-scoped table cache (see `emit::datatable_cache`) keyed by pointer identity
+//!   plus an FNV-1a hash of contents. The cache is emitted as a `OnceLock<Mutex<HashMap<key,
+//!   Arc<Vec<Vec<String>>>>>>` referenced via the supplied `cache_idents.cache` identifier.
+//! - Conversion of the cached rows into the concrete type requested by the step signature.
+//! - Diagnostics for cache misses to aid tests and telemetry. The `CacheIdents` passed in are the
+//!   identifiers produced by the emitter for the key type and the cache `OnceLock<HashMap<...>>`,
+//!   so we can reference them while generating argument initialization code.
 
-use super::super::args::{DataTableArg, classify::is_cached_table};
-use super::BoundDataTableArg;
-use super::{StepMeta, step_error_tokens};
-use crate::codegen::wrapper::datatable_shared::{
-    record_cache_miss_tokens, table_arc_tokens, table_content_match_tokens,
-};
 use proc_macro2::TokenStream as TokenStream2;
 use quote::format_ident;
+
+use super::{
+    super::args::{DataTableArg, classify::is_cached_table},
+    BoundDataTableArg,
+    StepMeta,
+    step_error_tokens,
+};
+use crate::codegen::wrapper::datatable_shared::{
+    record_cache_miss_tokens,
+    table_arc_tokens,
+    table_content_match_tokens,
+};
 
 /// Identifiers for datatable caching infrastructure emitted alongside the wrapper.
 pub(super) struct CacheIdents<'a> {
@@ -121,13 +124,12 @@ fn gen_cache_entry_match_tokens(
 
 /// Emit the datatable extraction, caching, and conversion block.
 ///
-/// 1. Ensures the optional table input is present, otherwise raises a missing
-///    datatable error.
+/// 1. Ensures the optional table input is present, otherwise raises a missing datatable error.
 /// 2. Builds a cache key from pointer plus FNV-1a hash.
-/// 3. Checks the cache: reuses an existing `Arc` when contents match; records
-///    a miss and inserts a new `Arc` otherwise.
-/// 4. Wraps the `Arc` in `CachedTable` and converts to the requested type when
-///    the step does not expect a cached wrapper directly.
+/// 3. Checks the cache: reuses an existing `Arc` when contents match; records a miss and inserts a
+///    new `Arc` otherwise.
+/// 4. Wraps the `Arc` in `CachedTable` and converts to the requested type when the step does not
+///    expect a cached wrapper directly.
 fn gen_datatable_body(
     is_cached_table: bool,
     step_meta: StepMeta<'_>,
@@ -196,10 +198,9 @@ fn gen_datatable_body(
 ///
 /// # Parameters
 /// - `datatable`: The datatable argument metadata (pattern, type), if present.
-/// - `step_meta`: Step metadata (pattern and function identifier) for error
-///   reporting.
-/// - `cache_idents`: Identifiers for the cache key type and cache storage
-///   variable generated alongside the wrapper.
+/// - `step_meta`: Step metadata (pattern and function identifier) for error reporting.
+/// - `cache_idents`: Identifiers for the cache key type and cache storage variable generated
+///   alongside the wrapper.
 ///
 /// # Returns
 /// `Some(TokenStream2)` containing the datatable binding, or `None` if no

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/arguments/fixtures.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/arguments/fixtures.rs
@@ -2,8 +2,7 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::format_ident;
 
-use super::super::args::Arg;
-use super::BoundArg;
+use super::{super::args::Arg, BoundArg};
 use crate::codegen::rstest_bdd_path;
 
 /// Context for generating fixture declarations in step wrappers.

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/arguments/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/arguments/mod.rs
@@ -1,9 +1,10 @@
 //! Argument code generation utilities shared by wrapper emission logic.
 
-use super::args::{Arg, DataTableArg, StepStructArg};
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use rstest_bdd_patterns::requires_quote_stripping;
+
+use super::args::{Arg, DataTableArg, StepStructArg};
 
 mod bindings;
 
@@ -13,7 +14,11 @@ mod step_parse;
 mod step_struct;
 
 use bindings::{
-    BoundArg, BoundDataTableArg, BoundDocStringArg, BoundStepStructArg, wrapper_binding_idents,
+    BoundArg,
+    BoundDataTableArg,
+    BoundDocStringArg,
+    BoundStepStructArg,
+    wrapper_binding_idents,
 };
 use datatable::{CacheIdents, gen_datatable_decl};
 use fixtures::gen_fixture_decls;

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/arguments/step_parse.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/arguments/step_parse.rs
@@ -4,10 +4,10 @@
 //! step arguments from regex captures, including support for the `:string` type
 //! hint which strips surrounding quotes.
 
-use super::super::args::Arg;
-use super::{StepMeta, is_str_reference, step_error_tokens};
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
+
+use super::{super::args::Arg, StepMeta, is_str_reference, step_error_tokens};
 
 /// Context for generating argument binding code.
 struct BindingContext<'a> {

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/arguments/step_struct.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/arguments/step_struct.rs
@@ -5,11 +5,11 @@
 //! the capture collection and conversion code, including `:string` hint
 //! handling for quoted captures.
 
-use super::step_parse::gen_quote_strip_to_stripped;
-use super::{StepMeta, step_error_tokens};
-use crate::codegen::wrapper::args::StepStructArg;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
+
+use super::{StepMeta, step_error_tokens, step_parse::gen_quote_strip_to_stripped};
+use crate::codegen::wrapper::args::StepStructArg;
 
 /// Placeholder information needed for step struct code generation.
 pub(super) struct PlaceholderInfo<'a> {

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/arguments/tests/bindings.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/arguments/tests/bindings.rs
@@ -1,9 +1,9 @@
 //! Tests for wrapper-local argument bindings.
 
-use super::super::bindings as arg_bindings;
-use super::*;
 use quote::format_ident;
 use syn::parse_quote;
+
+use super::{super::bindings as arg_bindings, *};
 
 #[test]
 fn collect_ordered_arguments_preserves_call_order() {

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/arguments/tests/helpers.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/arguments/tests/helpers.rs
@@ -1,10 +1,10 @@
 //! Test helper functions for argument preparation tests.
 
-use super::super::bindings;
-use super::super::*;
-use crate::codegen::wrapper::args::Arg;
 use quote::quote;
 use syn::parse_quote;
+
+use super::super::{bindings, *};
+use crate::codegen::wrapper::args::Arg;
 
 /// Create a sample `StepMeta` for testing.
 pub fn sample_meta<'a>(pattern: &'a syn::LitStr, ident: &'a syn::Ident) -> StepMeta<'a> {

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/arguments/tests/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/arguments/tests/mod.rs
@@ -3,15 +3,20 @@
 mod bindings;
 mod helpers;
 
-use super::*;
-use crate::codegen::wrapper::args::Arg;
 use helpers::{
-    bind_args, build_arguments, build_bindings, generate_step_parse_for_single_arg,
-    generate_step_parse_with_hint, sample_meta,
+    bind_args,
+    build_arguments,
+    build_bindings,
+    generate_step_parse_for_single_arg,
+    generate_step_parse_with_hint,
+    sample_meta,
 };
 use quote::{format_ident, quote};
 use rstest::rstest;
 use syn::parse_quote;
+
+use super::*;
+use crate::codegen::wrapper::args::Arg;
 
 #[test]
 fn prepare_argument_processing_handles_all_argument_types() {

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/emit/assembly/body.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/emit/assembly/body.rs
@@ -4,16 +4,17 @@
 //! between sync and async wrapper emission, keeping `assembly.rs` focused on
 //! orchestration and within the project's file length limits.
 
-use super::super::super::args::ExtractedArgs;
-use super::super::super::arguments::{
-    StepMeta, collect_ordered_arguments, prepare_argument_processing,
-};
-use super::super::datatable_cache::{
-    DatatableCacheComponents, generate_datatable_cache_definitions,
-};
-use super::super::identifiers::generate_wrapper_signature;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
+
+use super::super::{
+    super::{
+        args::ExtractedArgs,
+        arguments::{StepMeta, collect_ordered_arguments, prepare_argument_processing},
+    },
+    datatable_cache::{DatatableCacheComponents, generate_datatable_cache_definitions},
+    identifiers::generate_wrapper_signature,
+};
 
 /// Generate a compile-time assertion that the step struct field count matches the
 /// expected number of placeholder captures.

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/emit/assembly/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/emit/assembly/mod.rs
@@ -5,20 +5,23 @@
 //! emission entry point focused on orchestration while centralizing the logic
 //! that shapes the wrapper's structure.
 
-use super::super::arguments::PreparedArgs;
-use super::super::arguments::StepMeta;
-use super::call_expr::generate_call_expression;
-use super::errors::{WrapperErrors, prepare_wrapper_errors};
-use crate::return_classifier::ReturnKind;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
+
+use super::{
+    super::arguments::{PreparedArgs, StepMeta},
+    call_expr::generate_call_expression,
+    errors::{WrapperErrors, prepare_wrapper_errors},
+};
+use crate::return_classifier::ReturnKind;
 
 mod async_wrapper;
 
 mod body;
 
-const WRAPPER_EXPECT_REASON: &str = "rstest-bdd step wrapper pattern requires these patterns \
-for parameter extraction, Result normalization, and closure-based error handling";
+const WRAPPER_EXPECT_REASON: &str = "rstest-bdd step wrapper pattern requires these patterns for \
+                                     parameter extraction, Result normalization, and \
+                                     closure-based error handling";
 const LINT_SHADOW_REUSE: &str = "clippy::shadow_reuse";
 const LINT_UNNECESSARY_WRAPS: &str = "clippy::unnecessary_wraps";
 const LINT_STR_TO_STRING: &str = "clippy::str_to_string";

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/emit/assembly/tests.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/emit/assembly/tests.rs
@@ -1,18 +1,28 @@
 //! Tests for wrapper lint suppression emission.
 
-use super::{
-    LINT_NEEDLESS_PASS_BY_VALUE, LINT_REDUNDANT_CLOSURE, LINT_REDUNDANT_CLOSURE_FOR_METHOD_CALLS,
-    LINT_SHADOW_REUSE, LINT_STR_TO_STRING, LINT_UNNECESSARY_WRAPS, PreparedArgs, StepMeta,
-    WRAPPER_EXPECT_REASON, WrapperAssembly, WrapperIdentifiers, WrapperKind,
-    assemble_wrapper_function,
-};
-use crate::return_classifier::ReturnKind;
+use std::collections::HashSet;
+
 use proc_macro2::Span;
 use quote::{format_ident, quote};
 use rstest::rstest;
-use std::collections::HashSet;
-use syn::Token;
-use syn::punctuated::Punctuated;
+use syn::{Token, punctuated::Punctuated};
+
+use super::{
+    LINT_NEEDLESS_PASS_BY_VALUE,
+    LINT_REDUNDANT_CLOSURE,
+    LINT_REDUNDANT_CLOSURE_FOR_METHOD_CALLS,
+    LINT_SHADOW_REUSE,
+    LINT_STR_TO_STRING,
+    LINT_UNNECESSARY_WRAPS,
+    PreparedArgs,
+    StepMeta,
+    WRAPPER_EXPECT_REASON,
+    WrapperAssembly,
+    WrapperIdentifiers,
+    WrapperKind,
+    assemble_wrapper_function,
+};
+use crate::return_classifier::ReturnKind;
 
 fn path_to_string(path: &syn::Path) -> String {
     path.segments

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/emit/call_expr.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/emit/call_expr.rs
@@ -1,8 +1,9 @@
 //! Call expression generation based on step return kind.
 
-use crate::return_classifier::ReturnKind;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
+
+use crate::return_classifier::ReturnKind;
 
 /// Generate the call expression for a step function based on its return kind.
 ///
@@ -10,11 +11,11 @@ use quote::quote;
 /// and wraps the result according to the inferred [`ReturnKind`]:
 ///
 /// - [`ReturnKind::Unit`]: Discards the return value and yields `Ok(None)`.
-/// - [`ReturnKind::Value`]: Wraps the value via `__rstest_bdd_payload_from_value`,
-///   which boxes non-unit values or returns `None` for unit.
-/// - [`ReturnKind::ResultUnit`] / [`ReturnKind::ResultValue`]: Unpacks the
-///   `Result`, mapping `Ok(value)` through the payload helper and converting
-///   `Err(e)` to a `String` for the step error.
+/// - [`ReturnKind::Value`]: Wraps the value via `__rstest_bdd_payload_from_value`, which boxes
+///   non-unit values or returns `None` for unit.
+/// - [`ReturnKind::ResultUnit`] / [`ReturnKind::ResultValue`]: Unpacks the `Result`, mapping
+///   `Ok(value)` through the payload helper and converting `Err(e)` to a `String` for the step
+///   error.
 ///
 /// When `is_async` is `true`, the generated call expression includes `.await`.
 pub(super) fn generate_call_expression(

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/emit/datatable_cache.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/emit/datatable_cache.rs
@@ -4,18 +4,19 @@
 //! version of the incoming `&[&[&str]]` data table. The cache is scoped per
 //! wrapper function and keyed by a struct containing:
 //! - The table pointer (for fast reuse when the exact slice is re-sent).
-//! - An FNV-1a hash of the table contents (to detect identical-but-copied
-//!   tables).
-//!   `DatatableCacheComponents` returns the token fragments for the key type and
-//!   the `OnceLock<Mutex<HashMap<key, Arc<_>>>>` cache. These are stitched into
-//!   the wrapper body by `arguments::datatable`, which uses the cache to avoid
-//!   re-cloning table contents on every call.
+//! - An FNV-1a hash of the table contents (to detect identical-but-copied tables).
+//!   `DatatableCacheComponents` returns the token fragments for the key type and the
+//!   `OnceLock<Mutex<HashMap<key, Arc<_>>>>` cache. These are stitched into the wrapper body by
+//!   `arguments::datatable`, which uses the cache to avoid re-cloning table contents on every call.
 
-use crate::codegen::wrapper::datatable_shared::{
-    cache_key_impl_tokens, cache_key_struct_tokens, cache_static_tokens,
-};
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
+
+use crate::codegen::wrapper::datatable_shared::{
+    cache_key_impl_tokens,
+    cache_key_struct_tokens,
+    cache_static_tokens,
+};
 
 /// Components generated for datatable caching infrastructure.
 ///

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/emit/errors.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/emit/errors.rs
@@ -1,8 +1,9 @@
 //! Error token generation for wrapper functions.
 
-use super::super::arguments::{StepMeta, step_error_tokens};
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
+
+use super::super::arguments::{StepMeta, step_error_tokens};
 
 /// Pre-generated error tokens for wrapper function error paths.
 pub(super) struct WrapperErrors {

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/emit/identifiers.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/emit/identifiers.rs
@@ -5,10 +5,12 @@
 //! generating invalid symbols when step function names contain Unicode.
 //! A global counter ensures uniqueness across all generated wrappers.
 
-use crate::utils::ident::sanitize_ident;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 use proc_macro2::TokenStream as TokenStream2;
 use quote::format_ident;
-use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::utils::ident::sanitize_ident;
 
 static COUNTER: AtomicUsize = AtomicUsize::new(0);
 
@@ -142,6 +144,4 @@ pub(in crate::codegen::wrapper::emit) fn generate_wrapper_signature(
 /// let second = next_wrapper_id();  // e.g. 1
 /// assert_eq!(second, first + 1);
 /// ```
-pub(super) fn next_wrapper_id() -> usize {
-    COUNTER.fetch_add(1, Ordering::Relaxed)
-}
+pub(super) fn next_wrapper_id() -> usize { COUNTER.fetch_add(1, Ordering::Relaxed) }

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/emit/mod.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/emit/mod.rs
@@ -1,9 +1,10 @@
 //! Code emission helpers for wrapper generation.
 
-use super::args::{Arg, ExtractedArgs};
-use crate::return_classifier::ReturnKind;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
+
+use super::args::{Arg, ExtractedArgs};
+use crate::return_classifier::ReturnKind;
 
 mod assembly;
 mod call_expr;

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/emit/tests.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/emit/tests.rs
@@ -1,9 +1,10 @@
 //! Tests for wrapper code generation helpers.
 
-use super::identifiers::{WrapperIdents, generate_wrapper_identifiers};
-use crate::utils::ident::sanitize_ident;
 use rstest::rstest;
 use syn::parse_str;
+
+use super::identifiers::{WrapperIdents, generate_wrapper_identifiers};
+use crate::utils::ident::sanitize_ident;
 
 #[rstest]
 #[case(

--- a/crates/rstest-bdd-macros/src/datatable/mod.rs
+++ b/crates/rstest-bdd-macros/src/datatable/mod.rs
@@ -12,10 +12,6 @@ mod validation;
 
 use proc_macro::TokenStream;
 
-pub(crate) fn derive_data_table_row(input: TokenStream) -> TokenStream {
-    row::expand(input)
-}
+pub(crate) fn derive_data_table_row(input: TokenStream) -> TokenStream { row::expand(input) }
 
-pub(crate) fn derive_data_table(input: TokenStream) -> TokenStream {
-    table::expand(input)
-}
+pub(crate) fn derive_data_table(input: TokenStream) -> TokenStream { table::expand(input) }

--- a/crates/rstest-bdd-macros/src/datatable/parser.rs
+++ b/crates/rstest-bdd-macros/src/datatable/parser.rs
@@ -3,8 +3,10 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use syn::Type;
 
-use crate::datatable::config::{Accessor, FieldConfig, FieldSpec};
-use crate::datatable::validation::is_string_type;
+use crate::datatable::{
+    config::{Accessor, FieldConfig, FieldSpec},
+    validation::is_string_type,
+};
 
 pub(crate) fn accessor_expr(
     field: &FieldSpec,

--- a/crates/rstest-bdd-macros/src/datatable/rename.rs
+++ b/crates/rstest-bdd-macros/src/datatable/rename.rs
@@ -12,18 +12,14 @@ use syn::LitStr;
 /// - `lowercase`: all letters are lowercase.
 /// - `UPPERCASE`: all letters are uppercase.
 /// - `snake_case`: words are separated by underscores.
-/// - `SCREAMING_SNAKE_CASE`: words are separated by underscores and all letters
-///   are uppercase.
+/// - `SCREAMING_SNAKE_CASE`: words are separated by underscores and all letters are uppercase.
 /// - `kebab-case`: words are separated by hyphens.
-/// - `SCREAMING-KEBAB-CASE`: words are separated by hyphens and all letters are
-///   uppercase.
-/// - `camelCase`: the first word is lowercase and subsequent words are
-///   capitalized.
+/// - `SCREAMING-KEBAB-CASE`: words are separated by hyphens and all letters are uppercase.
+/// - `camelCase`: the first word is lowercase and subsequent words are capitalized.
 /// - `PascalCase`: each word is capitalized with no separators.
-/// - `Title Case`: each word is capitalized and separated by spaces. This is
-///   distinct from `PascalCase`, which concatenates words, and mirrors the
-///   human-readable headers often used in Gherkin scenarios (for example
-///   `Given Name`).
+/// - `Title Case`: each word is capitalized and separated by spaces. This is distinct from
+///   `PascalCase`, which concatenates words, and mirrors the human-readable headers often used in
+///   Gherkin scenarios (for example `Given Name`).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum RenameRule {
     Lower,

--- a/crates/rstest-bdd-macros/src/datatable/row/attributes.rs
+++ b/crates/rstest-bdd-macros/src/datatable/row/attributes.rs
@@ -7,9 +7,11 @@
 use proc_macro2::{Ident, Span};
 use syn::{Attribute, ExprPath, Field, Fields, LitStr, Token, Type, spanned::Spanned};
 
-use crate::datatable::config::{Accessor, DefaultValue, FieldConfig, FieldSpec, StructConfig};
-use crate::datatable::rename::RenameRule;
-use crate::datatable::validation::{is_bool_type, option_inner_type};
+use crate::datatable::{
+    config::{Accessor, DefaultValue, FieldConfig, FieldSpec, StructConfig},
+    rename::RenameRule,
+    validation::{is_bool_type, option_inner_type},
+};
 
 pub(crate) fn parse_struct_config(attrs: &[Attribute]) -> syn::Result<StructConfig> {
     let mut rename_rule = None;
@@ -242,8 +244,9 @@ fn ensure_when(violation: bool, span: Span, message: &str) -> syn::Result<()> {
 mod tests {
     //! Unit tests for `#[datatable]` row attribute parsing.
 
-    use super::*;
     use syn::{Data, parse_quote};
+
+    use super::*;
 
     #[test]
     fn parse_struct_config_reads_rename_rule() {

--- a/crates/rstest-bdd-macros/src/datatable/row/bindings.rs
+++ b/crates/rstest-bdd-macros/src/datatable/row/bindings.rs
@@ -11,8 +11,10 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use syn::Type;
 
-use crate::datatable::config::{DefaultValue, FieldSpec};
-use crate::datatable::parser::accessor_expr;
+use crate::datatable::{
+    config::{DefaultValue, FieldSpec},
+    parser::accessor_expr,
+};
 
 pub(crate) fn build_field_binding(
     index: usize,

--- a/crates/rstest-bdd-macros/src/datatable/row/mod.rs
+++ b/crates/rstest-bdd-macros/src/datatable/row/mod.rs
@@ -8,15 +8,18 @@ mod bindings;
 
 use attributes::{collect_fields, parse_struct_config};
 use bindings::build_field_binding;
-
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use syn::{Data, DataStruct, DeriveInput, Generics, Type, parse_macro_input, spanned::Spanned};
 
-use crate::codegen::rstest_bdd_path;
-use crate::datatable::config::{Accessor, FieldConfig, FieldSpec};
-use crate::datatable::validation::is_string_type;
+use crate::{
+    codegen::rstest_bdd_path,
+    datatable::{
+        config::{Accessor, FieldConfig, FieldSpec},
+        validation::is_string_type,
+    },
+};
 
 pub(crate) fn expand(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/crates/rstest-bdd-macros/src/datatable/table/attributes.rs
+++ b/crates/rstest-bdd-macros/src/datatable/table/attributes.rs
@@ -69,8 +69,9 @@ fn parse_row_type(meta: &syn::meta::ParseNestedMeta) -> syn::Result<Type> {
 mod tests {
     //! Unit tests for `#[datatable]` table attribute parsing.
 
-    use super::*;
     use syn::parse_quote;
+
+    use super::*;
 
     #[test]
     fn parse_struct_attrs_supports_row_and_map() {

--- a/crates/rstest-bdd-macros/src/datatable/table/mod.rs
+++ b/crates/rstest-bdd-macros/src/datatable/table/mod.rs
@@ -6,13 +6,21 @@
 mod attributes;
 
 use attributes::{MapKind, TableConfig, parse_struct_attrs};
-
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{
-    Data, DataStruct, DeriveInput, Field, Fields, GenericArgument, PathArguments, Type, TypePath,
-    parse_macro_input, spanned::Spanned,
+    Data,
+    DataStruct,
+    DeriveInput,
+    Field,
+    Fields,
+    GenericArgument,
+    PathArguments,
+    Type,
+    TypePath,
+    parse_macro_input,
+    spanned::Spanned,
 };
 
 use crate::codegen::rstest_bdd_path;

--- a/crates/rstest-bdd-macros/src/lib.rs
+++ b/crates/rstest-bdd-macros/src/lib.rs
@@ -1,10 +1,9 @@
 //! Attribute macros enabling Behaviour-Driven testing with `rstest`.
 //!
 //! # Feature flags
-//! - `compile-time-validation`: registers steps at compile time and attaches
-//!   spans for diagnostics.
-//! - `strict-compile-time-validation`: escalates missing or ambiguous steps to
-//!   compile errors; implies `compile-time-validation`.
+//! - `compile-time-validation`: registers steps at compile time and attaches spans for diagnostics.
+//! - `strict-compile-time-validation`: escalates missing or ambiguous steps to compile errors;
+//!   implies `compile-time-validation`.
 //!
 //! Both features are disabled by default.
 mod codegen;
@@ -19,13 +18,11 @@ mod step_keyword;
 mod utils;
 mod validation;
 
-pub(crate) use step_keyword::StepKeyword;
-
-use proc_macro::TokenStream;
 use std::panic::UnwindSafe;
 
-use proc_macro_error::entry_point;
-use proc_macro_error::proc_macro_error;
+use proc_macro::TokenStream;
+use proc_macro_error::{entry_point, proc_macro_error};
+pub(crate) use step_keyword::StepKeyword;
 
 /// Run a procedural macro while mapping panics into `proc_macro_error`
 /// diagnostics.
@@ -126,16 +123,15 @@ pub fn then(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// Attribute macro binding a test function to a single Gherkin scenario.
 ///
 /// Selector semantics:
-/// - Supply either `index = N` (zero-based) or `name = "Scenario title"` to
-///   disambiguate when the feature defines multiple scenarios.
+/// - Supply either `index = N` (zero-based) or `name = "Scenario title"` to disambiguate when the
+///   feature defines multiple scenarios.
 /// - When omitted, the macro targets the first scenario in the feature file.
 ///
 /// Tag filtering:
-/// - Provide `tags = "expr"` to keep only scenarios whose tag sets satisfy the
-///   expression before applying selectors.
-/// - Expressions accept case-sensitive tag names combined with `not`, `and`,
-///   and `or`, following the precedence `not` > `and` > `or`. Parentheses may
-///   be used to override the default binding.
+/// - Provide `tags = "expr"` to keep only scenarios whose tag sets satisfy the expression before
+///   applying selectors.
+/// - Expressions accept case-sensitive tag names combined with `not`, `and`, and `or`, following
+///   the precedence `not` > `and` > `or`. Parentheses may be used to override the default binding.
 ///
 /// Example:
 /// ```ignore
@@ -165,18 +161,14 @@ pub fn scenario(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_error]
 #[proc_macro_derive(ScenarioState)]
-pub fn derive_scenario_state(input: TokenStream) -> TokenStream {
-    scenario_state::derive(input)
-}
+pub fn derive_scenario_state(input: TokenStream) -> TokenStream { scenario_state::derive(input) }
 
 /// Derive
 /// [`rstest_bdd::StepArgs`](https://docs.rs/rstest-bdd/latest/rstest_bdd/trait.StepArgs.html)
 /// for a struct whose fields map to pattern placeholders.
 #[proc_macro_error]
 #[proc_macro_derive(StepArgs)]
-pub fn derive_step_args(input: TokenStream) -> TokenStream {
-    step_args::derive(input)
-}
+pub fn derive_step_args(input: TokenStream) -> TokenStream { step_args::derive(input) }
 
 /// Discover all `.feature` files under the given directory and generate one
 /// test per Gherkin `Scenario`.
@@ -186,10 +178,10 @@ pub fn derive_step_args(input: TokenStream) -> TokenStream {
 /// - It is resolved relative to `CARGO_MANIFEST_DIR` at macro-expansion time.
 ///
 /// Expansion:
-/// - Emits a module named after `dir` (sanitized) containing one test function
-///   per discovered scenario.
-/// - Each generated test executes the matched steps via the registered
-///   `#[given]`, `#[when]`, and `#[then]` functions.
+/// - Emits a module named after `dir` (sanitized) containing one test function per discovered
+///   scenario.
+/// - Each generated test executes the matched steps via the registered `#[given]`, `#[when]`, and
+///   `#[then]` functions.
 ///
 /// Example:
 /// ```rust,ignore
@@ -202,8 +194,8 @@ pub fn derive_step_args(input: TokenStream) -> TokenStream {
 /// ```
 ///
 /// Errors:
-/// - Emits a compile error if the directory does not exist, contains no
-///   `.feature` files, or if parsing fails.
+/// - Emits a compile error if the directory does not exist, contains no `.feature` files, or if
+///   parsing fails.
 #[proc_macro]
 pub fn scenarios(input: TokenStream) -> TokenStream {
     run_with_macro_errors(|| macros::scenarios(input))

--- a/crates/rstest-bdd-macros/src/macros/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/mod.rs
@@ -8,15 +8,14 @@
 //! It also owns the machinery the three step attributes share, because
 //! `#[given]`, `#[when]`, and `#[then]` differ only by their `StepKeyword`:
 //!
-//! - `StepAttrArgs` parses the attribute arguments — an optional pattern
-//!   literal, the `expr = "..."` cucumber-rs spelling, and the `result` /
-//!   `value` return-kind hint.
-//! - `determine_step_pattern` falls back to inferring a pattern from the
-//!   function name when none is supplied.
-//! - `extract_step_args_or_abort` and `signature_error_help` turn a signature
-//!   rejection into a keyword-specific diagnostic with accurate spans.
-//! - `step_attr` drives that sequence and `inject_skip_scope` wraps the body so
-//!   the runtime can validate `skip!` against the enclosing scope.
+//! - `StepAttrArgs` parses the attribute arguments — an optional pattern literal, the `expr =
+//!   "..."` cucumber-rs spelling, and the `result` / `value` return-kind hint.
+//! - `determine_step_pattern` falls back to inferring a pattern from the function name when none is
+//!   supplied.
+//! - `extract_step_args_or_abort` and `signature_error_help` turn a signature rejection into a
+//!   keyword-specific diagnostic with accurate spans.
+//! - `step_attr` drives that sequence and `inject_skip_scope` wraps the body so the runtime can
+//!   validate `skip!` against the enclosing scope.
 //!
 //! Note the direction of delegation: `given`, `when`, and `then` are one-line
 //! shims that call `step_attr` with their keyword, rather than owning an
@@ -27,8 +26,10 @@
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::parse::{Parse, ParseStream};
-use syn::parse_quote;
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_quote,
+};
 
 mod given;
 mod scenario;
@@ -42,12 +43,13 @@ pub(crate) use scenarios::scenarios;
 pub(crate) use then::then;
 pub(crate) use when::when;
 
-use crate::codegen::wrapper::args::ExtractedArgs;
-use crate::codegen::wrapper::{WrapperConfig, extract_args, generate_wrapper_code};
-use crate::return_classifier::{ReturnKind, ReturnOverride, classify_return_type};
-use crate::utils::{
-    errors::error_to_tokens,
-    pattern::{infer_pattern, placeholder_names},
+use crate::{
+    codegen::wrapper::{WrapperConfig, args::ExtractedArgs, extract_args, generate_wrapper_code},
+    return_classifier::{ReturnKind, ReturnOverride, classify_return_type},
+    utils::{
+        errors::error_to_tokens,
+        pattern::{infer_pattern, placeholder_names},
+    },
 };
 
 /// Parsed arguments for step attribute macros.
@@ -242,9 +244,11 @@ fn signature_error_help(err_message: &str, keyword: crate::StepKeyword) -> Strin
 
     if err_message.contains("unsupported parameter pattern") {
         return concat!(
-            "Bind the parameter to a simple identifier (e.g., `tuple: (i32, i32)` or `user: User`) ",
+            "Bind the parameter to a simple identifier (e.g., `tuple: (i32, i32)` or `user: \
+             User`) ",
             "and destructure it inside the step body."
-        ).to_owned();
+        )
+        .to_owned();
     }
 
     if err_message.contains("methods are not supported; remove `self`") {
@@ -253,7 +257,9 @@ fn signature_error_help(err_message: &str, keyword: crate::StepKeyword) -> Strin
 
     let kw_name = keyword_name(keyword);
     format!(
-        "Use a step attribute (such as `#[{kw_name}]`) on `fn name(...args...)` with supported step arguments/fixtures (step attributes include `#[given]`, `#[when]`, and `#[then]`); remove `self` if present."
+        "Use a step attribute (such as `#[{kw_name}]`) on `fn name(...args...)` with supported \
+         step arguments/fixtures (step attributes include `#[given]`, `#[when]`, and `#[then]`); \
+         remove `self` if present."
     )
 }
 
@@ -371,8 +377,7 @@ mod tests {
     //! Unit tests for step-attribute diagnostic help text.
 
     use super::signature_error_help;
-    use crate::StepKeyword;
-    use crate::codegen::wrapper::args::classify::DUPLICATE_DATATABLE_ERROR;
+    use crate::{StepKeyword, codegen::wrapper::args::classify::DUPLICATE_DATATABLE_ERROR};
 
     #[test]
     fn duplicate_datatable_help_names_the_remedy() {

--- a/crates/rstest-bdd-macros/src/macros/scenario/args.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenario/args.rs
@@ -5,7 +5,8 @@
 
 use proc_macro2::Span;
 use syn::{
-    LitInt, LitStr,
+    LitInt,
+    LitStr,
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
     token::Comma,
@@ -191,8 +192,9 @@ fn selector_conflict_error(
 mod tests {
     //! Unit tests for `#[scenario]` attribute argument parsing.
 
-    use super::ScenarioArgs;
     use quote::quote;
+
+    use super::ScenarioArgs;
 
     fn parse_scenario_args(tokens: proc_macro2::TokenStream) -> syn::Result<ScenarioArgs> {
         syn::parse2(tokens)

--- a/crates/rstest-bdd-macros/src/macros/scenario/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenario/mod.rs
@@ -25,9 +25,10 @@ mod paths;
 mod return_kind;
 mod selection;
 
+use std::path::PathBuf;
+
 use proc_macro::TokenStream;
 use proc_macro2::Span;
-use std::path::PathBuf;
 
 #[rustfmt::skip]
 use crate::codegen::scenario::{
@@ -37,15 +38,20 @@ use crate::codegen::scenario::{
 use crate::parsing::feature::{
     parse_and_load_feature, ScenarioData,
 };
-use crate::parsing::tags::TagExpression;
-use crate::utils::fixtures::extract_function_fixtures;
-use crate::validation::parameters::process_scenario_outline_examples;
-use crate::validation::placeholder::{ExampleHeaders, validate_step_placeholders};
-
-use self::args::ScenarioArgs;
-use self::paths::canonical_feature_path;
-use self::return_kind::classify_scenario_return;
-use self::selection::{ensure_feature_not_empty, resolve_candidate_indices, select_scenario};
+use self::{
+    args::ScenarioArgs,
+    paths::canonical_feature_path,
+    return_kind::classify_scenario_return,
+    selection::{ensure_feature_not_empty, resolve_candidate_indices, select_scenario},
+};
+use crate::{
+    parsing::tags::TagExpression,
+    utils::fixtures::extract_function_fixtures,
+    validation::{
+        parameters::process_scenario_outline_examples,
+        placeholder::{ExampleHeaders, validate_step_placeholders},
+    },
+};
 
 struct ScenarioTagFilter {
     expr: TagExpression,

--- a/crates/rstest-bdd-macros/src/macros/scenario/paths.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenario/paths.rs
@@ -4,10 +4,13 @@
 //! symlinks through `cap-std` ambient directories. Missing files fall back
 //! to the original input so compile errors reference the user-specified path.
 
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::{LazyLock, RwLock},
+};
+
 use cap_std::{ambient_authority, fs::Dir};
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use std::sync::{LazyLock, RwLock};
 
 /// Cache of canonicalized feature paths to avoid repeated filesystem lookups.
 static FEATURE_PATH_CACHE: LazyLock<RwLock<HashMap<PathBuf, String>>> =
@@ -16,14 +19,12 @@ static FEATURE_PATH_CACHE: LazyLock<RwLock<HashMap<PathBuf, String>>> =
 /// Normalize path components so equivalent inputs share cache entries.
 ///
 /// Policy:
-/// - Do not alter absolute or prefixed paths; leave absolute resolution to the
-///   filesystem canonicalization.
+/// - Do not alter absolute or prefixed paths; leave absolute resolution to the filesystem
+///   canonicalization.
 /// - Collapse internal `.` segments.
-/// - Collapse `..` only when a prior non-`..` segment exists; otherwise
-///   preserve leading `..`.
+/// - Collapse `..` only when a prior non-`..` segment exists; otherwise preserve leading `..`.
 fn normalize(path: &Path) -> PathBuf {
-    use std::ffi::OsString;
-    use std::path::Component;
+    use std::{ffi::OsString, path::Component};
 
     if path.is_absolute() {
         return path.to_path_buf();
@@ -58,8 +59,9 @@ mod windows_paths {
     //! These tests complement the surrounding platform-independent path logic
     //! with drive-relative and UNC paths that cannot be represented on Unix.
 
-    use super::normalize;
     use std::path::Path;
+
+    use super::normalize;
 
     #[test]
     fn preserves_drive_relative_parent_segments() {
@@ -157,16 +159,18 @@ fn clear_feature_path_cache() {
 mod tests {
     //! Unit tests for canonical feature path handling.
 
-    use super::{canonical_feature_path, canonicalize_with_cap_std, clear_feature_path_cache};
+    use std::{
+        env,
+        path::{Path, PathBuf},
+    };
+
     use rstest::{fixture, rstest};
     use serial_test::serial;
-    use std::env;
-    use std::path::{Path, PathBuf};
+
+    use super::{canonical_feature_path, canonicalize_with_cap_std, clear_feature_path_cache};
 
     #[fixture]
-    fn cache_cleared() {
-        clear_feature_path_cache();
-    }
+    fn cache_cleared() { clear_feature_path_cache(); }
 
     fn dir_and_target(path: &Path) -> std::io::Result<(super::Dir, PathBuf)> {
         let authority = super::ambient_authority();

--- a/crates/rstest-bdd-macros/src/macros/scenario/paths.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenario/paths.rs
@@ -169,6 +169,7 @@ mod tests {
 
     use super::{canonical_feature_path, canonicalize_with_cap_std, clear_feature_path_cache};
 
+    #[rstest_bdd_test_macros::allow_fixture_expansion_lints]
     #[fixture]
     fn cache_cleared() { clear_feature_path_cache(); }
 

--- a/crates/rstest-bdd-macros/src/macros/scenario/selection.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenario/selection.rs
@@ -7,10 +7,8 @@
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 
+use super::{ScenarioLookup, args::ScenarioSelector};
 use crate::parsing::feature::{ScenarioData, extract_scenario_steps};
-
-use super::ScenarioLookup;
-use super::args::ScenarioSelector;
 
 pub(super) fn ensure_feature_not_empty(
     path_lit: &syn::LitStr,
@@ -204,7 +202,8 @@ fn ambiguous_scenario_error(
         .collect::<Vec<_>>()
         .join(", ");
     let message = format!(
-        "found multiple scenarios named \"{name}\"; use the `index` selector to disambiguate (matching indexes: {indexes}; lines: {lines})",
+        "found multiple scenarios named \"{name}\"; use the `index` selector to disambiguate \
+         (matching indexes: {indexes}; lines: {lines})",
     );
     syn::Error::new(span, message)
 }

--- a/crates/rstest-bdd-macros/src/macros/scenarios/macro_args/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/macro_args/mod.rs
@@ -14,10 +14,12 @@
 //! shared source of truth so macro/runtime policy semantics do not drift.
 
 pub(crate) use rstest_bdd_policy::{RuntimeMode, TestAttributeHint};
-use syn::LitStr;
-use syn::parse::{Parse, ParseStream};
-use syn::punctuated::Punctuated;
-use syn::token::Comma;
+use syn::{
+    LitStr,
+    parse::{Parse, ParseStream},
+    punctuated::Punctuated,
+    token::Comma,
+};
 
 /// Compatibility aliases that map legacy runtime syntax to harness selection.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/rstest-bdd-macros/src/macros/scenarios/macro_args/tests/combined_arguments.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/macro_args/tests/combined_arguments.rs
@@ -1,10 +1,14 @@
 //! Parameterized tests for combined `scenarios!` argument parsing cases.
 
+use syn::parse_quote;
+
 use super::{
-    RuntimeCompatibilityAlias, RuntimeMode, ScenariosArgs, runtime_compatibility_alias,
+    RuntimeCompatibilityAlias,
+    RuntimeMode,
+    ScenariosArgs,
+    runtime_compatibility_alias,
     try_parse_scenarios_args,
 };
-use syn::parse_quote;
 
 #[rstest::rstest]
 #[case::scenarios_args_parses_all_arguments(

--- a/crates/rstest-bdd-macros/src/macros/scenarios/macro_args/tests/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/macro_args/tests/mod.rs
@@ -1,11 +1,16 @@
 //! Unit tests for `scenarios!` macro argument parsing.
 
-use super::{
-    FixtureSpec, RuntimeCompatibilityAlias, RuntimeMode, ScenariosArgs, TestAttributeHint,
-    runtime_compatibility_alias,
-};
 use quote::quote;
 use syn::parse_quote;
+
+use super::{
+    FixtureSpec,
+    RuntimeCompatibilityAlias,
+    RuntimeMode,
+    ScenariosArgs,
+    TestAttributeHint,
+    runtime_compatibility_alias,
+};
 
 fn try_parse_scenarios_args(tokens: proc_macro2::TokenStream) -> syn::Result<ScenariosArgs> {
     syn::parse2(tokens)
@@ -27,9 +32,7 @@ macro_rules! parse_scenarios_args {
 fn parse_fixture_spec(tokens: proc_macro2::TokenStream) -> syn::Result<FixtureSpec> {
     syn::parse2(tokens)
 }
-fn type_to_string(ty: &syn::Type) -> String {
-    quote!(#ty).to_string()
-}
+fn type_to_string(ty: &syn::Type) -> String { quote!(#ty).to_string() }
 
 // Centralizes error-message checking so individual rejection tests stay one-liners.
 fn assert_parse_error_contains(result: syn::Result<ScenariosArgs>, expected_keyword: &str) {
@@ -94,9 +97,7 @@ fn fixture_spec_rejects_missing_colon() {
 }
 
 #[test]
-fn fixture_spec_rejects_missing_type() {
-    assert_fixture_parse_fails(parse_quote!(world:));
-}
+fn fixture_spec_rejects_missing_type() { assert_fixture_parse_fails(parse_quote!(world:)); }
 #[test]
 fn scenarios_args_parses_positional_dir() {
     let args: ScenariosArgs = parse_scenarios_args!(parse_quote!("tests/features"));

--- a/crates/rstest-bdd-macros/src/macros/scenarios/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/mod.rs
@@ -12,24 +12,35 @@ mod macro_args;
 mod path_resolution;
 mod test_generation;
 
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
+
 use proc_macro::TokenStream;
 use proc_macro_error::emit_warning;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
-use std::collections::HashSet;
-use std::path::{Path, PathBuf};
 
-use crate::parsing::feature::{extract_scenario_steps, parse_and_load_feature};
-use crate::parsing::tags::TagExpression;
-use crate::utils::errors::{error_to_tokens, normalized_dir_read_error};
-use crate::utils::ident::sanitize_ident;
-
-use self::feature_discovery::collect_feature_files;
-use self::macro_args::{FixtureSpec, RuntimeMode, ScenariosArgs};
-use self::test_generation::{ScenarioTestContext, generate_scenario_test};
-
-pub(crate) use self::macro_args::RuntimeMode as ScenariosRuntimeMode;
-pub(crate) use self::macro_args::TestAttributeHint as ScenariosTestAttributeHint;
+pub(crate) use self::macro_args::{
+    RuntimeMode as ScenariosRuntimeMode,
+    TestAttributeHint as ScenariosTestAttributeHint,
+};
+use self::{
+    feature_discovery::collect_feature_files,
+    macro_args::{FixtureSpec, RuntimeMode, ScenariosArgs},
+    test_generation::{ScenarioTestContext, generate_scenario_test},
+};
+use crate::{
+    parsing::{
+        feature::{extract_scenario_steps, parse_and_load_feature},
+        tags::TagExpression,
+    },
+    utils::{
+        errors::{error_to_tokens, normalized_dir_read_error},
+        ident::sanitize_ident,
+    },
+};
 
 struct TagFilter {
     expr: TagExpression,
@@ -182,16 +193,14 @@ fn emit_runtime_deprecation_warning(runtime: RuntimeMode, harness: Option<&syn::
     if harness.is_some() {
         emit_warning!(
             Span::call_site(),
-            "the `runtime = \"tokio-current-thread\"` argument is \
-             deprecated and redundant when an explicit `harness` is set; \
-             remove the `runtime` argument"
+            "the `runtime = \"tokio-current-thread\"` argument is deprecated and redundant when \
+             an explicit `harness` is set; remove the `runtime` argument"
         );
     } else {
         emit_warning!(
             Span::call_site(),
-            "the `runtime = \"tokio-current-thread\"` syntax is \
-             deprecated; use \
-             `harness = rstest_bdd_harness_tokio::TokioHarness` instead"
+            "the `runtime = \"tokio-current-thread\"` syntax is deprecated; use `harness = \
+             rstest_bdd_harness_tokio::TokioHarness` instead"
         );
     }
 }
@@ -265,11 +274,11 @@ pub(crate) fn scenarios(input: TokenStream) -> TokenStream {
 mod tests {
     //! Unit tests for the `scenarios!` macro entry point.
 
-    use super::feature_discovery::collect_feature_files;
-    use std::fs;
-    use std::os::unix::fs::symlink;
-    use std::path::Path;
+    use std::{fs, os::unix::fs::symlink, path::Path};
+
     use tempfile::tempdir;
+
+    use super::feature_discovery::collect_feature_files;
 
     #[test]
     fn collects_symlinked_feature_files_without_following_directory_loops() {

--- a/crates/rstest-bdd-macros/src/macros/scenarios/path_resolution.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/path_resolution.rs
@@ -2,10 +2,9 @@
 //! resolution through `cap-std` before falling back to `std::fs` for escape
 //! hatches.
 
-use cap_std::AmbientAuthority;
-use cap_std::ambient_authority;
-use cap_std::fs::Dir;
 use std::path::{Path, PathBuf};
+
+use cap_std::{AmbientAuthority, ambient_authority, fs::Dir};
 
 fn canonicalize_absolute_path(
     path: &Path,

--- a/crates/rstest-bdd-macros/src/macros/scenarios/test_generation/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/test_generation/mod.rs
@@ -4,25 +4,35 @@
 //! fixture parameters and scenario outline example parameters, as well as
 //! lint suppression for fixtures consumed via `StepContext`.
 
+use std::{collections::HashSet, path::Path};
+
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
-use std::collections::HashSet;
-use std::path::Path;
-
-use crate::codegen::rstest_bdd_harness_tokio_path;
-use crate::codegen::scenario::{
-    FeaturePath, ScenarioConfig, ScenarioName, ScenarioReturnKind, generate_scenario_code,
-};
-use crate::parsing::examples::ExampleTable;
-use crate::parsing::feature::ScenarioData;
-use crate::parsing::tags::TagExpression;
-use crate::return_classifier::{ReturnKind, classify_return_type};
-use crate::utils::fixtures::extract_function_fixtures;
-use crate::utils::ident::sanitize_ident;
-use crate::utils::result_type::try_extract_result_error_type;
 
 use super::macro_args::{
-    FixtureSpec, RuntimeCompatibilityAlias, RuntimeMode, runtime_compatibility_alias,
+    FixtureSpec,
+    RuntimeCompatibilityAlias,
+    RuntimeMode,
+    runtime_compatibility_alias,
+};
+use crate::{
+    codegen::{
+        rstest_bdd_harness_tokio_path,
+        scenario::{
+            FeaturePath,
+            ScenarioConfig,
+            ScenarioName,
+            ScenarioReturnKind,
+            generate_scenario_code,
+        },
+    },
+    parsing::{examples::ExampleTable, feature::ScenarioData, tags::TagExpression},
+    return_classifier::{ReturnKind, classify_return_type},
+    utils::{
+        fixtures::extract_function_fixtures,
+        ident::sanitize_ident,
+        result_type::try_extract_result_error_type,
+    },
 };
 
 /// Context for generating a scenario test, capturing the feature file stem,

--- a/crates/rstest-bdd-macros/src/macros/scenarios/test_generation/tests/mod.rs
+++ b/crates/rstest-bdd-macros/src/macros/scenarios/test_generation/tests/mod.rs
@@ -1,18 +1,26 @@
 //! Unit tests for scenario test generation helpers.
 
-use rstest::rstest;
+use std::collections::HashSet;
 
-use super::super::macro_args::FixtureSpec;
-use super::super::macro_args::RuntimeCompatibilityAlias;
-use super::super::macro_args::RuntimeMode;
-use super::super::macro_args::runtime_compatibility_alias;
-use super::{
-    build_fixture_params, build_lint_attributes, build_test_signature, dedupe_name,
-    resolve_effective_runtime, resolve_fixture_error_type, resolve_harness_path,
-};
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use std::collections::HashSet;
+use rstest::rstest;
+
+use super::{
+    super::macro_args::{
+        FixtureSpec,
+        RuntimeCompatibilityAlias,
+        RuntimeMode,
+        runtime_compatibility_alias,
+    },
+    build_fixture_params,
+    build_lint_attributes,
+    build_test_signature,
+    dedupe_name,
+    resolve_effective_runtime,
+    resolve_fixture_error_type,
+    resolve_harness_path,
+};
 
 #[test]
 fn deduplicates_duplicate_titles() {
@@ -72,9 +80,7 @@ macro_rules! assert_fixtures_before_examples {
     }};
 }
 
-fn sig_to_string(sig: &syn::Signature) -> String {
-    quote!(#sig).to_string()
-}
+fn sig_to_string(sig: &syn::Signature) -> String { quote!(#sig).to_string() }
 
 #[test]
 fn build_lint_attributes_empty_fixtures_produces_no_attributes() {

--- a/crates/rstest-bdd-macros/src/parsing/examples.rs
+++ b/crates/rstest-bdd-macros/src/parsing/examples.rs
@@ -1,10 +1,15 @@
 //! Extraction of example tables from scenarios.
 
-use crate::utils::errors::error_to_tokens;
-use crate::validation::examples::{
-    extract_and_validate_headers, flatten_and_validate_rows, validate_header_consistency,
-};
 use proc_macro2::TokenStream;
+
+use crate::{
+    utils::errors::error_to_tokens,
+    validation::examples::{
+        extract_and_validate_headers,
+        flatten_and_validate_rows,
+        validate_header_consistency,
+    },
+};
 
 /// Rows parsed from a `Scenario Outline` examples table.
 ///
@@ -84,8 +89,9 @@ pub(crate) fn extract_examples(
 mod tests {
     //! Tests for example table extraction.
 
-    use super::get_first_examples_table;
     use gherkin::{LineCol, Scenario, Span};
+
+    use super::get_first_examples_table;
 
     fn empty_scenario() -> Scenario {
         Scenario {

--- a/crates/rstest-bdd-macros/src/parsing/feature/missing_examples_tests.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/missing_examples_tests.rs
@@ -1,7 +1,8 @@
 //! Behavioural tests covering scenario outlines without Examples tables.
 
-use super::*;
 use gherkin::{Feature, LineCol, Scenario, Span};
+
+use super::*;
 
 #[test]
 fn scenario_outline_missing_examples_surfaces_scenario_name() {

--- a/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/mod.rs
@@ -1,15 +1,20 @@
 //! Feature file loading and scenario extraction.
 
-use gherkin::{Feature, GherkinEnv, Scenario, Step, StepType};
-use std::collections::HashMap;
 use std::{
+    collections::HashMap,
     path::{Path, PathBuf},
     sync::{LazyLock, RwLock},
 };
 
-use crate::parsing::examples::ExampleTable;
-use crate::parsing::tags::{self, TagExpression};
-use crate::utils::errors::error_to_tokens;
+use gherkin::{Feature, GherkinEnv, Scenario, Step, StepType};
+
+use crate::{
+    parsing::{
+        examples::ExampleTable,
+        tags::{self, TagExpression},
+    },
+    utils::errors::error_to_tokens,
+};
 cfg_if::cfg_if! {
     if #[cfg(feature = "compile-time-validation")] {
         use crate::validation::examples::{validate_examples_in_feature_text, FeatureText};

--- a/crates/rstest-bdd-macros/src/parsing/feature/step_extraction_tests.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/step_extraction_tests.rs
@@ -7,11 +7,13 @@
 //! These tests live separately from `tests.rs` to keep the entry-point test
 //! module small, whilst still covering the richer step-extraction surface area.
 
-use super::*;
 use gherkin::StepType;
 use rstest::rstest;
 
-use super::support::{ExamplesBuilder, FeatureBuilder, StepBuilder, assert_feature_extraction};
+use super::{
+    support::{ExamplesBuilder, FeatureBuilder, StepBuilder, assert_feature_extraction},
+    *,
+};
 
 #[rstest]
 #[case::prepends_background_steps(

--- a/crates/rstest-bdd-macros/src/parsing/feature/support.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/support.rs
@@ -1,7 +1,8 @@
 //! Test support builders for feature parsing tests.
 
-use super::{ParsedStep, ScenarioData as ExtractedScenarioData, extract_scenario_steps};
 use gherkin::{Background, Examples, LineCol, Scenario, Span, Step, StepType, Table};
+
+use super::{ParsedStep, ScenarioData as ExtractedScenarioData, extract_scenario_steps};
 
 // Intentionally expect `unreachable_patterns` today (we match all current variants).
 // If `gherkin::StepType` adds variants, this expectation stops triggering and
@@ -20,13 +21,9 @@ fn kw(ty: StepType) -> String {
     .to_owned()
 }
 
-fn zero_span() -> Span {
-    Span { start: 0, end: 0 }
-}
+fn zero_span() -> Span { Span { start: 0, end: 0 } }
 
-fn zero_pos() -> LineCol {
-    LineCol { line: 0, col: 0 }
-}
+fn zero_pos() -> LineCol { LineCol { line: 0, col: 0 } }
 
 /// Construct a `Table` from an iterable of rows (each row being an iterable of cells).
 ///
@@ -111,9 +108,7 @@ pub(super) struct ExamplesBuilder {
 
 impl ExamplesBuilder {
     /// Start building an Examples block.
-    pub(super) fn new() -> Self {
-        Self { table: None }
-    }
+    pub(super) fn new() -> Self { Self { table: None } }
 
     /// Set the Examples table rows (including the header row).
     pub(super) fn with_table<I, R, S>(mut self, rows: I) -> Self
@@ -278,8 +273,9 @@ pub(super) fn assert_feature_extraction(
 mod tests {
     //! Tests for feature parsing test support builders.
 
-    use super::*;
     use gherkin::StepType;
+
+    use super::*;
 
     #[test]
     fn step_builder_overrides_keyword_and_collects_arguments() {

--- a/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
+++ b/crates/rstest-bdd-macros/src/parsing/feature/tests.rs
@@ -7,11 +7,11 @@ mod step_extraction_tests;
 #[path = "support.rs"]
 mod support;
 
-use super::*;
 use gherkin::StepType;
 use rstest::rstest;
-
 use support::{FeatureBuilder, StepBuilder};
+
+use super::*;
 
 #[rstest]
 #[case("And", StepType::Given, crate::StepKeyword::And)]
@@ -68,6 +68,7 @@ fn reports_requested_index_and_available_count_on_oob() {
 #[test]
 fn caches_features_by_path() {
     use std::io::Write;
+
     use tempfile::NamedTempFile;
     super::clear_feature_cache();
     let mut tf = NamedTempFile::new().expect("create temp feature");

--- a/crates/rstest-bdd-macros/src/parsing/placeholder.rs
+++ b/crates/rstest-bdd-macros/src/parsing/placeholder.rs
@@ -5,8 +5,9 @@
 //! cucumber-rs-style parameterization where `Given I have <count> items` with
 //! an Examples row `| count | = | 5 |` becomes `Given I have 5 items`.
 
-use regex::Regex;
 use std::sync::LazyLock;
+
+use regex::Regex;
 use thiserror::Error;
 
 /// Regex pattern matching `<placeholder>` tokens in step text.
@@ -96,9 +97,7 @@ pub fn substitute_placeholders(
 /// Checks if a text contains any placeholder tokens.
 ///
 /// Returns `true` if the text contains at least one `<placeholder>` pattern.
-pub fn contains_placeholders(text: &str) -> bool {
-    PLACEHOLDER_RE.is_match(text)
-}
+pub fn contains_placeholders(text: &str) -> bool { PLACEHOLDER_RE.is_match(text) }
 
 /// Extracts all placeholder names from a text.
 ///
@@ -117,8 +116,9 @@ fn extract_placeholder_names(text: &str) -> Vec<String> {
 mod tests {
     //! Unit tests for parsing placeholder syntax.
 
-    use super::*;
     use rstest::rstest;
+
+    use super::*;
 
     #[rstest]
     #[case(

--- a/crates/rstest-bdd-macros/src/parsing/tags/ast.rs
+++ b/crates/rstest-bdd-macros/src/parsing/tags/ast.rs
@@ -15,8 +15,7 @@
 //! the filtering logic aligned with compile-time diagnostics while avoiding
 //! needless work once the outcome is known.
 
-use std::borrow::Cow;
-use std::collections::HashSet;
+use std::{borrow::Cow, collections::HashSet};
 
 use super::parser::Parser;
 

--- a/crates/rstest-bdd-macros/src/parsing/tags/lexer.rs
+++ b/crates/rstest-bdd-macros/src/parsing/tags/lexer.rs
@@ -44,9 +44,7 @@ pub(super) struct Lexer<'a> {
 }
 
 impl<'a> Lexer<'a> {
-    pub(super) fn new(input: &'a str) -> Self {
-        Self { input, pos: 0 }
-    }
+    pub(super) fn new(input: &'a str) -> Self { Self { input, pos: 0 } }
 
     pub(super) fn next_token(&mut self) -> Result<Token, TagExprError> {
         self.skip_whitespace();
@@ -160,6 +158,4 @@ impl<'a> Lexer<'a> {
     }
 }
 
-fn is_tag_char(ch: char) -> bool {
-    ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-')
-}
+fn is_tag_char(ch: char) -> bool { ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-') }

--- a/crates/rstest-bdd-macros/src/parsing/tags/mod.rs
+++ b/crates/rstest-bdd-macros/src/parsing/tags/mod.rs
@@ -31,8 +31,8 @@
 //!
 //! # Tokens recognized by the lexer
 //!
-//! - Tag names written as `@identifier`, where identifiers may contain ASCII
-//!   letters, digits, underscores, and hyphens.
+//! - Tag names written as `@identifier`, where identifiers may contain ASCII letters, digits,
+//!   underscores, and hyphens.
 //! - Case-insensitive keywords `not`, `and`, and `or`.
 //! - Opening and closing parentheses for grouping.
 //! - End-of-input markers used to report trailing tokens.

--- a/crates/rstest-bdd-macros/src/parsing/tags/parser.rs
+++ b/crates/rstest-bdd-macros/src/parsing/tags/parser.rs
@@ -8,8 +8,10 @@
 
 use std::marker::PhantomData;
 
-use super::ast::{Expr, TagExprError};
-use super::lexer::{Lexer, Token, TokenKind};
+use super::{
+    ast::{Expr, TagExprError},
+    lexer::{Lexer, Token, TokenKind},
+};
 
 /// Strategy for parsing left-associative binary operator chains.
 struct ChainParseStrategy<'a, F, P, B> {
@@ -49,9 +51,7 @@ impl<'a> Parser<'a> {
         Ok(Self { lexer, current })
     }
 
-    pub(super) fn parse_expression(&mut self) -> Result<Expr, TagExprError> {
-        self.parse_or()
-    }
+    pub(super) fn parse_expression(&mut self) -> Result<Expr, TagExprError> { self.parse_or() }
 
     pub(super) fn expect_end(&self) -> Result<(), TagExprError> {
         if matches!(self.current.kind, TokenKind::End) {

--- a/crates/rstest-bdd-macros/src/pattern.rs
+++ b/crates/rstest-bdd-macros/src/pattern.rs
@@ -9,7 +9,6 @@ mod validation {
     use proc_macro_error::abort;
     use proc_macro2::Span;
     use regex::Regex;
-
     use rstest_bdd_patterns::{build_regex_from_pattern, extract_captured_values};
 
     pub(crate) struct MacroPattern {
@@ -34,9 +33,7 @@ mod validation {
             }
         }
 
-        pub(crate) const fn as_str(&self) -> &'static str {
-            self.text
-        }
+        pub(crate) const fn as_str(&self) -> &'static str { self.text }
 
         pub(crate) fn regex(&self, span: Span) -> &Regex {
             self.regex.get_or_init(|| {
@@ -54,17 +51,16 @@ mod validation {
     }
 
     impl From<&'static str> for MacroPattern {
-        fn from(value: &'static str) -> Self {
-            Self::new(value)
-        }
+        fn from(value: &'static str) -> Self { Self::new(value) }
     }
 
     #[cfg(test)]
     mod tests {
         //! Unit tests for compile-time pattern helpers.
 
-        use super::MacroPattern;
         use proc_macro2::Span;
+
+        use super::MacroPattern;
 
         #[test]
         fn compiles_pattern_once() {

--- a/crates/rstest-bdd-macros/src/return_classifier/mod.rs
+++ b/crates/rstest-bdd-macros/src/return_classifier/mod.rs
@@ -66,7 +66,8 @@ pub(crate) fn classify_return_type(
                 if is_definitely_non_result_type(ty) {
                     Err(syn::Error::new_spanned(
                         ty,
-                        "return override `result` requires a return type shaped like `Result<T, E>` or `StepResult<T, E>`",
+                        "return override `result` requires a return type shaped like `Result<T, \
+                         E>` or `StepResult<T, E>`",
                     ))
                 } else {
                     // We cannot resolve type aliases during macro expansion.
@@ -107,9 +108,7 @@ fn classify_result_like(ty: &Type) -> Option<ReturnKind> {
 /// However, the runtime helper [`__rstest_bdd_payload_from_value`] identifies
 /// unit aliases via `TypeId` comparison, so steps returning unit aliases will
 /// still produce `None` payloads rather than boxed `()` values.
-fn is_unit_type(ty: &Type) -> bool {
-    matches!(ty, Type::Tuple(tuple) if tuple.elems.is_empty())
-}
+fn is_unit_type(ty: &Type) -> bool { matches!(ty, Type::Tuple(tuple) if tuple.elems.is_empty()) }
 
 fn is_definitely_non_result_type(ty: &Type) -> bool {
     match ty {
@@ -200,14 +199,10 @@ fn is_step_result_path(path: &Path) -> bool {
     })
 }
 
-pub(crate) fn first_type_argument(path: &Path) -> Option<&Type> {
-    nth_type_argument(path, 0)
-}
+pub(crate) fn first_type_argument(path: &Path) -> Option<&Type> { nth_type_argument(path, 0) }
 
 /// Extracts the error type `E` from `Result<T, E>` or `StepResult<T, E>`.
-pub(crate) fn second_type_argument(path: &Path) -> Option<&Type> {
-    nth_type_argument(path, 1)
-}
+pub(crate) fn second_type_argument(path: &Path) -> Option<&Type> { nth_type_argument(path, 1) }
 
 fn nth_type_argument(path: &Path, n: usize) -> Option<&Type> {
     let segment = path.segments.last()?;

--- a/crates/rstest-bdd-macros/src/return_classifier/tests.rs
+++ b/crates/rstest-bdd-macros/src/return_classifier/tests.rs
@@ -157,9 +157,7 @@ fn second_type_argument_returns_none_for_single_generic() {
 #[test]
 fn override_result_requires_result_like_return_type() {
     let func: syn::ItemFn = syn::parse_quote!(
-        fn step() -> u8 {
-            1
-        }
+        fn step() -> u8 { 1 }
     );
     let err = match classify_return_type(&func.sig.output, Some(ReturnOverride::Result)) {
         Ok(kind) => panic!("expected result override to fail, got {kind:?}"),

--- a/crates/rstest-bdd-macros/src/scenario_state.rs
+++ b/crates/rstest-bdd-macros/src/scenario_state.rs
@@ -137,8 +137,9 @@ impl FieldLabel<'_> {
 mod tests {
     //! Unit tests for the `ScenarioState` derive helpers.
 
-    use super::*;
     use quote::quote;
+
+    use super::*;
 
     fn expand_tokens(input: TokenStream2) -> syn::Result<TokenStream2> {
         let derive_input = syn::parse2::<DeriveInput>(input)?;

--- a/crates/rstest-bdd-macros/src/step_args.rs
+++ b/crates/rstest-bdd-macros/src/step_args.rs
@@ -202,10 +202,11 @@ fn expand_named_struct(
 mod tests {
     //! Unit tests for step argument parsing.
 
-    use super::expand;
     use proc_macro2::TokenStream as TokenStream2;
     use quote::quote;
     use syn::DeriveInput;
+
+    use super::expand;
 
     fn expand_tokens(tokens: TokenStream2) -> syn::Result<TokenStream2> {
         let input = syn::parse2::<DeriveInput>(tokens)?;

--- a/crates/rstest-bdd-macros/src/step_keyword.rs
+++ b/crates/rstest-bdd-macros/src/step_keyword.rs
@@ -5,13 +5,12 @@
 //! A newtype wrapper is used to satisfy Rust's orphan rules when implementing
 //! foreign traits like `ToTokens`.
 
+use std::{fmt, str::FromStr};
+
 use gherkin::Step;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{ToTokens, quote};
 use rstest_bdd_patterns::StepKeyword as BaseKeyword;
-use std::fmt;
-use std::str::FromStr;
-
 // Re-export error types from the patterns crate.
 pub(crate) use rstest_bdd_patterns::UnsupportedStepType;
 
@@ -50,9 +49,7 @@ impl StepKeyword {
             reason = "used by validation module behind compile-time-validation feature"
         )
     )]
-    pub(crate) fn as_str(self) -> &'static str {
-        self.0.as_str()
-    }
+    pub(crate) fn as_str(self) -> &'static str { self.0.as_str() }
 
     /// Resolve conjunctions to the semantic keyword of the previous step.
     ///
@@ -94,9 +91,7 @@ impl FromStr for StepKeyword {
 impl TryFrom<&str> for StepKeyword {
     type Error = StepKeywordParseError;
 
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        value.parse()
-    }
+    fn try_from(value: &str) -> Result<Self, Self::Error> { value.parse() }
 }
 
 impl TryFrom<gherkin::StepType> for StepKeyword {
@@ -157,9 +152,10 @@ impl ToTokens for StepKeyword {
 mod tests {
     //! Unit tests for step keyword parsing and conversion.
 
-    use super::*;
     use gherkin::StepType;
     use rstest::rstest;
+
+    use super::*;
 
     #[rstest]
     #[case("Given", StepKeyword::Given)]

--- a/crates/rstest-bdd-macros/src/utils/errors.rs
+++ b/crates/rstest-bdd-macros/src/utils/errors.rs
@@ -3,9 +3,7 @@
 use proc_macro2::TokenStream;
 
 /// Convert a `syn::Error` into a `TokenStream` for macro errors.
-pub(crate) fn error_to_tokens(err: &syn::Error) -> TokenStream {
-    err.to_compile_error()
-}
+pub(crate) fn error_to_tokens(err: &syn::Error) -> TokenStream { err.to_compile_error() }
 
 /// Produce a deterministic message when reading a directory fails.
 ///

--- a/crates/rstest-bdd-macros/src/utils/fixtures.rs
+++ b/crates/rstest-bdd-macros/src/utils/fixtures.rs
@@ -4,7 +4,9 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 
 use crate::utils::result_type::{
-    is_referenced_result_type, try_extract_result_inner_type, ungroup_type,
+    is_referenced_result_type,
+    try_extract_result_inner_type,
+    ungroup_type,
 };
 
 /// Generated code for wiring scenario fixture parameters into `StepContext`.
@@ -208,9 +210,10 @@ fn find_from_attr(attrs: &[syn::Attribute]) -> syn::Result<Option<syn::Path>> {
 mod tests {
     //! Unit tests for fixture extraction from function signatures.
 
-    use super::*;
     use rstest::rstest;
     use syn::parse_quote;
+
+    use super::*;
 
     #[test]
     fn non_ref_fixture_cell_ident_uses_index() {

--- a/crates/rstest-bdd-macros/src/utils/ident.rs
+++ b/crates/rstest-bdd-macros/src/utils/ident.rs
@@ -78,8 +78,9 @@ const RUST_KEYWORDS: &[&str] = &[
 mod tests {
     //! Unit tests for identifier sanitization helpers.
 
-    use super::sanitize_ident;
     use rstest::rstest;
+
+    use super::sanitize_ident;
 
     #[test]
     fn sanitizes_invalid_identifiers() {

--- a/crates/rstest-bdd-macros/src/utils/pattern/mod.rs
+++ b/crates/rstest-bdd-macros/src/utils/pattern/mod.rs
@@ -277,9 +277,7 @@ pub(crate) fn infer_pattern(ident: &Ident) -> LitStr {
 /// assert_eq!(normalize_param_name("param"), "param");
 /// assert_eq!(normalize_param_name("__param"), "_param");
 /// ```
-pub(crate) fn normalize_param_name(name: &str) -> &str {
-    name.strip_prefix('_').unwrap_or(name)
-}
+pub(crate) fn normalize_param_name(name: &str) -> &str { name.strip_prefix('_').unwrap_or(name) }
 
 /// Check if an identifier matches a header after normalization.
 ///

--- a/crates/rstest-bdd-macros/src/utils/pattern/tests.rs
+++ b/crates/rstest-bdd-macros/src/utils/pattern/tests.rs
@@ -1,8 +1,9 @@
 //! Tests for pattern utilities.
 
-use super::*;
 use rstest::rstest;
 use syn::parse_quote;
+
+use super::*;
 
 #[rstest]
 #[case("_param", "param")]

--- a/crates/rstest-bdd-macros/src/utils/result_type.rs
+++ b/crates/rstest-bdd-macros/src/utils/result_type.rs
@@ -107,9 +107,10 @@ pub(crate) fn try_extract_result_error_type(ty: &Type) -> Option<Type> {
 mod tests {
     //! Unit tests for detecting `Result`-like return types.
 
-    use super::*;
     use rstest::rstest;
     use syn::parse_quote;
+
+    use super::*;
 
     #[rstest]
     #[case("Result<MyWorld, String>", "MyWorld")]

--- a/crates/rstest-bdd-macros/src/validation/examples.rs
+++ b/crates/rstest-bdd-macros/src/validation/examples.rs
@@ -1,7 +1,8 @@
 //! Validation routines for example tables in features.
 
-use crate::utils::errors::error_to_tokens;
 use proc_macro2::TokenStream;
+
+use crate::utils::errors::error_to_tokens;
 
 /// Wraps the full feature file text content.
 #[cfg(feature = "compile-time-validation")]
@@ -10,23 +11,17 @@ pub(crate) struct FeatureText<'a>(&'a str);
 
 #[cfg(feature = "compile-time-validation")]
 impl<'a> FeatureText<'a> {
-    pub(crate) fn new(text: &'a str) -> Self {
-        Self(text)
-    }
+    pub(crate) fn new(text: &'a str) -> Self { Self(text) }
 }
 
 #[cfg(feature = "compile-time-validation")]
 impl AsRef<str> for FeatureText<'_> {
-    fn as_ref(&self) -> &str {
-        self.0
-    }
+    fn as_ref(&self) -> &str { self.0 }
 }
 
 #[cfg(feature = "compile-time-validation")]
 impl<'a> From<&'a str> for FeatureText<'a> {
-    fn from(text: &'a str) -> Self {
-        Self(text)
-    }
+    fn from(text: &'a str) -> Self { Self(text) }
 }
 
 /// Wraps a single row from an Examples table.
@@ -124,8 +119,9 @@ fn format_malformed_examples_error(row: usize, actual: usize, expected: usize) -
 #[cfg(all(test, feature = "compile-time-validation"))]
 mod column_tests {
     //! Tests for column counting in Examples tables.
-    use super::{TableRow, count_columns};
     use rstest::rstest;
+
+    use super::{TableRow, count_columns};
 
     #[rstest]
     #[case("| a | b |", 3)]
@@ -205,8 +201,9 @@ pub(crate) fn flatten_and_validate_rows(
 #[cfg(all(test, feature = "compile-time-validation"))]
 mod tests {
     //! Tests for validating Examples tables and error reporting.
-    use super::*;
     use rstest::rstest;
+
+    use super::*;
 
     fn error_message(text: &str) -> String {
         match validate_examples_in_feature_text(FeatureText::new(text)) {

--- a/crates/rstest-bdd-macros/src/validation/parameters.rs
+++ b/crates/rstest-bdd-macros/src/validation/parameters.rs
@@ -3,9 +3,9 @@
 //! Underscore-prefixed parameter names (e.g., `_param`) match unprefixed headers
 //! (e.g., `param`), enabling idiomatic Rust unused parameter marking.
 
-use crate::utils::errors::error_to_tokens;
-use crate::utils::pattern::ident_matches_normalized;
 use proc_macro2::TokenStream;
+
+use crate::utils::{errors::error_to_tokens, pattern::ident_matches_normalized};
 
 fn parameter_matches_header(arg: &syn::FnArg, header: &str) -> bool {
     match arg {

--- a/crates/rstest-bdd-macros/src/validation/placeholder.rs
+++ b/crates/rstest-bdd-macros/src/validation/placeholder.rs
@@ -5,9 +5,9 @@
 //! happens at compile time during macro expansion, providing early feedback for
 //! misconfigured scenario outlines.
 
-use crate::parsing::feature::ParsedStep;
-use crate::parsing::placeholder::PLACEHOLDER_RE;
 use proc_macro2::Span;
+
+use crate::parsing::{feature::ParsedStep, placeholder::PLACEHOLDER_RE};
 
 /// Location where placeholder validation is performed.
 #[derive(Debug, Clone, Copy)]
@@ -35,17 +35,11 @@ impl ValidationContext {
 pub(crate) struct ExampleHeaders<'a>(&'a [String]);
 
 impl<'a> ExampleHeaders<'a> {
-    pub fn new(headers: &'a [String]) -> Self {
-        Self(headers)
-    }
+    pub fn new(headers: &'a [String]) -> Self { Self(headers) }
 
-    pub fn contains(&self, name: &str) -> bool {
-        self.0.iter().any(|h| h == name)
-    }
+    pub fn contains(&self, name: &str) -> bool { self.0.iter().any(|h| h == name) }
 
-    pub fn join(&self, sep: &str) -> String {
-        self.0.join(sep)
-    }
+    pub fn join(&self, sep: &str) -> String { self.0.join(sep) }
 }
 
 /// Validates all placeholders in steps reference columns in the Examples table.
@@ -125,8 +119,8 @@ fn validate_text_placeholders(
             return Err(syn::Error::new(
                 span,
                 format!(
-                    "Placeholder '<{placeholder}>' in {} not found in Examples table. \
-                     Available columns: [{}]",
+                    "Placeholder '<{placeholder}>' in {} not found in Examples table. Available \
+                     columns: [{}]",
                     context.as_str(),
                     headers.join(", ")
                 ),
@@ -137,23 +131,20 @@ fn validate_text_placeholders(
 }
 
 #[cfg(feature = "compile-time-validation")]
-fn step_span(step: &ParsedStep) -> Span {
-    step.span
-}
+fn step_span(step: &ParsedStep) -> Span { step.span }
 
 #[cfg(not(feature = "compile-time-validation"))]
-fn step_span(_step: &ParsedStep) -> Span {
-    Span::call_site()
-}
+fn step_span(_step: &ParsedStep) -> Span { Span::call_site() }
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests use unwrap for brevity")]
 mod tests {
     //! Unit tests for placeholder validation against example headers.
 
+    use rstest::rstest;
+
     use super::*;
     use crate::StepKeyword;
-    use rstest::rstest;
 
     /// Builder for creating test `ParsedStep` instances.
     struct ParsedStepBuilder {

--- a/crates/rstest-bdd-macros/src/validation/steps/crate_id.rs
+++ b/crates/rstest-bdd-macros/src/validation/steps/crate_id.rs
@@ -1,14 +1,13 @@
 //! Crate ID normalization utilities for step validation.
 
-use camino::{Utf8Path, Utf8PathBuf};
 use std::sync::LazyLock;
+
+use camino::{Utf8Path, Utf8PathBuf};
 
 pub(super) static CURRENT_CRATE_ID: LazyLock<Box<str>> =
     LazyLock::new(|| normalize_crate_id(&current_crate_id_raw()));
 
-pub(super) fn current_crate_id() -> &'static str {
-    CURRENT_CRATE_ID.as_ref()
-}
+pub(super) fn current_crate_id() -> &'static str { CURRENT_CRATE_ID.as_ref() }
 
 pub(super) fn normalize_crate_id(id: &str) -> Box<str> {
     let (name, path) = id.split_once(':').unwrap_or((id, ""));

--- a/crates/rstest-bdd-macros/src/validation/steps/messages.rs
+++ b/crates/rstest-bdd-macros/src/validation/steps/messages.rs
@@ -1,9 +1,7 @@
 //! Error message construction for step validation.
 
 use super::{CrateDefs, get_step_span};
-use crate::StepKeyword;
-use crate::parsing::feature::ParsedStep;
-use crate::pattern::MacroPattern;
+use crate::{StepKeyword, parsing::feature::ParsedStep, pattern::MacroPattern};
 
 pub(super) fn format_missing_step_error(
     resolved: StepKeyword,
@@ -86,8 +84,9 @@ where
 mod tests {
     //! Tests for step validation message formatting.
 
-    use super::*;
     use proc_macro2::Span;
+
+    use super::*;
 
     fn leak_pattern(text: &str) -> &'static MacroPattern {
         let leaked: &'static str = Box::leak(text.to_owned().into_boxed_str());

--- a/crates/rstest-bdd-macros/src/validation/steps/mod.rs
+++ b/crates/rstest-bdd-macros/src/validation/steps/mod.rs
@@ -13,17 +13,17 @@
 mod crate_id;
 mod messages;
 
-use std::collections::HashMap;
-use std::sync::{LazyLock, Mutex};
-
-use crate::StepKeyword;
-use crate::parsing::feature::ParsedStep;
-use crate::pattern::MacroPattern;
-#[cfg(not(test))]
-use proc_macro_error::emit_warning;
+use std::{
+    collections::HashMap,
+    sync::{LazyLock, Mutex},
+};
 
 use crate_id::{current_crate_id, normalize_crate_id};
 use messages::{format_ambiguous_step_error, format_missing_step_error};
+#[cfg(not(test))]
+use proc_macro_error::emit_warning;
+
+use crate::{StepKeyword, parsing::feature::ParsedStep, pattern::MacroPattern};
 
 type Registry = HashMap<Box<str>, CrateDefs>;
 
@@ -36,9 +36,7 @@ impl CrateDefs {
     fn patterns(&self, kw: StepKeyword) -> &[&'static MacroPattern] {
         self.by_kw.get(&kw).map_or(&[], Vec::as_slice)
     }
-    fn is_empty(&self) -> bool {
-        self.by_kw.values().all(Vec::is_empty)
-    }
+    fn is_empty(&self) -> bool { self.by_kw.values().all(Vec::is_empty) }
 }
 
 /// Global registry of step definitions.
@@ -166,7 +164,8 @@ fn validate_registry_state(
                 #[cfg(not(test))]
                 emit_warning!(
                     proc_macro2::Span::call_site(),
-                    "step registry has no definitions for crate ID '{}'. This may indicate a registry issue.",
+                    "step registry has no definitions for crate ID '{}'. This may indicate a \
+                     registry issue.",
                     crate_id_str
                 );
                 RegistryDecision::WarnAndSkip

--- a/crates/rstest-bdd-macros/src/validation/steps/tests/mod.rs
+++ b/crates/rstest-bdd-macros/src/validation/steps/tests/mod.rs
@@ -1,15 +1,23 @@
 //! Tests for step-definition validation: missing/single/ambiguous outcomes and registry behaviour.
-// Intentionally left without file-wide lint suppressions; add per-function #[expect(...)] where needed.
-use super::crate_id::{canonicalize_out_dir, normalize_crate_id};
-use super::*;
+// Intentionally left without file-wide lint suppressions; add per-function #[expect(...)] where
+// needed.
 use camino::Utf8PathBuf;
 use rstest::rstest;
 use serial_test::serial;
 use tempfile::{tempdir, tempdir_in};
 
+use super::{
+    crate_id::{canonicalize_out_dir, normalize_crate_id},
+    *,
+};
+
 mod support;
 use self::support::{
-    TempWorkingDir, assert_bullet_count, clear_registry, create_dir_all_cap, create_test_step,
+    TempWorkingDir,
+    assert_bullet_count,
+    clear_registry,
+    create_dir_all_cap,
+    create_test_step,
     temp_working_dir,
 };
 

--- a/crates/rstest-bdd-macros/src/validation/steps/tests/support.rs
+++ b/crates/rstest-bdd-macros/src/validation/steps/tests/support.rs
@@ -1,10 +1,11 @@
 //! Shared helpers for step validation tests.
 
-use super::*;
 use camino::{Utf8Path, Utf8PathBuf};
 use cap_std::{ambient_authority, fs_utf8::Dir};
 use rstest::fixture;
 use tempfile::tempdir;
+
+use super::*;
 
 pub(super) fn clear_registry() {
     let mut registry = match REGISTERED.lock() {
@@ -39,17 +40,11 @@ pub(super) struct TempWorkingDir {
 }
 
 impl TempWorkingDir {
-    fn new(temp: tempfile::TempDir, path: Utf8PathBuf) -> Self {
-        Self { _temp: temp, path }
-    }
+    fn new(temp: tempfile::TempDir, path: Utf8PathBuf) -> Self { Self { _temp: temp, path } }
 
-    pub(super) fn path(&self) -> &Utf8Path {
-        self.path.as_path()
-    }
+    pub(super) fn path(&self) -> &Utf8Path { self.path.as_path() }
 
-    pub(super) fn join(&self, relative: &str) -> Utf8PathBuf {
-        self.path.join(relative)
-    }
+    pub(super) fn join(&self, relative: &str) -> Utf8PathBuf { self.path.join(relative) }
 }
 
 fn should_skip_creation(path: &Utf8Path) -> bool {
@@ -129,6 +124,4 @@ fn temp_working_dir_inner() -> std::io::Result<TempWorkingDir> {
 }
 
 #[fixture]
-pub(super) fn temp_working_dir() -> std::io::Result<TempWorkingDir> {
-    temp_working_dir_inner()
-}
+pub(super) fn temp_working_dir() -> std::io::Result<TempWorkingDir> { temp_working_dir_inner() }

--- a/crates/rstest-bdd-macros/src/validation/steps/tests/support.rs
+++ b/crates/rstest-bdd-macros/src/validation/steps/tests/support.rs
@@ -123,5 +123,6 @@ fn temp_working_dir_inner() -> std::io::Result<TempWorkingDir> {
     Ok(TempWorkingDir::new(temp, temp_path))
 }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 pub(super) fn temp_working_dir() -> std::io::Result<TempWorkingDir> { temp_working_dir_inner() }

--- a/crates/rstest-bdd-macros/tests/args.rs
+++ b/crates/rstest-bdd-macros/tests/args.rs
@@ -1,7 +1,8 @@
 //! Tests for argument extraction helpers.
+use std::collections::HashSet;
+
 use quote::quote;
 use rstest::rstest;
-use std::collections::HashSet;
 use syn::parse_quote;
 #[path = "../src/codegen/wrapper/args/mod.rs"]
 #[expect(dead_code, reason = "test reuses only selected helpers")]
@@ -11,7 +12,11 @@ mod args_impl;
 use args_impl::{Arg, ExtractedArgs, extract_args};
 mod support;
 use support::{
-    find_datatable, fixture_count, has_docstring, ordered_parameter_names, step_arg_count,
+    find_datatable,
+    fixture_count,
+    has_docstring,
+    ordered_parameter_names,
+    step_arg_count,
 };
 /// Helper for invoking `extract_args` with placeholder names.
 /// Consolidates repeated placeholder setup across tests.

--- a/crates/rstest-bdd-macros/tests/args_str_ref.rs
+++ b/crates/rstest-bdd-macros/tests/args_str_ref.rs
@@ -1,7 +1,8 @@
 //! Tests for `&str` reference handling in argument extraction.
 
-use rstest::rstest;
 use std::collections::HashSet;
+
+use rstest::rstest;
 use syn::parse_quote;
 
 #[path = "../src/codegen/wrapper/args/mod.rs"]

--- a/crates/rstest-bdd-patterns/src/capture.rs
+++ b/crates/rstest-bdd-patterns/src/capture.rs
@@ -13,8 +13,7 @@ use regex::Regex;
 /// ```
 /// # use regex::Regex;
 /// # use rstest_bdd_patterns::extract_captured_values;
-/// let regex = Regex::new(r"^(\d+)-(\w+)$")
-///     .expect("example ensures fallible call succeeds");
+/// let regex = Regex::new(r"^(\d+)-(\w+)$").expect("example ensures fallible call succeeds");
 /// let values = extract_captured_values(&regex, "42-answer")
 ///     .expect("example ensures fallible call succeeds");
 /// assert_eq!(values, vec!["42".to_string(), "answer".to_string()]);
@@ -23,8 +22,7 @@ use regex::Regex;
 /// ```
 /// # use regex::Regex;
 /// # use rstest_bdd_patterns::extract_captured_values;
-/// let regex = Regex::new(r"^(\d+)$")
-///     .expect("example ensures fallible call succeeds");
+/// let regex = Regex::new(r"^(\d+)$").expect("example ensures fallible call succeeds");
 /// assert!(extract_captured_values(&regex, "nope").is_none());
 /// ```
 #[must_use]

--- a/crates/rstest-bdd-patterns/src/errors.rs
+++ b/crates/rstest-bdd-patterns/src/errors.rs
@@ -1,6 +1,7 @@
 //! Error types shared by the pattern parsing modules.
 
 use std::fmt;
+
 use thiserror::Error;
 
 /// Additional context for placeholder-related parsing errors.

--- a/crates/rstest-bdd-patterns/src/keyword.rs
+++ b/crates/rstest-bdd-patterns/src/keyword.rs
@@ -4,9 +4,9 @@
 //! runtime and proc-macro crates, ensuring consistent keyword handling across
 //! compile-time validation and runtime execution.
 
+use std::{fmt, str::FromStr};
+
 use gherkin::StepType;
-use std::fmt;
-use std::str::FromStr;
 
 /// Keyword used to categorize a step definition.
 ///
@@ -33,8 +33,7 @@ pub enum StepKeyword {
 /// One invocation lists each `(canonical rendering, variant)` pair exactly
 /// once and expands to both directions of the mapping:
 ///
-/// - the `KEYWORDS` table driving the case-insensitive
-///   [`StepKeyword::from_str`] lookup, and
+/// - the `KEYWORDS` table driving the case-insensitive [`StepKeyword::from_str`] lookup, and
 /// - the exhaustive match inside [`StepKeyword::as_str`].
 ///
 /// Adding or renaming a keyword therefore means editing exactly one list
@@ -144,9 +143,7 @@ impl FromStr for StepKeyword {
 impl TryFrom<&str> for StepKeyword {
     type Error = StepKeywordParseError;
 
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        value.parse()
-    }
+    fn try_from(value: &str) -> Result<Self, Self::Error> { value.parse() }
 }
 
 /// Error raised when converting a parsed Gherkin [`StepType`] into a
@@ -199,8 +196,9 @@ impl TryFrom<StepType> for StepKeyword {
 mod tests {
     //! Unit tests for step keyword parsing and conversion.
 
-    use super::*;
     use rstest::rstest;
+
+    use super::*;
 
     #[rstest]
     #[case("Given", StepKeyword::Given)]

--- a/crates/rstest-bdd-patterns/src/pattern/compiler.rs
+++ b/crates/rstest-bdd-patterns/src/pattern/compiler.rs
@@ -1,9 +1,10 @@
 //! Convert lexed tokens into anchored regular-expression sources.
 
-use crate::errors::{PatternError, placeholder_error};
-use crate::hint::get_type_pattern;
-
 use super::lexer::{Token, lex_pattern};
+use crate::{
+    errors::{PatternError, placeholder_error},
+    hint::get_type_pattern,
+};
 
 /// Process a single token, appending its regex representation to the output.
 ///

--- a/crates/rstest-bdd-patterns/src/pattern/lexer.rs
+++ b/crates/rstest-bdd-patterns/src/pattern/lexer.rs
@@ -1,11 +1,9 @@
 //! Pattern lexer converting pattern strings into semantic tokens.
 
-use std::iter::Peekable;
-use std::str::CharIndices;
-
-use crate::errors::PatternError;
+use std::{iter::Peekable, str::CharIndices};
 
 use super::placeholder::{PlaceholderSpec, parse_placeholder};
+use crate::errors::PatternError;
 
 /// Token produced by the pattern lexer.
 ///
@@ -76,9 +74,7 @@ impl<'pattern> LexerContext<'pattern> {
         }
     }
 
-    fn into_tokens(self) -> Vec<Token> {
-        self.tokens
-    }
+    fn into_tokens(self) -> Vec<Token> { self.tokens }
 }
 
 /// Tokenize a step pattern into literals and placeholders.
@@ -90,7 +86,7 @@ impl<'pattern> LexerContext<'pattern> {
 /// # Examples
 ///
 /// ```
-/// use rstest_bdd_patterns::pattern::lexer::{lex_pattern, Token};
+/// use rstest_bdd_patterns::pattern::lexer::{Token, lex_pattern};
 ///
 /// let tokens = lex_pattern("Given {value:u32}").expect("valid pattern syntax");
 /// assert_eq!(tokens.len(), 2);
@@ -153,13 +149,9 @@ fn handle_close_brace(index: usize, context: &mut LexerContext<'_>) {
     }
 }
 
-fn is_placeholder_start(ch: char) -> bool {
-    is_valid_placeholder_start(ch)
-}
+fn is_placeholder_start(ch: char) -> bool { is_valid_placeholder_start(ch) }
 
-fn is_valid_placeholder_start(ch: char) -> bool {
-    ch.is_ascii_alphabetic() || ch == '_'
-}
+fn is_valid_placeholder_start(ch: char) -> bool { ch.is_ascii_alphabetic() || ch == '_' }
 
 fn parse_and_consume_placeholder(
     bytes: &[u8],

--- a/crates/rstest-bdd-patterns/src/pattern/mod.rs
+++ b/crates/rstest-bdd-patterns/src/pattern/mod.rs
@@ -12,9 +12,10 @@ pub use compiler::build_regex_from_pattern;
 mod tests {
     //! Unit tests for the pattern module surface.
 
+    use std::fmt::Display;
+
     use super::build_regex_from_pattern;
     use crate::{PatternError, compile_regex_from_pattern};
-    use std::fmt::Display;
 
     fn expect_ok<T, E: Display>(result: Result<T, E>, context: &str) -> T {
         match result {

--- a/crates/rstest-bdd-patterns/src/specificity.rs
+++ b/crates/rstest-bdd-patterns/src/specificity.rs
@@ -4,9 +4,12 @@
 //! scoring to select the most specific match. More specific patterns have more
 //! literal text and fewer placeholders.
 
-use crate::PatternError;
-use crate::pattern::lexer::{Token, lex_pattern};
 use std::cmp::Ordering;
+
+use crate::{
+    PatternError,
+    pattern::lexer::{Token, lex_pattern},
+};
 
 /// Specificity score for a step pattern.
 ///
@@ -25,10 +28,10 @@ use std::cmp::Ordering;
 /// ```
 /// use rstest_bdd_patterns::SpecificityScore;
 ///
-/// let specific = SpecificityScore::calculate("the output is foo")
-///     .expect("valid specific pattern");
-/// let generic = SpecificityScore::calculate("the output is {value}")
-///     .expect("valid generic pattern");
+/// let specific =
+///     SpecificityScore::calculate("the output is foo").expect("valid specific pattern");
+/// let generic =
+///     SpecificityScore::calculate("the output is {value}").expect("valid generic pattern");
 /// assert!(specific > generic);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -53,8 +56,7 @@ impl SpecificityScore {
     /// ```
     /// use rstest_bdd_patterns::SpecificityScore;
     ///
-    /// let score = SpecificityScore::calculate("I have {count:u32} apples")
-    ///     .expect("valid pattern");
+    /// let score = SpecificityScore::calculate("I have {count:u32} apples").expect("valid pattern");
     /// assert_eq!(score.literal_chars, 14); // "I have " + " apples"
     /// assert_eq!(score.placeholder_count, 1);
     /// assert_eq!(score.typed_placeholder_count, 1);
@@ -113,9 +115,7 @@ impl Ord for SpecificityScore {
 }
 
 impl PartialOrd for SpecificityScore {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(self.cmp(other)) }
 }
 
 #[cfg(test)]

--- a/crates/rstest-bdd-patterns/tests/keyword_props.rs
+++ b/crates/rstest-bdd-patterns/tests/keyword_props.rs
@@ -9,7 +9,6 @@
 use std::str::FromStr;
 
 use proptest::prelude::*;
-
 use rstest_bdd_patterns::{StepKeyword, StepKeywordParseError};
 
 const ALL_KEYWORDS: [StepKeyword; 5] = [

--- a/crates/rstest-bdd-patterns/tests/patterns.rs
+++ b/crates/rstest-bdd-patterns/tests/patterns.rs
@@ -3,9 +3,11 @@
 
 use regex::Regex;
 use rstest::rstest;
-
 use rstest_bdd_patterns::{
-    build_regex_from_pattern, compile_regex_from_pattern, extract_captured_values, get_type_pattern,
+    build_regex_from_pattern,
+    compile_regex_from_pattern,
+    extract_captured_values,
+    get_type_pattern,
 };
 
 #[test]

--- a/crates/rstest-bdd-policy/src/lib.rs
+++ b/crates/rstest-bdd-policy/src/lib.rs
@@ -38,9 +38,7 @@ impl RuntimeMode {
     /// assert!(RuntimeMode::TokioCurrentThread.is_async());
     /// ```
     #[must_use]
-    pub const fn is_async(self) -> bool {
-        matches!(self, Self::TokioCurrentThread)
-    }
+    pub const fn is_async(self) -> bool { matches!(self, Self::TokioCurrentThread) }
 
     /// Returns a hint for which test attributes to generate.
     ///
@@ -126,9 +124,7 @@ const KNOWN_HARNESS_HINTS: [(&[&str], TestAttributeHint); 3] = [
 /// # Examples
 ///
 /// ```
-/// use rstest_bdd_policy::{
-///     resolve_test_attribute_hint_for_policy_path, TestAttributeHint,
-/// };
+/// use rstest_bdd_policy::{TestAttributeHint, resolve_test_attribute_hint_for_policy_path};
 ///
 /// assert_eq!(
 ///     resolve_test_attribute_hint_for_policy_path(&[
@@ -158,15 +154,12 @@ pub fn resolve_test_attribute_hint_for_policy_path(
 /// # Examples
 ///
 /// ```
-/// use rstest_bdd_policy::{
-///     resolve_test_attribute_hint_for_harness_path, TestAttributeHint,
-/// };
+/// use rstest_bdd_policy::{TestAttributeHint, resolve_test_attribute_hint_for_harness_path};
 ///
 /// assert_eq!(
-///     resolve_test_attribute_hint_for_harness_path(&[
-///         "rstest_bdd_harness_tokio",
-///         "TokioHarness",
-///     ]),
+///     resolve_test_attribute_hint_for_harness_path(
+///         &["rstest_bdd_harness_tokio", "TokioHarness",]
+///     ),
 ///     Some(TestAttributeHint::RstestWithTokioCurrentThread)
 /// );
 /// assert_eq!(
@@ -187,12 +180,20 @@ pub fn resolve_test_attribute_hint_for_harness_path(
 mod tests {
     //! Unit tests for policy configuration parsing and defaults.
 
-    use super::{
-        DEFAULT_ATTRIBUTE_POLICY_PATH, GPUI_ATTRIBUTE_POLICY_PATH, GPUI_HARNESS_PATH, RuntimeMode,
-        STD_HARNESS_PATH, TOKIO_ATTRIBUTE_POLICY_PATH, TOKIO_HARNESS_PATH, TestAttributeHint,
-        resolve_test_attribute_hint_for_harness_path, resolve_test_attribute_hint_for_policy_path,
-    };
     use rstest::rstest;
+
+    use super::{
+        DEFAULT_ATTRIBUTE_POLICY_PATH,
+        GPUI_ATTRIBUTE_POLICY_PATH,
+        GPUI_HARNESS_PATH,
+        RuntimeMode,
+        STD_HARNESS_PATH,
+        TOKIO_ATTRIBUTE_POLICY_PATH,
+        TOKIO_HARNESS_PATH,
+        TestAttributeHint,
+        resolve_test_attribute_hint_for_harness_path,
+        resolve_test_attribute_hint_for_policy_path,
+    };
 
     #[test]
     fn runtime_mode_sync_is_default() {

--- a/crates/rstest-bdd-server/Cargo.toml
+++ b/crates/rstest-bdd-server/Cargo.toml
@@ -50,6 +50,7 @@ tempfile = { workspace = true, optional = true }
 insta = { workspace = true, features = ["filters"] }
 proptest.workspace = true
 rstest.workspace = true
+rstest-bdd-test-macros.workspace = true
 rstest-bdd-server = { path = ".", features = ["test-support"] }
 tempfile.workspace = true
 # `io-util` supplies `duplex`/`empty`/`AsyncReadExt` for the in-process

--- a/crates/rstest-bdd-server/src/config.rs
+++ b/crates/rstest-bdd-server/src/config.rs
@@ -4,9 +4,7 @@
 //! server. All settings can be overridden via environment variables prefixed
 //! with `RSTEST_BDD_LSP_`.
 
-use std::env;
-use std::path::PathBuf;
-use std::str::FromStr;
+use std::{env, path::PathBuf, str::FromStr};
 
 use crate::error::ServerError;
 
@@ -69,11 +67,9 @@ const DEFAULT_DEBOUNCE_MS: u64 = 300;
 ///
 /// # Environment Variables
 ///
-/// - `RSTEST_BDD_LSP_LOG_LEVEL`: Sets the log level (trace, debug, info, warn,
-///   error)
+/// - `RSTEST_BDD_LSP_LOG_LEVEL`: Sets the log level (trace, debug, info, warn, error)
 /// - `RSTEST_BDD_LSP_DEBOUNCE_MS`: Delay before processing file changes
-/// - `RSTEST_BDD_LSP_WORKSPACE_ROOT`: Override workspace root path for
-///   discovery
+/// - `RSTEST_BDD_LSP_WORKSPACE_ROOT`: Override workspace root path for discovery
 #[derive(Debug, Clone)]
 pub struct ServerConfig {
     /// Log level (trace, debug, info, warn, error).
@@ -108,9 +104,7 @@ impl ServerConfig {
     ///
     /// Returns `ServerError::InvalidConfig` if an environment variable contains
     /// an invalid value.
-    pub fn from_env() -> Result<Self, ServerError> {
-        Self::from_env_with(|key| env::var(key))
-    }
+    pub fn from_env() -> Result<Self, ServerError> { Self::from_env_with(|key| env::var(key)) }
 
     fn from_env_with<F>(get_var: F) -> Result<Self, ServerError>
     where

--- a/crates/rstest-bdd-server/src/discovery/workspace.rs
+++ b/crates/rstest-bdd-server/src/discovery/workspace.rs
@@ -192,6 +192,7 @@ mod tests {
 
     use super::*;
 
+    #[rstest_bdd_test_macros::allow_fixture_expansion_lints]
     #[fixture]
     fn create_test_workspace() -> io::Result<TempDir> {
         let dir = TempDir::new()?;

--- a/crates/rstest-bdd-server/src/discovery/workspace.rs
+++ b/crates/rstest-bdd-server/src/discovery/workspace.rs
@@ -183,14 +183,6 @@ fn collect_feature_files_recursive(dir: &Path, features: &mut Vec<PathBuf>) {
     reason = "tests require explicit panic messages for debugging failures"
 )]
 mod tests {
-    //! Unit tests for workspace discovery.
-
-    use super::*;
-    use rstest::{fixture, rstest};
-    use std::fs;
-    use std::io;
-    use tempfile::TempDir;
-
     #[fixture]
     fn create_test_workspace() -> io::Result<TempDir> {
         let dir = TempDir::new()?;

--- a/crates/rstest-bdd-server/src/discovery/workspace.rs
+++ b/crates/rstest-bdd-server/src/discovery/workspace.rs
@@ -183,6 +183,14 @@ fn collect_feature_files_recursive(dir: &Path, features: &mut Vec<PathBuf>) {
     reason = "tests require explicit panic messages for debugging failures"
 )]
 mod tests {
+    //! Unit tests for workspace discovery.
+
+    use super::*;
+    use rstest::{fixture, rstest};
+    use std::fs;
+    use std::io;
+    use tempfile::TempDir;
+
     #[fixture]
     fn create_test_workspace() -> io::Result<TempDir> {
         let dir = TempDir::new()?;

--- a/crates/rstest-bdd-server/src/discovery/workspace.rs
+++ b/crates/rstest-bdd-server/src/discovery/workspace.rs
@@ -185,11 +185,12 @@ fn collect_feature_files_recursive(dir: &Path, features: &mut Vec<PathBuf>) {
 mod tests {
     //! Unit tests for workspace discovery.
 
-    use super::*;
+    use std::{fs, io};
+
     use rstest::{fixture, rstest};
-    use std::fs;
-    use std::io;
     use tempfile::TempDir;
+
+    use super::*;
 
     #[fixture]
     fn create_test_workspace() -> io::Result<TempDir> {
@@ -245,7 +246,8 @@ edition = "2024"
     ///
     /// # Arguments
     ///
-    /// * `relative_dir` - Path segments relative to the workspace root (e.g., `&["tests", "features"]`)
+    /// * `relative_dir` - Path segments relative to the workspace root (e.g., `&["tests",
+    ///   "features"]`)
     /// * `filename` - Name of the feature file to create
     /// * `content` - Content to write to the feature file
     ///

--- a/crates/rstest-bdd-server/src/handlers/deferred_replay.rs
+++ b/crates/rstest-bdd-server/src/handlers/deferred_replay.rs
@@ -10,18 +10,26 @@ use async_lsp::ClientSocket;
 use lsp_types::DidSaveTextDocumentParams;
 use tracing::{Instrument, debug, info_span, warn};
 
-use crate::indexing::{
-    FeatureFileIndex, FeatureIndexError, RustStepIndexError, RustStepIndexResult, WorkspaceRoot,
-    index_feature_source, index_feature_source_owned, index_rust_file, index_rust_source,
+use super::{
+    diagnostics::{FeatureDiagnosticPublication, publish_all_feature_diagnostics},
+    text_document::{apply_feature_index_result, apply_rust_index_result, index_saved_document},
+    util::has_extension,
+    workspace_metrics::{record_deferred_save_depth, record_workspace_outcome},
 };
-use crate::server::ServerState;
-
-use super::diagnostics::{FeatureDiagnosticPublication, publish_all_feature_diagnostics};
-use super::text_document::{
-    apply_feature_index_result, apply_rust_index_result, index_saved_document,
+use crate::{
+    indexing::{
+        FeatureFileIndex,
+        FeatureIndexError,
+        RustStepIndexError,
+        RustStepIndexResult,
+        WorkspaceRoot,
+        index_feature_source,
+        index_feature_source_owned,
+        index_rust_file,
+        index_rust_source,
+    },
+    server::ServerState,
 };
-use super::util::has_extension;
-use super::workspace_metrics::{record_deferred_save_depth, record_workspace_outcome};
 
 /// Completed indexes from a deferred did-save replay worker.
 pub struct DeferredDocumentSavesIndexed {
@@ -179,8 +187,7 @@ mod tests {
     use metrics::with_local_recorder;
 
     use super::*;
-    use crate::config::ServerConfig;
-    use crate::handlers::workspace_metrics::WorkspaceRecorder;
+    use crate::{config::ServerConfig, handlers::workspace_metrics::WorkspaceRecorder};
 
     #[test]
     fn deferred_replay_delivery_failure_records_a_bounded_outcome() {

--- a/crates/rstest-bdd-server/src/handlers/definition.rs
+++ b/crates/rstest-bdd-server/src/handlers/definition.rs
@@ -5,17 +5,14 @@
 //! annotated with `#[given]`, `#[when]`, or `#[then]`, the handler returns
 //! all matching feature step locations.
 
-use std::path::Path;
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 
 use async_lsp::ResponseError;
 use lsp_types::{GotoDefinitionParams, GotoDefinitionResponse, Location, Url};
 use tracing::debug;
 
-use crate::indexing::CompiledStepDefinition;
-use crate::server::ServerState;
-
 use super::util::{gherkin_span_to_lsp_range, has_extension};
+use crate::{indexing::CompiledStepDefinition, server::ServerState};
 
 /// Handle `textDocument/definition` requests.
 ///
@@ -174,20 +171,22 @@ fn find_matching_feature_locations(
 mod tests {
     //! Unit tests for go-to-definition handling.
 
-    use super::*;
-    use crate::config::ServerConfig;
-    use crate::discovery::WorkspaceInfo;
-    use crate::handlers::handle_did_save_text_document;
+    use std::path::PathBuf;
+
     use lsp_types::{DidSaveTextDocumentParams, Position, TextDocumentIdentifier};
     use rstest::{fixture, rstest};
-    use std::path::PathBuf;
     use tempfile::TempDir;
+
+    use super::*;
+    use crate::{
+        config::ServerConfig,
+        discovery::WorkspaceInfo,
+        handlers::handle_did_save_text_document,
+    };
 
     #[rstest_bdd_test_macros::allow_fixture_expansion_lints]
     #[fixture]
-    fn test_state() -> ServerState {
-        ServerState::new(ServerConfig::default())
-    }
+    fn test_state() -> ServerState { ServerState::new(ServerConfig::default()) }
 
     #[rstest]
     fn find_step_at_position_returns_none_for_empty_registry(test_state: ServerState) {

--- a/crates/rstest-bdd-server/src/handlers/definition.rs
+++ b/crates/rstest-bdd-server/src/handlers/definition.rs
@@ -183,6 +183,7 @@ mod tests {
     use std::path::PathBuf;
     use tempfile::TempDir;
 
+    #[rstest_bdd_test_macros::allow_fixture_expansion_lints]
     #[fixture]
     fn test_state() -> ServerState {
         ServerState::new(ServerConfig::default())

--- a/crates/rstest-bdd-server/src/handlers/diagnostics/compute.rs
+++ b/crates/rstest-bdd-server/src/handlers/diagnostics/compute.rs
@@ -11,11 +11,12 @@ use std::{path::Path, sync::Arc};
 
 use lsp_types::{Diagnostic, DiagnosticSeverity, Range};
 
-use crate::indexing::{CompiledStepDefinition, FeatureFileIndex, IndexedStep};
-use crate::server::ServerState;
-
 use super::{CODE_UNIMPLEMENTED_STEP, CODE_UNUSED_STEP_DEFINITION, DIAGNOSTIC_SOURCE};
-use crate::handlers::util::gherkin_span_to_lsp_range;
+use crate::{
+    handlers::util::gherkin_span_to_lsp_range,
+    indexing::{CompiledStepDefinition, FeatureFileIndex, IndexedStep},
+    server::ServerState,
+};
 
 /// Compute diagnostics for unimplemented feature steps.
 ///

--- a/crates/rstest-bdd-server/src/handlers/diagnostics/mod.rs
+++ b/crates/rstest-bdd-server/src/handlers/diagnostics/mod.rs
@@ -4,16 +4,15 @@
 //! files and Rust step definitions, publishing them via the LSP protocol.
 //! Diagnostics are triggered on file save and report:
 //!
-//! - **Unimplemented feature steps**: Steps in `.feature` files with no
-//!   matching Rust implementation.
-//! - **Unused step definitions**: Rust step definitions not matched by any
-//!   feature step.
-//! - **Placeholder count mismatches**: Step patterns with a different number
-//!   of placeholders than the function has step arguments.
-//! - **Table/docstring expectation mismatches**: Feature steps with tables or
-//!   docstrings that don't match what the Rust implementation expects.
-//! - **Scenario outline column mismatches**: Scenario outlines with
-//!   placeholders that don't match the Examples table columns.
+//! - **Unimplemented feature steps**: Steps in `.feature` files with no matching Rust
+//!   implementation.
+//! - **Unused step definitions**: Rust step definitions not matched by any feature step.
+//! - **Placeholder count mismatches**: Step patterns with a different number of placeholders than
+//!   the function has step arguments.
+//! - **Table/docstring expectation mismatches**: Feature steps with tables or docstrings that don't
+//!   match what the Rust implementation expects.
+//! - **Scenario outline column mismatches**: Scenario outlines with placeholders that don't match
+//!   the Examples table columns.
 
 mod compute;
 mod placeholder;

--- a/crates/rstest-bdd-server/src/handlers/diagnostics/placeholder.rs
+++ b/crates/rstest-bdd-server/src/handlers/diagnostics/placeholder.rs
@@ -4,18 +4,16 @@
 //! step argument counts. A placeholder count mismatch indicates that the
 //! function signature doesn't match the pattern's expectations.
 
-use std::collections::HashSet;
-use std::path::Path;
-use std::sync::Arc;
+use std::{collections::HashSet, path::Path, sync::Arc};
 
 use lsp_types::{Diagnostic, DiagnosticSeverity};
 use rstest_bdd_patterns::pattern::lexer::{Token, lex_pattern};
 
-use crate::indexing::{CompiledStepDefinition, IndexedStepParameter};
-use crate::server::ServerState;
-
-use super::compute::step_type_to_attribute;
-use super::{CODE_PLACEHOLDER_COUNT_MISMATCH, DIAGNOSTIC_SOURCE};
+use super::{CODE_PLACEHOLDER_COUNT_MISMATCH, DIAGNOSTIC_SOURCE, compute::step_type_to_attribute};
+use crate::{
+    indexing::{CompiledStepDefinition, IndexedStepParameter},
+    server::ServerState,
+};
 
 /// Compute diagnostics for signature mismatches in step definitions.
 ///
@@ -26,17 +24,15 @@ use super::{CODE_PLACEHOLDER_COUNT_MISMATCH, DIAGNOSTIC_SOURCE};
 /// # Example
 ///
 /// ```no_run
-/// use rstest_bdd_server::config::ServerConfig;
-/// use rstest_bdd_server::server::ServerState;
 /// use std::path::Path;
+///
+/// use rstest_bdd_server::{config::ServerConfig, server::ServerState};
 ///
 /// let state = ServerState::new(ServerConfig::default());
 /// let rust_path = Path::new("steps.rs");
 ///
-/// let diagnostics = rstest_bdd_server::handlers::compute_signature_mismatch_diagnostics(
-///     &state,
-///     rust_path,
-/// );
+/// let diagnostics =
+///     rstest_bdd_server::handlers::compute_signature_mismatch_diagnostics(&state, rust_path);
 /// // Returns diagnostics for any step where placeholder count != step argument count
 /// for diag in &diagnostics {
 ///     println!("{}", diag.message);
@@ -110,8 +106,8 @@ fn extract_placeholder_names(tokens: &[Token]) -> HashSet<String> {
 ///
 /// A step argument is a parameter that either:
 /// - Is a step struct (`#[step_args]`) which bundles all placeholders, OR
-/// - Is not a datatable/docstring parameter AND has a normalized name that
-///   appears in the placeholder set
+/// - Is not a datatable/docstring parameter AND has a normalized name that appears in the
+///   placeholder set
 ///
 /// Step structs bypass the datatable/docstring exclusion because they are
 /// explicitly marked as step arguments regardless of other attributes.
@@ -152,9 +148,7 @@ fn count_step_arguments(
 ///
 /// Strips a single leading underscore to match the macro behaviour, where
 /// users prefix parameters with `_` to suppress unused warnings.
-fn normalize_param_name(name: &str) -> String {
-    name.strip_prefix('_').unwrap_or(name).to_owned()
-}
+fn normalize_param_name(name: &str) -> String { name.strip_prefix('_').unwrap_or(name).to_owned() }
 
 /// Build a diagnostic for a placeholder count mismatch.
 fn build_placeholder_mismatch_diagnostic(
@@ -173,8 +167,8 @@ fn build_placeholder_mismatch_diagnostic(
         code_description: None,
         source: Some(DIAGNOSTIC_SOURCE.to_owned()),
         message: format!(
-            "Placeholder count mismatch: pattern has {} placeholder occurrence(s) but \
-             function has {} step argument(s) - #[{}(\"{}\")]",
+            "Placeholder count mismatch: pattern has {} placeholder occurrence(s) but function \
+             has {} step argument(s) - #[{}(\"{}\")]",
             placeholder_count,
             step_arg_count,
             step_type_to_attribute(step_def.keyword),

--- a/crates/rstest-bdd-server/src/handlers/diagnostics/publish.rs
+++ b/crates/rstest-bdd-server/src/handlers/diagnostics/publish.rs
@@ -12,27 +12,16 @@ use std::path::Path;
 use async_lsp::lsp_types::{Diagnostic, PublishDiagnosticsParams, Url, notification};
 use tracing::{debug, warn};
 
-use crate::indexing::RustStepIndexDiagnostic;
-use crate::server::ServerState;
-
 use super::{
-    CODE_INVALID_STEP_ATTRIBUTE_ARGUMENTS, CODE_MULTIPLE_STEP_ATTRIBUTES, DIAGNOSTIC_SOURCE,
+    CODE_INVALID_STEP_ATTRIBUTE_ARGUMENTS,
+    CODE_MULTIPLE_STEP_ATTRIBUTES,
+    DIAGNOSTIC_SOURCE,
     compute::{compute_unimplemented_step_diagnostics, compute_unused_step_diagnostics},
-    table_docstring::compute_table_docstring_mismatch_diagnostics,
-    scenario_outline::compute_scenario_outline_column_diagnostics,
     placeholder::compute_signature_mismatch_diagnostics,
+    scenario_outline::compute_scenario_outline_column_diagnostics,
+    table_docstring::compute_table_docstring_mismatch_diagnostics,
 };
-
-
-//! Diagnostic publishing via LSP.
-//!
-//! This module handles publishing diagnostics to the LSP client via
-//! `textDocument/publishDiagnostics` notifications. All publishing flows
-//! through the canonical [`publish_with`] boundary: one place owns the
-//! client/URI guards, parameter construction, notification, and error
-//! logging. The per-file-kind functions only differ in the diagnostics they
-//! compute.
-};
+use crate::{indexing::RustStepIndexDiagnostic, server::ServerState};
 
 /// Compute all diagnostics for a feature file, or `None` when the file has
 /// no feature index (in which case nothing is published, preserving any

--- a/crates/rstest-bdd-server/src/handlers/diagnostics/publish.rs
+++ b/crates/rstest-bdd-server/src/handlers/diagnostics/publish.rs
@@ -241,6 +241,7 @@ mod tests {
     ///
     /// Both payload snapshots publish from the same workspace; only the file
     /// they target and the diagnostics they compute differ.
+    #[rstest_bdd_test_macros::allow_fixture_expansion_lints]
     #[fixture]
     fn publish_scenario() -> SingleFilePairScenario {
         ScenarioBuilder::new().with_single_file_pair(FEATURE_SOURCE, RUST_SOURCE)

--- a/crates/rstest-bdd-server/src/handlers/diagnostics/publish.rs
+++ b/crates/rstest-bdd-server/src/handlers/diagnostics/publish.rs
@@ -15,12 +15,23 @@ use tracing::{debug, warn};
 use crate::indexing::RustStepIndexDiagnostic;
 use crate::server::ServerState;
 
-use super::compute::{compute_unimplemented_step_diagnostics, compute_unused_step_diagnostics};
-use super::placeholder::compute_signature_mismatch_diagnostics;
-use super::scenario_outline::compute_scenario_outline_column_diagnostics;
-use super::table_docstring::compute_table_docstring_mismatch_diagnostics;
 use super::{
     CODE_INVALID_STEP_ATTRIBUTE_ARGUMENTS, CODE_MULTIPLE_STEP_ATTRIBUTES, DIAGNOSTIC_SOURCE,
+    compute::{compute_unimplemented_step_diagnostics, compute_unused_step_diagnostics},
+    table_docstring::compute_table_docstring_mismatch_diagnostics,
+    scenario_outline::compute_scenario_outline_column_diagnostics,
+    placeholder::compute_signature_mismatch_diagnostics,
+};
+
+
+//! Diagnostic publishing via LSP.
+//!
+//! This module handles publishing diagnostics to the LSP client via
+//! `textDocument/publishDiagnostics` notifications. All publishing flows
+//! through the canonical [`publish_with`] boundary: one place owns the
+//! client/URI guards, parameter construction, notification, and error
+//! logging. The per-file-kind functions only differ in the diagnostics they
+//! compute.
 };
 
 /// Compute all diagnostics for a feature file, or `None` when the file has
@@ -191,10 +202,11 @@ mod tests {
     use proptest::prelude::*;
     use rstest::{fixture, rstest};
 
-    use crate::config::ServerConfig;
-    use crate::test_support::{ScenarioBuilder, SingleFilePairScenario};
-
     use super::*;
+    use crate::{
+        config::ServerConfig,
+        test_support::{ScenarioBuilder, SingleFilePairScenario},
+    };
 
     const FEATURE_SOURCE: &str = concat!(
         "Feature: demo\n",
@@ -239,13 +251,9 @@ mod tests {
     /// Diagnostic computation under test, in `prepare_publish`'s shape.
     type ComputeDiagnostics = fn(&ServerState, &Path) -> Option<Vec<Diagnostic>>;
 
-    fn feature_file(scenario: &SingleFilePairScenario) -> &Path {
-        &scenario.feature_path
-    }
+    fn feature_file(scenario: &SingleFilePairScenario) -> &Path { &scenario.feature_path }
 
-    fn rust_file(scenario: &SingleFilePairScenario) -> &Path {
-        &scenario.rust_path
-    }
+    fn rust_file(scenario: &SingleFilePairScenario) -> &Path { &scenario.rust_path }
 
     /// Pin the published payload for each file kind.
     ///
@@ -305,9 +313,7 @@ mod tests {
     /// capture.
     #[tokio::test]
     async fn missing_feature_index_emits_no_notification_through_client() {
-        use async_lsp::MainLoop;
-        use async_lsp::lsp_types::notification::LogMessage;
-        use async_lsp::router::Router;
+        use async_lsp::{MainLoop, lsp_types::notification::LogMessage, router::Router};
         use lsp_types::{LogMessageParams, MessageType};
         use tokio::io::AsyncReadExt;
         use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};

--- a/crates/rstest-bdd-server/src/handlers/diagnostics/rust_index.rs
+++ b/crates/rstest-bdd-server/src/handlers/diagnostics/rust_index.rs
@@ -7,10 +7,8 @@
 
 use std::path::Path;
 
-use crate::indexing::RustStepIndexDiagnostic;
-use crate::server::ServerState;
-
 use super::publish::{compute_rust_file_diagnostics, publish_with};
+use crate::{indexing::RustStepIndexDiagnostic, server::ServerState};
 
 /// Publish all Rust-file diagnostics, including recoverable indexing failures.
 ///
@@ -56,9 +54,10 @@ mod tests {
     use lsp_types::{DiagnosticSeverity, NumberOrString, Position, Range};
     use rstest::rstest;
 
-    use super::super::DIAGNOSTIC_SOURCE;
-    use super::super::publish::build_rust_index_diagnostic;
-    use super::*;
+    use super::{
+        super::{DIAGNOSTIC_SOURCE, publish::build_rust_index_diagnostic},
+        *,
+    };
 
     #[test]
     fn maps_invalid_step_attribute_arguments_to_a_warning() {

--- a/crates/rstest-bdd-server/src/handlers/diagnostics/scenario_outline.rs
+++ b/crates/rstest-bdd-server/src/handlers/diagnostics/scenario_outline.rs
@@ -3,23 +3,22 @@
 //! This module validates that scenario outline placeholders (`<column>`)
 //! match the columns defined in the Examples table:
 //!
-//! - **Missing column**: A step uses `<foo>` but the Examples table lacks a
-//!   `foo` column header.
-//! - **Surplus column**: The Examples table has a `bar` column but no step
-//!   references `<bar>`.
+//! - **Missing column**: A step uses `<foo>` but the Examples table lacks a `foo` column header.
+//! - **Surplus column**: The Examples table has a `bar` column but no step references `<bar>`.
 
-use std::collections::{HashMap, HashSet};
-use std::sync::LazyLock;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::LazyLock,
+};
 
 use lsp_types::{Diagnostic, DiagnosticSeverity};
 use regex::Regex;
 
-use crate::handlers::util::gherkin_span_to_lsp_range;
-use crate::indexing::{
-    FeatureFileIndex, IndexedExamplesTable, IndexedScenarioOutline, IndexedStep,
-};
-
 use super::{CODE_EXAMPLE_COLUMN_MISSING, CODE_EXAMPLE_COLUMN_SURPLUS, DIAGNOSTIC_SOURCE};
+use crate::{
+    handlers::util::gherkin_span_to_lsp_range,
+    indexing::{FeatureFileIndex, IndexedExamplesTable, IndexedScenarioOutline, IndexedStep},
+};
 
 /// Regex for extracting `<placeholder>` tokens from scenario outline step text.
 ///
@@ -50,10 +49,8 @@ struct OutlinePlaceholders {
 /// Compute diagnostics for scenario outline example column mismatches.
 ///
 /// For each scenario outline, checks that:
-/// 1. All `<placeholder>` references in steps have matching columns in the
-///    Examples table.
-/// 2. All Examples table columns are referenced by at least one step
-///    placeholder.
+/// 1. All `<placeholder>` references in steps have matching columns in the Examples table.
+/// 2. All Examples table columns are referenced by at least one step placeholder.
 ///
 /// # Example
 ///
@@ -63,9 +60,8 @@ struct OutlinePlaceholders {
 /// // Obtain a FeatureFileIndex from indexing
 /// # let feature_index: FeatureFileIndex = todo!();
 ///
-/// let diagnostics = rstest_bdd_server::handlers::compute_scenario_outline_column_diagnostics(
-///     &feature_index,
-/// );
+/// let diagnostics =
+///     rstest_bdd_server::handlers::compute_scenario_outline_column_diagnostics(&feature_index);
 /// // Returns diagnostics when placeholders don't match column headers
 /// for diag in &diagnostics {
 ///     println!("{}", diag.message);
@@ -274,8 +270,8 @@ fn build_missing_column_diagnostic(
         code_description: None,
         source: Some(DIAGNOSTIC_SOURCE.to_owned()),
         message: format!(
-            "Placeholder '<{placeholder}>' has no matching column in Examples table. \
-             Available columns: [{available_str}]"
+            "Placeholder '<{placeholder}>' has no matching column in Examples table. Available \
+             columns: [{available_str}]"
         ),
         related_information: None,
         tags: None,
@@ -301,7 +297,8 @@ fn build_surplus_column_diagnostic(
         code_description: None,
         source: Some(DIAGNOSTIC_SOURCE.to_owned()),
         message: format!(
-            "Examples column '{}' is not referenced by any step placeholder in the scenario outline",
+            "Examples column '{}' is not referenced by any step placeholder in the scenario \
+             outline",
             column.name
         ),
         related_information: None,

--- a/crates/rstest-bdd-server/src/handlers/diagnostics/table_docstring.rs
+++ b/crates/rstest-bdd-server/src/handlers/diagnostics/table_docstring.rs
@@ -8,15 +8,18 @@ use std::sync::Arc;
 use lsp_types::Diagnostic;
 use rstest_bdd_patterns::SpecificityScore;
 
-use crate::indexing::{CompiledStepDefinition, FeatureFileIndex, IndexedStep};
-use crate::server::ServerState;
-
-use super::compute::{DiagnosticSpec, FeatureStepDiagnosticKind, build_step_diagnostic};
 use super::{
-    CODE_DOCSTRING_EXPECTED, CODE_DOCSTRING_NOT_EXPECTED, CODE_TABLE_EXPECTED,
+    CODE_DOCSTRING_EXPECTED,
+    CODE_DOCSTRING_NOT_EXPECTED,
+    CODE_TABLE_EXPECTED,
     CODE_TABLE_NOT_EXPECTED,
+    compute::{DiagnosticSpec, FeatureStepDiagnosticKind, build_step_diagnostic},
 };
-use crate::handlers::util::gherkin_span_to_lsp_range;
+use crate::{
+    handlers::util::gherkin_span_to_lsp_range,
+    indexing::{CompiledStepDefinition, FeatureFileIndex, IndexedStep},
+    server::ServerState,
+};
 
 /// Compute diagnostics for table/docstring expectation mismatches.
 ///
@@ -26,9 +29,11 @@ use crate::handlers::util::gherkin_span_to_lsp_range;
 /// # Example
 ///
 /// ```no_run
-/// use rstest_bdd_server::config::ServerConfig;
-/// use rstest_bdd_server::server::ServerState;
-/// use rstest_bdd_server::indexing::FeatureFileIndex;
+/// use rstest_bdd_server::{
+///     config::ServerConfig,
+///     indexing::FeatureFileIndex,
+///     server::ServerState,
+/// };
 ///
 /// let state = ServerState::new(ServerConfig::default());
 /// // Obtain a FeatureFileIndex from state.feature_index(path)

--- a/crates/rstest-bdd-server/src/handlers/diagnostics/tests/mod.rs
+++ b/crates/rstest-bdd-server/src/handlers/diagnostics/tests/mod.rs
@@ -1,18 +1,19 @@
 //! Shared fixtures and assertion helpers for diagnostics tests.
 
-use super::compute::step_type_to_attribute;
-use super::*;
-use crate::server::ServerState;
-use crate::test_support::{DiagnosticCheckType, ScenarioBuilder};
+use std::path::Path;
+
 use lsp_types::{Diagnostic, DiagnosticSeverity};
 use rstest::{fixture, rstest};
-use std::path::Path;
+
+use super::{compute::step_type_to_attribute, *};
+use crate::{
+    server::ServerState,
+    test_support::{DiagnosticCheckType, ScenarioBuilder},
+};
 
 /// Fixture providing the infrastructure for diagnostic tests.
 #[fixture]
-fn scenario_builder() -> ScenarioBuilder {
-    ScenarioBuilder::new()
-}
+fn scenario_builder() -> ScenarioBuilder { ScenarioBuilder::new() }
 
 /// Helper to compute feature diagnostics for a path.
 fn compute_feature_diagnostics_for_path(

--- a/crates/rstest-bdd-server/src/handlers/diagnostics/tests/mod.rs
+++ b/crates/rstest-bdd-server/src/handlers/diagnostics/tests/mod.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 
 /// Fixture providing the infrastructure for diagnostic tests.
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn scenario_builder() -> ScenarioBuilder { ScenarioBuilder::new() }
 

--- a/crates/rstest-bdd-server/src/handlers/implementation.rs
+++ b/crates/rstest-bdd-server/src/handlers/implementation.rs
@@ -8,14 +8,20 @@
 use std::sync::Arc;
 
 use async_lsp::ResponseError;
-use lsp_types::request::{GotoImplementationParams, GotoImplementationResponse};
-use lsp_types::{Location, Position, Range, Url};
+use lsp_types::{
+    Location,
+    Position,
+    Range,
+    Url,
+    request::{GotoImplementationParams, GotoImplementationResponse},
+};
 use tracing::debug;
 
-use crate::indexing::{CompiledStepDefinition, FeatureFileIndex, IndexedStep};
-use crate::server::ServerState;
-
 use super::util::{has_extension, lsp_position_to_byte_offset};
+use crate::{
+    indexing::{CompiledStepDefinition, FeatureFileIndex, IndexedStep},
+    server::ServerState,
+};
 
 /// Handle `textDocument/implementation` requests.
 ///
@@ -129,14 +135,18 @@ fn build_rust_location(step_def: &Arc<CompiledStepDefinition>) -> Option<Locatio
 mod tests {
     //! Unit tests for go-to-implementation handling.
 
-    use super::*;
-    use crate::config::ServerConfig;
-    use crate::discovery::WorkspaceInfo;
-    use crate::handlers::handle_did_save_text_document;
+    use std::path::PathBuf;
+
     use gherkin::Span;
     use lsp_types::{DidSaveTextDocumentParams, TextDocumentIdentifier};
-    use std::path::PathBuf;
     use tempfile::TempDir;
+
+    use super::*;
+    use crate::{
+        config::ServerConfig,
+        discovery::WorkspaceInfo,
+        handlers::handle_did_save_text_document,
+    };
 
     #[test]
     fn find_step_at_position_returns_none_for_empty_index() {
@@ -154,8 +164,9 @@ mod tests {
 
     #[test]
     fn find_step_at_position_returns_step_on_matching_position() {
-        use crate::indexing::IndexedStep;
         use gherkin::StepType;
+
+        use crate::indexing::IndexedStep;
 
         let source = "Feature: demo\n  Scenario: s\n    Given a step\n";
         let index = FeatureFileIndex {

--- a/crates/rstest-bdd-server/src/handlers/lifecycle/mod.rs
+++ b/crates/rstest-bdd-server/src/handlers/lifecycle/mod.rs
@@ -3,22 +3,28 @@
 //! This module implements the core lifecycle protocol handlers required by
 //! the LSP specification: `initialize`, `initialized`, and `shutdown`.
 
-use std::path::{Path, PathBuf};
-use std::time::Instant;
+use std::{
+    path::{Path, PathBuf},
+    time::Instant,
+};
 
-use async_lsp::ClientSocket;
-use async_lsp::ResponseError;
+use async_lsp::{ClientSocket, ResponseError};
 use lsp_types::{InitializeParams, InitializeResult, InitializedParams, ServerInfo, Url};
 use tracing::{Instrument, debug, info, warn};
 
-use crate::discovery::{WorkspaceInfo, discover_workspace};
-use crate::error::ServerError;
-use crate::indexing::WorkspaceRoot;
-use crate::server::{ServerState, build_server_capabilities};
-
-use super::deferred_replay::start_deferred_document_save_replay;
-use super::workspace_metrics::{
-    record_deferred_save_depth, record_workspace_outcome, record_workspace_preparation_duration,
+use super::{
+    deferred_replay::start_deferred_document_save_replay,
+    workspace_metrics::{
+        record_deferred_save_depth,
+        record_workspace_outcome,
+        record_workspace_preparation_duration,
+    },
+};
+use crate::{
+    discovery::{WorkspaceInfo, discover_workspace},
+    error::ServerError,
+    indexing::WorkspaceRoot,
+    server::{ServerState, build_server_capabilities},
 };
 /// Outcome of the synchronous part of handling an `initialize` request.
 ///
@@ -48,7 +54,6 @@ pub struct InitializeOutcome {
 /// # Errors
 ///
 /// Returns a `ResponseError` when the server is already initialized.
-///
 pub fn handle_initialise(
     state: &mut ServerState,
     params: InitializeParams,
@@ -377,9 +382,7 @@ fn extract_workspace_path(
 /// Convert a URL to a file system path.
 ///
 /// Only handles `file://` URLs; returns `None` for other schemes.
-fn url_to_path(url: &Url) -> Option<PathBuf> {
-    url.to_file_path().ok()
-}
+fn url_to_path(url: &Url) -> Option<PathBuf> { url.to_file_path().ok() }
 
 /// Convert a server error to an LSP response error.
 fn response_error(err: &ServerError, code: async_lsp::ErrorCode) -> ResponseError {

--- a/crates/rstest-bdd-server/src/handlers/lifecycle/tests.rs
+++ b/crates/rstest-bdd-server/src/handlers/lifecycle/tests.rs
@@ -5,28 +5,32 @@ mod delivery_failure;
 mod paths;
 mod retry;
 
-use super::*;
-use crate::config::ServerConfig;
-use async_lsp::MainLoop;
-use async_lsp::router::Router;
+use std::ops::ControlFlow;
+
+use async_lsp::{MainLoop, router::Router};
 use lsp_types::{
-    ClientCapabilities, DidSaveTextDocumentParams, TextDocumentIdentifier, WorkspaceFolder,
+    ClientCapabilities,
+    DidSaveTextDocumentParams,
+    TextDocumentIdentifier,
+    WorkspaceFolder,
 };
 use rstest::{fixture, rstest};
-use std::ops::ControlFlow;
 use tempfile::TempDir;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
-use crate::handlers::{
-    DeferredDocumentSavesIndexed, handle_deferred_document_saves_indexed,
-    handle_did_save_text_document,
+use super::*;
+use crate::{
+    config::ServerConfig,
+    handlers::{
+        DeferredDocumentSavesIndexed,
+        handle_deferred_document_saves_indexed,
+        handle_did_save_text_document,
+    },
 };
 
 #[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
-fn create_test_state() -> ServerState {
-    ServerState::new(ServerConfig::default())
-}
+fn create_test_state() -> ServerState { ServerState::new(ServerConfig::default()) }
 
 #[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
@@ -365,36 +369,4 @@ async fn initialization_returns_before_workspace_preparation_finishes() {
     if let Some(background_task) = background_task {
         background_task.abort();
     }
-}
-
-#[test]
-fn stale_workspace_preparation_is_discarded_after_initialize_retry() {
-    let workspace = cargo_workspace().expect("create Cargo workspace");
-    let workspace_uri = Url::from_file_path(workspace.path()).expect("workspace URI");
-    let mut state = ServerState::new(ServerConfig::default());
-    let cancelled = handle_initialise(
-        &mut state,
-        InitializeParams {
-            workspace_folders: Some(vec![WorkspaceFolder {
-                uri: workspace_uri,
-                name: "cancelled-workspace".to_owned(),
-            }]),
-            ..Default::default()
-        },
-    )
-    .expect("initialization should succeed");
-    let retry =
-        handle_initialise(&mut state, InitializeParams::default()).expect("retry should succeed");
-    let preparation = prepare_workspace(workspace.path());
-
-    assert_eq!(retry.workspace_path, None);
-    assert!(state.workspace_folders().is_empty());
-    handle_workspace_ready(
-        &mut state,
-        WorkspaceReadyEvent {
-            preparation,
-            initialization_id: cancelled.workspace_initialization_id,
-        },
-    );
-    assert!(state.workspace_info().is_none());
 }

--- a/crates/rstest-bdd-server/src/handlers/lifecycle/tests.rs
+++ b/crates/rstest-bdd-server/src/handlers/lifecycle/tests.rs
@@ -22,11 +22,13 @@ use crate::handlers::{
     handle_did_save_text_document,
 };
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn create_test_state() -> ServerState {
     ServerState::new(ServerConfig::default())
 }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn create_init_params() -> InitializeParams {
     InitializeParams {
@@ -37,6 +39,7 @@ fn create_init_params() -> InitializeParams {
 }
 
 /// Fixture providing a platform-specific test path.
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn platform_test_path() -> PathBuf {
     #[cfg(windows)]

--- a/crates/rstest-bdd-server/src/handlers/lifecycle/tests/deferred_save.rs
+++ b/crates/rstest-bdd-server/src/handlers/lifecycle/tests/deferred_save.rs
@@ -2,11 +2,11 @@
 
 use lsp_types::{DidSaveTextDocumentParams, TextDocumentIdentifier, Url};
 
-use super::super::{WorkspaceReadyEvent, handle_workspace_ready, prepare_workspace};
-use super::cargo_workspace;
-use crate::config::ServerConfig;
-use crate::handlers::handle_did_save_text_document;
-use crate::server::ServerState;
+use super::{
+    super::{WorkspaceReadyEvent, handle_workspace_ready, prepare_workspace},
+    cargo_workspace,
+};
+use crate::{config::ServerConfig, handlers::handle_did_save_text_document, server::ServerState};
 
 #[test]
 fn workspace_ready_replays_a_deferred_disk_backed_feature_save() {

--- a/crates/rstest-bdd-server/src/handlers/lifecycle/tests/delivery_failure.rs
+++ b/crates/rstest-bdd-server/src/handlers/lifecycle/tests/delivery_failure.rs
@@ -4,12 +4,15 @@ use async_lsp::ClientSocket;
 use lsp_types::{DidSaveTextDocumentParams, TextDocumentIdentifier, Url};
 use metrics::with_local_recorder;
 
-use super::super::{WorkspaceReadyEvent, emit_workspace_ready, prepare_workspace};
-use super::cargo_workspace;
-use crate::config::ServerConfig;
-use crate::handlers::handle_did_save_text_document;
-use crate::handlers::workspace_metrics::WorkspaceRecorder;
-use crate::server::ServerState;
+use super::{
+    super::{WorkspaceReadyEvent, emit_workspace_ready, prepare_workspace},
+    cargo_workspace,
+};
+use crate::{
+    config::ServerConfig,
+    handlers::{handle_did_save_text_document, workspace_metrics::WorkspaceRecorder},
+    server::ServerState,
+};
 
 #[test]
 fn workspace_ready_delivery_failure_keeps_deferred_saves_for_the_stopped_router() {

--- a/crates/rstest-bdd-server/src/handlers/lifecycle/tests/paths.rs
+++ b/crates/rstest-bdd-server/src/handlers/lifecycle/tests/paths.rs
@@ -1,13 +1,11 @@
 //! Unit tests for workspace-path conversion.
 
-use std::path::PathBuf;
-use std::str::FromStr;
+use std::{path::PathBuf, str::FromStr};
 
 use lsp_types::Url;
 use rstest::rstest;
 
-use super::super::url_to_path;
-use super::platform_test_path;
+use super::{super::url_to_path, platform_test_path};
 
 #[test]
 fn url_to_path_returns_none_for_non_file_url() {

--- a/crates/rstest-bdd-server/src/handlers/lifecycle/tests/retry.rs
+++ b/crates/rstest-bdd-server/src/handlers/lifecycle/tests/retry.rs
@@ -1,18 +1,23 @@
 //! Regression coverage for retrying workspace preparation with pending saves.
 
 use lsp_types::{
-    DidSaveTextDocumentParams, InitializeParams, TextDocumentIdentifier, Url, WorkspaceFolder,
+    DidSaveTextDocumentParams,
+    InitializeParams,
+    TextDocumentIdentifier,
+    Url,
+    WorkspaceFolder,
 };
 use metrics::with_local_recorder;
 
-use super::super::{
-    WorkspaceReadyEvent, handle_initialise, handle_workspace_ready, prepare_workspace,
+use super::{
+    super::{WorkspaceReadyEvent, handle_initialise, handle_workspace_ready, prepare_workspace},
+    cargo_workspace,
 };
-use super::cargo_workspace;
-use crate::config::ServerConfig;
-use crate::handlers::handle_did_save_text_document;
-use crate::handlers::workspace_metrics::WorkspaceRecorder;
-use crate::server::ServerState;
+use crate::{
+    config::ServerConfig,
+    handlers::{handle_did_save_text_document, workspace_metrics::WorkspaceRecorder},
+    server::ServerState,
+};
 
 #[test]
 fn initialization_retry_clears_deferred_saves() {
@@ -60,6 +65,38 @@ fn initialization_retry_clears_deferred_saves() {
         WorkspaceReadyEvent {
             preparation: prepare_workspace(workspace.path()),
             initialization_id: first_initialization.workspace_initialization_id,
+        },
+    );
+    assert!(state.workspace_info().is_none());
+}
+
+#[test]
+fn stale_workspace_preparation_is_discarded_after_initialize_retry() {
+    let workspace = cargo_workspace().expect("create Cargo workspace");
+    let workspace_uri = Url::from_file_path(workspace.path()).expect("workspace URI");
+    let mut state = ServerState::new(ServerConfig::default());
+    let cancelled = handle_initialise(
+        &mut state,
+        InitializeParams {
+            workspace_folders: Some(vec![WorkspaceFolder {
+                uri: workspace_uri,
+                name: "cancelled-workspace".to_owned(),
+            }]),
+            ..Default::default()
+        },
+    )
+    .expect("initialization should succeed");
+    let retry =
+        handle_initialise(&mut state, InitializeParams::default()).expect("retry should succeed");
+    let preparation = prepare_workspace(workspace.path());
+
+    assert_eq!(retry.workspace_path, None);
+    assert!(state.workspace_folders().is_empty());
+    handle_workspace_ready(
+        &mut state,
+        WorkspaceReadyEvent {
+            preparation,
+            initialization_id: cancelled.workspace_initialization_id,
         },
     );
     assert!(state.workspace_info().is_none());

--- a/crates/rstest-bdd-server/src/handlers/mod.rs
+++ b/crates/rstest-bdd-server/src/handlers/mod.rs
@@ -16,13 +16,22 @@ mod workspace_metrics;
 pub use deferred_replay::{DeferredDocumentSavesIndexed, handle_deferred_document_saves_indexed};
 pub use definition::handle_definition;
 pub use diagnostics::{
-    compute_scenario_outline_column_diagnostics, compute_signature_mismatch_diagnostics,
-    compute_table_docstring_mismatch_diagnostics, compute_unimplemented_step_diagnostics,
-    compute_unused_step_diagnostics, publish_all_feature_diagnostics, publish_feature_diagnostics,
+    compute_scenario_outline_column_diagnostics,
+    compute_signature_mismatch_diagnostics,
+    compute_table_docstring_mismatch_diagnostics,
+    compute_unimplemented_step_diagnostics,
+    compute_unused_step_diagnostics,
+    publish_all_feature_diagnostics,
+    publish_feature_diagnostics,
 };
 pub use implementation::handle_implementation;
 pub use lifecycle::{
-    WorkspaceReadyEvent, handle_initialise, handle_initialised, handle_shutdown,
-    handle_workspace_ready, initialize_async, launch_workspace_preparation,
+    WorkspaceReadyEvent,
+    handle_initialise,
+    handle_initialised,
+    handle_shutdown,
+    handle_workspace_ready,
+    initialize_async,
+    launch_workspace_preparation,
 };
 pub use text_document::handle_did_save_text_document;

--- a/crates/rstest-bdd-server/src/handlers/text_document.rs
+++ b/crates/rstest-bdd-server/src/handlers/text_document.rs
@@ -9,31 +9,26 @@ use lsp_types::DidSaveTextDocumentParams;
 use metrics::{counter, describe_counter};
 use tracing::{debug, warn};
 
-use crate::indexing::{
-    FeatureIndexError, RustStepIndexError, index_feature_source, index_rust_file, index_rust_source,
-    server::ServerState,
-    indexing::{index_feature_file, index_feature_source, index_rust_file, index_rust_source},
-};
-
-use super::diagnostics::{
-    FeatureDiagnosticPublication, clear_rust_index_diagnostics, publish_all_feature_diagnostics,
-    publish_feature_diagnostics, publish_rust_index_result_diagnostics,
-    diagnostics::{,
-    publish_rust_diagnostics,
-    publish_feature_diagnostics,
-    publish_all_feature_diagnostics,
-};
-use super::workspace_metrics::{record_deferred_save_depth, record_workspace_outcome};
-
-
-//! Text document notification handlers.
-//!
-//! Phase 7 focuses on building language-server foundations. This module
-//! provides the on-save indexing pipeline for `.feature` files and Rust step
-//! definition sources. Indexing results are stored in the shared server state.
-//! After indexing, diagnostics are computed and published via the LSP protocol.
+use super::{
     diagnostics::{
+        FeatureDiagnosticPublication,
+        clear_rust_index_diagnostics,
+        publish_all_feature_diagnostics,
+        publish_feature_diagnostics,
+        publish_rust_index_result_diagnostics,
+    },
+    util::has_extension,
+    workspace_metrics::{record_deferred_save_depth, record_workspace_outcome},
 };
+use crate::{
+    indexing::{
+        FeatureIndexError,
+        RustStepIndexError,
+        index_feature_source,
+        index_rust_file,
+        index_rust_source,
+    },
+    server::ServerState,
 };
 
 const INDEXING_COUNTER: &str = "rstest_bdd_server_indexing_total";
@@ -219,17 +214,23 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use ::metrics::{
-        Counter, CounterFn, Gauge, Histogram, Key, KeyName, Metadata, Recorder, SharedString, Unit,
+        Counter,
+        CounterFn,
+        Gauge,
+        Histogram,
+        Key,
+        KeyName,
+        Metadata,
+        Recorder,
+        SharedString,
+        Unit,
         with_local_recorder,
     };
     use lsp_types::{TextDocumentIdentifier, Url};
     use tempfile::TempDir;
 
-    use crate::config::ServerConfig;
-    use crate::discovery::WorkspaceInfo;
-    use crate::server::ServerState;
-
     use super::*;
+    use crate::{config::ServerConfig, discovery::WorkspaceInfo, server::ServerState};
 
     #[derive(Default)]
     struct IndexingRecorder {
@@ -346,13 +347,9 @@ mod tests {
             }
         }
 
-        fn register_gauge(&self, _: &Key, _: &Metadata<'_>) -> Gauge {
-            Gauge::noop()
-        }
+        fn register_gauge(&self, _: &Key, _: &Metadata<'_>) -> Gauge { Gauge::noop() }
 
-        fn register_histogram(&self, _: &Key, _: &Metadata<'_>) -> Histogram {
-            Histogram::noop()
-        }
+        fn register_histogram(&self, _: &Key, _: &Metadata<'_>) -> Histogram { Histogram::noop() }
     }
 
     fn did_save_params(path: &std::path::Path, text: Option<&str>) -> DidSaveTextDocumentParams {

--- a/crates/rstest-bdd-server/src/handlers/text_document.rs
+++ b/crates/rstest-bdd-server/src/handlers/text_document.rs
@@ -11,15 +11,30 @@ use tracing::{debug, warn};
 
 use crate::indexing::{
     FeatureIndexError, RustStepIndexError, index_feature_source, index_rust_file, index_rust_source,
+    server::ServerState,
+    indexing::{index_feature_file, index_feature_source, index_rust_file, index_rust_source},
 };
-use crate::server::ServerState;
 
 use super::diagnostics::{
     FeatureDiagnosticPublication, clear_rust_index_diagnostics, publish_all_feature_diagnostics,
     publish_feature_diagnostics, publish_rust_index_result_diagnostics,
+    diagnostics::{,
+    publish_rust_diagnostics,
+    publish_feature_diagnostics,
+    publish_all_feature_diagnostics,
 };
-use super::util::has_extension;
 use super::workspace_metrics::{record_deferred_save_depth, record_workspace_outcome};
+
+
+//! Text document notification handlers.
+//!
+//! Phase 7 focuses on building language-server foundations. This module
+//! provides the on-save indexing pipeline for `.feature` files and Rust step
+//! definition sources. Indexing results are stored in the shared server state.
+//! After indexing, diagnostics are computed and published via the LSP protocol.
+    diagnostics::{
+};
+};
 
 const INDEXING_COUNTER: &str = "rstest_bdd_server_indexing_total";
 

--- a/crates/rstest-bdd-server/src/handlers/util/mod.rs
+++ b/crates/rstest-bdd-server/src/handlers/util/mod.rs
@@ -13,10 +13,9 @@ use std::path::Path;
 use gherkin::Span;
 use lsp_types::{Position, Range};
 
-use crate::util::utf16_code_units;
-
 // Re-export for backwards compatibility
 pub use crate::util::byte_col_to_utf16_col;
+use crate::util::utf16_code_units;
 
 /// Check whether `path` has the file extension `ext`, ignoring ASCII case.
 ///
@@ -34,6 +33,7 @@ pub use crate::util::byte_col_to_utf16_col;
 ///
 /// ```
 /// use std::path::Path;
+///
 /// use rstest_bdd_server::handlers::util::has_extension;
 ///
 /// assert!(has_extension(Path::new("steps.rs"), "rs"));

--- a/crates/rstest-bdd-server/src/handlers/util/tests.rs
+++ b/crates/rstest-bdd-server/src/handlers/util/tests.rs
@@ -1,18 +1,17 @@
 //! Unit tests for handler utility helpers.
 
-use super::*;
 use proptest::prelude::*;
 use rstest::{fixture, rstest};
 
-#[fixture]
-fn two_line_source() -> &'static str {
-    "Feature: demo\n  Scenario: s\n"
-}
+use super::*;
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
-fn three_line_source() -> &'static str {
-    "Feature: demo\n  Scenario: s\n    Given a step\n"
-}
+fn two_line_source() -> &'static str { "Feature: demo\n  Scenario: s\n" }
+
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
+#[fixture]
+fn three_line_source() -> &'static str { "Feature: demo\n  Scenario: s\n    Given a step\n" }
 
 #[rstest]
 #[case(0, 0, 0)]

--- a/crates/rstest-bdd-server/src/handlers/workspace_metrics.rs
+++ b/crates/rstest-bdd-server/src/handlers/workspace_metrics.rs
@@ -4,18 +4,26 @@
 //! fixed operations and outcomes only; client paths and source text never form
 //! part of a metric key.
 
-use std::time::Duration;
-
-use metrics::{counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram};
-
 #[cfg(test)]
 use std::sync::{Arc, Mutex, PoisonError};
+use std::time::Duration;
 
 #[cfg(test)]
 use metrics::{
-    Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, KeyName, Metadata, Recorder,
-    SharedString, Unit,
+    Counter,
+    CounterFn,
+    Gauge,
+    GaugeFn,
+    Histogram,
+    HistogramFn,
+    Key,
+    KeyName,
+    Metadata,
+    Recorder,
+    SharedString,
+    Unit,
 };
+use metrics::{counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram};
 
 const WORKSPACE_COUNTER: &str = "rstest_bdd_server_workspace_preparation_total";
 const DEFERRED_SAVE_GAUGE: &str = "rstest_bdd_server_deferred_document_saves";

--- a/crates/rstest-bdd-server/src/indexing/feature/docstring.rs
+++ b/crates/rstest-bdd-server/src/indexing/feature/docstring.rs
@@ -12,23 +12,15 @@ use super::FeatureSource;
 pub(super) struct LineContent<'a>(&'a str);
 
 impl<'a> LineContent<'a> {
-    pub(super) fn new(line: &'a str) -> Self {
-        Self(line)
-    }
+    pub(super) fn new(line: &'a str) -> Self { Self(line) }
 
-    pub(super) fn as_str(&self) -> &'a str {
-        self.0
-    }
+    pub(super) fn as_str(&self) -> &'a str { self.0 }
 
-    pub(super) fn trim_start(&self) -> &'a str {
-        self.0.trim_start()
-    }
+    pub(super) fn trim_start(&self) -> &'a str { self.0.trim_start() }
 }
 
 impl AsRef<str> for LineContent<'_> {
-    fn as_ref(&self) -> &str {
-        self.0
-    }
+    fn as_ref(&self) -> &str { self.0 }
 }
 
 /// Tracks the state whilst scanning for docstring delimiters.

--- a/crates/rstest-bdd-server/src/indexing/feature/mod.rs
+++ b/crates/rstest-bdd-server/src/indexing/feature/mod.rs
@@ -1,13 +1,15 @@
 //! Gherkin `.feature` file indexing support.
 
-use std::borrow::Cow;
-use std::ops::Range;
-use std::path::PathBuf;
+use std::{borrow::Cow, ops::Range, path::PathBuf};
 
 use gherkin::GherkinEnv;
 
 use super::{
-    FeatureFileIndex, FeatureIndexError, IndexedDocstring, IndexedScenarioOutline, IndexedStep,
+    FeatureFileIndex,
+    FeatureIndexError,
+    IndexedDocstring,
+    IndexedScenarioOutline,
+    IndexedStep,
     IndexedTable,
 };
 
@@ -17,7 +19,10 @@ mod table;
 
 use docstring::find_docstring_span;
 use outline::{
-    ScenarioStepIndices, build_scenario_outline, extract_example_columns, is_scenario_outline,
+    ScenarioStepIndices,
+    build_scenario_outline,
+    extract_example_columns,
+    is_scenario_outline,
 };
 
 /// Accumulates indexed steps and scenario outlines during feature indexing.
@@ -33,21 +38,13 @@ struct IndexingAccumulators<'a> {
 struct FeatureSource<'a>(&'a str);
 
 impl<'a> FeatureSource<'a> {
-    fn new(source: &'a str) -> Self {
-        Self(source)
-    }
+    fn new(source: &'a str) -> Self { Self(source) }
 
-    fn as_str(&self) -> &'a str {
-        self.0
-    }
+    fn as_str(&self) -> &'a str { self.0 }
 
-    fn get(&self, range: Range<usize>) -> Option<&'a str> {
-        self.0.get(range)
-    }
+    fn get(&self, range: Range<usize>) -> Option<&'a str> { self.0.get(range) }
 
-    fn len(&self) -> usize {
-        self.0.len()
-    }
+    fn len(&self) -> usize { self.0.len() }
 }
 
 /// Parse and index a `.feature` file from source text.
@@ -65,7 +62,7 @@ impl<'a> FeatureSource<'a> {
 /// ```rust,no_run
 /// use std::path::PathBuf;
 ///
-/// use rstest_bdd_server::indexing::{index_feature_source, FeatureIndexError};
+/// use rstest_bdd_server::indexing::{FeatureIndexError, index_feature_source};
 ///
 /// # fn main() -> Result<(), FeatureIndexError> {
 /// let feature = "Feature: demo\n  Scenario: s\n    Given a message\n";

--- a/crates/rstest-bdd-server/src/indexing/feature/outline.rs
+++ b/crates/rstest-bdd-server/src/indexing/feature/outline.rs
@@ -5,8 +5,7 @@
 
 use gherkin::Span;
 
-use super::FeatureSource;
-use super::table::extract_header_cell_spans;
+use super::{FeatureSource, table::extract_header_cell_spans};
 use crate::indexing::{IndexedExampleColumn, IndexedExamplesTable, IndexedScenarioOutline};
 
 /// Step index ranges for building a scenario outline.

--- a/crates/rstest-bdd-server/src/indexing/feature/table.rs
+++ b/crates/rstest-bdd-server/src/indexing/feature/table.rs
@@ -2,8 +2,7 @@
 
 use gherkin::Span;
 
-use super::FeatureSource;
-use super::docstring::LineContent;
+use super::{FeatureSource, docstring::LineContent};
 
 /// Extract byte spans for each header cell in a Gherkin Examples table.
 ///
@@ -89,6 +88,4 @@ fn trim_ascii_whitespace(bytes: &[u8], mut start: usize, mut end: usize) -> (usi
     (start, end)
 }
 
-fn is_ascii_space(b: u8) -> bool {
-    matches!(b, b' ' | b'\t')
-}
+fn is_ascii_space(b: u8) -> bool { matches!(b, b' ' | b'\t') }

--- a/crates/rstest-bdd-server/src/indexing/feature/tests.rs
+++ b/crates/rstest-bdd-server/src/indexing/feature/tests.rs
@@ -1,7 +1,8 @@
 //! Tests for feature file indexing.
 
-use super::*;
 use tempfile::TempDir;
+
+use super::*;
 
 fn index_feature(path: &std::path::Path, source: &str) -> FeatureFileIndex {
     match index_feature_source(path.to_path_buf(), source) {

--- a/crates/rstest-bdd-server/src/indexing/mod.rs
+++ b/crates/rstest-bdd-server/src/indexing/mod.rs
@@ -5,8 +5,8 @@
 //!
 //! - Feature steps (keyword, text, step span)
 //! - Feature doc strings, data tables, and Examples header columns
-//! - Rust step definitions annotated with `#[given]`, `#[when]`, and `#[then]`
-//!   (keyword, pattern string, parameters, table/doc string expectations)
+//! - Rust step definitions annotated with `#[given]`, `#[when]`, and `#[then]` (keyword, pattern
+//!   string, parameters, table/doc string expectations)
 //!
 //! The implementation relies on the `gherkin` crate for syntactic parsing.
 //! Where `gherkin` does not expose spans (for example doc string blocks and

--- a/crates/rstest-bdd-server/src/indexing/mod.rs
+++ b/crates/rstest-bdd-server/src/indexing/mod.rs
@@ -17,8 +17,7 @@
 //! the step attribute (e.g., `#[given("...")]`) to enable accurate diagnostic
 //! highlighting in language server clients.
 
-use std::ops::Deref;
-use std::path::PathBuf;
+use std::{ops::Deref, path::PathBuf};
 
 use gherkin::{Span, StepType};
 
@@ -189,9 +188,7 @@ pub struct RustStepIndexResult {
 impl Deref for RustStepIndexResult {
     type Target = RustStepFileIndex;
 
-    fn deref(&self) -> &Self::Target {
-        &self.index
-    }
+    fn deref(&self) -> &Self::Target { &self.index }
 }
 
 /// Span information for a Rust step attribute and its associated function.

--- a/crates/rstest-bdd-server/src/indexing/registry.rs
+++ b/crates/rstest-bdd-server/src/indexing/registry.rs
@@ -11,16 +11,21 @@
 //! indexed steps. This avoids rebuilding state for the entire workspace on
 //! every save while ensuring stale entries are not retained.
 
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use gherkin::StepType;
 use regex::Regex;
 use rstest_bdd_patterns::{PatternError, compile_regex_from_pattern};
 
 use super::{
-    IndexedStepDefinition, IndexedStepParameter, RustAttributeSpan, RustFunctionId,
+    IndexedStepDefinition,
+    IndexedStepParameter,
+    RustAttributeSpan,
+    RustFunctionId,
     RustStepFileIndex,
 };
 
@@ -52,7 +57,8 @@ pub struct CompiledStepDefinition {
 /// Error raised when a step pattern cannot be compiled.
 #[derive(Debug, thiserror::Error)]
 #[error(
-    "failed to compile step pattern '{pattern}' for {keyword:?} step '{function}' in {path}: {source}"
+    "failed to compile step pattern '{pattern}' for {keyword:?} step '{function}' in {path}: \
+     {source}"
 )]
 pub struct StepPatternCompileError {
     /// Absolute path to the Rust source file containing the step.
@@ -118,7 +124,8 @@ impl StepDefinitionRegistry {
 
     #[expect(
         clippy::unused_self,
-        reason = "method kept on the registry type to allow future use of configuration/state while matching the refactor contract"
+        reason = "method kept on the registry type to allow future use of configuration/state \
+                  while matching the refactor contract"
     )]
     fn compile_steps(
         &self,
@@ -139,7 +146,8 @@ impl StepDefinitionRegistry {
 
     #[expect(
         clippy::ptr_arg,
-        reason = "signature uses &PathBuf to match the refactor contract; PathBuf cloning is required for HashMap keys"
+        reason = "signature uses &PathBuf to match the refactor contract; PathBuf cloning is \
+                  required for HashMap keys"
     )]
     fn insert_compiled_steps(&mut self, path: &PathBuf, compiled: Vec<CompiledStepDefinition>) {
         if compiled.is_empty() {

--- a/crates/rstest-bdd-server/src/indexing/rust/mod.rs
+++ b/crates/rstest-bdd-server/src/indexing/rust/mod.rs
@@ -6,15 +6,14 @@
 //!
 //! The indexer intentionally mirrors the macro behaviour:
 //!
-//! - Missing attribute arguments infer the pattern from the function name by
-//!   replacing underscores with spaces.
+//! - Missing attribute arguments infer the pattern from the function name by replacing underscores
+//!   with spaces.
 //! - A string literal containing only whitespace also triggers inference.
-//! - The literal empty string (`""`) registers an empty pattern and does not
-//!   infer.
-//! - A data table is expected when a parameter is named `datatable` or has a
-//!   `#[datatable]` parameter attribute.
-//! - A doc string is expected when a parameter is named `docstring` and its
-//!   type resolves to `String` (either `String` or `std::string::String`).
+//! - The literal empty string (`""`) registers an empty pattern and does not infer.
+//! - A data table is expected when a parameter is named `datatable` or has a `#[datatable]`
+//!   parameter attribute.
+//! - A doc string is expected when a parameter is named `docstring` and its type resolves to
+//!   `String` (either `String` or `std::string::String`).
 
 use std::path::{Path, PathBuf};
 
@@ -22,8 +21,14 @@ use gherkin::StepType;
 use syn::spanned::Spanned;
 
 use super::{
-    IndexedStepDefinition, IndexedStepParameter, RustAttributeSpan, RustFunctionId,
-    RustStepFileIndex, RustStepIndexDiagnostic, RustStepIndexError, RustStepIndexResult,
+    IndexedStepDefinition,
+    IndexedStepParameter,
+    RustAttributeSpan,
+    RustFunctionId,
+    RustStepFileIndex,
+    RustStepIndexDiagnostic,
+    RustStepIndexError,
+    RustStepIndexResult,
 };
 
 mod params;

--- a/crates/rstest-bdd-server/src/indexing/rust/params.rs
+++ b/crates/rstest-bdd-server/src/indexing/rust/params.rs
@@ -6,8 +6,7 @@
 //! rendering is delegated to the sibling [`type_render`](super::type_render)
 //! module.
 
-use super::IndexedStepParameter;
-use super::type_render;
+use super::{IndexedStepParameter, type_render};
 
 /// Parse function parameters into indexed step parameters.
 pub(super) fn parse_function_parameters(

--- a/crates/rstest-bdd-server/src/indexing/rust/tests.rs
+++ b/crates/rstest-bdd-server/src/indexing/rust/tests.rs
@@ -1,6 +1,7 @@
 //! Tests for Rust step definition indexing.
 use proptest::prelude::*;
 use rstest::rstest;
+
 use super::*;
 
 #[test]

--- a/crates/rstest-bdd-server/src/indexing/rust/tests.rs
+++ b/crates/rstest-bdd-server/src/indexing/rust/tests.rs
@@ -1,8 +1,7 @@
 //! Tests for Rust step definition indexing.
-
-use super::*;
 use proptest::prelude::*;
 use rstest::rstest;
+use super::*;
 
 #[test]
 fn indexes_step_definitions_and_infers_patterns() {

--- a/crates/rstest-bdd-server/src/indexing/rust/type_render.rs
+++ b/crates/rstest-bdd-server/src/indexing/rust/type_render.rs
@@ -247,8 +247,9 @@ fn render_expr(expr: &Expr) -> String {
 mod tests {
     //! Unit tests for rendering Rust types in the index.
 
-    use super::*;
     use syn::{Type, parse_quote};
+
+    use super::*;
 
     fn assert_renders(ty: &Type, expected: &str) {
         assert_eq!(render_type(ty), expected);

--- a/crates/rstest-bdd-server/src/indexing/workspace.rs
+++ b/crates/rstest-bdd-server/src/indexing/workspace.rs
@@ -6,15 +6,15 @@
 //! path validation and capability-rooted file reads live here at the server
 //! boundary rather than in the indexing domain.
 
-use std::fmt;
-use std::path::{Component, Path};
+use std::{
+    fmt,
+    path::{Component, Path},
+};
 
 use camino::{Utf8Path, Utf8PathBuf};
-use cap_std::ambient_authority;
-use cap_std::fs_utf8::Dir;
+use cap_std::{ambient_authority, fs_utf8::Dir};
 
-use crate::error::ServerError;
-use crate::indexing::FeatureIndexError;
+use crate::{error::ServerError, indexing::FeatureIndexError};
 
 /// Validated capability for reading files beneath one workspace root.
 pub struct WorkspaceRoot {
@@ -50,9 +50,7 @@ impl WorkspaceRoot {
 
     /// Return the validated root path.
     #[must_use]
-    pub fn path(&self) -> &Utf8Path {
-        &self.path
-    }
+    pub fn path(&self) -> &Utf8Path { &self.path }
 
     /// Duplicate the directory capability for background file reads.
     ///
@@ -108,12 +106,13 @@ impl WorkspaceRoot {
 mod tests {
     //! Unit tests for the workspace-root file-read adapter boundary.
 
-    use super::*;
     #[cfg(unix)]
     use std::ffi::OsString;
     #[cfg(unix)]
     use std::os::unix::ffi::OsStringExt;
     use std::path::PathBuf;
+
+    use super::*;
 
     fn open_workspace_with_feature(
         workspace: &Path,

--- a/crates/rstest-bdd-server/src/lib.rs
+++ b/crates/rstest-bdd-server/src/lib.rs
@@ -16,11 +16,9 @@
 //!
 //! The server can be configured via environment variables:
 //!
-//! - `RSTEST_BDD_LSP_LOG_LEVEL`: Log verbosity (trace, debug, info, warn,
-//!   error)
+//! - `RSTEST_BDD_LSP_LOG_LEVEL`: Log verbosity (trace, debug, info, warn, error)
 //! - `RSTEST_BDD_LSP_DEBOUNCE_MS`: Delay before processing file changes
-//! - `RSTEST_BDD_LSP_WORKSPACE_ROOT`: Override workspace root path for
-//!   discovery
+//! - `RSTEST_BDD_LSP_WORKSPACE_ROOT`: Override workspace root path for discovery
 //!
 //! # Example
 //!

--- a/crates/rstest-bdd-server/src/logging.rs
+++ b/crates/rstest-bdd-server/src/logging.rs
@@ -4,8 +4,7 @@
 //! Logs are written to stderr to avoid interfering with JSON-RPC communication
 //! on stdout.
 
-use tracing_subscriber::EnvFilter;
-use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan};
 
 use crate::config::ServerConfig;
 

--- a/crates/rstest-bdd-server/src/main.rs
+++ b/crates/rstest-bdd-server/src/main.rs
@@ -4,28 +4,38 @@
 //! (IDE) integration with the rstest-bdd Behaviour-Driven Development (BDD)
 //! testing framework. It communicates via JSON-RPC over stdin/stdout.
 
-use std::ops::ControlFlow;
-use std::path::PathBuf;
+use std::{ops::ControlFlow, path::PathBuf};
 
-use async_lsp::concurrency::ConcurrencyLayer;
-use async_lsp::panic::CatchUnwindLayer;
-use async_lsp::router::Router;
-use async_lsp::server::LifecycleLayer;
-use async_lsp::tracing::TracingLayer;
+use async_lsp::{
+    concurrency::ConcurrencyLayer,
+    panic::CatchUnwindLayer,
+    router::Router,
+    server::LifecycleLayer,
+    tracing::TracingLayer,
+};
 use clap::Parser;
 use lsp_types::{notification, request};
+use rstest_bdd_server::{
+    config::{LogLevel, ServerConfig},
+    error::ServerError,
+    handlers::{
+        DeferredDocumentSavesIndexed,
+        WorkspaceReadyEvent,
+        handle_deferred_document_saves_indexed,
+        handle_definition,
+        handle_did_save_text_document,
+        handle_implementation,
+        handle_initialise,
+        handle_initialised,
+        handle_shutdown,
+        handle_workspace_ready,
+        launch_workspace_preparation,
+    },
+    logging::init_logging,
+    server::ServerState,
+};
 use tower::ServiceBuilder;
 use tracing::{info, warn};
-
-use rstest_bdd_server::config::{LogLevel, ServerConfig};
-use rstest_bdd_server::error::ServerError;
-use rstest_bdd_server::handlers::{
-    DeferredDocumentSavesIndexed, WorkspaceReadyEvent, handle_deferred_document_saves_indexed,
-    handle_definition, handle_did_save_text_document, handle_implementation, handle_initialise,
-    handle_initialised, handle_shutdown, handle_workspace_ready, launch_workspace_preparation,
-};
-use rstest_bdd_server::logging::init_logging;
-use rstest_bdd_server::server::ServerState;
 
 /// LSP server for rstest-bdd Behaviour-Driven Development (BDD) testing framework.
 #[derive(Parser, Debug)]

--- a/crates/rstest-bdd-server/src/server.rs
+++ b/crates/rstest-bdd-server/src/server.rs
@@ -3,20 +3,31 @@
 //! This module defines the central state shared across all LSP handlers and
 //! provides the service construction for the language server.
 
-use std::collections::HashMap;
-use std::path::Path;
+use std::{collections::HashMap, path::Path};
 
 use async_lsp::ClientSocket;
-use lsp_types::{ClientCapabilities, ServerCapabilities, WorkspaceFolder};
-use lsp_types::{TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions};
+use lsp_types::{
+    ClientCapabilities,
+    ServerCapabilities,
+    TextDocumentSyncCapability,
+    TextDocumentSyncKind,
+    TextDocumentSyncOptions,
+    WorkspaceFolder,
+};
 use tracing::warn;
 
-use crate::config::ServerConfig;
-use crate::discovery::WorkspaceInfo;
-use crate::error::ServerError;
-use crate::indexing::{
-    FeatureFileIndex, FeatureIndexError, RustStepFileIndex, StepDefinitionRegistry, WorkspaceRoot,
-    index_feature_source_owned,
+use crate::{
+    config::ServerConfig,
+    discovery::WorkspaceInfo,
+    error::ServerError,
+    indexing::{
+        FeatureFileIndex,
+        FeatureIndexError,
+        RustStepFileIndex,
+        StepDefinitionRegistry,
+        WorkspaceRoot,
+        index_feature_source_owned,
+    },
 };
 
 mod deferred_saves;
@@ -103,8 +114,7 @@ impl ServerState {
     /// # Examples
     ///
     /// ```
-    /// use rstest_bdd_server::config::ServerConfig;
-    /// use rstest_bdd_server::server::ServerState;
+    /// use rstest_bdd_server::{config::ServerConfig, server::ServerState};
     ///
     /// let config = ServerConfig::default();
     /// let state = ServerState::new(config);
@@ -131,15 +141,11 @@ impl ServerState {
     }
 
     /// Store the client socket for sending notifications.
-    pub fn set_client(&mut self, client: ClientSocket) {
-        self.client = Some(client);
-    }
+    pub fn set_client(&mut self, client: ClientSocket) { self.client = Some(client); }
 
     /// Access the client socket for sending notifications.
     #[must_use]
-    pub fn client(&self) -> Option<&ClientSocket> {
-        self.client.as_ref()
-    }
+    pub fn client(&self) -> Option<&ClientSocket> { self.client.as_ref() }
 
     /// Store client capabilities received during initialization.
     pub fn set_client_capabilities(&mut self, capabilities: ClientCapabilities) {
@@ -225,9 +231,7 @@ impl ServerState {
 
     /// Access the workspace folders provided by the client.
     #[must_use]
-    pub fn workspace_folders(&self) -> &[WorkspaceFolder] {
-        &self.workspace_folders
-    }
+    pub fn workspace_folders(&self) -> &[WorkspaceFolder] { &self.workspace_folders }
 
     /// Store discovered workspace information and its read capability.
     ///
@@ -278,9 +282,7 @@ impl ServerState {
 
     /// Access discovered workspace information, if available.
     #[must_use]
-    pub fn workspace_info(&self) -> Option<&WorkspaceInfo> {
-        self.workspace_info.as_ref()
-    }
+    pub fn workspace_info(&self) -> Option<&WorkspaceInfo> { self.workspace_info.as_ref() }
 
     /// Index a disk-backed feature file through the workspace-root capability.
     ///
@@ -301,20 +303,14 @@ impl ServerState {
 
     /// Access the current server configuration.
     #[must_use]
-    pub fn config(&self) -> &ServerConfig {
-        &self.config
-    }
+    pub fn config(&self) -> &ServerConfig { &self.config }
 
     /// Mark the server as initialized.
-    pub fn mark_initialised(&mut self) {
-        self.initialized = true;
-    }
+    pub fn mark_initialised(&mut self) { self.initialized = true; }
 
     /// Check if the server is initialized.
     #[must_use]
-    pub fn is_initialised(&self) -> bool {
-        self.initialized
-    }
+    pub fn is_initialised(&self) -> bool { self.initialized }
 
     /// Insert or update the cached index for a `.feature` file.
     pub fn upsert_feature_index(&mut self, index: FeatureFileIndex) {
@@ -340,9 +336,7 @@ impl ServerState {
 
     /// Access the compiled step registry.
     #[must_use]
-    pub fn step_registry(&self) -> &StepDefinitionRegistry {
-        &self.step_registry
-    }
+    pub fn step_registry(&self) -> &StepDefinitionRegistry { &self.step_registry }
 
     /// Insert or update the cached index for a Rust source file.
     ///

--- a/crates/rstest-bdd-server/src/server/deferred_saves.rs
+++ b/crates/rstest-bdd-server/src/server/deferred_saves.rs
@@ -96,14 +96,10 @@ impl DeferredDocumentSaves {
     }
 
     /// Return the number of retained saves.
-    pub(super) fn len(&self) -> usize {
-        self.saves.len()
-    }
+    pub(super) fn len(&self) -> usize { self.saves.len() }
 
     #[cfg(test)]
-    fn recomputed_byte_count(&self) -> usize {
-        self.saves.iter().map(save_byte_count).sum()
-    }
+    fn recomputed_byte_count(&self) -> usize { self.saves.iter().map(save_byte_count).sum() }
 }
 
 fn save_byte_count(params: &DidSaveTextDocumentParams) -> usize {

--- a/crates/rstest-bdd-server/src/server/workspace_task.rs
+++ b/crates/rstest-bdd-server/src/server/workspace_task.rs
@@ -10,9 +10,7 @@ pub(super) struct WorkspaceTask(Option<JoinHandle<()>>);
 
 impl WorkspaceTask {
     /// Return whether an owned task is still retained.
-    pub(super) fn has_retained_task(&self) -> bool {
-        self.0.is_some()
-    }
+    pub(super) fn has_retained_task(&self) -> bool { self.0.is_some() }
 
     /// Abort and discard the currently owned task.
     pub(super) fn abort(&mut self) {
@@ -30,14 +28,10 @@ impl ServerState {
     }
 
     /// Drop the owned task handle after its result has been applied.
-    pub(crate) fn clear_workspace_task(&mut self) {
-        self.workspace_task.0 = None;
-    }
+    pub(crate) fn clear_workspace_task(&mut self) { self.workspace_task.0 = None; }
 
     /// Take the task so shutdown can cancel and await it.
-    pub fn take_workspace_task(&mut self) -> Option<JoinHandle<()>> {
-        self.workspace_task.0.take()
-    }
+    pub fn take_workspace_task(&mut self) -> Option<JoinHandle<()>> { self.workspace_task.0.take() }
 }
 
 #[cfg(test)]

--- a/crates/rstest-bdd-server/src/test_support.rs
+++ b/crates/rstest-bdd-server/src/test_support.rs
@@ -6,16 +6,19 @@
 //! - File indexing via simulated LSP save events
 //! - Scenario building for diagnostic and navigation tests
 //! - Newtype wrappers for improved type safety
-use lsp_types::{DidSaveTextDocumentParams, TextDocumentIdentifier, Url};
 use std::path::Path;
-use tempfile::TempDir;
 
 use camino::Utf8Path;
-use cap_std::ambient_authority;
-use cap_std::fs_utf8::Dir;
+use cap_std::{ambient_authority, fs_utf8::Dir};
+use lsp_types::{DidSaveTextDocumentParams, TextDocumentIdentifier, Url};
+use tempfile::TempDir;
 
-use crate::discovery::WorkspaceInfo;
-use crate::{config::ServerConfig, handlers::handle_did_save_text_document, server::ServerState};
+use crate::{
+    config::ServerConfig,
+    discovery::WorkspaceInfo,
+    handlers::handle_did_save_text_document,
+    server::ServerState,
+};
 
 /// Newtype wrapper for test file names to improve type safety.
 #[derive(Debug, Clone)]

--- a/crates/rstest-bdd-server/src/test_support.rs
+++ b/crates/rstest-bdd-server/src/test_support.rs
@@ -6,7 +6,6 @@
 //! - File indexing via simulated LSP save events
 //! - Scenario building for diagnostic and navigation tests
 //! - Newtype wrappers for improved type safety
-
 use lsp_types::{DidSaveTextDocumentParams, TextDocumentIdentifier, Url};
 use std::path::Path;
 use tempfile::TempDir;
@@ -15,31 +14,23 @@ use camino::Utf8Path;
 use cap_std::ambient_authority;
 use cap_std::fs_utf8::Dir;
 
-use crate::config::ServerConfig;
 use crate::discovery::WorkspaceInfo;
-use crate::handlers::handle_did_save_text_document;
-use crate::server::ServerState;
+use crate::{config::ServerConfig, handlers::handle_did_save_text_document, server::ServerState};
 
 /// Newtype wrapper for test file names to improve type safety.
 #[derive(Debug, Clone)]
 pub struct Filename(pub(crate) String);
 
 impl From<&str> for Filename {
-    fn from(s: &str) -> Self {
-        Self(s.into())
-    }
+    fn from(s: &str) -> Self { Self(s.into()) }
 }
 
 impl From<String> for Filename {
-    fn from(s: String) -> Self {
-        Self(s)
-    }
+    fn from(s: String) -> Self { Self(s) }
 }
 
 impl AsRef<str> for Filename {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
+    fn as_ref(&self) -> &str { &self.0 }
 }
 
 /// Newtype wrapper for file contents to improve type safety.
@@ -47,21 +38,15 @@ impl AsRef<str> for Filename {
 pub struct FileContent(pub(crate) String);
 
 impl From<&str> for FileContent {
-    fn from(s: &str) -> Self {
-        Self(s.into())
-    }
+    fn from(s: &str) -> Self { Self(s.into()) }
 }
 
 impl From<String> for FileContent {
-    fn from(s: String) -> Self {
-        Self(s)
-    }
+    fn from(s: String) -> Self { Self(s) }
 }
 
 impl AsRef<str> for FileContent {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
+    fn as_ref(&self) -> &str { &self.0 }
 }
 
 /// Specifies which diagnostic checks to run in parameterized tests.
@@ -281,9 +266,7 @@ impl ScenarioBuilder {
 }
 
 impl Default for ScenarioBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
+    fn default() -> Self { Self::new() }
 }
 
 /// Test scenario with a single feature and Rust file pair.

--- a/crates/rstest-bdd-server/src/util.rs
+++ b/crates/rstest-bdd-server/src/util.rs
@@ -24,9 +24,7 @@
 /// ```
 #[inline]
 #[must_use]
-pub fn utf16_code_units(ch: char) -> u32 {
-    if u32::from(ch) <= 0xFFFF { 1 } else { 2 }
-}
+pub fn utf16_code_units(ch: char) -> u32 { if u32::from(ch) <= 0xffff { 1 } else { 2 } }
 
 /// Convert a byte column offset to UTF-16 code units for a single line.
 ///

--- a/crates/rstest-bdd-server/tests/definition_navigation.rs
+++ b/crates/rstest-bdd-server/tests/definition_navigation.rs
@@ -4,14 +4,22 @@
 //! matching feature steps in `.feature` files.
 
 use lsp_types::{
-    DidSaveTextDocumentParams, GotoDefinitionParams, PartialResultParams, Position,
-    TextDocumentIdentifier, TextDocumentPositionParams, Url, WorkDoneProgressParams,
+    DidSaveTextDocumentParams,
+    GotoDefinitionParams,
+    PartialResultParams,
+    Position,
+    TextDocumentIdentifier,
+    TextDocumentPositionParams,
+    Url,
+    WorkDoneProgressParams,
 };
-use rstest_bdd_server::config::ServerConfig;
-use rstest_bdd_server::discovery::WorkspaceInfo;
-use rstest_bdd_server::handlers::{handle_definition, handle_did_save_text_document};
-use rstest_bdd_server::server::ServerState;
-use rstest_bdd_server::test_support::write_workspace_file;
+use rstest_bdd_server::{
+    config::ServerConfig,
+    discovery::WorkspaceInfo,
+    handlers::{handle_definition, handle_did_save_text_document},
+    server::ServerState,
+    test_support::write_workspace_file,
+};
 use tempfile::TempDir;
 
 /// Helper to create `GotoDefinitionParams` for a given URI and position.

--- a/crates/rstest-bdd-server/tests/diagnostics_basic.rs
+++ b/crates/rstest-bdd-server/tests/diagnostics_basic.rs
@@ -10,19 +10,17 @@
 mod support;
 
 use rstest::{fixture, rstest};
-use rstest_bdd_server::handlers::{
-    compute_unimplemented_step_diagnostics, compute_unused_step_diagnostics,
+use rstest_bdd_server::{
+    handlers::{compute_unimplemented_step_diagnostics, compute_unused_step_diagnostics},
+    server::ServerState,
+    test_support::DiagnosticCheckType,
 };
-use rstest_bdd_server::server::ServerState;
-use rstest_bdd_server::test_support::DiagnosticCheckType;
 use support::{ScenarioBuilder, TestScenario};
 use tempfile::TempDir;
 
 /// Fixture providing a fresh scenario builder for each test.
 #[fixture]
-fn scenario_builder() -> ScenarioBuilder {
-    ScenarioBuilder::new()
-}
+fn scenario_builder() -> ScenarioBuilder { ScenarioBuilder::new() }
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Test-local helpers

--- a/crates/rstest-bdd-server/tests/diagnostics_basic.rs
+++ b/crates/rstest-bdd-server/tests/diagnostics_basic.rs
@@ -19,6 +19,7 @@ use support::{ScenarioBuilder, TestScenario};
 use tempfile::TempDir;
 
 /// Fixture providing a fresh scenario builder for each test.
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn scenario_builder() -> ScenarioBuilder { ScenarioBuilder::new() }
 

--- a/crates/rstest-bdd-server/tests/diagnostics_placeholder.rs
+++ b/crates/rstest-bdd-server/tests/diagnostics_placeholder.rs
@@ -11,6 +11,7 @@ use support::{ScenarioBuilder, TestScenario};
 use tempfile::TempDir;
 
 /// Fixture providing a fresh scenario builder for each test.
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn scenario_builder() -> ScenarioBuilder { ScenarioBuilder::new() }
 

--- a/crates/rstest-bdd-server/tests/diagnostics_placeholder.rs
+++ b/crates/rstest-bdd-server/tests/diagnostics_placeholder.rs
@@ -6,16 +6,13 @@
 mod support;
 
 use rstest::{fixture, rstest};
-use rstest_bdd_server::handlers::compute_signature_mismatch_diagnostics;
-use rstest_bdd_server::server::ServerState;
+use rstest_bdd_server::{handlers::compute_signature_mismatch_diagnostics, server::ServerState};
 use support::{ScenarioBuilder, TestScenario};
 use tempfile::TempDir;
 
 /// Fixture providing a fresh scenario builder for each test.
 #[fixture]
-fn scenario_builder() -> ScenarioBuilder {
-    ScenarioBuilder::new()
-}
+fn scenario_builder() -> ScenarioBuilder { ScenarioBuilder::new() }
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Test-local helpers

--- a/crates/rstest-bdd-server/tests/diagnostics_scenario_outline.rs
+++ b/crates/rstest-bdd-server/tests/diagnostics_scenario_outline.rs
@@ -14,6 +14,7 @@ use support::{ScenarioBuilder, TestScenario};
 use tempfile::TempDir;
 
 /// Fixture providing a fresh scenario builder for each test.
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn scenario_builder() -> ScenarioBuilder { ScenarioBuilder::new() }
 

--- a/crates/rstest-bdd-server/tests/diagnostics_scenario_outline.rs
+++ b/crates/rstest-bdd-server/tests/diagnostics_scenario_outline.rs
@@ -6,16 +6,16 @@
 mod support;
 
 use rstest::{fixture, rstest};
-use rstest_bdd_server::handlers::compute_scenario_outline_column_diagnostics;
-use rstest_bdd_server::server::ServerState;
+use rstest_bdd_server::{
+    handlers::compute_scenario_outline_column_diagnostics,
+    server::ServerState,
+};
 use support::{ScenarioBuilder, TestScenario};
 use tempfile::TempDir;
 
 /// Fixture providing a fresh scenario builder for each test.
 #[fixture]
-fn scenario_builder() -> ScenarioBuilder {
-    ScenarioBuilder::new()
-}
+fn scenario_builder() -> ScenarioBuilder { ScenarioBuilder::new() }
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Test-local helpers

--- a/crates/rstest-bdd-server/tests/diagnostics_table_docstring.rs
+++ b/crates/rstest-bdd-server/tests/diagnostics_table_docstring.rs
@@ -7,16 +7,16 @@
 mod support;
 
 use rstest::{fixture, rstest};
-use rstest_bdd_server::handlers::compute_table_docstring_mismatch_diagnostics;
-use rstest_bdd_server::server::ServerState;
+use rstest_bdd_server::{
+    handlers::compute_table_docstring_mismatch_diagnostics,
+    server::ServerState,
+};
 use support::{ScenarioBuilder, TestScenario};
 use tempfile::TempDir;
 
 /// Fixture providing a fresh scenario builder for each test.
 #[fixture]
-fn scenario_builder() -> ScenarioBuilder {
-    ScenarioBuilder::new()
-}
+fn scenario_builder() -> ScenarioBuilder { ScenarioBuilder::new() }
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Test-local helpers

--- a/crates/rstest-bdd-server/tests/diagnostics_table_docstring.rs
+++ b/crates/rstest-bdd-server/tests/diagnostics_table_docstring.rs
@@ -15,6 +15,7 @@ use support::{ScenarioBuilder, TestScenario};
 use tempfile::TempDir;
 
 /// Fixture providing a fresh scenario builder for each test.
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn scenario_builder() -> ScenarioBuilder { ScenarioBuilder::new() }
 

--- a/crates/rstest-bdd-server/tests/feature_indexing_on_save.rs
+++ b/crates/rstest-bdd-server/tests/feature_indexing_on_save.rs
@@ -1,15 +1,18 @@
 //! Behavioural test for `.feature` file indexing on save.
 
+use std::path::Path;
+
 use lsp_types::{DidSaveTextDocumentParams, TextDocumentIdentifier, Url};
 use rstest::{fixture, rstest};
-use rstest_bdd_server::discovery::WorkspaceInfo;
-use std::path::Path;
+use rstest_bdd_server::{
+    config::ServerConfig,
+    discovery::WorkspaceInfo,
+    handlers::handle_did_save_text_document,
+    server::ServerState,
+};
 use tempfile::TempDir;
 
-
-//! Behavioural test for `.feature` file indexing on save.
-};
-
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn workspace_root() -> TempDir {
     let Ok(workspace_root) = TempDir::new() else {
@@ -18,6 +21,7 @@ fn workspace_root() -> TempDir {
     workspace_root
 }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn state_for_workspace(#[default(Path::new(""))] root: &Path) -> ServerState {
     let mut state = ServerState::new(ServerConfig::default());

--- a/crates/rstest-bdd-server/tests/feature_indexing_on_save.rs
+++ b/crates/rstest-bdd-server/tests/feature_indexing_on_save.rs
@@ -2,12 +2,13 @@
 
 use lsp_types::{DidSaveTextDocumentParams, TextDocumentIdentifier, Url};
 use rstest::{fixture, rstest};
-use rstest_bdd_server::config::ServerConfig;
 use rstest_bdd_server::discovery::WorkspaceInfo;
-use rstest_bdd_server::handlers::handle_did_save_text_document;
-use rstest_bdd_server::server::ServerState;
 use std::path::Path;
 use tempfile::TempDir;
+
+
+//! Behavioural test for `.feature` file indexing on save.
+};
 
 #[fixture]
 fn workspace_root() -> TempDir {

--- a/crates/rstest-bdd-server/tests/has_extension_props.rs
+++ b/crates/rstest-bdd-server/tests/has_extension_props.rs
@@ -7,19 +7,14 @@
 use std::path::PathBuf;
 
 use proptest::prelude::*;
-
 use rstest_bdd_server::handlers::util::has_extension;
 
 /// Strategy producing a plausible lowercase extension (letters only so case
 /// permutation is meaningful).
-fn extension() -> impl Strategy<Value = String> {
-    "[a-z]{1,8}"
-}
+fn extension() -> impl Strategy<Value = String> { "[a-z]{1,8}" }
 
 /// Strategy producing a file stem free of dots and path separators.
-fn stem() -> impl Strategy<Value = String> {
-    "[a-zA-Z0-9_-]{1,12}"
-}
+fn stem() -> impl Strategy<Value = String> { "[a-zA-Z0-9_-]{1,12}" }
 
 /// Apply a per-character case flip mask to an ASCII string.
 fn permute_case(s: &str, mask: &[bool]) -> String {

--- a/crates/rstest-bdd-server/tests/implementation_navigation.rs
+++ b/crates/rstest-bdd-server/tests/implementation_navigation.rs
@@ -3,16 +3,23 @@
 //! These tests verify end-to-end navigation from feature steps in `.feature`
 //! files to matching Rust step implementations.
 
-use lsp_types::request::{GotoImplementationParams, GotoImplementationResponse};
 use lsp_types::{
-    DidSaveTextDocumentParams, PartialResultParams, Position, TextDocumentIdentifier,
-    TextDocumentPositionParams, Url, WorkDoneProgressParams,
+    DidSaveTextDocumentParams,
+    PartialResultParams,
+    Position,
+    TextDocumentIdentifier,
+    TextDocumentPositionParams,
+    Url,
+    WorkDoneProgressParams,
+    request::{GotoImplementationParams, GotoImplementationResponse},
 };
-use rstest_bdd_server::config::ServerConfig;
-use rstest_bdd_server::discovery::WorkspaceInfo;
-use rstest_bdd_server::handlers::{handle_did_save_text_document, handle_implementation};
-use rstest_bdd_server::server::ServerState;
-use rstest_bdd_server::test_support::write_workspace_file;
+use rstest_bdd_server::{
+    config::ServerConfig,
+    discovery::WorkspaceInfo,
+    handlers::{handle_did_save_text_document, handle_implementation},
+    server::ServerState,
+    test_support::write_workspace_file,
+};
 use tempfile::TempDir;
 
 fn make_params(uri: Url, line: u32, character: u32) -> GotoImplementationParams {
@@ -168,7 +175,8 @@ fn implementation_respects_keyword_matching() {
     let (_dir, feature_path, state) = ImplementationTestScenario::new()
         .with_feature(
             "test.feature",
-            "Feature: test\n  Scenario: example\n    Given a step\n    When a step\n    Then a step\n",
+            "Feature: test\n  Scenario: example\n    Given a step\n    When a step\n    Then a \
+             step\n",
         )
         .with_rust_steps(
             "steps.rs",
@@ -191,11 +199,13 @@ fn implementation_matches_parameterized_patterns() {
     let (_dir, feature_path, state) = ImplementationTestScenario::new()
         .with_feature(
             "test.feature",
-            "Feature: test\n  Scenario: example\n    Given I have 5 items\n    Given I have 10 items\n",
+            "Feature: test\n  Scenario: example\n    Given I have 5 items\n    Given I have 10 \
+             items\n",
         )
         .with_rust_steps(
             "steps.rs",
-            "use rstest_bdd_macros::given;\n\n#[given(\"I have {count:u32} items\")]\nfn have_items(count: u32) {}\n",
+            "use rstest_bdd_macros::given;\n\n#[given(\"I have {count:u32} items\")]\nfn \
+             have_items(count: u32) {}\n",
         )
         .build();
 

--- a/crates/rstest-bdd-server/tests/rust_step_indexing_on_save.rs
+++ b/crates/rstest-bdd-server/tests/rust_step_indexing_on_save.rs
@@ -6,10 +6,11 @@ use lsp_types::{
     DidSaveTextDocumentParams, NumberOrString, PublishDiagnosticsParams, TextDocumentIdentifier,
     Url,
 };
-use rstest_bdd_server::config::ServerConfig;
-use rstest_bdd_server::handlers::handle_did_save_text_document;
-use rstest_bdd_server::server::ServerState;
 use tempfile::TempDir;
+
+
+//! Behavioural test for Rust step indexing on save.
+};
 
 fn did_save_params(uri: Url, text: Option<&str>) -> DidSaveTextDocumentParams {
     DidSaveTextDocumentParams {

--- a/crates/rstest-bdd-server/tests/rust_step_indexing_on_save.rs
+++ b/crates/rstest-bdd-server/tests/rust_step_indexing_on_save.rs
@@ -3,14 +3,18 @@
 use std::path::Path;
 
 use lsp_types::{
-    DidSaveTextDocumentParams, NumberOrString, PublishDiagnosticsParams, TextDocumentIdentifier,
+    DidSaveTextDocumentParams,
+    NumberOrString,
+    PublishDiagnosticsParams,
+    TextDocumentIdentifier,
     Url,
 };
-use tempfile::TempDir;
-
-
-//! Behavioural test for Rust step indexing on save.
+use rstest_bdd_server::{
+    config::ServerConfig,
+    handlers::handle_did_save_text_document,
+    server::ServerState,
 };
+use tempfile::TempDir;
 
 fn did_save_params(uri: Url, text: Option<&str>) -> DidSaveTextDocumentParams {
     DidSaveTextDocumentParams {
@@ -321,8 +325,7 @@ fn did_save_retains_valid_steps_after_recoverable_attribute_diagnostic() {
 
 #[tokio::test]
 async fn did_save_clears_recoverable_index_diagnostics_after_success_and_parse_failure() {
-    use async_lsp::MainLoop;
-    use async_lsp::router::Router;
+    use async_lsp::{MainLoop, router::Router};
     use tokio::io::AsyncReadExt;
     use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 

--- a/crates/rstest-bdd-server/tests/smoke_lsp/clearing.rs
+++ b/crates/rstest-bdd-server/tests/smoke_lsp/clearing.rs
@@ -6,8 +6,12 @@
 
 use rstest::rstest;
 
-use super::wire::{did_save, is_non_empty_diagnostics, shutdown_and_exit};
-use super::{MAX_RECV_MESSAGES, ServerHandle, server};
+use super::{
+    MAX_RECV_MESSAGES,
+    ServerHandle,
+    server,
+    wire::{did_save, is_non_empty_diagnostics, shutdown_and_exit},
+};
 
 /// Exercise the canonical publication boundary end-to-end through the public
 /// publishers. An unimplemented step first emits a non-empty

--- a/crates/rstest-bdd-server/tests/smoke_lsp/main.rs
+++ b/crates/rstest-bdd-server/tests/smoke_lsp/main.rs
@@ -37,6 +37,7 @@ const MAX_RECV_MESSAGES: usize = 20;
 // ---------------------------------------------------------------------------
 
 /// Fixture providing a temporary directory for each test.
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn temp_dir() -> TempDir { new_temp_dir() }
 
@@ -44,6 +45,7 @@ fn temp_dir() -> TempDir { new_temp_dir() }
 /// directory.  The server is spawned, the initialize handshake is
 /// performed, and the caller receives handles needed for interaction
 /// and teardown.
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn server(temp_dir: TempDir) -> ServerHandle { init_server_handle(temp_dir) }
 

--- a/crates/rstest-bdd-server/tests/smoke_lsp/main.rs
+++ b/crates/rstest-bdd-server/tests/smoke_lsp/main.rs
@@ -9,16 +9,21 @@
 mod clearing;
 mod wire;
 
-use std::io::BufReader;
-use std::path::{Path, PathBuf};
-use std::process::{Child, ChildStdin};
+use std::{
+    io::BufReader,
+    path::{Path, PathBuf},
+    process::{Child, ChildStdin},
+};
 
 use rstest::{fixture, rstest};
 use serde_json::{Value, json};
 use tempfile::TempDir;
-
 use wire::{
-    MessageReceiver, did_save, initialize, is_non_empty_diagnostics, shutdown_and_exit,
+    MessageReceiver,
+    did_save,
+    initialize,
+    is_non_empty_diagnostics,
+    shutdown_and_exit,
     spawn_server,
 };
 
@@ -33,18 +38,14 @@ const MAX_RECV_MESSAGES: usize = 20;
 
 /// Fixture providing a temporary directory for each test.
 #[fixture]
-fn temp_dir() -> TempDir {
-    new_temp_dir()
-}
+fn temp_dir() -> TempDir { new_temp_dir() }
 
 /// Fixture providing an initialized LSP server backed by a temporary
 /// directory.  The server is spawned, the initialize handshake is
 /// performed, and the caller receives handles needed for interaction
 /// and teardown.
 #[fixture]
-fn server(temp_dir: TempDir) -> ServerHandle {
-    init_server_handle(temp_dir)
-}
+fn server(temp_dir: TempDir) -> ServerHandle { init_server_handle(temp_dir) }
 
 /// Create a new temporary directory, panicking with a descriptive
 /// message on failure.
@@ -52,9 +53,7 @@ fn server(temp_dir: TempDir) -> ServerHandle {
     clippy::expect_used,
     reason = "temp dir creation failure is a test-fatal I/O error"
 )]
-fn new_temp_dir() -> TempDir {
-    TempDir::new().expect("temp dir")
-}
+fn new_temp_dir() -> TempDir { TempDir::new().expect("temp dir") }
 
 /// Perform the full server setup: spawn, initialize handshake, and
 /// return a [`ServerHandle`].
@@ -94,9 +93,7 @@ struct ServerHandle {
 
 impl ServerHandle {
     /// Convenience accessor for the workspace root path.
-    fn workspace_root(&self) -> &Path {
-        self.dir.path()
-    }
+    fn workspace_root(&self) -> &Path { self.dir.path() }
 }
 
 // ---------------------------------------------------------------------------
@@ -288,10 +285,7 @@ fn smoke_diagnostics_published_for_unimplemented_step(mut server: ServerHandle) 
     let diag_msg = server
         .receiver
         .recv_notification_matching(is_non_empty_diagnostics, MAX_RECV_MESSAGES)
-        .expect(
-            "expected a publishDiagnostics notification \
-             for the unimplemented step",
-        );
+        .expect("expected a publishDiagnostics notification for the unimplemented step");
 
     let diags = diag_msg["params"]["diagnostics"]
         .as_array()
@@ -306,8 +300,7 @@ fn smoke_diagnostics_published_for_unimplemented_step(mut server: ServerHandle) 
     assert!(
         first_msg.contains("a step with no implementation")
             || first_msg.contains("No Rust implementation"),
-        "diagnostic message should mention the unimplemented step, \
-         got: {first_msg}"
+        "diagnostic message should mention the unimplemented step, got: {first_msg}"
     );
 
     shutdown_and_exit(&mut server.stdin, &server.receiver, &mut server.child, 99);

--- a/crates/rstest-bdd-server/tests/smoke_lsp/wire.rs
+++ b/crates/rstest-bdd-server/tests/smoke_lsp/wire.rs
@@ -4,11 +4,13 @@
 //! server lifecycle helpers for driving the `rstest-bdd-lsp` binary in
 //! end-to-end tests.
 
-use std::io::{BufRead, BufReader, Read, Write};
-use std::path::Path;
-use std::process::{Child, Command, Stdio};
-use std::sync::mpsc;
-use std::time::Duration;
+use std::{
+    io::{BufRead, BufReader, Read, Write},
+    path::Path,
+    process::{Child, Command, Stdio},
+    sync::mpsc,
+    time::Duration,
+};
 
 use serde_json::{Value, json};
 

--- a/crates/rstest-bdd-server/tests/step_registry_on_save.rs
+++ b/crates/rstest-bdd-server/tests/step_registry_on_save.rs
@@ -2,9 +2,11 @@
 
 use gherkin::StepType;
 use lsp_types::{DidSaveTextDocumentParams, TextDocumentIdentifier, Url};
-use rstest_bdd_server::config::ServerConfig;
-use rstest_bdd_server::handlers::handle_did_save_text_document;
-use rstest_bdd_server::server::ServerState;
+use rstest_bdd_server::{
+    config::ServerConfig,
+    handlers::handle_did_save_text_document,
+    server::ServerState,
+};
 use tempfile::TempDir;
 
 #[test]

--- a/crates/rstest-bdd-test-macros/Cargo.toml
+++ b/crates/rstest-bdd-test-macros/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "rstest-bdd-test-macros"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Test-only procedural macros for scoped fixture lint allowances."
+repository.workspace = true
+publish = false
+
+[lib]
+proc-macro = true
+
+[lints]
+workspace = true
+
+[dependencies]
+quote.workspace = true
+syn.workspace = true
+
+[dev-dependencies]
+rstest.workspace = true

--- a/crates/rstest-bdd-test-macros/src/lib.rs
+++ b/crates/rstest-bdd-test-macros/src/lib.rs
@@ -1,0 +1,47 @@
+//! Test-only procedural macros for lint allowances required by macro expansion.
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Item, parse_macro_input};
+
+/// Allows `unused_braces` only for an `rstest` fixture expansion.
+///
+/// `rstest` wraps fixture bodies in a nested block. A single-expression body
+/// then trips `unused_braces` under denied warnings, while the workspace
+/// formatter collapses a multi-line workaround back into that shape.
+///
+/// Apply this attribute immediately above `#[fixture]`. It deliberately uses
+/// `allow` rather than `expect`: fixture bodies may be multi-statement, where
+/// an expectation would be unfulfilled. The Clippy expectation is conditional
+/// because `clippy::allow_attributes` is unavailable outside a Clippy run.
+///
+/// # Examples
+///
+/// ```
+/// use rstest::fixture;
+/// use rstest_bdd_test_macros::allow_fixture_expansion_lints;
+///
+/// #[allow_fixture_expansion_lints]
+/// #[fixture]
+/// fn seed() -> u32 { 7 }
+/// ```
+#[proc_macro_attribute]
+pub fn allow_fixture_expansion_lints(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let parsed_item = parse_macro_input!(item as Item);
+
+    quote! {
+        #[allow(
+            unused_braces,
+            reason = "fixture macro expansion adds a redundant block around expression bodies"
+        )]
+        #[cfg_attr(
+            clippy,
+            expect(
+                clippy::allow_attributes,
+                reason = "the fixture expansion needs a scoped unused-braces allowance"
+            )
+        )]
+        #parsed_item
+    }
+    .into()
+}

--- a/crates/rstest-bdd-test-macros/tests/fixture_lint.rs
+++ b/crates/rstest-bdd-test-macros/tests/fixture_lint.rs
@@ -1,0 +1,25 @@
+//! Proves fixture lint allowances remain scoped to macro-generated code.
+
+#![deny(unused_braces)]
+
+use rstest::{fixture, rstest};
+
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
+#[fixture]
+fn expression_fixture() -> u8 { 7 }
+
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
+#[fixture]
+fn multi_statement_fixture() -> u8 {
+    let mut fixture_value = 10;
+    fixture_value += 1;
+    fixture_value
+}
+
+#[rstest]
+fn fixture_lint_allowance_supports_each_fixture_shape(
+    expression_fixture: u8,
+    multi_statement_fixture: u8,
+) {
+    assert_eq!(expression_fixture + multi_statement_fixture, 18);
+}

--- a/crates/rstest-bdd/Cargo.toml
+++ b/crates/rstest-bdd/Cargo.toml
@@ -39,6 +39,7 @@ camino.workspace = true
 cap-std.workspace = true
 insta.workspace = true
 rstest.workspace = true
+rstest-bdd-test-macros.workspace = true
 rstest-bdd-macros.workspace = true
 rstest-bdd-harness = { workspace = true, features = ["testing"] }
 trybuild.workspace = true

--- a/crates/rstest-bdd/src/async_step.rs
+++ b/crates/rstest-bdd/src/async_step.rs
@@ -15,8 +15,13 @@ use crate::{StepContext, StepFn, StepFuture};
 /// # Examples
 ///
 /// ```rust
-/// use rstest_bdd::async_step::sync_to_async;
-/// use rstest_bdd::{StepContext, StepError, StepExecution, StepFuture};
+/// use rstest_bdd::{
+///     StepContext,
+///     StepError,
+///     StepExecution,
+///     StepFuture,
+///     async_step::sync_to_async,
+/// };
 ///
 /// fn my_sync_step(
 ///     _ctx: &mut StepContext<'_>,
@@ -38,7 +43,8 @@ use crate::{StepContext, StepFn, StepFuture};
 /// ```
 #[expect(
     clippy::type_complexity,
-    reason = "currying captures StepFn, so this helper cannot return the AsyncStepFn fn-pointer alias"
+    reason = "currying captures StepFn, so this helper cannot return the AsyncStepFn fn-pointer \
+              alias"
 )]
 pub fn sync_to_async(
     sync_fn: StepFn,

--- a/crates/rstest-bdd/src/config.rs
+++ b/crates/rstest-bdd/src/config.rs
@@ -66,12 +66,11 @@ pub fn clear_fail_on_skipped_override() {
 mod tests {
     //! Unit tests for runtime configuration handling.
 
-    use super::*;
     use serial_test::serial;
 
-    fn reset_override() {
-        clear_fail_on_skipped_override();
-    }
+    use super::*;
+
+    fn reset_override() { clear_fail_on_skipped_override(); }
 
     #[test]
     #[serial]

--- a/crates/rstest-bdd/src/context/entry.rs
+++ b/crates/rstest-bdd/src/context/entry.rs
@@ -9,11 +9,15 @@
 //! pair is irreducible: `std::cell` exposes shared and mutable borrowing
 //! through the distinct `Ref`/`RefMut` types.
 
-use std::any::{Any, TypeId};
-use std::cell::{Ref, RefCell, RefMut};
+use std::{
+    any::{Any, TypeId},
+    cell::{Ref, RefCell, RefMut},
+};
 
-use super::error::FixtureBorrowError;
-use super::guards::{FixtureRef, FixtureRefMut};
+use super::{
+    error::FixtureBorrowError,
+    guards::{FixtureRef, FixtureRefMut},
+};
 
 pub(super) struct FixtureEntry<'a> {
     kind: FixtureKind<'a>,

--- a/crates/rstest-bdd/src/context/error.rs
+++ b/crates/rstest-bdd/src/context/error.rs
@@ -46,8 +46,8 @@ pub enum FixtureBorrowError {
     /// The fixture was inserted by shared reference and cannot be borrowed
     /// mutably; insert it with `insert_owned` to enable mutation.
     #[error(
-        "fixture '{name}' was inserted by shared reference and cannot be borrowed mutably; \
-         insert it with `insert_owned` to enable mutation"
+        "fixture '{name}' was inserted by shared reference and cannot be borrowed mutably; insert \
+         it with `insert_owned` to enable mutation"
     )]
     NotMutable {
         /// The requested fixture name.
@@ -56,19 +56,13 @@ pub enum FixtureBorrowError {
 }
 
 impl FixtureBorrowError {
-    pub(super) fn not_found(name: &str) -> Self {
-        Self::NotFound { name: name.into() }
-    }
+    pub(super) fn not_found(name: &str) -> Self { Self::NotFound { name: name.into() } }
 
-    pub(super) fn type_mismatch(name: &str) -> Self {
-        Self::TypeMismatch { name: name.into() }
-    }
+    pub(super) fn type_mismatch(name: &str) -> Self { Self::TypeMismatch { name: name.into() } }
 
     pub(super) fn already_borrowed(name: &str) -> Self {
         Self::AlreadyBorrowed { name: name.into() }
     }
 
-    pub(super) fn not_mutable(name: &str) -> Self {
-        Self::NotMutable { name: name.into() }
-    }
+    pub(super) fn not_mutable(name: &str) -> Self { Self::NotMutable { name: name.into() } }
 }

--- a/crates/rstest-bdd/src/context/guards.rs
+++ b/crates/rstest-bdd/src/context/guards.rs
@@ -8,8 +8,10 @@
 //! `Deref`/`DerefMut`, [`FixtureRef::value`], or
 //! [`FixtureRefMut::value_mut`].
 
-use std::cell::{Ref, RefMut};
-use std::ops::{Deref, DerefMut};
+use std::{
+    cell::{Ref, RefMut},
+    ops::{Deref, DerefMut},
+};
 
 /// Borrowed fixture reference that keeps any underlying `RefCell` borrow
 /// alive for the duration of a step.
@@ -28,13 +30,9 @@ enum FixtureRefInner<'a, T> {
 }
 
 impl<'a, T> FixtureRef<'a, T> {
-    pub(super) fn shared(value: &'a T) -> Self {
-        Self(FixtureRefInner::Shared(value))
-    }
+    pub(super) fn shared(value: &'a T) -> Self { Self(FixtureRefInner::Shared(value)) }
 
-    pub(super) fn borrowed(guard: Ref<'a, T>) -> Self {
-        Self(FixtureRefInner::Borrowed(guard))
-    }
+    pub(super) fn borrowed(guard: Ref<'a, T>) -> Self { Self(FixtureRefInner::Borrowed(guard)) }
 
     /// Access the borrowed value as an immutable reference.
     #[must_use]
@@ -49,15 +47,11 @@ impl<'a, T> FixtureRef<'a, T> {
 impl<T> Deref for FixtureRef<'_, T> {
     type Target = T;
 
-    fn deref(&self) -> &T {
-        self.value()
-    }
+    fn deref(&self) -> &T { self.value() }
 }
 
 impl<T> AsRef<T> for FixtureRef<'_, T> {
-    fn as_ref(&self) -> &T {
-        self.value()
-    }
+    fn as_ref(&self) -> &T { self.value() }
 }
 
 /// Borrowed mutable fixture reference tied to the lifetime of the step borrow.
@@ -71,41 +65,29 @@ impl<T> AsRef<T> for FixtureRef<'_, T> {
 pub struct FixtureRefMut<'a, T>(RefMut<'a, T>);
 
 impl<'a, T> FixtureRefMut<'a, T> {
-    pub(super) fn borrowed(guard: RefMut<'a, T>) -> Self {
-        Self(guard)
-    }
+    pub(super) fn borrowed(guard: RefMut<'a, T>) -> Self { Self(guard) }
 
     /// Access the borrowed value mutably.
     #[must_use]
-    pub fn value_mut(&mut self) -> &mut T {
-        &mut self.0
-    }
+    pub fn value_mut(&mut self) -> &mut T { &mut self.0 }
 }
 
 impl<T> Deref for FixtureRefMut<'_, T> {
     type Target = T;
 
-    fn deref(&self) -> &T {
-        &self.0
-    }
+    fn deref(&self) -> &T { &self.0 }
 }
 
 impl<T> DerefMut for FixtureRefMut<'_, T> {
-    fn deref_mut(&mut self) -> &mut T {
-        &mut self.0
-    }
+    fn deref_mut(&mut self) -> &mut T { &mut self.0 }
 }
 
 impl<T> AsRef<T> for FixtureRefMut<'_, T> {
-    fn as_ref(&self) -> &T {
-        &self.0
-    }
+    fn as_ref(&self) -> &T { &self.0 }
 }
 
 impl<T> AsMut<T> for FixtureRefMut<'_, T> {
-    fn as_mut(&mut self) -> &mut T {
-        self.value_mut()
-    }
+    fn as_mut(&mut self) -> &mut T { self.value_mut() }
 }
 
 impl<T: std::fmt::Debug> std::fmt::Debug for FixtureRef<'_, T> {
@@ -130,16 +112,13 @@ impl<T: std::fmt::Debug> std::fmt::Debug for FixtureRefMut<'_, T> {
 mod tests {
     //! Tests for the public guard access surface.
 
-    use super::*;
     use std::cell::RefCell;
 
-    fn read_through_as_ref(guard: &impl AsRef<u32>) -> u32 {
-        *guard.as_ref()
-    }
+    use super::*;
 
-    fn increment_through_as_mut(guard: &mut impl AsMut<u32>) {
-        *guard.as_mut() += 1;
-    }
+    fn read_through_as_ref(guard: &impl AsRef<u32>) -> u32 { *guard.as_ref() }
+
+    fn increment_through_as_mut(guard: &mut impl AsMut<u32>) { *guard.as_mut() += 1; }
 
     #[test]
     fn guards_expose_the_advertised_access_surface() {

--- a/crates/rstest-bdd/src/context/insert_outcome.rs
+++ b/crates/rstest-bdd/src/context/insert_outcome.rs
@@ -26,9 +26,7 @@ pub enum InsertOutcome {
 impl InsertOutcome {
     /// Whether the value was recorded as an override.
     #[must_use]
-    pub const fn is_inserted(&self) -> bool {
-        matches!(self, Self::Inserted(_))
-    }
+    pub const fn is_inserted(&self) -> bool { matches!(self, Self::Inserted(_)) }
 
     /// Consume the outcome and return the displaced previous override, when
     /// the insert succeeded and one existed.

--- a/crates/rstest-bdd/src/context/mod.rs
+++ b/crates/rstest-bdd/src/context/mod.rs
@@ -21,9 +21,11 @@
 //! passes, fails (unwinds), or is skipped — so no fixture state leaks across
 //! scenario boundaries and no caller-side reset discipline is required.
 
-use std::any::{Any, TypeId};
-use std::cell::RefCell;
-use std::collections::HashMap;
+use std::{
+    any::{Any, TypeId},
+    cell::RefCell,
+    collections::HashMap,
+};
 
 mod entry;
 mod error;
@@ -64,7 +66,9 @@ pub const RSTEST_BDD_HARNESS_CONTEXT_FIXTURE: &str = "rstest_bdd_harness_context
 /// ctx.insert_owned::<String>("second", &second);
 ///
 /// let mut a = ctx.try_borrow_mut::<u32>("first").expect("first fixture");
-/// let mut b = ctx.try_borrow_mut::<String>("second").expect("second fixture");
+/// let mut b = ctx
+///     .try_borrow_mut::<String>("second")
+///     .expect("second fixture");
 /// *a += 1;
 /// b.push('!');
 /// assert_eq!(*a, 2);
@@ -107,9 +111,7 @@ impl<'a> StepContext<'a> {
     /// can back a mutable fixture. Callers must retain the returned cell for as
     /// long as the context references it.
     #[must_use]
-    pub fn owned_cell<T: Any>(value: T) -> RefCell<Box<dyn Any>> {
-        RefCell::new(Box::new(value))
-    }
+    pub fn owned_cell<T: Any>(value: T) -> RefCell<Box<dyn Any>> { RefCell::new(Box::new(value)) }
 
     /// Insert a fixture reference by name.
     pub fn insert<T: Any>(&mut self, name: &'static str, value: &'a T) {
@@ -132,7 +134,8 @@ impl<'a> StepContext<'a> {
         let actual = guard.as_ref().type_id();
         assert!(
             actual == TypeId::of::<T>(),
-            "insert_owned: stored value type ({actual:?}) does not match requested {:?} for fixture '{name}'",
+            "insert_owned: stored value type ({actual:?}) does not match requested {:?} for \
+             fixture '{name}'",
             TypeId::of::<T>()
         );
         self.fixtures.insert(name, FixtureEntry::owned::<T>(cell));
@@ -337,12 +340,10 @@ impl<'a> StepContext<'a> {
     ///
     /// # Errors
     ///
-    /// - [`FixtureBorrowError::NotFound`] when no fixture or override is
-    ///   registered under `name`.
-    /// - [`FixtureBorrowError::TypeMismatch`] when the entry stores a
-    ///   different type than `T`.
-    /// - [`FixtureBorrowError::AlreadyBorrowed`] when a mutable guard for
-    ///   the same fixture is alive.
+    /// - [`FixtureBorrowError::NotFound`] when no fixture or override is registered under `name`.
+    /// - [`FixtureBorrowError::TypeMismatch`] when the entry stores a different type than `T`.
+    /// - [`FixtureBorrowError::AlreadyBorrowed`] when a mutable guard for the same fixture is
+    ///   alive.
     pub fn try_borrow<'b, T: Any>(
         &'b self,
         name: &str,
@@ -367,8 +368,8 @@ impl<'a> StepContext<'a> {
     /// - [`FixtureBorrowError::NotFound`] when neither fixture nor override exists under `name`.
     /// - [`FixtureBorrowError::TypeMismatch`] when the entry stores a different type than `T`.
     /// - [`FixtureBorrowError::AlreadyBorrowed`] when any same-fixture guard is alive.
-    /// - [`FixtureBorrowError::NotMutable`] when a shared fixture has no applicable
-    ///   step-returned override.
+    /// - [`FixtureBorrowError::NotMutable`] when a shared fixture has no applicable step-returned
+    ///   override.
     pub fn try_borrow_mut<'b, T: Any>(
         &'b self,
         name: &str,
@@ -395,6 +396,4 @@ impl<'a> StepContext<'a> {
 ///
 /// Kept as a named predicate so the mirrored `eprintln!` call site stays a
 /// simple two-branch condition.
-fn warn_logging_is_disabled() -> bool {
-    !log::log_enabled!(log::Level::Warn)
-}
+fn warn_logging_is_disabled() -> bool { !log::log_enabled!(log::Level::Warn) }

--- a/crates/rstest-bdd/src/context/tests/mod.rs
+++ b/crates/rstest-bdd/src/context/tests/mod.rs
@@ -1,16 +1,15 @@
 //! Tests for step context and fixture management.
 
-use super::*;
 use std::sync::Once;
+
+use super::*;
 
 mod guard_borrowing;
 
 struct NoopLogger;
 
 impl log::Log for NoopLogger {
-    fn enabled(&self, _: &log::Metadata<'_>) -> bool {
-        true
-    }
+    fn enabled(&self, _: &log::Metadata<'_>) -> bool { true }
     fn log(&self, _: &log::Record<'_>) {}
     fn flush(&self) {}
 }

--- a/crates/rstest-bdd/src/datatable/cached.rs
+++ b/crates/rstest-bdd/src/datatable/cached.rs
@@ -6,8 +6,7 @@
 //! borrow the rows for read-only access or clone them when ownership is
 //! required.
 
-use std::ops::Deref;
-use std::sync::Arc;
+use std::{ops::Deref, sync::Arc};
 
 /// Shared, owned representation of a parsed data table.
 pub type OwnedTableArc = Arc<Vec<Vec<String>>>;
@@ -16,9 +15,11 @@ pub type OwnedTableArc = Arc<Vec<Vec<String>>>;
 mod diagnostics {
     //! Per-thread cache-miss counters used by tests and diagnostics builds.
 
-    use std::collections::HashMap;
-    use std::sync::{Mutex, OnceLock};
-    use std::thread;
+    use std::{
+        collections::HashMap,
+        sync::{Mutex, OnceLock},
+        thread,
+    };
 
     fn counters() -> &'static Mutex<HashMap<thread::ThreadId, usize>> {
         static COUNTERS: OnceLock<Mutex<HashMap<thread::ThreadId, usize>>> = OnceLock::new();
@@ -60,16 +61,12 @@ pub fn record_cache_miss() {
 /// in tests and when the `diagnostics` feature is enabled.
 #[cfg(any(test, feature = "diagnostics"))]
 #[must_use]
-pub fn cache_miss_count() -> usize {
-    diagnostics::count()
-}
+pub fn cache_miss_count() -> usize { diagnostics::count() }
 
 /// Reset the cache miss counter for the current thread. Available in tests and
 /// when the `diagnostics` feature is enabled.
 #[cfg(any(test, feature = "diagnostics"))]
-pub fn reset_cache_miss_count() {
-    diagnostics::reset();
-}
+pub fn reset_cache_miss_count() { diagnostics::reset(); }
 
 /// Shareable view of a parsed data table.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -88,53 +85,37 @@ impl CachedTable {
 
     /// Construct a cache from an existing shared table.
     #[must_use]
-    pub fn from_arc(rows: OwnedTableArc) -> Self {
-        Self { rows }
-    }
+    pub fn from_arc(rows: OwnedTableArc) -> Self { Self { rows } }
 
     /// Borrow the cached rows.
     #[must_use]
-    pub fn as_rows(&self) -> &[Vec<String>] {
-        self.rows.as_slice()
-    }
+    pub fn as_rows(&self) -> &[Vec<String>] { self.rows.as_slice() }
 
     /// Borrow the underlying shared allocation without cloning the `Arc`.
     #[must_use]
-    pub fn as_arc_ref(&self) -> &OwnedTableArc {
-        &self.rows
-    }
+    pub fn as_arc_ref(&self) -> &OwnedTableArc { &self.rows }
 
     /// Obtain a stable pointer to the shared allocation.
     #[must_use]
-    pub fn as_ptr(&self) -> *const Vec<Vec<String>> {
-        Arc::as_ptr(&self.rows)
-    }
+    pub fn as_ptr(&self) -> *const Vec<Vec<String>> { Arc::as_ptr(&self.rows) }
 
     /// Access the underlying shared allocation.
     #[must_use]
-    pub fn as_arc(&self) -> OwnedTableArc {
-        Arc::clone(&self.rows)
-    }
+    pub fn as_arc(&self) -> OwnedTableArc { Arc::clone(&self.rows) }
 }
 
 impl Deref for CachedTable {
     type Target = [Vec<String>];
 
-    fn deref(&self) -> &Self::Target {
-        self.as_rows()
-    }
+    fn deref(&self) -> &Self::Target { self.as_rows() }
 }
 
 impl AsRef<[Vec<String>]> for CachedTable {
-    fn as_ref(&self) -> &[Vec<String>] {
-        self.as_rows()
-    }
+    fn as_ref(&self) -> &[Vec<String>] { self.as_rows() }
 }
 
 impl From<Vec<Vec<String>>> for CachedTable {
-    fn from(rows: Vec<Vec<String>>) -> Self {
-        Self::new(rows)
-    }
+    fn from(rows: Vec<Vec<String>>) -> Self { Self::new(rows) }
 }
 
 impl From<CachedTable> for Vec<Vec<String>> {

--- a/crates/rstest-bdd/src/datatable/parsers.rs
+++ b/crates/rstest-bdd/src/datatable/parsers.rs
@@ -67,9 +67,7 @@ pub struct TruthyBoolError {
 impl TruthyBoolError {
     /// Returns the original, unclassified input.
     #[must_use]
-    pub fn value(&self) -> &str {
-        &self.value
-    }
+    pub fn value(&self) -> &str { &self.value }
 }
 
 /// Trims leading and trailing whitespace before parsing a value.
@@ -131,7 +129,5 @@ where
     /// assert_eq!(err.original_input(), " not a number ");
     /// ```
     #[must_use]
-    pub fn original_input(&self) -> &str {
-        &self.original_input
-    }
+    pub fn original_input(&self) -> &str { &self.original_input }
 }

--- a/crates/rstest-bdd/src/datatable/rows.rs
+++ b/crates/rstest-bdd/src/datatable/rows.rs
@@ -1,7 +1,6 @@
 //! Typed row abstractions used when parsing datatable content.
 
-use std::convert::TryFrom;
-use std::ops::Deref;
+use std::{convert::TryFrom, ops::Deref};
 
 use derive_more::From;
 
@@ -29,17 +28,13 @@ pub struct Rows<T>(Vec<T>);
 impl<T> Deref for Rows<T> {
     type Target = [T];
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
+    fn deref(&self) -> &Self::Target { &self.0 }
 }
 
 impl<T> Rows<T> {
     /// Consumes the wrapper, returning the inner [`Vec`].
     #[must_use]
-    pub fn into_vec(self) -> Vec<T> {
-        self.0
-    }
+    pub fn into_vec(self) -> Vec<T> { self.0 }
 }
 
 impl<T> IntoIterator for Rows<T> {
@@ -68,9 +63,7 @@ impl<'a, T> IntoIterator for &'a mut Rows<T> {
     type Item = &'a mut T;
     type IntoIter = std::slice::IterMut<'a, T>;
 
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.iter_mut()
-    }
+    fn into_iter(self) -> Self::IntoIter { self.0.iter_mut() }
 }
 
 impl<T> TryFrom<Vec<Vec<String>>> for Rows<T>

--- a/crates/rstest-bdd/src/datatable/spec.rs
+++ b/crates/rstest-bdd/src/datatable/spec.rs
@@ -1,7 +1,6 @@
 //! Header and row specifications for the datatable runtime.
 
-use std::collections::HashMap;
-use std::error::Error as StdError;
+use std::{collections::HashMap, error::Error as StdError};
 
 use super::DataTableError;
 
@@ -35,15 +34,11 @@ impl HeaderSpec {
 
     /// Returns the number of columns declared in the header.
     #[must_use]
-    pub fn len(&self) -> usize {
-        self.columns.len()
-    }
+    pub fn len(&self) -> usize { self.columns.len() }
 
     /// Returns `true` when the header is empty.
     #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.columns.is_empty()
-    }
+    pub fn is_empty(&self) -> bool { self.columns.is_empty() }
 
     /// Fetches a column name by index.
     #[must_use]
@@ -68,9 +63,7 @@ impl HeaderSpec {
 
     /// Returns the names of all columns.
     #[must_use]
-    pub fn columns(&self) -> &[String] {
-        &self.columns
-    }
+    pub fn columns(&self) -> &[String] { &self.columns }
 }
 
 /// Representation of a single row within a data table.
@@ -102,34 +95,24 @@ impl<'h> RowSpec<'h> {
 
     /// Returns the 1-based row number, including any header.
     #[must_use]
-    pub fn row_number(&self) -> usize {
-        self.row_number
-    }
+    pub fn row_number(&self) -> usize { self.row_number }
 
     /// Returns the zero-based row index relative to the data rows (excluding
     /// the header).
     #[must_use]
-    pub fn index(&self) -> usize {
-        self.index
-    }
+    pub fn index(&self) -> usize { self.index }
 
     /// Returns the number of cells in the row.
     #[must_use]
-    pub fn len(&self) -> usize {
-        self.cells.len()
-    }
+    pub fn len(&self) -> usize { self.cells.len() }
 
     /// Returns `true` when the row contains no cells.
     #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.cells.is_empty()
-    }
+    pub fn is_empty(&self) -> bool { self.cells.is_empty() }
 
     /// Provides immutable access to the underlying cells.
     #[must_use]
-    pub fn cells(&self) -> &[String] {
-        &self.cells
-    }
+    pub fn cells(&self) -> &[String] { &self.cells }
 
     /// Retrieves the cell at a given index.
     ///

--- a/crates/rstest-bdd/src/datatable/tests.rs
+++ b/crates/rstest-bdd/src/datatable/tests.rs
@@ -1,18 +1,16 @@
 //! Tests the datatable runtime parsing, error reporting, and helper parsers.
 
-use std::error::Error as StdError;
-use std::fmt;
+use std::{error::Error as StdError, fmt};
+
+use rstest::rstest;
 
 use super::{DataTableError, DataTableRow, RowSpec, Rows, trimmed, truthy_bool};
-use rstest::rstest;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct FakeError;
 
 impl fmt::Display for FakeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("boom")
-    }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { f.write_str("boom") }
 }
 
 impl StdError for FakeError {}
@@ -145,9 +143,7 @@ fn uneven_rows_are_rejected() {
     impl DataTableRow for HeaderOnly {
         const REQUIRES_HEADER: bool = true;
 
-        fn parse_row(_row: RowSpec<'_>) -> Result<Self, DataTableError> {
-            Ok(Self)
-        }
+        fn parse_row(_row: RowSpec<'_>) -> Result<Self, DataTableError> { Ok(Self) }
     }
 
     let rows = vec![
@@ -219,9 +215,7 @@ fn trimmed_preserves_inner_error() {
     impl std::str::FromStr for Dummy {
         type Err = FakeError;
 
-        fn from_str(_s: &str) -> Result<Self, Self::Err> {
-            Err(FakeError)
-        }
+        fn from_str(_s: &str) -> Result<Self, Self::Err> { Err(FakeError) }
     }
 
     let Err(err) = trimmed::<Dummy>("1") else {

--- a/crates/rstest-bdd/src/execution/error/format.rs
+++ b/crates/rstest-bdd/src/execution/error/format.rs
@@ -26,8 +26,8 @@ impl ExecutionError {
     ///
     /// ```
     /// use i18n_embed::fluent::fluent_language_loader;
-    /// use unic_langid::langid;
     /// use rstest_bdd::execution::ExecutionError;
+    /// use unic_langid::langid;
     ///
     /// let loader = {
     ///     use i18n_embed::LanguageLoader;
@@ -37,7 +37,9 @@ impl ExecutionError {
     ///         .expect("en-US locale should always be available");
     ///     loader
     /// };
-    /// let error = ExecutionError::Skip { message: Some("not implemented".into()) };
+    /// let error = ExecutionError::Skip {
+    ///     message: Some("not implemented".into()),
+    /// };
     /// let message = error.format_with_loader(&loader);
     /// assert!(message.contains("skipped"));
     /// assert!(message.contains("not implemented"));

--- a/crates/rstest-bdd/src/execution/error/mod.rs
+++ b/crates/rstest-bdd/src/execution/error/mod.rs
@@ -85,10 +85,10 @@
 //!
 //! 1. Check [`is_skip()`][ExecutionError::is_skip] to separate skips from failures
 //! 2. Use [`skip_message()`][ExecutionError::skip_message] to extract optional skip reasons
-//! 3. Use [`Display`] or [`format_with_loader()`][ExecutionError::format_with_loader]
-//!    for user-facing messages
-//! 4. Access [`std::error::Error::source()`] on `HandlerFailed` to inspect the
-//!    underlying [`StepError`]
+//! 3. Use [`Display`] or [`format_with_loader()`][ExecutionError::format_with_loader] for
+//!    user-facing messages
+//! 4. Access [`std::error::Error::source()`] on `HandlerFailed` to inspect the underlying
+//!    [`StepError`]
 //!
 //! [`execute_step`]: crate::execution::execute_step
 //! [`Display`]: std::fmt::Display
@@ -125,12 +125,11 @@ impl From<FixtureRequirement> for MissingFixtureDiagnostic {
 ///
 /// # Variants
 ///
-/// - [`Skip`][Self::Skip]: Control flow signal indicating the step requested
-///   skipping. This is not an error condition but a deliberate execution path.
-/// - [`StepNotFound`][Self::StepNotFound]: The step pattern was not found in
-///   the registry.
-/// - [`MissingFixtures`][Self::MissingFixtures]: Required fixtures were not
-///   available in the context.
+/// - [`Skip`][Self::Skip]: Control flow signal indicating the step requested skipping. This is not
+///   an error condition but a deliberate execution path.
+/// - [`StepNotFound`][Self::StepNotFound]: The step pattern was not found in the registry.
+/// - [`MissingFixtures`][Self::MissingFixtures]: Required fixtures were not available in the
+///   context.
 /// - [`HandlerFailed`][Self::HandlerFailed]: The step handler returned an error.
 ///
 /// # Examples
@@ -138,7 +137,9 @@ impl From<FixtureRequirement> for MissingFixtureDiagnostic {
 /// ```
 /// use rstest_bdd::execution::ExecutionError;
 ///
-/// let error = ExecutionError::Skip { message: Some("not implemented yet".into()) };
+/// let error = ExecutionError::Skip {
+///     message: Some("not implemented yet".into()),
+/// };
 /// assert!(error.is_skip());
 /// assert_eq!(error.skip_message(), Some("not implemented yet"));
 /// ```
@@ -235,9 +236,7 @@ impl ExecutionError {
     /// assert!(!not_found.is_skip());
     /// ```
     #[must_use]
-    pub fn is_skip(&self) -> bool {
-        matches!(self, Self::Skip { .. })
-    }
+    pub fn is_skip(&self) -> bool { matches!(self, Self::Skip { .. }) }
 
     /// Returns the skip message if this is a skip error.
     ///
@@ -249,7 +248,9 @@ impl ExecutionError {
     /// ```
     /// use rstest_bdd::execution::ExecutionError;
     ///
-    /// let skip_with_msg = ExecutionError::Skip { message: Some("reason".into()) };
+    /// let skip_with_msg = ExecutionError::Skip {
+    ///     message: Some("reason".into()),
+    /// };
     /// assert_eq!(skip_with_msg.skip_message(), Some("reason"));
     ///
     /// let skip_no_msg = ExecutionError::Skip { message: None };

--- a/crates/rstest-bdd/src/execution/fixtures.rs
+++ b/crates/rstest-bdd/src/execution/fixtures.rs
@@ -3,15 +3,18 @@
 //! This module keeps missing-fixture diagnostic assembly separate from the
 //! high-level step execution flow.
 
-use std::collections::HashSet;
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
-use crate::context::{RSTEST_BDD_HARNESS_CONTEXT_FIXTURE, StepContext};
-use crate::registry::fixture_requirements_for_step;
-use crate::{FixtureRequirement, Step};
-
-use super::StepExecutionRequest;
-use super::error::{ExecutionError, MissingFixtureDiagnostic, MissingFixturesDetails};
+use super::{
+    StepExecutionRequest,
+    error::{ExecutionError, MissingFixtureDiagnostic, MissingFixturesDetails},
+};
+use crate::{
+    FixtureRequirement,
+    Step,
+    context::{RSTEST_BDD_HARNESS_CONTEXT_FIXTURE, StepContext},
+    registry::fixture_requirements_for_step,
+};
 
 /// Validate that all required fixtures are present in the context.
 ///

--- a/crates/rstest-bdd/src/execution/mod.rs
+++ b/crates/rstest-bdd/src/execution/mod.rs
@@ -7,30 +7,33 @@
 //!
 //! # Key Components
 //!
-//! - [`RuntimeMode`]: Canonical definition of execution modes (sync, async
-//!   variants), re-exported from `rstest_bdd_policy`.
-//! - [`TestAttributeHint`]: Canonical definition for test attribute generation
-//!   hints, re-exported from `rstest_bdd_policy`.
+//! - [`RuntimeMode`]: Canonical definition of execution modes (sync, async variants), re-exported
+//!   from `rstest_bdd_policy`.
+//! - [`TestAttributeHint`]: Canonical definition for test attribute generation hints, re-exported
+//!   from `rstest_bdd_policy`.
 //! - [`StepExecutionRequest`]: Groups step data and diagnostic context for execution.
-//! - Helper functions for step execution, fixture validation, and skip encoding.
-//!   `RuntimeMode` and `TestAttributeHint` are re-exported from
-//!   `rstest_bdd_policy`, the shared source of truth used by the macro crate.
-//!   Runtime and macro tests guard that single-source policy boundary.
+//! - Helper functions for step execution, fixture validation, and skip encoding. `RuntimeMode` and
+//!   `TestAttributeHint` are re-exported from `rstest_bdd_policy`, the shared source of truth used
+//!   by the macro crate. Runtime and macro tests guard that single-source policy boundary.
 
 mod error;
 /// Fixture validation helpers for step execution.
 mod fixtures;
 
-use std::any::Any;
-use std::sync::Arc;
-
-use crate::context::StepContext;
-use crate::{
-    Step, StepExecution, StepExecutionMode, StepKeyword, StepText, find_step_with_metadata,
-};
-use fixtures::validate_required_fixtures;
+use std::{any::Any, sync::Arc};
 
 pub use error::{ExecutionError, MissingFixtureDiagnostic, MissingFixturesDetails};
+use fixtures::validate_required_fixtures;
+
+use crate::{
+    Step,
+    StepExecution,
+    StepExecutionMode,
+    StepKeyword,
+    StepText,
+    context::StepContext,
+    find_step_with_metadata,
+};
 
 /// Prefix character for encoded skip messages with no message content.
 pub(crate) const SKIP_NONE_PREFIX: char = '\u{0}';
@@ -43,7 +46,6 @@ pub(crate) const SKIP_SOME_PREFIX: char = '\u{1}';
 /// This type is re-exported from `rstest_bdd_policy` to keep the public API in
 /// `rstest_bdd::execution` stable for downstream users.
 pub use rstest_bdd_policy::RuntimeMode;
-
 /// Hint for which test attributes the macro layer should generate
 /// (canonical definition).
 ///
@@ -107,7 +109,7 @@ fn handle_step_result(
 /// # Examples
 ///
 /// ```
-/// use rstest_bdd::execution::{encode_skip_message, decode_skip_message};
+/// use rstest_bdd::execution::{decode_skip_message, encode_skip_message};
 ///
 /// // Round-trip with no message
 /// let encoded = encode_skip_message(None);
@@ -158,7 +160,7 @@ pub fn encode_skip_message(message: Option<String>) -> String {
 /// # Examples
 ///
 /// ```
-/// use rstest_bdd::execution::{encode_skip_message, decode_skip_message};
+/// use rstest_bdd::execution::{decode_skip_message, encode_skip_message};
 ///
 /// let encoded = encode_skip_message(Some("test".to_string()));
 /// assert_eq!(decode_skip_message(encoded), Some("test".to_string()));
@@ -245,20 +247,23 @@ pub struct StepExecutionRequest<'a> {
 ///
 /// Returns [`ExecutionError`] for all failure cases:
 ///
-/// - [`ExecutionError::Skip`]: The step requested skipping (control flow signal,
-///   not an error). Use [`ExecutionError::is_skip`] to detect this case.
-/// - [`ExecutionError::StepNotFound`]: No step matching the keyword and text
-///   was found in the registry.
-/// - [`ExecutionError::MissingFixtures`]: The step requires fixtures that are
-///   not available in the context.
-/// - [`ExecutionError::HandlerFailed`]: The step handler function returned an
-///   error during execution.
+/// - [`ExecutionError::Skip`]: The step requested skipping (control flow signal, not an error). Use
+///   [`ExecutionError::is_skip`] to detect this case.
+/// - [`ExecutionError::StepNotFound`]: No step matching the keyword and text was found in the
+///   registry.
+/// - [`ExecutionError::MissingFixtures`]: The step requires fixtures that are not available in the
+///   context.
+/// - [`ExecutionError::HandlerFailed`]: The step handler function returned an error during
+///   execution.
 ///
 /// # Examples
 ///
 /// ```
-/// use rstest_bdd::execution::{execute_step, ExecutionError, StepExecutionRequest};
-/// use rstest_bdd::{StepContext, StepKeyword};
+/// use rstest_bdd::{
+///     StepContext,
+///     StepKeyword,
+///     execution::{ExecutionError, StepExecutionRequest, execute_step},
+/// };
 ///
 /// let request = StepExecutionRequest {
 ///     index: 0,
@@ -305,8 +310,11 @@ pub fn execute_step(
 /// # Examples
 ///
 /// ```rust,no_run
-/// use rstest_bdd::execution::{execute_step_async, ExecutionError, StepExecutionRequest};
-/// use rstest_bdd::{StepContext, StepKeyword};
+/// use rstest_bdd::{
+///     StepContext,
+///     StepKeyword,
+///     execution::{ExecutionError, StepExecutionRequest, execute_step_async},
+/// };
 ///
 /// let request = StepExecutionRequest {
 ///     index: 0,

--- a/crates/rstest-bdd/src/execution/tests.rs
+++ b/crates/rstest-bdd/src/execution/tests.rs
@@ -14,9 +14,8 @@ use std::sync::Arc;
 
 use rstest::rstest;
 
-use crate::{StepError, StepKeyword};
-
 use super::{ExecutionError, MissingFixturesDetails, RuntimeMode, TestAttributeHint};
+use crate::{StepError, StepKeyword};
 
 #[test]
 fn runtime_mode_sync_is_default() {
@@ -89,7 +88,8 @@ fn test_attribute_hint_exhaustive_variant_guard() {
 
 #[expect(
     deprecated,
-    reason = "FIXME: https://github.com/leynos/rstest-bdd/issues/409 - testing deprecated skip encoding functions"
+    reason = "FIXME: https://github.com/leynos/rstest-bdd/issues/409 - testing deprecated skip \
+              encoding functions"
 )]
 mod deprecated_skip_encoding {
     //! Tests for deprecated skip encoding functions.
@@ -100,7 +100,10 @@ mod deprecated_skip_encoding {
     use rstest::rstest;
 
     use super::super::{
-        SKIP_NONE_PREFIX, SKIP_SOME_PREFIX, decode_skip_message, encode_skip_message,
+        SKIP_NONE_PREFIX,
+        SKIP_SOME_PREFIX,
+        decode_skip_message,
+        encode_skip_message,
     };
 
     #[test]

--- a/crates/rstest-bdd/src/lib.rs
+++ b/crates/rstest-bdd/src/lib.rs
@@ -19,9 +19,7 @@ mod skip;
 /// assert_eq!(greet(), "Hello from rstest-bdd!");
 /// ```
 #[must_use]
-pub fn greet() -> &'static str {
-    "Hello from rstest-bdd!"
-}
+pub fn greet() -> &'static str { "Hello from rstest-bdd!" }
 
 #[cfg(feature = "diagnostics")]
 use ctor::ctor;
@@ -46,45 +44,66 @@ mod types;
 pub mod test_support;
 
 pub use context::{
-    FixtureBorrowError, FixtureRef, FixtureRefMut, InsertOutcome,
-    RSTEST_BDD_HARNESS_CONTEXT_FIXTURE, StepContext,
+    FixtureBorrowError,
+    FixtureRef,
+    FixtureRefMut,
+    InsertOutcome,
+    RSTEST_BDD_HARNESS_CONTEXT_FIXTURE,
+    StepContext,
 };
 pub use localization::{
-    LocalizationError, Localizations, current_languages, install_localization_loader,
+    LocalizationError,
+    Localizations,
+    current_languages,
+    install_localization_loader,
     select_localizations,
 };
 pub use pattern::StepPattern;
 pub use placeholder::extract_placeholders;
 #[cfg(feature = "diagnostics")]
 pub use registry::dump_registry;
-pub use registry::record_bypassed_steps;
-pub use registry::record_bypassed_steps_with_tags;
 pub use registry::{
-    FixtureRequirement, Step, StepFixtureRequirements, duplicate_steps, find_step, find_step_async,
-    find_step_async_with_mode, find_step_with_metadata, find_step_with_mode, lookup_step,
-    lookup_step_async, lookup_step_async_with_mode, unused_steps,
+    FixtureRequirement,
+    Step,
+    StepFixtureRequirements,
+    duplicate_steps,
+    find_step,
+    find_step_async,
+    find_step_async_with_mode,
+    find_step_with_metadata,
+    find_step_with_mode,
+    lookup_step,
+    lookup_step_async,
+    lookup_step_async_with_mode,
+    record_bypassed_steps,
+    record_bypassed_steps_with_tags,
+    unused_steps,
 };
 
 /// Whether the crate was built with the `diagnostics` feature enabled.
 #[must_use]
-pub const fn diagnostics_enabled() -> bool {
-    cfg!(feature = "diagnostics")
-}
+pub const fn diagnostics_enabled() -> bool { cfg!(feature = "diagnostics") }
+pub use execution::{ExecutionError, MissingFixtureDiagnostic, MissingFixturesDetails};
 #[doc(hidden)]
 pub use panic_support::catch_unwind_future as __rstest_bdd_catch_unwind_future;
 #[doc(hidden)]
 pub use skip::{
-    ScopeKind as __rstest_bdd_scope_kind, SkipRequest, StepScopeGuard as __rstest_bdd_scope_guard,
+    ScopeKind as __rstest_bdd_scope_kind,
+    SkipRequest,
+    StepScopeGuard as __rstest_bdd_scope_guard,
     enter_scope as __rstest_bdd_enter_scope,
     request_current_skip as __rstest_bdd_request_current_skip,
 };
 #[doc(hidden)]
 pub use skip_helpers::{
-    __rstest_bdd_assert_scenario_detail_flag, __rstest_bdd_assert_scenario_detail_message_absent,
+    __rstest_bdd_assert_scenario_detail_flag,
+    __rstest_bdd_assert_scenario_detail_message_absent,
     __rstest_bdd_assert_scenario_detail_message_contains,
     __rstest_bdd_assert_step_skipped_message_absent,
-    __rstest_bdd_assert_step_skipped_message_contains, __rstest_bdd_expect_skip_flag,
-    __rstest_bdd_expect_skip_message_absent, __rstest_bdd_expect_skip_message_contains,
+    __rstest_bdd_assert_step_skipped_message_contains,
+    __rstest_bdd_expect_skip_flag,
+    __rstest_bdd_expect_skip_message_absent,
+    __rstest_bdd_expect_skip_message_contains,
     __rstest_bdd_unwrap_step_skipped,
 };
 pub use state::{ScenarioState, Slot};
@@ -94,12 +113,24 @@ pub use step_args::{StepArgs, StepArgsError};
 #[doc(hidden)]
 pub use tokio as __rstest_bdd_tokio;
 pub use types::{
-    AsyncStepFn, PatternStr, PlaceholderError, PlaceholderSyntaxError, StepCtx, StepDoc,
-    StepExecution, StepExecutionMode, StepFn, StepFuture, StepKeyword, StepKeywordParseError,
-    StepPatternError, StepTable, StepText, StepTextRef, UnsupportedStepType,
+    AsyncStepFn,
+    PatternStr,
+    PlaceholderError,
+    PlaceholderSyntaxError,
+    StepCtx,
+    StepDoc,
+    StepExecution,
+    StepExecutionMode,
+    StepFn,
+    StepFuture,
+    StepKeyword,
+    StepKeywordParseError,
+    StepPatternError,
+    StepTable,
+    StepText,
+    StepTextRef,
+    UnsupportedStepType,
 };
-
-pub use execution::{ExecutionError, MissingFixtureDiagnostic, MissingFixturesDetails};
 
 #[cfg(feature = "diagnostics")]
 #[ctor]

--- a/crates/rstest-bdd/src/localization.rs
+++ b/crates/rstest-bdd/src/localization.rs
@@ -1,11 +1,15 @@
 //! Localization utilities used by the public macros and runtime diagnostics.
 
-use std::cell::RefCell;
-use std::sync::{LazyLock, RwLock};
+use std::{
+    cell::RefCell,
+    sync::{LazyLock, RwLock},
+};
 
 use fluent::FluentArgs;
-use i18n_embed::I18nEmbedError;
-use i18n_embed::fluent::{FluentLanguageLoader, fluent_language_loader};
+use i18n_embed::{
+    I18nEmbedError,
+    fluent::{FluentLanguageLoader, fluent_language_loader},
+};
 use rust_embed::RustEmbed;
 use thiserror::Error;
 use unic_langid::LanguageIdentifier;
@@ -148,9 +152,7 @@ pub fn current_languages() -> Result<Vec<LanguageIdentifier>, LocalizationError>
 /// );
 /// ```
 #[must_use]
-pub fn message(id: &str) -> String {
-    with_loader(|loader| loader.get(id))
-}
+pub fn message(id: &str) -> String { with_loader(|loader| loader.get(id)) }
 
 /// Retrieve a localized string with Fluent arguments supplied via a closure.
 ///

--- a/crates/rstest-bdd/src/macros.rs
+++ b/crates/rstest-bdd/src/macros.rs
@@ -133,7 +133,7 @@ macro_rules! __rstest_bdd_assert_scenario_skipped_base {
 ///
 /// # Examples
 /// ```
-/// use rstest_bdd::{assert_step_skipped, StepExecution};
+/// use rstest_bdd::{StepExecution, assert_step_skipped};
 ///
 /// let message = assert_step_skipped!(
 ///     StepExecution::skipped(Some("pending dependency".into())),
@@ -146,15 +146,16 @@ macro_rules! assert_step_skipped {
     ($expr:expr $(,)?) => {
         $crate::__rstest_bdd_assert_step_skipped_base!($expr)
     };
-    ($expr:expr, message = $value:expr $(,)?) => {
+    ($expr:expr,message = $value:expr $(,)?) => {
         $crate::__rstest_bdd_assert_step_skipped_message_contains($expr, $value)
     };
-    ($expr:expr, message_absent = $value:expr $(,)?) => {
+    ($expr:expr,message_absent = $value:expr $(,)?) => {
         $crate::__rstest_bdd_assert_step_skipped_message_absent($expr, $value)
     };
     ($expr:expr, $($rest:tt)+) => {
         compile_error!(
-            "unsupported assert_step_skipped! arguments; expected `message = ...` or `message_absent = ...`",
+            "unsupported assert_step_skipped! arguments; expected `message = ...` or \
+             `message_absent = ...`",
         );
     };
 }
@@ -168,19 +169,17 @@ macro_rules! assert_step_skipped {
 ///
 /// # Examples
 /// ```
-/// use rstest_bdd::assert_scenario_skipped;
-/// use rstest_bdd::reporting::{ScenarioStatus, SkippedScenario};
+/// use rstest_bdd::{
+///     assert_scenario_skipped,
+///     reporting::{ScenarioStatus, SkippedScenario},
+/// };
 ///
 /// let status = ScenarioStatus::Skipped(SkippedScenario::new(
 ///     Some("pending upstream".into()),
 ///     true,
 ///     false,
 /// ));
-/// let details = assert_scenario_skipped!(
-///     status,
-///     message = "pending",
-///     allow_skipped = true,
-/// );
+/// let details = assert_scenario_skipped!(status, message = "pending", allow_skipped = true,);
 /// assert!(details.allow_skipped());
 /// ```
 #[macro_export]
@@ -201,16 +200,16 @@ macro_rules! assert_scenario_skipped {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __rstest_bdd_assert_scenario_detail {
-    ($details:expr, message, None) => {
+    ($details:expr,message,None) => {
         $crate::__rstest_bdd_assert_scenario_detail_message_absent(&$details, true)
     };
-    ($details:expr, message, $value:expr) => {
+    ($details:expr,message, $value:expr) => {
         $crate::__rstest_bdd_assert_scenario_detail_message_contains(&$details, $value)
     };
-    ($details:expr, message_absent, $value:expr) => {
+    ($details:expr,message_absent, $value:expr) => {
         $crate::__rstest_bdd_assert_scenario_detail_message_absent(&$details, $value)
     };
-    ($details:expr, allow_skipped, $value:expr) => {
+    ($details:expr,allow_skipped, $value:expr) => {
         $crate::__rstest_bdd_assert_scenario_detail_flag(
             &$details,
             "allow_skipped",
@@ -218,7 +217,7 @@ macro_rules! __rstest_bdd_assert_scenario_detail {
             $value,
         )
     };
-    ($details:expr, forced_failure, $value:expr) => {
+    ($details:expr,forced_failure, $value:expr) => {
         $crate::__rstest_bdd_assert_scenario_detail_flag(
             &$details,
             "forced_failure",

--- a/crates/rstest-bdd/src/panic_support.rs
+++ b/crates/rstest-bdd/src/panic_support.rs
@@ -1,9 +1,11 @@
 //! Helpers for rendering panic payloads.
 
-use std::any::Any;
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::{
+    any::Any,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use crate::localization;
 
@@ -16,8 +18,7 @@ use crate::localization;
 /// ```
 /// use rstest_bdd::panic_message;
 ///
-/// let err = std::panic::catch_unwind(|| panic!("boom"))
-///     .expect_err("expected panic");
+/// let err = std::panic::catch_unwind(|| panic!("boom")).expect_err("expected panic");
 /// assert_eq!(panic_message(err.as_ref()), "boom");
 /// ```
 #[must_use]
@@ -99,9 +100,7 @@ impl<F> CatchUnwindFuture<F> {
     ///     other => panic!("expected ready Ok(42), got {other:?}"),
     /// }
     /// ```
-    pub fn new(inner: F) -> Self {
-        Self(Box::pin(inner))
-    }
+    pub fn new(inner: F) -> Self { Self(Box::pin(inner)) }
 }
 
 impl<F> Future for CatchUnwindFuture<F>

--- a/crates/rstest-bdd/src/pattern.rs
+++ b/crates/rstest-bdd/src/pattern.rs
@@ -2,11 +2,15 @@
 //! This module defines `StepPattern`, a lightweight wrapper around a pattern
 //! literal that compiles lazily to a regular expression.
 
-use crate::types::{PlaceholderSyntaxError, StepPatternError};
+use std::{
+    hash::{Hash, Hasher},
+    sync::OnceLock,
+};
+
 use regex::Regex;
 use rstest_bdd_patterns::{PatternError, SpecificityScore, compile_regex_from_pattern};
-use std::hash::{Hash, Hasher};
-use std::sync::OnceLock;
+
+use crate::types::{PlaceholderSyntaxError, StepPatternError};
 
 /// Pattern text used to match a step at runtime.
 #[derive(Debug)]
@@ -20,17 +24,13 @@ pub struct StepPattern {
 // `&'static StepPattern` to be used as a stable map key while keeping
 // semantics intuitive and independent of allocation identity.
 impl PartialEq for StepPattern {
-    fn eq(&self, other: &Self) -> bool {
-        self.text == other.text
-    }
+    fn eq(&self, other: &Self) -> bool { self.text == other.text }
 }
 
 impl Eq for StepPattern {}
 
 impl Hash for StepPattern {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.text.hash(state);
-    }
+    fn hash<H: Hasher>(&self, state: &mut H) { self.text.hash(state); }
 }
 
 impl From<PatternError> for StepPatternError {
@@ -57,9 +57,7 @@ impl StepPattern {
 
     /// Access the underlying pattern string.
     #[must_use]
-    pub const fn as_str(&self) -> &'static str {
-        self.text
-    }
+    pub const fn as_str(&self) -> &'static str { self.text }
 
     /// Compile the pattern into a regular expression, caching the result.
     ///
@@ -68,13 +66,10 @@ impl StepPattern {
     /// generated regex fails to compile.
     ///
     /// # Notes
-    /// - This operation is idempotent. Subsequent calls after a successful
-    ///   compilation are no-ops.
-    /// - This method is thread-safe; concurrent calls may race to build a
-    ///   `Regex`, but only the first successful value is cached.
-    pub fn compile(&self) -> Result<(), StepPatternError> {
-        self.compiled_regex().map(|_| ())
-    }
+    /// - This operation is idempotent. Subsequent calls after a successful compilation are no-ops.
+    /// - This method is thread-safe; concurrent calls may race to build a `Regex`, but only the
+    ///   first successful value is cached.
+    pub fn compile(&self) -> Result<(), StepPatternError> { self.compiled_regex().map(|_| ()) }
 
     /// Return the compiled regular expression, compiling it on first use.
     ///
@@ -102,10 +97,9 @@ impl StepPattern {
     ///
     /// # Notes
     ///
-    /// - This operation is idempotent. Subsequent calls after a successful
-    ///   calculation are no-ops.
-    /// - This method is thread-safe; concurrent calls may race to compute
-    ///   the score, but only the first successful value is cached.
+    /// - This operation is idempotent. Subsequent calls after a successful calculation are no-ops.
+    /// - This method is thread-safe; concurrent calls may race to compute the score, but only the
+    ///   first successful value is cached.
     ///
     /// # Examples
     ///
@@ -130,17 +124,16 @@ impl StepPattern {
 }
 
 impl From<&'static str> for StepPattern {
-    fn from(value: &'static str) -> Self {
-        Self::new(value)
-    }
+    fn from(value: &'static str) -> Self { Self::new(value) }
 }
 
 #[cfg(test)]
 mod tests {
     //! Unit tests for step pattern compilation and caching.
 
-    use super::*;
     use std::ptr;
+
+    use super::*;
 
     #[test]
     fn compiled_regex_returns_cached_regex_after_compilation() {

--- a/crates/rstest-bdd/src/placeholder.rs
+++ b/crates/rstest-bdd/src/placeholder.rs
@@ -2,9 +2,12 @@
 //! This module re-exports the shared pattern engine and exposes the
 //! runtime-facing helper for capturing placeholders from steps.
 
-use crate::pattern::StepPattern;
-use crate::types::{PlaceholderError, StepText};
 use rstest_bdd_patterns::extract_captured_values;
+
+use crate::{
+    pattern::StepPattern,
+    types::{PlaceholderError, StepText},
+};
 
 /// Extract placeholder values from a step string using a pattern.
 ///
@@ -13,12 +16,9 @@ use rstest_bdd_patterns::extract_captured_values;
 /// use and cached for subsequent calls.
 ///
 /// # Errors
-/// - [`PlaceholderError::PatternMismatch`]: the provided text does not match
-///   the pattern.
-/// - [`PlaceholderError::InvalidPlaceholder`]: pattern contains malformed
-///   placeholders.
-/// - [`PlaceholderError::InvalidPattern`]: generated regular expression failed
-///   to compile.
+/// - [`PlaceholderError::PatternMismatch`]: the provided text does not match the pattern.
+/// - [`PlaceholderError::InvalidPlaceholder`]: pattern contains malformed placeholders.
+/// - [`PlaceholderError::InvalidPattern`]: generated regular expression failed to compile.
 pub fn extract_placeholders(
     pattern: &StepPattern,
     text: StepText<'_>,

--- a/crates/rstest-bdd/src/registry/async_lookup.rs
+++ b/crates/rstest-bdd/src/registry/async_lookup.rs
@@ -36,7 +36,8 @@ pub fn lookup_step_async_with_mode(
     })
 }
 
-/// Find a registered async step whose pattern matches the provided text, including its execution mode.
+/// Find a registered async step whose pattern matches the provided text, including its execution
+/// mode.
 ///
 /// # Examples
 ///

--- a/crates/rstest-bdd/src/registry/diagnostics.rs
+++ b/crates/rstest-bdd/src/registry/diagnostics.rs
@@ -5,12 +5,16 @@
 //! Keeping the implementation here keeps the core registry surface small and
 //! helps keep `registry.rs` under the project file size limit.
 
-use super::{StepKey, USED_STEPS, all_steps, resolve_step, step_by_key};
-use crate::reporting::{self, ScenarioStatus};
-use crate::types::StepKeyword;
+use std::sync::{LazyLock, Mutex};
+
 use hashbrown::HashSet;
 use serde::Serialize;
-use std::sync::{LazyLock, Mutex};
+
+use super::{StepKey, USED_STEPS, all_steps, resolve_step, step_by_key};
+use crate::{
+    reporting::{self, ScenarioStatus},
+    types::StepKeyword,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(super) struct BypassedStepRecord {

--- a/crates/rstest-bdd/src/registry/fixtures.rs
+++ b/crates/rstest-bdd/src/registry/fixtures.rs
@@ -6,9 +6,8 @@
 
 use inventory::iter;
 
-use crate::{StepKeyword, StepPattern};
-
 use super::Step;
+use crate::{StepKeyword, StepPattern};
 
 /// Name and Rust type requested for a fixture by a step definition.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -53,8 +52,7 @@ mod tests {
     //! Unit tests for step fixture requirement metadata.
 
     use super::*;
-    use crate::StepKeyword;
-    use crate::registry::Step;
+    use crate::{StepKeyword, registry::Step};
 
     /// A sentinel pattern used only by the unit tests below.
     static UNIT_TEST_PATTERN: crate::StepPattern =

--- a/crates/rstest-bdd/src/registry/introspection.rs
+++ b/crates/rstest-bdd/src/registry/introspection.rs
@@ -4,8 +4,9 @@
 //! definitions, and a JSON dump — consumed by `cargo bdd` and test-suite
 //! health checks.
 
-use super::{Step, StepKey, USED_STEPS, all_steps};
 use hashbrown::HashMap;
+
+use super::{Step, StepKey, USED_STEPS, all_steps};
 
 /// Return registered steps that were never executed.
 #[must_use]
@@ -51,17 +52,14 @@ pub fn duplicate_steps() -> Vec<Vec<&'static Step>> {
 /// assert!(json.contains("\"steps\""));
 /// ```
 #[cfg(feature = "diagnostics")]
-pub fn dump_registry() -> serde_json::Result<String> {
-    super::diagnostics::dump_registry()
-}
+pub fn dump_registry() -> serde_json::Result<String> { super::diagnostics::dump_registry() }
 
 #[cfg(test)]
 mod tests {
     //! Unit tests for registry introspection queries.
 
-    use crate::{StepContext, StepError, StepExecution, StepFuture, StepKeyword, step};
-
     use super::{all_steps, duplicate_steps, unused_steps};
+    use crate::{StepContext, StepError, StepExecution, StepFuture, StepKeyword, step};
 
     const USED_PATTERN: &str = "introspection used step";
     const UNUSED_PATTERN: &str = "introspection unused step";

--- a/crates/rstest-bdd/src/registry/mod.rs
+++ b/crates/rstest-bdd/src/registry/mod.rs
@@ -1,14 +1,20 @@
 //! Step registration, lookup, and placeholder matching.
 //! Defines `Step`, the `step!` registration macro, and the global registry.
 
-use crate::pattern::StepPattern;
-use crate::placeholder::extract_placeholders;
-use crate::types::{AsyncStepFn, PatternStr, StepExecutionMode, StepFn, StepKeyword, StepText};
+use std::{
+    hash::{BuildHasher, Hash, Hasher},
+    sync::{LazyLock, Mutex},
+};
+
 use hashbrown::{HashMap, HashSet};
 use inventory::iter;
 use rstest_bdd_patterns::SpecificityScore;
-use std::hash::{BuildHasher, Hash, Hasher};
-use std::sync::{LazyLock, Mutex};
+
+use crate::{
+    pattern::StepPattern,
+    placeholder::extract_placeholders,
+    types::{AsyncStepFn, PatternStr, StepExecutionMode, StepFn, StepKeyword, StepText},
+};
 
 mod async_lookup;
 mod bypassed;
@@ -19,7 +25,9 @@ mod fixtures;
 mod introspection;
 
 pub use async_lookup::{
-    find_step_async_with_mode, find_step_with_mode, lookup_step_async_with_mode,
+    find_step_async_with_mode,
+    find_step_with_mode,
+    lookup_step_async_with_mode,
 };
 pub use bypassed::{record_bypassed_steps, record_bypassed_steps_with_tags};
 pub use fixtures::{FixtureRequirement, StepFixtureRequirements, fixture_requirements_for_step};
@@ -92,7 +100,15 @@ pub struct Step {
 #[macro_export]
 macro_rules! step {
     // Internal arm: 5 arguments with pre-compiled pattern reference
-    (@pattern $keyword:expr, $pattern:expr, $handler:path, $async_handler:path, $fixtures:expr, $mode:expr) => {
+    (
+        @pattern
+        $keyword:expr,
+        $pattern:expr,
+        $handler:path,
+        $async_handler:path,
+        $fixtures:expr,
+        $mode:expr
+    ) => {
         const _: () = {
             $crate::submit! {
                 $crate::Step {
@@ -137,7 +153,7 @@ macro_rules! step {
     // Public arm: 4 arguments (auto-generate async handler for backward compatibility)
     // This arm MUST come before the 5-argument arm because Rust macro matching
     // is greedy and would otherwise try to parse fixtures as an async_handler path.
-    ($keyword:expr, $pattern:expr, $handler:path, & $fixtures:expr, mode = $mode:expr $(,)?) => {
+    ($keyword:expr, $pattern:expr, $handler:path, & $fixtures:expr,mode = $mode:expr $(,)?) => {
         const _: () = {
             static PATTERN: $crate::StepPattern = $crate::StepPattern::new($pattern);
             $crate::step!(
@@ -163,7 +179,14 @@ macro_rules! step {
         };
     };
     // Public arm: 5 arguments (explicit async handler)
-    ($keyword:expr, $pattern:expr, $handler:path, $async_handler:path, $fixtures:expr, mode = $mode:expr $(,)?) => {
+    (
+        $keyword:expr,
+        $pattern:expr,
+        $handler:path,
+        $async_handler:path,
+        $fixtures:expr,mode =
+        $mode:expr $(,)?
+    ) => {
         const _: () = {
             static PATTERN: $crate::StepPattern = $crate::StepPattern::new($pattern);
             $crate::step!(
@@ -235,13 +258,9 @@ fn mark_used(key: StepKey) {
         .insert(key);
 }
 
-fn all_steps() -> Vec<&'static Step> {
-    iter::<Step>.into_iter().collect()
-}
+fn all_steps() -> Vec<&'static Step> { iter::<Step>.into_iter().collect() }
 
-fn step_by_key(key: StepKey) -> Option<&'static Step> {
-    STEP_MAP.get(&key).copied()
-}
+fn step_by_key(key: StepKey) -> Option<&'static Step> { STEP_MAP.get(&key).copied() }
 
 fn resolve_exact_step(keyword: StepKeyword, pattern: PatternStr<'_>) -> Option<&'static Step> {
     // Compute the hash as if the key were (keyword, pattern.as_str()) because

--- a/crates/rstest-bdd/src/reporting/json.rs
+++ b/crates/rstest-bdd/src/reporting/json.rs
@@ -65,10 +65,13 @@ impl<'a> From<&'a ScenarioRecord> for JsonScenario<'a> {
 ///
 /// # Examples
 /// ```rust
-/// use rstest_bdd::reporting::{json, ScenarioMetadata, ScenarioRecord, ScenarioStatus};
+/// use rstest_bdd::reporting::{ScenarioMetadata, ScenarioRecord, ScenarioStatus, json};
 ///
 /// let metadata = ScenarioMetadata::new("feature", "scenario", 1, Vec::new());
-/// let records = vec![ScenarioRecord::from_metadata(metadata, ScenarioStatus::Passed)];
+/// let records = vec![ScenarioRecord::from_metadata(
+///     metadata,
+///     ScenarioStatus::Passed,
+/// )];
 /// let mut buffer = Vec::new();
 /// json::write(&mut buffer, &records).unwrap();
 /// let output = String::from_utf8(buffer).unwrap();
@@ -85,10 +88,13 @@ pub fn write<W: Write>(writer: &mut W, records: &[ScenarioRecord]) -> serde_json
 ///
 /// # Examples
 /// ```rust
-/// use rstest_bdd::reporting::{json, record, ScenarioMetadata, ScenarioRecord, ScenarioStatus};
+/// use rstest_bdd::reporting::{ScenarioMetadata, ScenarioRecord, ScenarioStatus, json, record};
 ///
 /// let metadata = ScenarioMetadata::new("feature", "scenario", 1, Vec::new());
-/// record(ScenarioRecord::from_metadata(metadata, ScenarioStatus::Passed));
+/// record(ScenarioRecord::from_metadata(
+///     metadata,
+///     ScenarioStatus::Passed,
+/// ));
 /// let mut buffer = Vec::new();
 /// json::write_snapshot(&mut buffer).unwrap();
 /// assert!(!buffer.is_empty());
@@ -105,10 +111,13 @@ pub fn write_snapshot<W: Write>(writer: &mut W) -> serde_json::Result<()> {
 ///
 /// # Examples
 /// ```rust
-/// use rstest_bdd::reporting::{json, ScenarioMetadata, ScenarioRecord, ScenarioStatus};
+/// use rstest_bdd::reporting::{ScenarioMetadata, ScenarioRecord, ScenarioStatus, json};
 ///
 /// let metadata = ScenarioMetadata::new("feature", "scenario", 1, Vec::new());
-/// let records = vec![ScenarioRecord::from_metadata(metadata, ScenarioStatus::Passed)];
+/// let records = vec![ScenarioRecord::from_metadata(
+///     metadata,
+///     ScenarioStatus::Passed,
+/// )];
 /// let json = json::to_string(&records).unwrap();
 /// assert!(json.contains("\"scenario_name\":\"scenario\""));
 /// ```
@@ -123,10 +132,13 @@ pub fn to_string(records: &[ScenarioRecord]) -> serde_json::Result<String> {
 ///
 /// # Examples
 /// ```rust
-/// use rstest_bdd::reporting::{json, record, ScenarioMetadata, ScenarioRecord, ScenarioStatus};
+/// use rstest_bdd::reporting::{ScenarioMetadata, ScenarioRecord, ScenarioStatus, json, record};
 ///
 /// let metadata = ScenarioMetadata::new("feature", "scenario", 1, Vec::new());
-/// record(ScenarioRecord::from_metadata(metadata, ScenarioStatus::Passed));
+/// record(ScenarioRecord::from_metadata(
+///     metadata,
+///     ScenarioStatus::Passed,
+/// ));
 /// let json = json::snapshot_string().unwrap();
 /// assert!(json.contains("\"feature_path\":\"feature\""));
 /// ```

--- a/crates/rstest-bdd/src/reporting/junit.rs
+++ b/crates/rstest-bdd/src/reporting/junit.rs
@@ -15,12 +15,13 @@ const FAIL_ON_SKIPPED_MESSAGE: &str = "Scenario skipped with fail_on_skipped ena
 ///
 /// # Examples
 /// ```
-/// use rstest_bdd::reporting::{
-///     junit, ScenarioMetadata, ScenarioRecord, ScenarioStatus,
-/// };
+/// use rstest_bdd::reporting::{ScenarioMetadata, ScenarioRecord, ScenarioStatus, junit};
 ///
 /// let metadata = ScenarioMetadata::new("feature", "scenario", 1, Vec::new());
-/// let records = vec![ScenarioRecord::from_metadata(metadata, ScenarioStatus::Passed)];
+/// let records = vec![ScenarioRecord::from_metadata(
+///     metadata,
+///     ScenarioStatus::Passed,
+/// )];
 /// let mut output = String::new();
 /// junit::write(&mut output, &records).unwrap();
 /// assert!(output.contains("<testsuite"));
@@ -46,7 +47,8 @@ pub fn write<W: Write>(writer: &mut W, records: &[ScenarioRecord]) -> fmt::Resul
     writer.write_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")?;
     writeln!(
         writer,
-        "<testsuite name=\"rstest-bdd\" tests=\"{tests}\" failures=\"{failures}\" skipped=\"{skipped}\">",
+        "<testsuite name=\"rstest-bdd\" tests=\"{tests}\" failures=\"{failures}\" \
+         skipped=\"{skipped}\">",
     )?;
     for record in records {
         writer.write_str("  <testcase name=\"")?;
@@ -83,12 +85,13 @@ pub fn write<W: Write>(writer: &mut W, records: &[ScenarioRecord]) -> fmt::Resul
 ///
 /// # Examples
 /// ```
-/// use rstest_bdd::reporting::{
-///     junit, record, ScenarioMetadata, ScenarioRecord, ScenarioStatus,
-/// };
+/// use rstest_bdd::reporting::{ScenarioMetadata, ScenarioRecord, ScenarioStatus, junit, record};
 ///
 /// let metadata = ScenarioMetadata::new("feature", "scenario", 1, Vec::new());
-/// record(ScenarioRecord::from_metadata(metadata, ScenarioStatus::Passed));
+/// record(ScenarioRecord::from_metadata(
+///     metadata,
+///     ScenarioStatus::Passed,
+/// ));
 /// let mut output = String::new();
 /// junit::write_snapshot(&mut output).unwrap();
 /// assert!(output.contains("</testsuite>"));

--- a/crates/rstest-bdd/src/reporting/mod.rs
+++ b/crates/rstest-bdd/src/reporting/mod.rs
@@ -13,10 +13,9 @@
 //! (for example via `#[serial_test::serial]`) to avoid cross-test contamination.
 //! The API does not reset records automatically; callers remain responsible for
 //! draining the collector between assertions.
-use std::sync::{Mutex, MutexGuard, OnceLock};
-
 #[cfg(feature = "diagnostics")]
 use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::{Mutex, MutexGuard, OnceLock};
 
 mod record;
 pub use record::{ScenarioMetadata, ScenarioRecord, ScenarioStatus, ScenarioTags, SkippedScenario};
@@ -32,9 +31,7 @@ pub mod junit;
 static RUN_DUMP_SEEDS: OnceLock<AtomicU8> = OnceLock::new();
 
 #[cfg(feature = "diagnostics")]
-fn dump_seeds_state() -> &'static AtomicU8 {
-    RUN_DUMP_SEEDS.get_or_init(|| AtomicU8::new(0))
-}
+fn dump_seeds_state() -> &'static AtomicU8 { RUN_DUMP_SEEDS.get_or_init(|| AtomicU8::new(0)) }
 
 #[cfg(feature = "diagnostics")]
 fn reset_dump_seeds_state() {
@@ -90,13 +87,9 @@ impl DumpSeed {
     /// }
     /// ```
     #[must_use]
-    pub const fn new(callback: fn()) -> Self {
-        Self { callback }
-    }
+    pub const fn new(callback: fn()) -> Self { Self { callback } }
 
-    fn run(self) {
-        (self.callback)();
-    }
+    fn run(self) { (self.callback)(); }
 }
 
 #[cfg(feature = "diagnostics")]
@@ -119,9 +112,7 @@ pub fn run_dump_seeds() {
     struct SetDone(&'static AtomicU8);
 
     impl Drop for SetDone {
-        fn drop(&mut self) {
-            self.0.store(2, Ordering::SeqCst);
-        }
+        fn drop(&mut self) { self.0.store(2, Ordering::SeqCst); }
     }
 
     // States:
@@ -144,42 +135,65 @@ pub fn run_dump_seeds() {
 /// # Examples
 /// ```no_run
 /// use rstest_bdd::reporting::{
-///     drain, record, snapshot, ScenarioMetadata, ScenarioRecord, ScenarioStatus,
+///     ScenarioMetadata,
+///     ScenarioRecord,
+///     ScenarioStatus,
+///     drain,
+///     record,
+///     snapshot,
 /// };
 ///
 /// let metadata = ScenarioMetadata::new("feature", "scenario", 1, Vec::new());
-/// record(ScenarioRecord::from_metadata(metadata, ScenarioStatus::Passed));
+/// record(ScenarioRecord::from_metadata(
+///     metadata,
+///     ScenarioStatus::Passed,
+/// ));
 /// let records = drain();
 /// assert_eq!(records.len(), 1);
 /// ```
-pub fn record(record: ScenarioRecord) {
-    lock_reports().push(record);
-}
+pub fn record(record: ScenarioRecord) { lock_reports().push(record); }
 
 /// Retrieve a snapshot of the recorded scenarios without clearing them.
 ///
 /// # Examples
 /// ```no_run
-/// use rstest_bdd::reporting::{record, snapshot, ScenarioMetadata, ScenarioRecord, ScenarioStatus};
+/// use rstest_bdd::reporting::{
+///     ScenarioMetadata,
+///     ScenarioRecord,
+///     ScenarioStatus,
+///     record,
+///     snapshot,
+/// };
 ///
 /// let metadata = ScenarioMetadata::new("feature", "scenario", 1, Vec::new());
-/// record(ScenarioRecord::from_metadata(metadata, ScenarioStatus::Passed));
+/// record(ScenarioRecord::from_metadata(
+///     metadata,
+///     ScenarioStatus::Passed,
+/// ));
 /// let records = snapshot();
 /// assert_eq!(records[0].scenario_name(), "scenario");
 /// ```
 #[must_use]
-pub fn snapshot() -> Vec<ScenarioRecord> {
-    lock_reports().clone()
-}
+pub fn snapshot() -> Vec<ScenarioRecord> { lock_reports().clone() }
 
 /// Remove and return all recorded scenario outcomes.
 ///
 /// # Examples
 /// ```no_run
-/// use rstest_bdd::reporting::{drain, record, snapshot, ScenarioMetadata, ScenarioRecord, ScenarioStatus};
+/// use rstest_bdd::reporting::{
+///     ScenarioMetadata,
+///     ScenarioRecord,
+///     ScenarioStatus,
+///     drain,
+///     record,
+///     snapshot,
+/// };
 ///
 /// let metadata = ScenarioMetadata::new("feature", "scenario", 1, Vec::new());
-/// record(ScenarioRecord::from_metadata(metadata, ScenarioStatus::Passed));
+/// record(ScenarioRecord::from_metadata(
+///     metadata,
+///     ScenarioStatus::Passed,
+/// ));
 /// let drained = drain();
 /// assert!(snapshot().is_empty());
 /// assert_eq!(drained.len(), 1);

--- a/crates/rstest-bdd/src/reporting/record.rs
+++ b/crates/rstest-bdd/src/reporting/record.rs
@@ -92,9 +92,7 @@ impl ScenarioRecord {
     /// assert_eq!(record.feature_path(), "feature");
     /// ```
     #[must_use]
-    pub fn feature_path(&self) -> &str {
-        &self.feature_path
-    }
+    pub fn feature_path(&self) -> &str { &self.feature_path }
 
     /// Access the recorded scenario name.
     ///
@@ -107,9 +105,7 @@ impl ScenarioRecord {
     /// assert_eq!(record.scenario_name(), "scenario");
     /// ```
     #[must_use]
-    pub fn scenario_name(&self) -> &str {
-        &self.scenario_name
-    }
+    pub fn scenario_name(&self) -> &str { &self.scenario_name }
 
     /// Access the recorded scenario line number.
     ///
@@ -122,9 +118,7 @@ impl ScenarioRecord {
     /// assert_eq!(record.line(), 42);
     /// ```
     #[must_use]
-    pub fn line(&self) -> u32 {
-        self.line
-    }
+    pub fn line(&self) -> u32 { self.line }
 
     /// Access the recorded scenario tags.
     ///
@@ -137,9 +131,7 @@ impl ScenarioRecord {
     /// assert_eq!(record.tags(), &["@tag".to_string()]);
     /// ```
     #[must_use]
-    pub fn tags(&self) -> &[String] {
-        self.tags.as_ref()
-    }
+    pub fn tags(&self) -> &[String] { self.tags.as_ref() }
 
     /// Access the stored status value.
     ///
@@ -152,9 +144,7 @@ impl ScenarioRecord {
     /// assert!(matches!(record.status(), ScenarioStatus::Passed));
     /// ```
     #[must_use]
-    pub fn status(&self) -> &ScenarioStatus {
-        &self.status
-    }
+    pub fn status(&self) -> &ScenarioStatus { &self.status }
 }
 
 /// Status of a scenario execution recorded by the collector.
@@ -231,9 +221,7 @@ impl SkippedScenario {
     /// assert_eq!(skipped.message(), Some("not implemented"));
     /// ```
     #[must_use]
-    pub fn message(&self) -> Option<&str> {
-        self.message.as_deref()
-    }
+    pub fn message(&self) -> Option<&str> { self.message.as_deref() }
 
     /// Whether the scenario allowed skipping without failing the run.
     ///
@@ -245,9 +233,7 @@ impl SkippedScenario {
     /// assert!(skipped.allow_skipped());
     /// ```
     #[must_use]
-    pub fn allow_skipped(&self) -> bool {
-        self.allow_skipped
-    }
+    pub fn allow_skipped(&self) -> bool { self.allow_skipped }
 
     /// Whether a skip forced the suite to fail due to the global configuration.
     ///
@@ -259,7 +245,5 @@ impl SkippedScenario {
     /// assert!(skipped.forced_failure());
     /// ```
     #[must_use]
-    pub fn forced_failure(&self) -> bool {
-        self.forced_failure
-    }
+    pub fn forced_failure(&self) -> bool { self.forced_failure }
 }

--- a/crates/rstest-bdd/src/reporting/tests.rs
+++ b/crates/rstest-bdd/src/reporting/tests.rs
@@ -1,7 +1,8 @@
 //! Unit tests for the reporting module.
 
-use super::*;
 use serial_test::serial;
+
+use super::*;
 
 #[test]
 #[serial]

--- a/crates/rstest-bdd/src/skip.rs
+++ b/crates/rstest-bdd/src/skip.rs
@@ -6,12 +6,14 @@
 //! configuration flag is enabled scenarios without an `@allow_skipped` tag
 //! panic after the final step instead of being marked as skipped.
 
-use std::cell::RefCell;
-use std::fmt;
-use std::marker::PhantomData;
-use std::panic;
-use std::rc::Rc;
-use std::thread::{self, ThreadId};
+use std::{
+    cell::RefCell,
+    fmt,
+    marker::PhantomData,
+    panic,
+    rc::Rc,
+    thread::{self, ThreadId},
+};
 
 thread_local! {
     static SCOPE_STACK: RefCell<Vec<ScopeEntry>> = const { RefCell::new(Vec::new()) };
@@ -27,15 +29,11 @@ pub struct SkipRequest {
 impl SkipRequest {
     /// Create a new skip request with an optional message.
     #[must_use]
-    pub fn new(message: Option<String>) -> Self {
-        Self { message }
-    }
+    pub fn new(message: Option<String>) -> Self { Self { message } }
 
     /// Consume the request, returning the original message.
     #[must_use]
-    pub fn into_message(self) -> Option<String> {
-        self.message
-    }
+    pub fn into_message(self) -> Option<String> { self.message }
 
     /// Panic with this skip request.
     #[track_caller]
@@ -173,8 +171,9 @@ impl fmt::Display for ScopeError {
                 let (scope, name, line) = metadata.describe();
                 write!(
                     f,
-                    "rstest_bdd::skip! may only run on the thread executing the {scope} '{}'\
-                     (defined at {}:{}). Expected thread id {:?} but {:?} attempted to invoke it.",
+                    "rstest_bdd::skip! may only run on the thread executing the {scope} \
+                     '{}'(defined at {}:{}). Expected thread id {:?} but {:?} attempted to invoke \
+                     it.",
                     name, metadata.file, line, expected, actual,
                 )
             }
@@ -245,9 +244,11 @@ impl fmt::Display for SkipRequest {
 mod tests {
     //! Unit tests for scenario skip handling.
 
-    use super::*;
-    use rstest::rstest;
     use std::panic::{self, UnwindSafe};
+
+    use rstest::rstest;
+
+    use super::*;
 
     fn with_test_scope<F: FnOnce()>(body: F) {
         let guard = enter_scope(ScopeKind::Step, "test_scope", file!(), line!());
@@ -335,9 +336,7 @@ mod tests {
             crate::skip!("helper triggered skip");
         }
 
-        fn helper() {
-            nested_helper();
-        }
+        fn helper() { nested_helper(); }
 
         let result = panic::catch_unwind(|| with_test_scope(helper));
         assert!(result.is_err(), "helper skip should raise panic payload");

--- a/crates/rstest-bdd/src/skip_helpers.rs
+++ b/crates/rstest-bdd/src/skip_helpers.rs
@@ -1,7 +1,6 @@
 //! Helpers shared by skip assertion macros.
 
-use crate::reporting::SkippedScenario;
-use crate::{StepExecution, panic_localized};
+use crate::{StepExecution, panic_localized, reporting::SkippedScenario};
 
 #[doc(hidden)]
 /// Ensure a skip message contains the expected substring, otherwise panic with

--- a/crates/rstest-bdd/src/state.rs
+++ b/crates/rstest-bdd/src/state.rs
@@ -34,25 +34,17 @@ pub struct Slot<T> {
 impl<T> Slot<T> {
     /// Construct an empty slot.
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
-    }
+    pub fn new() -> Self { Self::default() }
 
     /// Replace the slot contents, returning the previous value when present.
-    pub fn replace(&self, value: T) -> Option<T> {
-        self.inner.replace(Some(value))
-    }
+    pub fn replace(&self, value: T) -> Option<T> { self.inner.replace(Some(value)) }
 
     /// Store `value`, discarding any previous contents.
-    pub fn set(&self, value: T) {
-        let _ = self.replace(value);
-    }
+    pub fn set(&self, value: T) { let _ = self.replace(value); }
 
     /// Remove the current value from the slot.
     #[must_use]
-    pub fn take(&self) -> Option<T> {
-        self.inner.borrow_mut().take()
-    }
+    pub fn take(&self) -> Option<T> { self.inner.borrow_mut().take() }
 
     /// Borrow the value mutably, inserting one produced by `init` when empty.
     ///
@@ -96,20 +88,14 @@ impl<T> Slot<T> {
 
     /// Return `true` when the slot holds a value.
     #[must_use]
-    pub fn is_filled(&self) -> bool {
-        self.inner.borrow().is_some()
-    }
+    pub fn is_filled(&self) -> bool { self.inner.borrow().is_some() }
 
     /// Return `true` when the slot is empty.
     #[must_use]
-    pub fn is_empty(&self) -> bool {
-        !self.is_filled()
-    }
+    pub fn is_empty(&self) -> bool { !self.is_filled() }
 
     /// Remove the current value, leaving the slot empty.
-    pub fn clear(&self) {
-        let _ = self.take();
-    }
+    pub fn clear(&self) { let _ = self.take(); }
 }
 
 impl<T: std::fmt::Debug> std::fmt::Debug for Slot<T> {
@@ -144,8 +130,9 @@ pub trait ScenarioState: Default {
 mod tests {
     //! Unit tests for scenario state management.
 
-    use super::*;
     use rstest_bdd_macros::ScenarioState as ScenarioStateDerive;
+
+    use super::*;
 
     #[test]
     fn slot_replaces_values() {

--- a/crates/rstest-bdd/src/step_args.rs
+++ b/crates/rstest-bdd/src/step_args.rs
@@ -46,15 +46,11 @@ impl StepArgsError {
 
     /// Access the underlying error message.
     #[must_use]
-    pub fn message(&self) -> &str {
-        &self.message
-    }
+    pub fn message(&self) -> &str { &self.message }
 }
 
 impl fmt::Display for StepArgsError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.message)
-    }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { f.write_str(&self.message) }
 }
 
 impl std::error::Error for StepArgsError {}

--- a/crates/rstest-bdd/src/test_support.rs
+++ b/crates/rstest-bdd/src/test_support.rs
@@ -4,9 +4,8 @@
 //! It is gated behind the `test-support` feature to avoid including polling
 //! utilities in production builds.
 
-use crate::{StepExecution, StepFuture};
-
 pub use crate::async_step::sync_to_async;
+use crate::{StepExecution, StepFuture};
 
 /// Poll a step future to completion using a noop waker.
 ///
@@ -20,8 +19,7 @@ pub use crate::async_step::sync_to_async;
 /// # Examples
 ///
 /// ```rust
-/// use rstest_bdd::{StepContext, StepExecution, StepFuture};
-/// use rstest_bdd::test_support::poll_step_future;
+/// use rstest_bdd::{StepContext, StepExecution, StepFuture, test_support::poll_step_future};
 ///
 /// fn example_async<'a>(
 ///     _ctx: &'a mut StepContext<'_>,

--- a/crates/rstest-bdd/src/types/mod.rs
+++ b/crates/rstest-bdd/src/types/mod.rs
@@ -4,16 +4,16 @@
 //! keyword enum with parsing helpers, error types, and common type aliases used
 //! by the registry and runner.
 
-use crate::localization;
-use std::any::Any;
-use std::fmt;
-use std::future::Future;
-use std::pin::Pin;
+use std::{any::Any, fmt, future::Future, pin::Pin};
 
 // Re-export shared keyword types from rstest-bdd-patterns.
 pub use rstest_bdd_patterns::{
-    StepKeyword, StepKeywordParseError, UnsupportedStepType as UnsupportedStepTypeBase,
+    StepKeyword,
+    StepKeywordParseError,
+    UnsupportedStepType as UnsupportedStepTypeBase,
 };
+
+use crate::localization;
 
 /// Error raised when converting a parsed Gherkin [`gherkin::StepType`] into a
 /// [`StepKeyword`] fails.
@@ -53,9 +53,7 @@ impl fmt::Display for UnsupportedStepType {
 impl std::error::Error for UnsupportedStepType {}
 
 impl From<UnsupportedStepTypeBase> for UnsupportedStepType {
-    fn from(base: UnsupportedStepTypeBase) -> Self {
-        Self(base.0)
-    }
+    fn from(base: UnsupportedStepTypeBase) -> Self { Self(base.0) }
 }
 
 /// Wrapper for step pattern strings used in matching logic.
@@ -65,21 +63,15 @@ pub struct PatternStr<'a>(pub(crate) &'a str);
 impl<'a> PatternStr<'a> {
     /// Construct a new `PatternStr` from a string slice.
     #[must_use]
-    pub const fn new(s: &'a str) -> Self {
-        Self(s)
-    }
+    pub const fn new(s: &'a str) -> Self { Self(s) }
 
     /// Access the underlying string slice.
     #[must_use]
-    pub const fn as_str(self) -> &'a str {
-        self.0
-    }
+    pub const fn as_str(self) -> &'a str { self.0 }
 }
 
 impl<'a> From<&'a str> for PatternStr<'a> {
-    fn from(s: &'a str) -> Self {
-        Self::new(s)
-    }
+    fn from(s: &'a str) -> Self { Self::new(s) }
 }
 
 /// Wrapper borrowing step text content from scenarios.
@@ -89,21 +81,15 @@ pub struct StepText<'a>(pub(crate) &'a str);
 impl<'a> StepText<'a> {
     /// Construct a new `StepText` from a string slice.
     #[must_use]
-    pub const fn new(s: &'a str) -> Self {
-        Self(s)
-    }
+    pub const fn new(s: &'a str) -> Self { Self(s) }
 
     /// Access the underlying string slice.
     #[must_use]
-    pub const fn as_str(self) -> &'a str {
-        self.0
-    }
+    pub const fn as_str(self) -> &'a str { self.0 }
 }
 
 impl<'a> From<&'a str> for StepText<'a> {
-    fn from(s: &'a str) -> Self {
-        Self::new(s)
-    }
+    fn from(s: &'a str) -> Self { Self::new(s) }
 }
 
 /// Detailed information about placeholder parsing failures.
@@ -171,15 +157,11 @@ pub enum StepPatternError {
 }
 
 impl From<PlaceholderSyntaxError> for StepPatternError {
-    fn from(err: PlaceholderSyntaxError) -> Self {
-        Self::PlaceholderSyntax(err)
-    }
+    fn from(err: PlaceholderSyntaxError) -> Self { Self::PlaceholderSyntax(err) }
 }
 
 impl From<regex::Error> for StepPatternError {
-    fn from(err: regex::Error) -> Self {
-        Self::InvalidPattern(err)
-    }
+    fn from(err: regex::Error) -> Self { Self::InvalidPattern(err) }
 }
 
 impl fmt::Display for StepPatternError {
@@ -262,9 +244,7 @@ pub enum StepExecution {
 
 impl StepExecution {
     /// Construct a successful outcome with an optional value.
-    pub fn from_value(value: Option<Box<dyn Any>>) -> Self {
-        Self::Continue { value }
-    }
+    pub fn from_value(value: Option<Box<dyn Any>>) -> Self { Self::Continue { value } }
 
     /// Construct a skipped outcome with an optional reason.
     pub fn skipped(message: impl Into<Option<String>>) -> Self {
@@ -324,14 +304,18 @@ pub type StepFuture<'a> =
 ///
 /// - `StepContext<'_>` in parameter positions so `'fixtures` is inferred.
 /// - [`crate::async_step::sync_to_async`] for explicit sync-to-async wrappers.
-/// - [`StepCtx`], [`StepTextRef`], [`StepDoc`], and [`StepTable`] for concise
-///   explicit signatures.
+/// - [`StepCtx`], [`StepTextRef`], [`StepDoc`], and [`StepTable`] for concise explicit signatures.
 ///
 /// # Examples
 ///
 /// ```rust
-/// use rstest_bdd::async_step::sync_to_async;
-/// use rstest_bdd::{StepContext, StepError, StepExecution, StepFuture};
+/// use rstest_bdd::{
+///     StepContext,
+///     StepError,
+///     StepExecution,
+///     StepFuture,
+///     async_step::sync_to_async,
+/// };
 ///
 /// fn my_sync_step(
 ///     _ctx: &mut StepContext<'_>,

--- a/crates/rstest-bdd/src/types/tests.rs
+++ b/crates/rstest-bdd/src/types/tests.rs
@@ -1,11 +1,13 @@
 //! Unit tests for shared core types and helper enums.
 
-use super::*;
-use crate::localization::{ScopedLocalization, strip_directional_isolates};
+use std::str::FromStr;
+
 use gherkin::StepType;
 use rstest::rstest;
-use std::str::FromStr;
 use unic_langid::langid;
+
+use super::*;
+use crate::localization::{ScopedLocalization, strip_directional_isolates};
 
 fn kw_from_type(ty: StepType) -> StepKeyword {
     match StepKeyword::try_from(ty).map_err(UnsupportedStepType::from) {

--- a/crates/rstest-bdd/tests/argument_parsing.rs
+++ b/crates/rstest-bdd/tests/argument_parsing.rs
@@ -1,23 +1,18 @@
 //! Behavioural test for step argument parsing
 
-use rstest::fixture;
-use rstest_bdd_macros::{given, scenario, then, when};
 use std::cell::RefCell;
 
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenario, then, when};
+
 #[fixture]
-fn account() -> RefCell<u32> {
-    RefCell::new(0)
-}
+fn account() -> RefCell<u32> { RefCell::new(0) }
 
 #[given("I start with {amount:u32} dollars")]
-fn start_balance(account: &RefCell<u32>, amount: u32) {
-    *account.borrow_mut() = amount;
-}
+fn start_balance(account: &RefCell<u32>, amount: u32) { *account.borrow_mut() = amount; }
 
 #[when("I deposit {amount:u32} dollars")]
-fn deposit_amount(account: &RefCell<u32>, amount: u32) {
-    *account.borrow_mut() += amount;
-}
+fn deposit_amount(account: &RefCell<u32>, amount: u32) { *account.borrow_mut() += amount; }
 
 #[then("my balance is {expected:u32} dollars")]
 fn check_balance(account: &RefCell<u32>, expected: u32) {
@@ -25,6 +20,4 @@ fn check_balance(account: &RefCell<u32>, expected: u32) {
 }
 
 #[scenario(path = "tests/features/argument.feature")]
-fn deposit_scenario(account: RefCell<u32>) {
-    let _ = account;
-}
+fn deposit_scenario(account: RefCell<u32>) { let _ = account; }

--- a/crates/rstest-bdd/tests/argument_parsing.rs
+++ b/crates/rstest-bdd/tests/argument_parsing.rs
@@ -5,6 +5,7 @@ use std::cell::RefCell;
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn account() -> RefCell<u32> { RefCell::new(0) }
 

--- a/crates/rstest-bdd/tests/assert_macros.rs
+++ b/crates/rstest-bdd/tests/assert_macros.rs
@@ -3,11 +3,15 @@
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use rstest::rstest;
-use rstest_bdd::localization::{ScopedLocalization, strip_directional_isolates};
-use rstest_bdd::reporting::{ScenarioStatus, SkippedScenario};
 use rstest_bdd::{
-    StepExecution, assert_scenario_skipped, assert_step_err, assert_step_ok, assert_step_skipped,
+    StepExecution,
+    assert_scenario_skipped,
+    assert_step_err,
+    assert_step_ok,
+    assert_step_skipped,
+    localization::{ScopedLocalization, strip_directional_isolates},
     panic_message,
+    reporting::{ScenarioStatus, SkippedScenario},
 };
 use unic_langid::langid;
 
@@ -18,33 +22,19 @@ fn capture_panic_message(op: impl FnOnce()) -> String {
     }
 }
 
-fn panic_with_owned_string() {
-    std::panic::panic_any(String::from("owned"));
-}
+fn panic_with_owned_string() { std::panic::panic_any(String::from("owned")); }
 
-fn panic_with_static_str() {
-    std::panic::panic_any("static str");
-}
+fn panic_with_static_str() { std::panic::panic_any("static str"); }
 
-fn panic_with_i32() {
-    std::panic::panic_any(42_i32);
-}
+fn panic_with_i32() { std::panic::panic_any(42_i32); }
 
-fn panic_with_f64() {
-    std::panic::panic_any(2.5_f64);
-}
+fn panic_with_f64() { std::panic::panic_any(2.5_f64); }
 
-fn panic_with_bool_true() {
-    std::panic::panic_any(true);
-}
+fn panic_with_bool_true() { std::panic::panic_any(true); }
 
-fn panic_with_empty_string() {
-    std::panic::panic_any(String::new());
-}
+fn panic_with_empty_string() { std::panic::panic_any(String::new()); }
 
-fn panic_with_unicode_str() {
-    std::panic::panic_any("résumé");
-}
+fn panic_with_unicode_str() { std::panic::panic_any("résumé"); }
 
 /// Helper to test panic messages in French locale.
 fn assert_panic_in_french(op: impl FnOnce(), expected_substring: &str) {
@@ -117,9 +107,7 @@ fn assert_step_skipped_panics() {
     let _ = assert_step_skipped!(StepExecution::Continue { value: None });
 }
 
-fn assert_scenario_skipped_panics() {
-    let _ = assert_scenario_skipped!(ScenarioStatus::Passed);
-}
+fn assert_scenario_skipped_panics() { let _ = assert_scenario_skipped!(ScenarioStatus::Passed); }
 
 #[rstest]
 #[case::assert_step_ok(assert_step_ok_panics as fn(), "l'étape a renvoyé une erreur")]
@@ -165,9 +153,7 @@ fn assert_step_err_handles_custom_error_type() {
     struct CustomErr(&'static str);
 
     impl std::fmt::Display for CustomErr {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.write_str(self.0)
-        }
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { f.write_str(self.0) }
     }
 
     let res: Result<(), CustomErr> = Err(CustomErr("boom"));

--- a/crates/rstest-bdd/tests/async_registry.rs
+++ b/crates/rstest-bdd/tests/async_registry.rs
@@ -8,8 +8,17 @@
 
 use rstest::rstest;
 use rstest_bdd::{
-    AsyncStepFn, Step, StepContext, StepExecution, StepFuture, StepKeyword, find_step_async, iter,
-    lookup_step_async, step, unused_steps,
+    AsyncStepFn,
+    Step,
+    StepContext,
+    StepExecution,
+    StepFuture,
+    StepKeyword,
+    find_step_async,
+    iter,
+    lookup_step_async,
+    step,
+    unused_steps,
 };
 
 #[path = "common/noop_steps.rs"]

--- a/crates/rstest-bdd/tests/async_scenario.rs
+++ b/crates/rstest-bdd/tests/async_scenario.rs
@@ -20,9 +20,7 @@ thread_local! {
 }
 
 #[given("an async counter is initialized to 0")]
-fn async_counter_init() {
-    ASYNC_COUNTER.with(|c| *c.borrow_mut() = 0);
-}
+fn async_counter_init() { ASYNC_COUNTER.with(|c| *c.borrow_mut() = 0); }
 
 #[when("the async counter is incremented")]
 async fn async_counter_increment() {

--- a/crates/rstest-bdd/tests/async_semantic_behaviour.rs
+++ b/crates/rstest-bdd/tests/async_semantic_behaviour.rs
@@ -4,43 +4,43 @@
 #[path = "common/async_semantic_behaviour_support.rs"]
 mod async_semantic_behaviour_support;
 
-use std::cell::RefCell;
-use std::panic::catch_unwind;
-
-use rstest::fixture;
-use rstest_bdd::assert_scenario_skipped;
-use rstest_bdd::panic_message;
-use rstest_bdd::reporting::drain as drain_reports;
-use rstest_bdd_macros::{given, scenario, then, when};
-use serial_test::serial;
+use std::{cell::RefCell, panic::catch_unwind};
 
 #[cfg(feature = "diagnostics")]
 use async_semantic_behaviour_support::{BypassedStepQuery, assert_bypassed_step_recorded};
 use async_semantic_behaviour_support::{
-    CleanupProbe, ERROR_SCENARIO_NAME, FEATURE_PATH, SKIP_SCENARIO_NAME, ScenarioRef,
-    SemanticValue, StepRef, assert_feature_path_suffix, assert_handler_failure_context,
-    cleanup_drops, clear_events, push_event, reset_cleanup_drops, scenario_line, snapshot_events,
+    CleanupProbe,
+    ERROR_SCENARIO_NAME,
+    FEATURE_PATH,
+    SKIP_SCENARIO_NAME,
+    ScenarioRef,
+    SemanticValue,
+    StepRef,
+    assert_feature_path_suffix,
+    assert_handler_failure_context,
+    cleanup_drops,
+    clear_events,
+    push_event,
+    reset_cleanup_drops,
+    scenario_line,
+    snapshot_events,
 };
+use rstest::fixture;
+use rstest_bdd::{assert_scenario_skipped, panic_message, reporting::drain as drain_reports};
+use rstest_bdd_macros::{given, scenario, then, when};
+use serial_test::serial;
 
 #[fixture]
-fn semantic_order_fixture() -> RefCell<Vec<String>> {
-    RefCell::new(vec!["fixture-created".into()])
-}
+fn semantic_order_fixture() -> RefCell<Vec<String>> { RefCell::new(vec!["fixture-created".into()]) }
 
 #[fixture]
-fn semantic_value_fixture() -> SemanticValue {
-    SemanticValue(1)
-}
+fn semantic_value_fixture() -> SemanticValue { SemanticValue(1) }
 
 #[fixture]
-fn semantic_shared_counter() -> RefCell<usize> {
-    RefCell::new(0)
-}
+fn semantic_shared_counter() -> RefCell<usize> { RefCell::new(0) }
 
 #[fixture]
-fn semantic_cleanup_probe() -> CleanupProbe {
-    CleanupProbe
-}
+fn semantic_cleanup_probe() -> CleanupProbe { CleanupProbe }
 
 #[given("semantic async skip state is reset")]
 fn semantic_skip_state_reset() {

--- a/crates/rstest-bdd/tests/async_semantic_behaviour.rs
+++ b/crates/rstest-bdd/tests/async_semantic_behaviour.rs
@@ -30,15 +30,19 @@ use rstest_bdd::{assert_scenario_skipped, panic_message, reporting::drain as dra
 use rstest_bdd_macros::{given, scenario, then, when};
 use serial_test::serial;
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn semantic_order_fixture() -> RefCell<Vec<String>> { RefCell::new(vec!["fixture-created".into()]) }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn semantic_value_fixture() -> SemanticValue { SemanticValue(1) }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn semantic_shared_counter() -> RefCell<usize> { RefCell::new(0) }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn semantic_cleanup_probe() -> CleanupProbe { CleanupProbe }
 

--- a/crates/rstest-bdd/tests/async_step_functions.rs
+++ b/crates/rstest-bdd/tests/async_step_functions.rs
@@ -7,8 +7,17 @@
 
 use rstest::fixture;
 use rstest_bdd::{
-    StepContext, StepCtx, StepDoc, StepExecution, StepFuture, StepKeyword, StepTable, StepText,
-    StepTextRef, async_step::sync_to_async, find_step_with_metadata,
+    StepContext,
+    StepCtx,
+    StepDoc,
+    StepExecution,
+    StepFuture,
+    StepKeyword,
+    StepTable,
+    StepText,
+    StepTextRef,
+    async_step::sync_to_async,
+    find_step_with_metadata,
 };
 use rstest_bdd_macros::{given, scenario, then, when};
 
@@ -18,14 +27,10 @@ struct CounterState {
 }
 
 #[fixture]
-fn state() -> CounterState {
-    CounterState::default()
-}
+fn state() -> CounterState { CounterState::default() }
 
 #[given("a counter state starts at 0")]
-fn counter_state_starts_at_zero(#[from(state)] state: &mut CounterState) {
-    state.value = 0;
-}
+fn counter_state_starts_at_zero(#[from(state)] state: &mut CounterState) { state.value = 0; }
 
 #[when("an async step increments the state")]
 async fn async_step_increments_state(#[from(state)] state: &mut CounterState) {
@@ -35,9 +40,7 @@ async fn async_step_increments_state(#[from(state)] state: &mut CounterState) {
 }
 
 #[when("a sync step increments the state")]
-fn sync_step_increments_state(#[from(state)] state: &mut CounterState) {
-    state.value += 1;
-}
+fn sync_step_increments_state(#[from(state)] state: &mut CounterState) { state.value += 1; }
 
 #[then(expr = "the state value is {n}")]
 fn state_value_is(#[from(state)] state: &CounterState, n: usize) {

--- a/crates/rstest-bdd/tests/async_step_functions.rs
+++ b/crates/rstest-bdd/tests/async_step_functions.rs
@@ -26,6 +26,7 @@ struct CounterState {
     value: usize,
 }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn state() -> CounterState { CounterState::default() }
 

--- a/crates/rstest-bdd/tests/async_step_infrastructure.rs
+++ b/crates/rstest-bdd/tests/async_step_infrastructure.rs
@@ -3,26 +3,21 @@
 //! These tests verify that the async step registry infrastructure correctly
 //! normalizes synchronous step definitions into the async interface.
 
-use rstest_bdd_macros::{given, scenario, then, when};
 use std::cell::RefCell;
+
+use rstest_bdd_macros::{given, scenario, then, when};
 
 thread_local! {
     static EXECUTED: RefCell<Vec<&'static str>> = const { RefCell::new(Vec::new()) };
 }
 
-fn reset_executed() {
-    EXECUTED.with(|v| v.borrow_mut().clear());
-}
+fn reset_executed() { EXECUTED.with(|v| v.borrow_mut().clear()); }
 
 #[given("a synchronous step definition")]
-fn given_sync() {
-    EXECUTED.with(|v| v.borrow_mut().push("given"));
-}
+fn given_sync() { EXECUTED.with(|v| v.borrow_mut().push("given")); }
 
 #[when("the async wrapper is invoked")]
-fn when_async_wrapper() {
-    EXECUTED.with(|v| v.borrow_mut().push("when"));
-}
+fn when_async_wrapper() { EXECUTED.with(|v| v.borrow_mut().push("when")); }
 
 #[then("it returns an immediately-ready future")]
 fn then_ready_future() {
@@ -38,6 +33,4 @@ fn then_ready_future() {
 
 #[scenario(path = "tests/features/async_step.feature")]
 #[test]
-fn sync_step_normalized_to_async() {
-    reset_executed();
-}
+fn sync_step_normalized_to_async() { reset_executed(); }

--- a/crates/rstest-bdd/tests/common/async_semantic_behaviour_support.rs
+++ b/crates/rstest-bdd/tests/common/async_semantic_behaviour_support.rs
@@ -1,7 +1,6 @@
 //! Shared support for async semantic behaviour tests.
 
-use std::cell::RefCell;
-use std::path::Path;
+use std::{cell::RefCell, path::Path};
 
 use regex::Regex;
 #[cfg(feature = "diagnostics")]
@@ -120,9 +119,7 @@ pub(crate) fn reset_cleanup_drops() {
 }
 
 /// Returns the number of times [`CleanupProbe`] has been dropped in this thread.
-pub(crate) fn cleanup_drops() -> usize {
-    TEST_STATE.with(|state| state.borrow().cleanup_drops)
-}
+pub(crate) fn cleanup_drops() -> usize { TEST_STATE.with(|state| state.borrow().cleanup_drops) }
 
 /// Asserts that `actual` ends with `expected_suffix` using [`Path::ends_with`].
 ///
@@ -263,6 +260,7 @@ pub(crate) fn assert_bypassed_step_recorded(query: BypassedStepQuery<'_>) {
                     .and_then(Value::as_str)
                     .is_some_and(|message| message.contains(reason))
         }),
-        "expected a bypassed-step record for scenario '{scenario_name}' and pattern '{step_pattern}'",
+        "expected a bypassed-step record for scenario '{scenario_name}' and pattern \
+         '{step_pattern}'",
     );
 }

--- a/crates/rstest-bdd/tests/common/bulk_migration_steps.rs
+++ b/crates/rstest-bdd/tests/common/bulk_migration_steps.rs
@@ -26,6 +26,7 @@ pub struct LedgerState {
 /// Deriving `ScenarioState` gives `LedgerState` a `reset()` that clears every
 /// slot; `rstest` constructs a new instance per scenario, so no `Drop` guard is
 /// needed for the fixture-based shape.
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 pub fn ledger_state() -> LedgerState { LedgerState::default() }
 

--- a/crates/rstest-bdd/tests/common/bulk_migration_steps.rs
+++ b/crates/rstest-bdd/tests/common/bulk_migration_steps.rs
@@ -11,8 +11,7 @@
 //! shape recommended when steps do not also need mutable harness context.
 
 use rstest::fixture;
-use rstest_bdd::ScenarioState as _;
-use rstest_bdd::Slot;
+use rstest_bdd::{ScenarioState as _, Slot};
 use rstest_bdd_macros::{ScenarioState, given, then, when};
 
 /// Durable scenario state shared across steps within one scenario.
@@ -28,9 +27,7 @@ pub struct LedgerState {
 /// slot; `rstest` constructs a new instance per scenario, so no `Drop` guard is
 /// needed for the fixture-based shape.
 #[fixture]
-pub fn ledger_state() -> LedgerState {
-    LedgerState::default()
-}
+pub fn ledger_state() -> LedgerState { LedgerState::default() }
 
 /// Reset a fresh ledger so a scenario starts from a known-empty balance.
 #[given("a fresh ledger")]
@@ -56,9 +53,7 @@ pub fn an_entry_is_posted(ledger_state: &LedgerState, amount: i32) {
 /// total makes a no-op reset observable: without the clear, the earlier posting
 /// would still be counted.
 #[when("the running total is reset")]
-pub fn the_running_total_is_reset(ledger_state: &LedgerState) {
-    ledger_state.reset();
-}
+pub fn the_running_total_is_reset(ledger_state: &LedgerState) { ledger_state.reset(); }
 
 /// Assert the durable balance matches the expected total.
 #[then("the balance is {expected:i32}")]

--- a/crates/rstest-bdd/tests/common/running_total.rs
+++ b/crates/rstest-bdd/tests/common/running_total.rs
@@ -3,14 +3,10 @@
 use std::cell::RefCell;
 
 // Reset the accumulator so each scenario starts from a predictable baseline.
-pub fn set_total(total: &RefCell<i32>, value: i32) {
-    *total.borrow_mut() = value;
-}
+pub fn set_total(total: &RefCell<i32>, value: i32) { *total.borrow_mut() = value; }
 
 // Apply an additional value contributed by a translated step.
-pub fn add_to_total(total: &RefCell<i32>, value: i32) {
-    *total.borrow_mut() += value;
-}
+pub fn add_to_total(total: &RefCell<i32>, value: i32) { *total.borrow_mut() += value; }
 
 // Assert that the accumulator equals the expected sum once a scenario completes.
 pub fn assert_total(total: &RefCell<i32>, expected: i32) {

--- a/crates/rstest-bdd/tests/concurrent_mut_fixtures.rs
+++ b/crates/rstest-bdd/tests/concurrent_mut_fixtures.rs
@@ -18,14 +18,10 @@ struct LeftCounter(u32);
 struct RightCounter(u32);
 
 #[fixture]
-fn left() -> LeftCounter {
-    LeftCounter(10)
-}
+fn left() -> LeftCounter { LeftCounter(10) }
 
 #[fixture]
-fn right() -> RightCounter {
-    RightCounter(20)
-}
+fn right() -> RightCounter { RightCounter(20) }
 
 #[given("two counters are available")]
 fn counters_available(left: &LeftCounter, right: &RightCounter) {
@@ -81,9 +77,7 @@ impl HarnessAdapter for CountingHarness {
 }
 
 #[fixture]
-fn harness_world() -> HarnessWorld {
-    HarnessWorld::default()
-}
+fn harness_world() -> HarnessWorld { HarnessWorld::default() }
 
 #[given("the harness world starts empty")]
 fn harness_world_starts_empty(harness_world: &HarnessWorld) {

--- a/crates/rstest-bdd/tests/concurrent_mut_fixtures.rs
+++ b/crates/rstest-bdd/tests/concurrent_mut_fixtures.rs
@@ -17,9 +17,11 @@ struct LeftCounter(u32);
 #[derive(Default)]
 struct RightCounter(u32);
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn left() -> LeftCounter { LeftCounter(10) }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn right() -> RightCounter { RightCounter(20) }
 
@@ -76,6 +78,7 @@ impl HarnessAdapter for CountingHarness {
     }
 }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn harness_world() -> HarnessWorld { HarnessWorld::default() }
 

--- a/crates/rstest-bdd/tests/context_borrow_props.rs
+++ b/crates/rstest-bdd/tests/context_borrow_props.rs
@@ -50,9 +50,7 @@ impl HeldGuard<'_> {
         }
     }
 
-    fn is_mutable(&self) -> bool {
-        matches!(self, Self::Mutable { .. })
-    }
+    fn is_mutable(&self) -> bool { matches!(self, Self::Mutable { .. }) }
 }
 
 fn assert_mutable_acquire<'borrow, 'fixture: 'borrow>(

--- a/crates/rstest-bdd/tests/datatable.rs
+++ b/crates/rstest-bdd/tests/datatable.rs
@@ -78,7 +78,8 @@ fn typed_users_invalid(datatable: Vec<Vec<String>>) {
     };
     assert_eq!(
         err.to_string(),
-        "row 2, column 3 (active): unrecognised boolean value 'maybe' (expected yes/y/true/1 or no/n/false/0)"
+        "row 2, column 3 (active): unrecognised boolean value 'maybe' (expected yes/y/true/1 or \
+         no/n/false/0)"
     );
 }
 
@@ -106,13 +107,9 @@ struct DerivedRow {
 #[derive(Debug, Clone, PartialEq, Eq, DataTableRow)]
 struct TupleRow(String, u8, bool);
 
-fn default_region() -> String {
-    String::from("EMEA")
-}
+fn default_region() -> String { String::from("EMEA") }
 
-fn parse_age(value: &str) -> Result<u8, std::num::ParseIntError> {
-    value.trim().parse()
-}
+fn parse_age(value: &str) -> Result<u8, std::num::ParseIntError> { value.trim().parse() }
 
 #[derive(Debug, PartialEq, Eq, DataTable)]
 struct DerivedRowCollection(Rows<DerivedRow>);

--- a/crates/rstest-bdd/tests/datatable_cache.rs
+++ b/crates/rstest-bdd/tests/datatable_cache.rs
@@ -1,12 +1,17 @@
 //! Behavioural tests for cached data table conversion.
 
-use rstest_bdd::datatable::CachedTable;
-use rstest_bdd::{StepContext, StepKeyword, lookup_step};
+use std::{
+    collections::HashMap,
+    sync::{
+        Mutex,
+        OnceLock,
+        atomic::{AtomicUsize, Ordering},
+    },
+    thread,
+};
+
+use rstest_bdd::{StepContext, StepKeyword, datatable::CachedTable, lookup_step};
 use rstest_bdd_macros::given;
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Mutex, OnceLock};
-use std::thread;
 
 fn cached_calls() -> &'static Mutex<HashMap<thread::ThreadId, Vec<usize>>> {
     static CALLS: OnceLock<Mutex<HashMap<thread::ThreadId, Vec<usize>>>> = OnceLock::new();
@@ -53,13 +58,9 @@ fn take_values() -> Vec<String> {
 
 static CONVERSIONS: AtomicUsize = AtomicUsize::new(0);
 
-fn reset_conversions() {
-    CONVERSIONS.store(0, Ordering::Relaxed);
-}
+fn reset_conversions() { CONVERSIONS.store(0, Ordering::Relaxed); }
 
-fn conversion_count() -> usize {
-    CONVERSIONS.load(Ordering::Relaxed)
-}
+fn conversion_count() -> usize { CONVERSIONS.load(Ordering::Relaxed) }
 
 #[given("a cached table:")]
 fn cached_table(datatable: CachedTable) {

--- a/crates/rstest-bdd/tests/diagnostics_fixture.rs
+++ b/crates/rstest-bdd/tests/diagnostics_fixture.rs
@@ -5,14 +5,14 @@
 //! couple of scenario outcomes in that mode so the CLI can exercise the
 //! reporting pipeline without running a full behaviour suite.
 
-use rstest_bdd as bdd;
-#[cfg(feature = "diagnostics")]
-use serial_test::serial;
 #[cfg(feature = "diagnostics")]
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use rstest_bdd as bdd;
 #[cfg(feature = "diagnostics")]
 use rstest_bdd::{StepContext, StepExecution, StepFuture, StepKeyword, step};
+#[cfg(feature = "diagnostics")]
+use serial_test::serial;
 
 #[cfg(feature = "diagnostics")]
 #[path = "common/async_wrapper.rs"]
@@ -184,9 +184,7 @@ impl DumpStepsGuard {
 
 #[cfg(feature = "diagnostics")]
 impl Drop for DumpStepsGuard {
-    fn drop(&mut self) {
-        SHOULD_SEED.store(false, Ordering::SeqCst);
-    }
+    fn drop(&mut self) { SHOULD_SEED.store(false, Ordering::SeqCst); }
 }
 
 #[cfg(feature = "diagnostics")]

--- a/crates/rstest-bdd/tests/dump_registry.rs
+++ b/crates/rstest-bdd/tests/dump_registry.rs
@@ -1,7 +1,12 @@
 //! Unit tests for registry dumping.
 
 use rstest_bdd::{
-    StepContext, StepExecution, StepKeyword, dump_registry, find_step, record_bypassed_steps,
+    StepContext,
+    StepExecution,
+    StepKeyword,
+    dump_registry,
+    find_step,
+    record_bypassed_steps,
     reporting::{self, ScenarioMetadata, ScenarioRecord, ScenarioStatus, SkippedScenario},
     step,
 };

--- a/crates/rstest-bdd/tests/e2e_scenario.rs
+++ b/crates/rstest-bdd/tests/e2e_scenario.rs
@@ -4,14 +4,10 @@ use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 
 #[fixture]
-fn number() -> i32 {
-    21
-}
+fn number() -> i32 { 21 }
 
 #[fixture]
-fn multiplier() -> i32 {
-    2
-}
+fn multiplier() -> i32 { 2 }
 
 #[given("number is available")]
 fn check_number(number: i32) {

--- a/crates/rstest-bdd/tests/e2e_scenario.rs
+++ b/crates/rstest-bdd/tests/e2e_scenario.rs
@@ -3,9 +3,11 @@
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn number() -> i32 { 21 }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn multiplier() -> i32 { 2 }
 

--- a/crates/rstest-bdd/tests/execution_error.rs
+++ b/crates/rstest-bdd/tests/execution_error.rs
@@ -4,23 +4,22 @@ use std::sync::Arc;
 
 use i18n_embed::fluent::fluent_language_loader;
 use rstest::rstest;
-use rstest_bdd::execution::{ExecutionError, MissingFixtureDiagnostic, MissingFixturesDetails};
-use rstest_bdd::localization::{ScopedLocalization, strip_directional_isolates};
-use rstest_bdd::{Localizations, StepError, StepKeyword};
+use rstest_bdd::{
+    Localizations,
+    StepError,
+    StepKeyword,
+    execution::{ExecutionError, MissingFixtureDiagnostic, MissingFixturesDetails},
+    localization::{ScopedLocalization, strip_directional_isolates},
+};
 use unic_langid::{LanguageIdentifier, langid};
-
 /// Helper to create a Skip error without message.
-fn skip_without_message() -> ExecutionError {
-    ExecutionError::Skip { message: None }
-}
-
+fn skip_without_message() -> ExecutionError { ExecutionError::Skip { message: None } }
 /// Helper to create a Skip error with message.
 fn skip_with_message(msg: &str) -> ExecutionError {
     ExecutionError::Skip {
         message: Some(msg.into()),
     }
 }
-
 /// Helper to create a `StepNotFound` error.
 fn step_not_found() -> ExecutionError {
     ExecutionError::StepNotFound {
@@ -124,15 +123,20 @@ fn handler_failed() -> ExecutionError {
 )]
 #[case::step_not_found(
     step_not_found(),
-    "Step not found at index 3: Given a user named Alice (feature: features/auth.feature, scenario: User login)"
+    "Step not found at index 3: Given a user named Alice (feature: features/auth.feature, \
+     scenario: User login)"
 )]
 #[case::missing_fixtures(
     missing_fixtures(),
-    "Step 'a database connection' (defined at tests/steps.rs:42) requires fixtures db, cache, but the following are missing: db. Requested fixture information: db: DbPool. Available fixtures from scenario: cache, config  (feature: features/db.feature, scenario: Database query)"
+    "Step 'a database connection' (defined at tests/steps.rs:42) requires fixtures db, cache, but \
+     the following are missing: db. Requested fixture information: db: DbPool. Available fixtures \
+     from scenario: cache, config  (feature: features/db.feature, scenario: Database query)"
 )]
 #[case::handler_failed(
     handler_failed(),
-    "Step failed at index 1: When the user clicks submit - Error executing step 'the user clicks submit' via function 'click_submit': button not found (feature: features/form.feature, scenario: Form submission)"
+    "Step failed at index 1: When the user clicks submit - Error executing step 'the user clicks \
+     submit' via function 'click_submit': button not found (feature: features/form.feature, \
+     scenario: Form submission)"
 )]
 fn execution_error_display_uses_localized_messages_and_context(
     #[case] error: ExecutionError,

--- a/crates/rstest-bdd/tests/execution_fixtures_proptest.rs
+++ b/crates/rstest-bdd/tests/execution_fixtures_proptest.rs
@@ -3,8 +3,14 @@
 use std::sync::Arc;
 
 use proptest::prelude::*;
-use rstest_bdd::execution::{ExecutionError, StepExecutionRequest, execute_step};
-use rstest_bdd::{StepContext, StepError, StepExecution, StepKeyword, step};
+use rstest_bdd::{
+    StepContext,
+    StepError,
+    StepExecution,
+    StepKeyword,
+    execution::{ExecutionError, StepExecutionRequest, execute_step},
+    step,
+};
 
 const PROPERTY_STEP_TEXT: &str = "property missing fixture diagnostics";
 const FIXTURE_NAME_POOL: [&str; 12] = [

--- a/crates/rstest-bdd/tests/expr_syntax.rs
+++ b/crates/rstest-bdd/tests/expr_syntax.rs
@@ -2,10 +2,11 @@
 //!
 //! This syntax is provided for cucumber-rs migration compatibility.
 
+use std::cell::Cell;
+
 use rstest::rstest;
 use rstest_bdd::{Step, StepKeyword, iter};
 use rstest_bdd_macros::{given, scenario, then, when};
-use std::cell::Cell;
 
 thread_local! {
     static COUNTER: Cell<i32> = const { Cell::new(0) };
@@ -13,15 +14,11 @@ thread_local! {
 
 /// Step using `expr = "..."` syntax (cucumber-rs style).
 #[given(expr = "a counter initialized to zero")]
-fn counter_initialized() {
-    COUNTER.set(0);
-}
+fn counter_initialized() { COUNTER.set(0); }
 
 /// Step using `expr = "..."` syntax with placeholder.
 #[when(expr = "the counter is incremented by {amount}")]
-fn counter_incremented(amount: i32) {
-    COUNTER.set(COUNTER.get() + amount);
-}
+fn counter_incremented(amount: i32) { COUNTER.set(COUNTER.get() + amount); }
 
 /// Step using `expr = "..."` syntax for verification.
 #[then(expr = "the counter equals {expected}")]
@@ -57,6 +54,4 @@ type AliasResult<T> = Result<T, &'static str>;
     clippy::unnecessary_wraps,
     reason = "step intentionally returns a Result alias to exercise return-kind override"
 )]
-fn alias_result_with_expr_syntax() -> AliasResult<()> {
-    Ok(())
-}
+fn alias_result_with_expr_syntax() -> AliasResult<()> { Ok(()) }

--- a/crates/rstest-bdd/tests/fallible_scenario.rs
+++ b/crates/rstest-bdd/tests/fallible_scenario.rs
@@ -1,8 +1,10 @@
 //! Behavioural coverage for fallible scenario bodies.
 
 use rstest_bdd as bdd;
-use rstest_bdd::StepResult;
-use rstest_bdd::reporting::{ScenarioStatus, drain as drain_reports};
+use rstest_bdd::{
+    StepResult,
+    reporting::{ScenarioStatus, drain as drain_reports},
+};
 use rstest_bdd_macros::{given, scenario};
 use serial_test::serial;
 
@@ -22,9 +24,7 @@ fn fallible_scenario_is_skipped() {
     name = "fallible scenario success"
 )]
 #[serial]
-fn fallible_scenario_success() -> Result<(), &'static str> {
-    Ok(())
-}
+fn fallible_scenario_success() -> Result<(), &'static str> { Ok(()) }
 
 #[scenario(
     path = "tests/features/fallible_scenario.feature",
@@ -47,9 +47,7 @@ async fn fallible_async_helper() -> Result<(), &'static str> {
 )]
 #[serial]
 #[ignore = "exercised by fallible_error_does_not_record_pass"]
-fn fallible_scenario_error() -> Result<(), &'static str> {
-    Err("fallible scenario returned error")
-}
+fn fallible_scenario_error() -> Result<(), &'static str> { Err("fallible scenario returned error") }
 
 #[scenario(
     path = "tests/features/fallible_scenario.feature",

--- a/crates/rstest-bdd/tests/fixture_context.rs
+++ b/crates/rstest-bdd/tests/fixture_context.rs
@@ -1,8 +1,13 @@
 //! Behavioural test for fixture context injection
 
-use rstest_bdd::localization::{ScopedLocalization, strip_directional_isolates};
 use rstest_bdd::{
-    InsertOutcome, StepContext, StepError, StepKeyword, assert_step_err, assert_step_ok,
+    InsertOutcome,
+    StepContext,
+    StepError,
+    StepKeyword,
+    assert_step_err,
+    assert_step_ok,
+    localization::{ScopedLocalization, strip_directional_isolates},
     lookup_step,
 };
 use rstest_bdd_macros::given;

--- a/crates/rstest-bdd/tests/fixtures_macros/scenario_bulk_migration_cookbook.rs
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenario_bulk_migration_cookbook.rs
@@ -32,6 +32,7 @@ mod shared {
     }
 
     /// Fixture providing a fresh [`LedgerState`] per scenario.
+    #[rstest_bdd_test_macros::allow_fixture_expansion_lints]
     #[fixture]
     pub fn ledger_state() -> LedgerState {
         LedgerState::default()

--- a/crates/rstest-bdd/tests/fixtures_macros/scenarios_fixtures.rs
+++ b/crates/rstest-bdd/tests/fixtures_macros/scenarios_fixtures.rs
@@ -17,6 +17,7 @@ struct CounterWorld {
 }
 
 /// An rstest fixture that provides a counter world.
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn counter_world() -> RefCell<CounterWorld> {
     RefCell::new(CounterWorld::default())

--- a/crates/rstest-bdd/tests/i18n.rs
+++ b/crates/rstest-bdd/tests/i18n.rs
@@ -14,6 +14,7 @@ use running_total_helpers::{add_to_total, assert_total, assert_total_not, set_to
 /// Mutable accumulator shared by all multilingual scenarios.
 /// Using `RefCell` avoids borrowing conflicts between steps while keeping
 /// the fixture synchronous and lightweight.
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 // Keep the fixture body on one line per review feedback while avoiding
 // the `unused_braces` lint via an explicit `return` and preserving the

--- a/crates/rstest-bdd/tests/i18n.rs
+++ b/crates/rstest-bdd/tests/i18n.rs
@@ -5,11 +5,11 @@ mod running_total_helpers;
 use std::cell::RefCell;
 
 use rstest::fixture;
-use running_total_helpers::{add_to_total, assert_total, assert_total_not, set_total};
 // Import macros directly; re-exporting from `rstest_bdd` would create a
 // dependency cycle. Listing the macros crate in `[dev-dependencies]` keeps
 // the integration tests able to resolve these procedural macros.
 use rstest_bdd_macros::{given, scenario, then, when};
+use running_total_helpers::{add_to_total, assert_total, assert_total_not, set_total};
 
 /// Mutable accumulator shared by all multilingual scenarios.
 /// Using `RefCell` avoids borrowing conflicts between steps while keeping
@@ -22,9 +22,7 @@ use rstest_bdd_macros::{given, scenario, then, when};
 fn running_total() -> RefCell<i32> { return RefCell::new(0); }
 
 #[given("the starting value is {value:i32}")]
-fn starting_value(running_total: &RefCell<i32>, value: i32) {
-    set_total(running_total, value);
-}
+fn starting_value(running_total: &RefCell<i32>, value: i32) { set_total(running_total, value); }
 
 #[given("an additional value is {value:i32}")]
 fn additional_value(running_total: &RefCell<i32>, value: i32) {
@@ -32,14 +30,10 @@ fn additional_value(running_total: &RefCell<i32>, value: i32) {
 }
 
 #[when("I add {value:i32}")]
-fn add_value(running_total: &RefCell<i32>, value: i32) {
-    add_to_total(running_total, value);
-}
+fn add_value(running_total: &RefCell<i32>, value: i32) { add_to_total(running_total, value); }
 
 #[then("the total is {expected:i32}")]
-fn total_is(running_total: &RefCell<i32>, expected: i32) {
-    assert_total(running_total, expected);
-}
+fn total_is(running_total: &RefCell<i32>, expected: i32) { assert_total(running_total, expected); }
 
 #[then("the total is not {forbidden:i32}")]
 fn total_is_not(running_total: &RefCell<i32>, forbidden: i32) {

--- a/crates/rstest-bdd/tests/localization.rs
+++ b/crates/rstest-bdd/tests/localization.rs
@@ -1,11 +1,19 @@
 //! Behavioural coverage for localization helpers and diagnostics.
 
 use i18n_embed::fluent::fluent_language_loader;
-use rstest_bdd::localization::{
-    ScopedLocalization, current_languages, install_localization_loader, message, message_with_args,
-    select_localizations, strip_directional_isolates,
+use rstest_bdd::{
+    Localizations,
+    StepError,
+    localization::{
+        ScopedLocalization,
+        current_languages,
+        install_localization_loader,
+        message,
+        message_with_args,
+        select_localizations,
+        strip_directional_isolates,
+    },
 };
-use rstest_bdd::{Localizations, StepError};
 use serial_test::serial;
 use unic_langid::langid;
 

--- a/crates/rstest-bdd/tests/manual_async_scenario.rs
+++ b/crates/rstest-bdd/tests/manual_async_scenario.rs
@@ -19,9 +19,7 @@ fn manual_async_given() {
 }
 
 #[when("the manual async step continues")]
-fn manual_async_when() {
-    MANUAL_ASYNC_STATE.with(|s| s.borrow_mut().push_str(" -> when"));
-}
+fn manual_async_when() { MANUAL_ASYNC_STATE.with(|s| s.borrow_mut().push_str(" -> when")); }
 
 #[then("the manual async step completes")]
 fn manual_async_then() {

--- a/crates/rstest-bdd/tests/mutable_world_macro.rs
+++ b/crates/rstest-bdd/tests/mutable_world_macro.rs
@@ -32,19 +32,13 @@ mod macro_world {
     }
 
     #[fixture]
-    fn world() -> CounterWorld {
-        CounterWorld::default()
-    }
+    fn world() -> CounterWorld { CounterWorld::default() }
 
     #[given("the world starts at {value}")]
-    fn starts_at(world: &mut CounterWorld, value: usize) {
-        world.count = value;
-    }
+    fn starts_at(world: &mut CounterWorld, value: usize) { world.count = value; }
 
     #[when("the world increments")]
-    fn increments(world: &mut CounterWorld) {
-        world.count += 1;
-    }
+    fn increments(world: &mut CounterWorld) { world.count += 1; }
 
     #[then("the world equals {expected}")]
     fn equals(world: &CounterWorld, expected: usize) {

--- a/crates/rstest-bdd/tests/mutable_world_macro.rs
+++ b/crates/rstest-bdd/tests/mutable_world_macro.rs
@@ -31,6 +31,7 @@ mod macro_world {
         count: usize,
     }
 
+    #[rstest_bdd_test_macros::allow_fixture_expansion_lints]
     #[fixture]
     fn world() -> CounterWorld { CounterWorld::default() }
 

--- a/crates/rstest-bdd/tests/outline_placeholder.rs
+++ b/crates/rstest-bdd/tests/outline_placeholder.rs
@@ -3,9 +3,10 @@
 //! These tests verify that `<placeholder>` tokens in step text are substituted
 //! with values from the Examples table before step matching occurs.
 
+use std::sync::{LazyLock, Mutex, MutexGuard};
+
 use rstest_bdd_macros::{given, scenario, then, when};
 use serial_test::serial;
-use std::sync::{LazyLock, Mutex, MutexGuard};
 
 /// Tracks the current item count for arithmetic tests.
 static COUNT: LazyLock<Mutex<i32>> = LazyLock::new(|| Mutex::new(0));
@@ -30,21 +31,15 @@ fn add_count(value: i32) {
     *g += value;
 }
 
-fn get_count() -> i32 {
-    *get_count_guard()
-}
+fn get_count() -> i32 { *get_count_guard() }
 
 /// Step definition using `{n}` capture syntax to extract the substituted value.
 #[given("I have {n} items")]
-fn have_items(n: i32) {
-    set_count(n);
-}
+fn have_items(n: i32) { set_count(n); }
 
 /// Step definition using `{n}` capture syntax for the amount to add.
 #[when("I add {n} more items")]
-fn add_items(n: i32) {
-    add_count(n);
-}
+fn add_items(n: i32) { add_count(n); }
 
 /// Step definition that verifies the total matches the expected value.
 #[then("I should have {n} items")]

--- a/crates/rstest-bdd/tests/pattern_mismatch.rs
+++ b/crates/rstest-bdd/tests/pattern_mismatch.rs
@@ -8,9 +8,7 @@ use rstest_bdd_macros::given;
 static CAPTURED: AtomicU32 = AtomicU32::new(0);
 
 #[given("number {value:u32}")]
-fn number(value: u32) {
-    CAPTURED.store(value, Ordering::Relaxed);
-}
+fn number(value: u32) { CAPTURED.store(value, Ordering::Relaxed); }
 
 #[test]
 fn passes_captured_value() {

--- a/crates/rstest-bdd/tests/placeholder_parsing.rs
+++ b/crates/rstest-bdd/tests/placeholder_parsing.rs
@@ -1,8 +1,14 @@
 //! Tests for placeholder extraction logic.
 
 use rstest::rstest;
-use rstest_bdd::localization::{ScopedLocalization, strip_directional_isolates};
-use rstest_bdd::{PlaceholderError, StepPattern, StepPatternError, StepText, extract_placeholders};
+use rstest_bdd::{
+    PlaceholderError,
+    StepPattern,
+    StepPatternError,
+    StepText,
+    extract_placeholders,
+    localization::{ScopedLocalization, strip_directional_isolates},
+};
 use unic_langid::langid;
 
 mod support;
@@ -212,7 +218,8 @@ fn extraction_reports_invalid_placeholder_error() {
     assert!(matches!(err, PlaceholderError::InvalidPlaceholder(_)));
     assert_eq!(
         strip_directional_isolates(&err.to_string()),
-        "invalid placeholder syntax: invalid placeholder in step pattern at byte 6 (zero-based) for placeholder 'n'",
+        "invalid placeholder syntax: invalid placeholder in step pattern at byte 6 (zero-based) \
+         for placeholder 'n'",
     );
 }
 

--- a/crates/rstest-bdd/tests/registry_mark_used_props.rs
+++ b/crates/rstest-bdd/tests/registry_mark_used_props.rs
@@ -7,13 +7,23 @@
 //! `find_step_with_metadata`) against a pool of registered steps and asserts
 //! the invariant via `unused_steps`.
 
-use proptest::prelude::*;
 use std::collections::BTreeSet;
 
+use proptest::prelude::*;
 use rstest_bdd::{
-    StepContext, StepError, StepExecution, StepKeyword, find_step, find_step_async,
-    find_step_async_with_mode, find_step_with_metadata, lookup_step, lookup_step_async,
-    lookup_step_async_with_mode, step, unused_steps,
+    StepContext,
+    StepError,
+    StepExecution,
+    StepKeyword,
+    find_step,
+    find_step_async,
+    find_step_async_with_mode,
+    find_step_with_metadata,
+    lookup_step,
+    lookup_step_async,
+    lookup_step_async_with_mode,
+    step,
+    unused_steps,
 };
 
 #[expect(

--- a/crates/rstest-bdd/tests/result_fixture.rs
+++ b/crates/rstest-bdd/tests/result_fixture.rs
@@ -29,10 +29,12 @@ impl ResultWorld {
 }
 
 /// Fixture that returns `Result<ResultWorld, String>`.
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn world() -> Result<ResultWorld, String> { ResultWorld::try_new() }
 
 /// Fixture that always fails, for testing error propagation.
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn failing_world() -> Result<ResultWorld, String> { ResultWorld::try_new_failing() }
 
@@ -128,10 +130,12 @@ fn result_fixture_error_propagates() {
 // -- StepResult<T, E> fixture tests ---
 
 /// Fixture that returns `StepResult<ResultWorld, String>`.
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn step_result_world() -> StepResult<ResultWorld, String> { ResultWorld::try_new() }
 
 /// Fixture that always fails, for testing `StepResult` error propagation.
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn failing_step_result_world() -> StepResult<ResultWorld, String> {
     Err("step-result fixture initialization failed".to_owned())

--- a/crates/rstest-bdd/tests/result_fixture.rs
+++ b/crates/rstest-bdd/tests/result_fixture.rs
@@ -5,8 +5,10 @@
 //! and inject the inner `T` into step functions via `StepContext`.
 
 use rstest::fixture;
-use rstest_bdd::StepResult;
-use rstest_bdd::reporting::{ScenarioStatus, drain as drain_reports};
+use rstest_bdd::{
+    StepResult,
+    reporting::{ScenarioStatus, drain as drain_reports},
+};
 use rstest_bdd_macros::{given, scenario, then, when};
 use serial_test::serial;
 
@@ -21,26 +23,18 @@ impl ResultWorld {
         clippy::unnecessary_wraps,
         reason = "returns Result to exercise the Result-unwrapping fixture codegen path"
     )]
-    fn try_new() -> Result<Self, String> {
-        Ok(Self { value: 42 })
-    }
+    fn try_new() -> Result<Self, String> { Ok(Self { value: 42 }) }
 
-    fn try_new_failing() -> Result<Self, String> {
-        Err("fixture initialization failed".to_owned())
-    }
+    fn try_new_failing() -> Result<Self, String> { Err("fixture initialization failed".to_owned()) }
 }
 
 /// Fixture that returns `Result<ResultWorld, String>`.
 #[fixture]
-fn world() -> Result<ResultWorld, String> {
-    ResultWorld::try_new()
-}
+fn world() -> Result<ResultWorld, String> { ResultWorld::try_new() }
 
 /// Fixture that always fails, for testing error propagation.
 #[fixture]
-fn failing_world() -> Result<ResultWorld, String> {
-    ResultWorld::try_new_failing()
-}
+fn failing_world() -> Result<ResultWorld, String> { ResultWorld::try_new_failing() }
 
 #[given("a world initialized from a Result fixture")]
 fn given_world(world: &ResultWorld) {
@@ -48,9 +42,7 @@ fn given_world(world: &ResultWorld) {
 }
 
 #[when("the world is mutated")]
-fn when_mutated(world: &mut ResultWorld) {
-    world.value += 1;
-}
+fn when_mutated(world: &mut ResultWorld) { world.value += 1; }
 
 #[then("the world reflects the mutation")]
 fn then_mutated(world: &ResultWorld) {
@@ -62,9 +54,7 @@ fn then_mutated(world: &ResultWorld) {
     name = "successful fixture initialization"
 )]
 #[serial]
-fn result_fixture_success(world: Result<ResultWorld, String>) -> Result<(), String> {
-    Ok(())
-}
+fn result_fixture_success(world: Result<ResultWorld, String>) -> Result<(), String> { Ok(()) }
 
 #[scenario(
     path = "tests/features/result_fixture.feature",
@@ -139,9 +129,7 @@ fn result_fixture_error_propagates() {
 
 /// Fixture that returns `StepResult<ResultWorld, String>`.
 #[fixture]
-fn step_result_world() -> StepResult<ResultWorld, String> {
-    ResultWorld::try_new()
-}
+fn step_result_world() -> StepResult<ResultWorld, String> { ResultWorld::try_new() }
 
 /// Fixture that always fails, for testing `StepResult` error propagation.
 #[fixture]
@@ -158,9 +146,7 @@ fn given_step_result_world(step_result_world: &ResultWorld) {
 }
 
 #[when("the StepResult world is mutated")]
-fn when_step_result_mutated(step_result_world: &mut ResultWorld) {
-    step_result_world.value += 10;
-}
+fn when_step_result_mutated(step_result_world: &mut ResultWorld) { step_result_world.value += 10; }
 
 #[then("the StepResult world reflects the mutation")]
 fn then_step_result_mutated(step_result_world: &ResultWorld) {

--- a/crates/rstest-bdd/tests/scenario.rs
+++ b/crates/rstest-bdd/tests/scenario.rs
@@ -1,9 +1,10 @@
 //! Behavioural tests covering the `#[scenario]` macro
 
+use std::sync::{LazyLock, Mutex, MutexGuard};
+
 use rstest::rstest;
 use rstest_bdd_macros::{given, scenario, then, when};
 use serial_test::serial;
-use std::sync::{LazyLock, Mutex, MutexGuard};
 
 static EVENTS: LazyLock<Mutex<Vec<&'static str>>> = LazyLock::new(|| Mutex::new(Vec::new()));
 
@@ -38,14 +39,10 @@ where
 }
 
 #[given("a background step")]
-fn background_step() {
-    with_locked_events(|events| events.push("background"));
-}
+fn background_step() { with_locked_events(|events| events.push("background")); }
 
 #[given("another background step")]
-fn another_background_step() {
-    with_locked_events(|events| events.push("another background"));
-}
+fn another_background_step() { with_locked_events(|events| events.push("another background")); }
 
 #[given("a precondition")]
 fn precondition() {
@@ -54,14 +51,10 @@ fn precondition() {
 }
 
 #[when("an action occurs")]
-fn action() {
-    with_locked_events(|events| events.push("action"));
-}
+fn action() { with_locked_events(|events| events.push("action")); }
 
 #[then("a result is produced")]
-fn result() {
-    with_locked_events(|events| events.push("result"));
-}
+fn result() { with_locked_events(|events| events.push("result")); }
 
 #[scenario("tests/features/web_search.feature")]
 #[serial]

--- a/crates/rstest-bdd/tests/scenario_harness.rs
+++ b/crates/rstest-bdd/tests/scenario_harness.rs
@@ -1,15 +1,27 @@
 //! Behavioural tests verifying that `#[scenario]` accepts the `harness` and
 //! `attributes` parameters and delegates execution through the harness adapter.
 
+use std::{
+    panic::{AssertUnwindSafe, catch_unwind},
+    sync::{
+        LazyLock,
+        Mutex,
+        MutexGuard,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+};
+
 use rstest_bdd_harness::{
-    FailingHarness, HarnessAdapter, HarnessError, ScenarioMetadata, ScenarioRunRequest,
-    StdScenarioRunRequest, StdScenarioRunner,
+    FailingHarness,
+    HarnessAdapter,
+    HarnessError,
+    ScenarioMetadata,
+    ScenarioRunRequest,
+    StdScenarioRunRequest,
+    StdScenarioRunner,
 };
 use rstest_bdd_macros::{given, scenario, then, when};
 use serial_test::serial;
-use std::panic::{AssertUnwindSafe, catch_unwind};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{LazyLock, Mutex, MutexGuard};
 
 static EVENTS: LazyLock<Mutex<Vec<&'static str>>> = LazyLock::new(|| Mutex::new(Vec::new()));
 
@@ -48,32 +60,24 @@ fn precondition() {
 }
 
 #[when("an action occurs")]
-fn action() {
-    with_locked_events(|events| events.push("action"));
-}
+fn action() { with_locked_events(|events| events.push("action")); }
 
 #[then("a result is produced")]
-fn result() {
-    with_locked_events(|events| events.push("result"));
-}
+fn result() { with_locked_events(|events| events.push("result")); }
 
 #[scenario(
     path = "tests/features/web_search.feature",
     harness = rstest_bdd_harness::StdHarness,
 )]
 #[serial]
-fn scenario_with_harness() {
-    assert_and_clear_events();
-}
+fn scenario_with_harness() { assert_and_clear_events(); }
 
 #[scenario(
     path = "tests/features/web_search.feature",
     attributes = rstest_bdd_harness::DefaultAttributePolicy,
 )]
 #[serial]
-fn scenario_with_attributes() {
-    assert_and_clear_events();
-}
+fn scenario_with_attributes() { assert_and_clear_events(); }
 
 #[scenario(
     path = "tests/features/web_search.feature",
@@ -81,9 +85,7 @@ fn scenario_with_attributes() {
     attributes = rstest_bdd_harness::DefaultAttributePolicy,
 )]
 #[serial]
-fn scenario_with_harness_and_attributes() {
-    assert_and_clear_events();
-}
+fn scenario_with_harness_and_attributes() { assert_and_clear_events(); }
 
 // ---------------------------------------------------------------------------
 // Custom harness tests verifying that execution is actually delegated

--- a/crates/rstest-bdd/tests/scenario_state.rs
+++ b/crates/rstest-bdd/tests/scenario_state.rs
@@ -1,8 +1,7 @@
 //! Behaviour tests for scenario state slots and reset semantics.
 
 use rstest::fixture;
-use rstest_bdd::ScenarioState as _;
-use rstest_bdd::Slot;
+use rstest_bdd::{ScenarioState as _, Slot};
 use rstest_bdd_macros::{ScenarioState, given, scenario, then, when};
 
 #[derive(Default, ScenarioState)]
@@ -11,9 +10,7 @@ struct CartState {
 }
 
 #[fixture]
-fn cart_state() -> CartState {
-    CartState::default()
-}
+fn cart_state() -> CartState { CartState::default() }
 
 #[given("an empty cart state")]
 fn empty_state(cart_state: &CartState) {
@@ -27,9 +24,7 @@ fn record_value(cart_state: &CartState, value: i32) {
 }
 
 #[when("I clear the cart state")]
-fn clear_state(cart_state: &CartState) {
-    cart_state.reset();
-}
+fn clear_state(cart_state: &CartState) { cart_state.reset(); }
 
 #[then("the recorded value is {expected:i32}")]
 fn check_value(cart_state: &CartState, expected: i32) {

--- a/crates/rstest-bdd/tests/scenario_state.rs
+++ b/crates/rstest-bdd/tests/scenario_state.rs
@@ -9,6 +9,7 @@ struct CartState {
     total: Slot<i32>,
 }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn cart_state() -> CartState { CartState::default() }
 

--- a/crates/rstest-bdd/tests/scenarios_macro.rs
+++ b/crates/rstest-bdd/tests/scenarios_macro.rs
@@ -9,9 +9,7 @@ fn precondition() {}
 fn action() {}
 
 #[when("an action occurs with {n}")]
-fn action_with_num(n: i32) {
-    let _ = n;
-}
+fn action_with_num(n: i32) { let _ = n; }
 
 #[then("events are recorded")]
 fn events_recorded() {}

--- a/crates/rstest-bdd/tests/skip.rs
+++ b/crates/rstest-bdd/tests/skip.rs
@@ -41,9 +41,11 @@ impl Drop for FailOnSkippedGuard {
     fn drop(&mut self) { bdd::config::clear_fail_on_skipped_override(); }
 }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn fail_on_enabled() -> FailOnSkippedGuard { FailOnSkippedGuard::enable() }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn fail_on_disabled() -> FailOnSkippedGuard { FailOnSkippedGuard::disable() }
 

--- a/crates/rstest-bdd/tests/skip.rs
+++ b/crates/rstest-bdd/tests/skip.rs
@@ -2,21 +2,23 @@
 
 use std::path::Path;
 
-use rstest::fixture;
-use rstest_bdd as bdd;
-use rstest_bdd::assert_scenario_skipped;
-use rstest_bdd_macros::{given, scenario, then};
-use serial_test::serial;
-
 #[cfg(feature = "diagnostics")]
 use bdd::reporting;
 #[cfg(feature = "diagnostics")]
 use bdd::reporting::{
-    ScenarioMetadata, ScenarioRecord, SkippedScenario, record as record_scenario,
+    ScenarioMetadata,
+    ScenarioRecord,
+    SkippedScenario,
+    record as record_scenario,
 };
 use bdd::reporting::{ScenarioStatus, drain as drain_reports};
+use rstest::fixture;
+use rstest_bdd as bdd;
+use rstest_bdd::assert_scenario_skipped;
+use rstest_bdd_macros::{given, scenario, then};
 #[cfg(feature = "diagnostics")]
 use serde_json::Value;
+use serial_test::serial;
 
 #[must_use]
 struct FailOnSkippedGuard;
@@ -36,20 +38,14 @@ impl FailOnSkippedGuard {
 impl Drop for FailOnSkippedGuard {
     // Clearing the override re-exposes the RSTEST_BDD_FAIL_ON_SKIPPED variable.
     // Tests using this guard must be marked #[serial] to avoid races.
-    fn drop(&mut self) {
-        bdd::config::clear_fail_on_skipped_override();
-    }
+    fn drop(&mut self) { bdd::config::clear_fail_on_skipped_override(); }
 }
 
 #[fixture]
-fn fail_on_enabled() -> FailOnSkippedGuard {
-    FailOnSkippedGuard::enable()
-}
+fn fail_on_enabled() -> FailOnSkippedGuard { FailOnSkippedGuard::enable() }
 
 #[fixture]
-fn fail_on_disabled() -> FailOnSkippedGuard {
-    FailOnSkippedGuard::disable()
-}
+fn fail_on_disabled() -> FailOnSkippedGuard { FailOnSkippedGuard::disable() }
 
 fn assert_feature_path_suffix(actual: &str, expected_suffix: &str) {
     let actual_path = Path::new(actual);

--- a/crates/rstest-bdd/tests/step_definition_matching.rs
+++ b/crates/rstest-bdd/tests/step_definition_matching.rs
@@ -18,9 +18,7 @@ fn generic_step(item: String) {
 }
 
 #[given("overlap apples")]
-fn specific_step() {
-    SPECIFIC_CALLED.fetch_add(1, Ordering::Relaxed);
-}
+fn specific_step() { SPECIFIC_CALLED.fetch_add(1, Ordering::Relaxed); }
 
 #[test]
 fn find_step_returns_none_for_missing() {

--- a/crates/rstest-bdd/tests/step_error.rs
+++ b/crates/rstest-bdd/tests/step_error.rs
@@ -2,8 +2,11 @@
 
 use i18n_embed::fluent::fluent_language_loader;
 use rstest::rstest;
-use rstest_bdd::localization::{ScopedLocalization, strip_directional_isolates};
-use rstest_bdd::{Localizations, StepError};
+use rstest_bdd::{
+    Localizations,
+    StepError,
+    localization::{ScopedLocalization, strip_directional_isolates},
+};
 use unic_langid::{LanguageIdentifier, langid};
 
 #[rstest]

--- a/crates/rstest-bdd/tests/step_error_behaviour.rs
+++ b/crates/rstest-bdd/tests/step_error_behaviour.rs
@@ -4,7 +4,6 @@ mod step_error_common;
 
 use rstest::rstest;
 use rstest_bdd::{StepExecution, StepKeyword};
-
 use step_error_common::{FancyValue, StepInvocation, invoke_step};
 
 #[test]

--- a/crates/rstest-bdd/tests/step_error_common.rs
+++ b/crates/rstest-bdd/tests/step_error_common.rs
@@ -1,17 +1,16 @@
 //! Shared helpers for step error behavioural tests.
 
+use std::fmt;
+
 use rstest_bdd::{StepContext, StepError, StepExecution, StepKeyword};
 use rstest_bdd_macros::{given, then, when};
-use std::fmt;
 
 /// Simulate a step function that returns an execution failure.
 ///
 /// # Errors
 /// Always returns an error describing the failure.
 #[given("a failing step")]
-pub fn failing_step() -> Result<(), String> {
-    Err("boom".into())
-}
+pub fn failing_step() -> Result<(), String> { Err("boom".into()) }
 
 /// Simulate a step function that panics instead of returning an error.
 ///
@@ -21,9 +20,7 @@ pub fn failing_step() -> Result<(), String> {
 /// # Errors
 /// This function never returns an error because it panics.
 #[given("a panicking step")]
-pub fn panicking_step() -> Result<(), String> {
-    panic!("kaboom")
-}
+pub fn panicking_step() -> Result<(), String> { panic!("kaboom") }
 
 /// Simulate a panic that carries a non-string payload.
 ///
@@ -33,9 +30,7 @@ pub fn panicking_step() -> Result<(), String> {
 /// # Errors
 /// This function never returns an error because it panics.
 #[given("a non-string panicking step")]
-pub fn non_string_panicking_step() -> Result<(), String> {
-    std::panic::panic_any(123_i32)
-}
+pub fn non_string_panicking_step() -> Result<(), String> { std::panic::panic_any(123_i32) }
 
 /// Trivial step that succeeds without returning data.
 #[given("a successful step")]
@@ -46,18 +41,14 @@ pub fn successful_step() {}
 /// # Errors
 /// Always returns an error describing the failure.
 #[when("a failing when step")]
-pub fn failing_when_step() -> Result<(), String> {
-    Err("when boom".into())
-}
+pub fn failing_when_step() -> Result<(), String> { Err("when boom".into()) }
 
 /// Simulate a failing `then` step.
 ///
 /// # Errors
 /// Always returns an error describing the failure.
 #[then("a failing then step")]
-pub fn failing_then_step() -> Result<(), String> {
-    Err("then boom".into())
-}
+pub fn failing_then_step() -> Result<(), String> { Err("then boom".into()) }
 
 /// Convenience alias for steps that intentionally use a `Result`.
 pub type StepResult<T> = Result<T, &'static str>;
@@ -87,9 +78,7 @@ pub struct FancyValue(pub u16);
 pub struct FancyError(pub &'static str);
 
 impl fmt::Display for FancyError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.0)
-    }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { f.write_str(self.0) }
 }
 
 /// Step that surfaces an alias error to exercise step wrapper normalization.
@@ -97,9 +86,7 @@ impl fmt::Display for FancyError {
 /// # Errors
 /// Always returns an error describing the failure.
 #[given("an alias error step", result)]
-pub fn alias_error_step() -> StepResult<()> {
-    Err("alias boom")
-}
+pub fn alias_error_step() -> StepResult<()> { Err("alias boom") }
 
 /// Step that succeeds while returning a `Result` payload.
 ///
@@ -151,15 +138,11 @@ pub fn fallible_value_step_fails() -> Result<FancyValue, FancyError> {
 
 /// Step that consumes an incoming data table.
 #[given("a step requiring a table")]
-pub fn step_needing_table(datatable: Vec<Vec<String>>) {
-    let _ = datatable;
-}
+pub fn step_needing_table(datatable: Vec<Vec<String>>) { let _ = datatable; }
 
 /// Step that consumes an incoming docstring.
 #[given("a step requiring a docstring")]
-pub fn step_needing_docstring(docstring: String) {
-    let _ = docstring;
-}
+pub fn step_needing_docstring(docstring: String) { let _ = docstring; }
 
 /// Step implementation that raises a skip request during execution.
 ///
@@ -189,9 +172,7 @@ pub fn skip_request_step() {
 /// }
 /// ```
 #[given("number {value}")]
-pub fn parse_number(value: u32) {
-    let _ = value;
-}
+pub fn parse_number(value: u32) { let _ = value; }
 
 /// Step definition deliberately ignoring its captured argument to test errors.
 ///
@@ -205,9 +186,7 @@ pub fn parse_number(value: u32) {
 /// }
 /// ```
 #[given("no placeholders")]
-pub fn missing_capture(value: u32) {
-    let _ = value;
-}
+pub fn missing_capture(value: u32) { let _ = value; }
 
 /// In-memory description of a step invocation used by the behavioural tests.
 ///

--- a/crates/rstest-bdd/tests/step_error_keywords.rs
+++ b/crates/rstest-bdd/tests/step_error_keywords.rs
@@ -1,10 +1,10 @@
-//! Keyword-focused step-error scenarios exercising the `ExecutionError`, `PanicError`, and `MissingFixture` variants.
+//! Keyword-focused step-error scenarios exercising the `ExecutionError`, `PanicError`, and
+//! `MissingFixture` variants.
 
 mod step_error_common;
 
 use rstest::rstest;
 use rstest_bdd::{StepError, StepKeyword};
-
 use step_error_common::{StepInvocation, invoke_step};
 
 fn assert_step_error(
@@ -53,7 +53,8 @@ fn assert_step_error(
             assert_eq!(step, expected_step);
         }
         (other_actual, other_expected) => panic!(
-            "unexpected error for {step_pattern}: got {other_actual:?}, expected {other_expected:?}"
+            "unexpected error for {step_pattern}: got {other_actual:?}, expected \
+             {other_expected:?}"
         ),
     }
 }

--- a/crates/rstest-bdd/tests/step_execution_error.rs
+++ b/crates/rstest-bdd/tests/step_execution_error.rs
@@ -7,10 +7,10 @@
 //!
 //! # Error Types Tested
 //!
-//! - [`HandlerFailed`](rstest_bdd::execution::ExecutionError::HandlerFailed):
-//!   Step handler returns an error (e.g., `Err("message")`)
-//! - [`MissingFixtures`](rstest_bdd::execution::ExecutionError::MissingFixtures):
-//!   Step requires fixtures not available in the scenario context
+//! - [`HandlerFailed`](rstest_bdd::execution::ExecutionError::HandlerFailed): Step handler returns
+//!   an error (e.g., `Err("message")`)
+//! - [`MissingFixtures`](rstest_bdd::execution::ExecutionError::MissingFixtures): Step requires
+//!   fixtures not available in the scenario context
 //!
 //! # Note on `StepNotFound`
 //!

--- a/crates/rstest-bdd/tests/step_registry/execute_step_tests.rs
+++ b/crates/rstest-bdd/tests/step_registry/execute_step_tests.rs
@@ -31,6 +31,7 @@ fn make_request(index: usize, keyword: StepKeyword, text: &str) -> StepExecution
 }
 
 /// Shared fixture providing a default `StepContext` for test injection.
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn ctx() -> StepContext<'static> { StepContext::default() }
 

--- a/crates/rstest-bdd/tests/step_registry/execute_step_tests.rs
+++ b/crates/rstest-bdd/tests/step_registry/execute_step_tests.rs
@@ -1,8 +1,12 @@
 //! Behavioural tests for `execute_step` function.
 
 use rstest::{fixture, rstest};
-use rstest_bdd::execution::{ExecutionError, StepExecutionRequest, execute_step};
-use rstest_bdd::{RSTEST_BDD_HARNESS_CONTEXT_FIXTURE, StepContext, StepKeyword};
+use rstest_bdd::{
+    RSTEST_BDD_HARNESS_CONTEXT_FIXTURE,
+    StepContext,
+    StepKeyword,
+    execution::{ExecutionError, StepExecutionRequest, execute_step},
+};
 
 /// Helper enum to represent expected error types for parameterized testing.
 enum ExpectedExecutionError {
@@ -28,9 +32,7 @@ fn make_request(index: usize, keyword: StepKeyword, text: &str) -> StepExecution
 
 /// Shared fixture providing a default `StepContext` for test injection.
 #[fixture]
-fn ctx() -> StepContext<'static> {
-    StepContext::default()
-}
+fn ctx() -> StepContext<'static> { StepContext::default() }
 
 #[rstest]
 fn execute_step_succeeds_without_value(mut ctx: StepContext<'static>) {

--- a/crates/rstest-bdd/tests/step_registry/main.rs
+++ b/crates/rstest-bdd/tests/step_registry/main.rs
@@ -1,10 +1,17 @@
 //! Behavioural test for step registry.
 
 use rstest::rstest;
-use rstest_bdd::localization::{ScopedLocalization, strip_directional_isolates};
 use rstest_bdd::{
-    Step, StepContext, StepError, StepExecution, StepKeyword, StepText, find_step_with_metadata,
-    iter, unused_steps,
+    Step,
+    StepContext,
+    StepError,
+    StepExecution,
+    StepKeyword,
+    StepText,
+    find_step_with_metadata,
+    iter,
+    localization::{ScopedLocalization, strip_directional_isolates},
+    unused_steps,
 };
 use unic_langid::langid;
 

--- a/crates/rstest-bdd/tests/step_registry/wrappers.rs
+++ b/crates/rstest-bdd/tests/step_registry/wrappers.rs
@@ -7,9 +7,19 @@
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use rstest_bdd::{
-    FixtureRequirement, RSTEST_BDD_HARNESS_CONTEXT_FIXTURE, StepContext, StepError, StepExecution,
-    StepExecutionMode, StepFixtureRequirements, StepFuture, StepKeyword, StepPattern,
-    panic_message, step, submit,
+    FixtureRequirement,
+    RSTEST_BDD_HARNESS_CONTEXT_FIXTURE,
+    StepContext,
+    StepError,
+    StepExecution,
+    StepExecutionMode,
+    StepFixtureRequirements,
+    StepFuture,
+    StepKeyword,
+    StepPattern,
+    panic_message,
+    step,
+    submit,
 };
 
 use super::async_wrapper::{StepInvocationParams, wrap_sync_step_as_async};

--- a/crates/rstest-bdd/tests/step_return.rs
+++ b/crates/rstest-bdd/tests/step_return.rs
@@ -14,9 +14,7 @@ struct PrimaryValue(i32);
 struct SecondaryValue(i32);
 
 #[fixture]
-fn number() -> Number {
-    Number(1)
-}
+fn number() -> Number { Number(1) }
 
 #[given("base number is 1")]
 fn base(number: Number) {
@@ -24,9 +22,7 @@ fn base(number: Number) {
 }
 
 #[when("it is incremented")]
-fn increment(number: Number) -> Number {
-    Number(number.0 + 1)
-}
+fn increment(number: Number) -> Number { Number(number.0 + 1) }
 
 #[when("a fallible unit step succeeds")]
 #[expect(
@@ -138,24 +134,16 @@ fn fallible_result_fails() -> Result<(), &'static str> {
 }
 
 #[scenario(path = "tests/features/step_return.feature")]
-fn scenario_step_return(number: Number) {
-    let _ = number;
-}
+fn scenario_step_return(number: Number) { let _ = number; }
 
 #[fixture]
-fn primary_value() -> PrimaryValue {
-    PrimaryValue(10)
-}
+fn primary_value() -> PrimaryValue { PrimaryValue(10) }
 
 #[fixture]
-fn competing_primary_value() -> PrimaryValue {
-    PrimaryValue(15)
-}
+fn competing_primary_value() -> PrimaryValue { PrimaryValue(15) }
 
 #[fixture]
-fn secondary_value() -> SecondaryValue {
-    SecondaryValue(20)
-}
+fn secondary_value() -> SecondaryValue { SecondaryValue(20) }
 
 #[given("two competing fixtures")]
 fn two_competing(
@@ -200,60 +188,38 @@ fn scenario_step_return_ambiguous(
 }
 
 #[scenario(path = "tests/features/step_return_fallible_unit.feature")]
-fn scenario_fallible_unit(number: Number) {
-    let _ = number;
-}
+fn scenario_fallible_unit(number: Number) { let _ = number; }
 
 #[scenario(path = "tests/features/step_return_fallible_result_success.feature")]
-fn scenario_fallible_result_success(number: Number) {
-    let _ = number;
-}
+fn scenario_fallible_result_success(number: Number) { let _ = number; }
 
 #[scenario(path = "tests/features/step_return_fallible_result_failure.feature")]
 #[should_panic(expected = "value failure")]
-fn scenario_fallible_result_failure(number: Number) {
-    let _ = number;
-}
+fn scenario_fallible_result_failure(number: Number) { let _ = number; }
 
 #[scenario(path = "tests/features/step_return_std_result.feature")]
-fn scenario_std_result(number: Number) {
-    let _ = number;
-}
+fn scenario_std_result(number: Number) { let _ = number; }
 
 #[scenario(path = "tests/features/step_return_core_result.feature")]
-fn scenario_core_result(number: Number) {
-    let _ = number;
-}
+fn scenario_core_result(number: Number) { let _ = number; }
 
 #[scenario(path = "tests/features/step_return_core_result_failure.feature")]
 #[should_panic(expected = "core failure")]
-fn scenario_core_result_failure(number: Number) {
-    let _ = number;
-}
+fn scenario_core_result_failure(number: Number) { let _ = number; }
 
 #[scenario(path = "tests/features/step_return_stepresult.feature")]
-fn scenario_stepresult(number: Number) {
-    let _ = number;
-}
+fn scenario_stepresult(number: Number) { let _ = number; }
 
 #[scenario(path = "tests/features/step_return_stepresult_failure.feature")]
 #[should_panic(expected = "stepresult failure")]
-fn scenario_stepresult_failure(number: Number) {
-    let _ = number;
-}
+fn scenario_stepresult_failure(number: Number) { let _ = number; }
 
 #[scenario(path = "tests/features/step_return_value_override.feature")]
-fn scenario_value_override(number: Number) {
-    let _ = number;
-}
+fn scenario_value_override(number: Number) { let _ = number; }
 
 #[scenario(path = "tests/features/step_return_alias_override_success.feature")]
-fn scenario_alias_override_success(number: Number) {
-    let _ = number;
-}
+fn scenario_alias_override_success(number: Number) { let _ = number; }
 
 #[scenario(path = "tests/features/step_return_alias_override.feature")]
 #[should_panic(expected = "alias failure")]
-fn scenario_alias_override_failure(number: Number) {
-    let _ = number;
-}
+fn scenario_alias_override_failure(number: Number) { let _ = number; }

--- a/crates/rstest-bdd/tests/step_return.rs
+++ b/crates/rstest-bdd/tests/step_return.rs
@@ -13,6 +13,7 @@ struct PrimaryValue(i32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct SecondaryValue(i32);
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn number() -> Number { Number(1) }
 
@@ -136,12 +137,15 @@ fn fallible_result_fails() -> Result<(), &'static str> {
 #[scenario(path = "tests/features/step_return.feature")]
 fn scenario_step_return(number: Number) { let _ = number; }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn primary_value() -> PrimaryValue { PrimaryValue(10) }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn competing_primary_value() -> PrimaryValue { PrimaryValue(15) }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn secondary_value() -> SecondaryValue { SecondaryValue(20) }
 

--- a/crates/rstest-bdd/tests/string_hint.rs
+++ b/crates/rstest-bdd/tests/string_hint.rs
@@ -8,6 +8,7 @@ use std::cell::RefCell;
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then};
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn message() -> RefCell<String> { RefCell::new(String::new()) }
 

--- a/crates/rstest-bdd/tests/string_hint.rs
+++ b/crates/rstest-bdd/tests/string_hint.rs
@@ -3,14 +3,13 @@
 //! These tests verify that the complete code-generation pipeline correctly
 //! handles the :string type hint, including quote stripping at runtime.
 
-use rstest::fixture;
-use rstest_bdd_macros::{given, scenario, then};
 use std::cell::RefCell;
 
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenario, then};
+
 #[fixture]
-fn message() -> RefCell<String> {
-    RefCell::new(String::new())
-}
+fn message() -> RefCell<String> { RefCell::new(String::new()) }
 
 /// Step that captures a quoted string and strips the quotes.
 #[given("the message is {text:string}")]

--- a/crates/rstest-bdd/tests/struct_step_args.rs
+++ b/crates/rstest-bdd/tests/struct_step_args.rs
@@ -28,9 +28,11 @@ struct ProductState {
     product: Slot<ProductInput>,
 }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn cart_state() -> CartState { CartState::default() }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn product_state() -> ProductState { ProductState::default() }
 

--- a/crates/rstest-bdd/tests/struct_step_args.rs
+++ b/crates/rstest-bdd/tests/struct_step_args.rs
@@ -29,14 +29,10 @@ struct ProductState {
 }
 
 #[fixture]
-fn cart_state() -> CartState {
-    CartState::default()
-}
+fn cart_state() -> CartState { CartState::default() }
 
 #[fixture]
-fn product_state() -> ProductState {
-    ProductState::default()
-}
+fn product_state() -> ProductState { ProductState::default() }
 
 #[given("a cart containing {quantity:u32} {item} at ${price:f32}")]
 fn a_cart_with_items(#[step_args] details: CartInput, cart_state: &CartState) {

--- a/crates/rstest-bdd/tests/support/mod.rs
+++ b/crates/rstest-bdd/tests/support/mod.rs
@@ -7,9 +7,8 @@ use rstest_bdd::{PlaceholderSyntaxError, StepPattern, StepPatternError};
 /// # Example
 ///
 /// ```no_run
+/// use rstest_bdd::{StepText, extract_placeholders};
 /// use support::compiled;
-/// use rstest_bdd::StepText;
-/// use rstest_bdd::extract_placeholders;
 ///
 /// let pat = compiled("value {n:u32}");
 /// let caps = extract_placeholders(&pat, StepText::from("value 42"));

--- a/crates/rstest-bdd/tests/third_party_harness_cookbook.rs
+++ b/crates/rstest-bdd/tests/third_party_harness_cookbook.rs
@@ -4,12 +4,17 @@
 //! integration test executes the same contract through `#[scenario]`, proving
 //! the harness and steps run end-to-end.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use rstest_bdd_harness::{
-    AttributePolicy, HarnessAdapter, HarnessResult, ScenarioRunRequest, TestAttribute,
+    AttributePolicy,
+    HarnessAdapter,
+    HarnessResult,
+    ScenarioRunRequest,
+    TestAttribute,
 };
 use rstest_bdd_macros::{given, scenario, then, when};
 use serial_test::serial;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 static HARNESS_RAN: AtomicBool = AtomicBool::new(false);
 static GIVEN_SAW_EMPTY_WORLD: AtomicBool = AtomicBool::new(false);
@@ -23,9 +28,7 @@ pub struct World {
 }
 
 impl World {
-    fn spawn_empty(&mut self) {
-        self.entities += 1;
-    }
+    fn spawn_empty(&mut self) { self.entities += 1; }
 }
 
 /// Harness adapter shaped like a public third-party Bevy integration export.
@@ -48,9 +51,7 @@ pub struct BevyAttributePolicy;
 const BEVY_TEST_ATTRIBUTES: [TestAttribute; 1] = [TestAttribute::new("rstest::rstest")];
 
 impl AttributePolicy for BevyAttributePolicy {
-    fn test_attributes() -> &'static [TestAttribute] {
-        &BEVY_TEST_ATTRIBUTES
-    }
+    fn test_attributes() -> &'static [TestAttribute] { &BEVY_TEST_ATTRIBUTES }
 }
 
 fn reset_observations() {

--- a/crates/rstest-bdd/tests/trybuild_macros.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros.rs
@@ -6,16 +6,22 @@
 //!
 //! Normalizers rewrite fixture paths and strip nightly-only hints so the
 //! assertions remain stable across platforms.
+use std::{
+    borrow::Cow,
+    env,
+    io,
+    panic::{self, AssertUnwindSafe},
+    path::Path as StdPath,
+    process::Command,
+};
+
 use camino::{Utf8Path, Utf8PathBuf};
 use cap_std::{ambient_authority, fs::Dir};
-use std::borrow::Cow;
-use std::env;
-use std::io;
-use std::panic::{self, AssertUnwindSafe};
-use std::path::Path as StdPath;
-use std::process::Command;
 use wrappers::{
-    MacroFixtureCase, NormalizerInput, UiFixtureCase, normalize_fixture_paths,
+    MacroFixtureCase,
+    NormalizerInput,
+    UiFixtureCase,
+    normalize_fixture_paths,
     strip_nightly_macro_backtrace_hint,
 };
 

--- a/crates/rstest-bdd/tests/trybuild_macros/helper_tests.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros/helper_tests.rs
@@ -1,14 +1,20 @@
 //! Unit tests for normalizer and path helpers used by trybuild macro tests.
-use super::wrappers::{FixtureStderr, FixtureTestPath};
-use super::*;
-use super::{Normalizer, NormalizerInput};
+use std::{
+    any::Any,
+    borrow::Cow,
+    panic::{self, AssertUnwindSafe},
+};
+
 use camino::{Utf8Path, Utf8PathBuf};
 use cap_std::{ambient_authority, fs::Dir};
 use rstest::rstest;
-use std::any::Any;
-use std::borrow::Cow;
-use std::panic::{self, AssertUnwindSafe};
 
+use super::{
+    Normalizer,
+    NormalizerInput,
+    wrappers::{FixtureStderr, FixtureTestPath},
+    *,
+};
 fn write_fixture_file(crate_dir: &Dir, path: &Utf8Path, bytes: &[u8], label: &str) {
     if let Some(parent) = path.parent() {
         if let Err(error) = crate_dir.create_dir_all(parent.as_std_path()) {
@@ -19,7 +25,6 @@ fn write_fixture_file(crate_dir: &Dir, path: &Utf8Path, bytes: &[u8], label: &st
         panic!("failed to write {label}: {error}");
     }
 }
-
 fn captured_panic_message(result: Result<(), Box<dyn Any + Send>>) -> String {
     let Err(payload) = result else {
         panic!("expected helper to panic");
@@ -32,7 +37,6 @@ fn captured_panic_message(result: Result<(), Box<dyn Any + Send>>) -> String {
     };
     message.clone()
 }
-
 struct NormalizerFixture {
     expected_path: Utf8PathBuf,
     actual_path: Utf8PathBuf,
@@ -97,9 +101,7 @@ fn wip_stderr_path_builds_target_location() {
 
 #[test]
 #[should_panic(expected = "trybuild test path must include file name")]
-fn wip_stderr_path_panics_without_file_name() {
-    wip_stderr_path(Utf8Path::new("").as_std_path());
-}
+fn wip_stderr_path_panics_without_file_name() { wip_stderr_path(Utf8Path::new("").as_std_path()); }
 
 #[test]
 fn expected_stderr_path_replaces_extension() {

--- a/crates/rstest-bdd/tests/trybuild_macros/staging.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros/staging.rs
@@ -3,11 +3,10 @@
 //! Handles discovery and copying of feature files to the trybuild test
 //! environment, ensuring fixtures can locate their dependencies at compile time.
 
+use std::{env, io, path::Path as StdPath};
+
 use camino::{Utf8Path, Utf8PathBuf};
 use cap_std::{ambient_authority, fs::Dir};
-use std::env;
-use std::io;
-use std::path::Path as StdPath;
 
 const MACROS_FIXTURES_DIR: &str = "tests/fixtures_macros";
 const FEATURES_DIR: &str = "tests/features";

--- a/crates/rstest-bdd/tests/trybuild_macros/whitaker.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros/whitaker.rs
@@ -1,9 +1,12 @@
 //! Whitaker lint-gate regression tests for the trybuild macro suite.
 
+use std::{
+    env,
+    fs,
+    process::{Command, Output},
+};
+
 use camino::{Utf8Path, Utf8PathBuf};
-use std::env;
-use std::fs;
-use std::process::{Command, Output};
 
 #[test]
 fn whitaker_lint_gate_accepts_clean_and_rejects_panicking_fixtures() {
@@ -19,13 +22,8 @@ fn whitaker_lint_gate_accepts_clean_and_rejects_panicking_fixtures() {
     };
     let clean_manifest = write_whitaker_fixture(
         &temp_dir.join("clean"),
-        "//! Clean Whitaker fixture crate.\n\
-         pub fn clean_value(value: Option<u32>) -> u32 {\n\
-             let Some(number) = value else {\n\
-                 panic!(\"missing value\");\n\
-             };\n\
-             number\n\
-         }\n",
+        "//! Clean Whitaker fixture crate.\npub fn clean_value(value: Option<u32>) -> u32 {\nlet \
+         Some(number) = value else {\npanic!(\"missing value\");\n};\nnumber\n}\n",
     );
     let rejected_manifest = write_whitaker_fixture(
         &temp_dir.join("rejected"),
@@ -69,9 +67,7 @@ fn cargo_dylint_available() -> bool {
     command_succeeds(Command::new("cargo").arg("dylint").arg("--version"))
 }
 
-fn whitaker_available() -> bool {
-    command_succeeds(Command::new("whitaker").arg("--version"))
-}
+fn whitaker_available() -> bool { command_succeeds(Command::new("whitaker").arg("--version")) }
 
 fn command_succeeds(command: &mut Command) -> bool {
     match command.output() {
@@ -92,13 +88,8 @@ fn write_whitaker_fixture(crate_dir: &Utf8Path, lib_rs: &str) -> Utf8PathBuf {
     if let Err(err) = fs::write(
         manifest_path.as_std_path(),
         format!(
-            "[package]\n\
-             name = \"whitaker-rust-fixture-{fixture_name}\"\n\
-             version = \"0.0.0\"\n\
-             edition = \"2024\"\n\
-             \n\
-             [lib]\n\
-             path = \"src/lib.rs\"\n"
+            "[package]\nname = \"whitaker-rust-fixture-{fixture_name}\"\nversion = \
+             \"0.0.0\"\nedition = \"2024\"\n\n[lib]\npath = \"src/lib.rs\"\n"
         ),
     ) {
         panic!("failed to write Whitaker fixture manifest: {err}");

--- a/crates/rstest-bdd/tests/trybuild_macros/wrappers.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros/wrappers.rs
@@ -1,9 +1,9 @@
 //! Wrapper newtypes used by the trybuild macro fixtures and normalizer helpers.
 //! They centralize UTF-8 conversions so tests can work with camino paths and
 //! expose standard-path views when talking to trybuild.
+use std::{env, path::Path as StdPath};
+
 use camino::{Utf8Path, Utf8PathBuf};
-use std::env;
-use std::path::Path as StdPath;
 use the_newtype::Newtype;
 
 macro_rules! owned_str_newtype {
@@ -14,21 +14,15 @@ macro_rules! owned_str_newtype {
         impl ::std::ops::Deref for $name {
             type Target = str;
 
-            fn deref(&self) -> &Self::Target {
-                self.0.as_str()
-            }
+            fn deref(&self) -> &Self::Target { self.0.as_str() }
         }
 
         impl ::std::convert::AsRef<str> for $name {
-            fn as_ref(&self) -> &str {
-                self.0.as_str()
-            }
+            fn as_ref(&self) -> &str { self.0.as_str() }
         }
 
         impl<'a> ::std::convert::From<&'a str> for $name {
-            fn from(value: &'a str) -> Self {
-                Self(value.to_owned())
-            }
+            fn from(value: &'a str) -> Self { Self(value.to_owned()) }
         }
     };
 }
@@ -41,21 +35,15 @@ macro_rules! borrowed_str_newtype {
         impl<'a> ::std::ops::Deref for $name<'a> {
             type Target = str;
 
-            fn deref(&self) -> &Self::Target {
-                self.0
-            }
+            fn deref(&self) -> &Self::Target { self.0 }
         }
 
         impl<'a> ::std::convert::AsRef<str> for $name<'a> {
-            fn as_ref(&self) -> &str {
-                self.0
-            }
+            fn as_ref(&self) -> &str { self.0 }
         }
 
         impl<'a> ::std::convert::From<&'a str> for $name<'a> {
-            fn from(value: &'a str) -> Self {
-                Self(value)
-            }
+            fn from(value: &'a str) -> Self { Self(value) }
         }
     };
 }
@@ -63,29 +51,21 @@ macro_rules! borrowed_str_newtype {
 owned_str_newtype!(MacroFixtureCase);
 
 impl From<MacroFixtureCase> for Utf8PathBuf {
-    fn from(value: MacroFixtureCase) -> Self {
-        Self::from(value.0)
-    }
+    fn from(value: MacroFixtureCase) -> Self { Self::from(value.0) }
 }
 
 impl AsRef<StdPath> for MacroFixtureCase {
-    fn as_ref(&self) -> &StdPath {
-        Utf8Path::new(self.0.as_str()).as_std_path()
-    }
+    fn as_ref(&self) -> &StdPath { Utf8Path::new(self.0.as_str()).as_std_path() }
 }
 
 owned_str_newtype!(UiFixtureCase);
 
 impl From<UiFixtureCase> for Utf8PathBuf {
-    fn from(value: UiFixtureCase) -> Self {
-        Self::from(value.0)
-    }
+    fn from(value: UiFixtureCase) -> Self { Self::from(value.0) }
 }
 
 impl AsRef<StdPath> for UiFixtureCase {
-    fn as_ref(&self) -> &StdPath {
-        Utf8Path::new(self.0.as_str()).as_std_path()
-    }
+    fn as_ref(&self) -> &StdPath { Utf8Path::new(self.0.as_str()).as_std_path() }
 }
 
 borrowed_str_newtype!(NormalizerInput);

--- a/crates/rstest-bdd/tests/underscore_fixture.rs
+++ b/crates/rstest-bdd/tests/underscore_fixture.rs
@@ -9,24 +9,16 @@ struct StreamingState {
 }
 
 #[fixture]
-fn world() -> StreamingState {
-    StreamingState::default()
-}
+fn world() -> StreamingState { StreamingState::default() }
 
 #[fixture]
-fn _world() -> &'static str {
-    "explicit _world fixture"
-}
+fn _world() -> &'static str { "explicit _world fixture" }
 
 #[given("the streaming world is available")]
-fn world_is_available(_world: &mut StreamingState) {
-    _world.parsed_events = 1;
-}
+fn world_is_available(_world: &mut StreamingState) { _world.parsed_events = 1; }
 
 #[when("the parser runs once more")]
-fn parser_runs_again(_world: &mut StreamingState) {
-    _world.parsed_events += 1;
-}
+fn parser_runs_again(_world: &mut StreamingState) { _world.parsed_events += 1; }
 
 #[then("implicit underscore fixture lookup uses the world fixture")]
 #[expect(

--- a/crates/rstest-bdd/tests/underscore_fixture.rs
+++ b/crates/rstest-bdd/tests/underscore_fixture.rs
@@ -8,9 +8,11 @@ struct StreamingState {
     parsed_events: usize,
 }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn world() -> StreamingState { StreamingState::default() }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn _world() -> &'static str { "explicit _world fixture" }
 

--- a/crates/rstest-bdd/tests/underscore_scenario_param.rs
+++ b/crates/rstest-bdd/tests/underscore_scenario_param.rs
@@ -14,6 +14,7 @@ struct TestState {
     value: Slot<i32>,
 }
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn state() -> TestState { TestState::default() }
 

--- a/crates/rstest-bdd/tests/underscore_scenario_param.rs
+++ b/crates/rstest-bdd/tests/underscore_scenario_param.rs
@@ -15,14 +15,10 @@ struct TestState {
 }
 
 #[fixture]
-fn state() -> TestState {
-    TestState::default()
-}
+fn state() -> TestState { TestState::default() }
 
 #[given("a value of {value:i32}")]
-fn given_value(state: &mut TestState, value: i32) {
-    state.value.set(value);
-}
+fn given_value(state: &mut TestState, value: i32) { state.value.set(value); }
 
 #[when("the value is doubled")]
 fn when_doubled(state: &mut TestState) {

--- a/crates/rstest-bdd/tests/wrapper_shadow.rs
+++ b/crates/rstest-bdd/tests/wrapper_shadow.rs
@@ -1,10 +1,16 @@
 //! Regression tests ensuring wrapper inputs use unique identifiers.
 
+use std::sync::Mutex;
+
 use rstest_bdd::{
-    StepContext, StepKeyword, assert_step_err, assert_step_ok, find_step, lookup_step,
+    StepContext,
+    StepKeyword,
+    assert_step_err,
+    assert_step_ok,
+    find_step,
+    lookup_step,
 };
 use rstest_bdd_macros::given;
-use std::sync::Mutex;
 
 static CAPTURED_TEXT: Mutex<Option<String>> = Mutex::new(None);
 

--- a/docs/adr-002-stable-step-return-classification.md
+++ b/docs/adr-002-stable-step-return-classification.md
@@ -74,13 +74,12 @@ an alias that deliberately returns a payload, and applying it to a genuine
   best-effort default: a local alias of `Result<T, E>` was classified as a
   value, so an `Err` became an opaque payload and the scenario passed. The
   return-kind hint avoids the defect only when the caller already knows it is
-  required; prose guidance alone is not an adequate guard against a false
-  green.
+  required; prose guidance alone is not an adequate guard against a false green.
 - The implementation must therefore make unresolved classification explicit
-  without treating every named type as fallible. Roadmap item 11.3.1 tracks
-  the diagnostic or required-hint contract and its compile and runtime
-  regression matrix. Until it lands, fallible steps must spell `Result<...>`
-  or `rstest_bdd::StepResult<...>`, or use the `result` hint.
+  without treating every named type as fallible. Roadmap item 11.3.1 tracks the
+  diagnostic or required-hint contract and its compile and runtime regression
+  matrix. Until it lands, fallible steps must spell `Result<...>` or
+  `rstest_bdd::StepResult<...>`, or use the `result` hint.
 
 ## Alternatives considered
 

--- a/docs/adr-004-policy-crate.md
+++ b/docs/adr-004-policy-crate.md
@@ -58,9 +58,9 @@ The workspace now uses the internal crate `rstest-bdd-policy` to own
 - `rstest-bdd-macros` imports the shared policy enums directly from
   `rstest-bdd-policy`.
 - Regression tests in `crates/rstest-bdd/src/execution/tests.rs`,
-  `crates/rstest-bdd-macros/src/macros/scenarios/macro_args/tests/mod.rs`, and the
-  `execution_policy_reexports.rs` trybuild fixture assert that both surfaces
-  still use the shared types.
+  `crates/rstest-bdd-macros/src/macros/scenarios/macro_args/tests/mod.rs`, and
+  the `execution_policy_reexports.rs` trybuild fixture assert that both
+  surfaces still use the shared types.
 
 ## Goals and non-goals
 

--- a/docs/adr-006-fallible-scenario-functions.md
+++ b/docs/adr-006-fallible-scenario-functions.md
@@ -139,9 +139,9 @@ fn my_scenario() -> Result<(), MyError> {
   payloads would require a new ADR and API design.
 - In v0.6.0-beta3, a harness-generated test can leave the fallible scenario's
   outer `Result` unconsumed. The scenario behaves correctly at runtime, but
-  rustc emits `unused_must_use`, which becomes a hard error under `-D warnings`.
-  Roadmap item 11.3.2 tracks consuming or propagating this result across the
-  standard, Tokio, and GPUI generated-test paths.
+  rustc emits `unused_must_use`, which becomes a hard error under
+  `-D warnings`. Roadmap item 11.3.2 tracks consuming or propagating this
+  result across the standard, Tokio, and GPUI generated-test paths.
 - A unit-returning scenario still propagates `Err` from fallible steps. Users
   only need a fallible scenario signature when the scenario body itself needs
   to use `?`; this distinction should remain explicit in migration guidance.

--- a/docs/adr-011-first-party-scenario-state-and-cleanup.md
+++ b/docs/adr-011-first-party-scenario-state-and-cleanup.md
@@ -191,8 +191,8 @@ alternative for the thread-local interim pattern.
 - A `ScenarioStateCleanup` type (the `Drop` guard).
 - A cleanup-guard fixture-generating macro that produces
   `ScenarioStateCleanup` and `#[fixture] fn scenario_state_cleanup()`,
-  implementing the two-sided reset protocol: `reset_before_assignment()` in
-  the constructor, `reset_after_scenario()` in `Drop`.
+  implementing the two-sided reset protocol: `reset_before_assignment()` in the
+  constructor, `reset_after_scenario()` in `Drop`.
 
 This replaces the handwritten 50-line block with an import and a one-line
 scenario parameter.

--- a/docs/adr-016-pinned-nightly-rustfmt.md
+++ b/docs/adr-016-pinned-nightly-rustfmt.md
@@ -1,0 +1,53 @@
+# Architectural decision record (ADR) 016: pin the nightly rustfmt toolchain
+
+## Status
+
+Accepted (2026-08-16): use the dated nightly formatter selected by
+`FMT_TOOLCHAIN`, and require every workspace member to inherit the root lint
+policy through `lints.workspace = true`.
+
+## Date
+
+2026-08-16
+
+## Context and problem statement
+
+The workspace's `.rustfmt.toml` enables unstable formatting options. Stable
+`rustfmt` therefore ignores part of the repository's formatting contract and
+can produce a different workspace-wide reformat from the one checked by CI. The
+workspace also has a root Clippy, Rust, and Rustdoc policy that only applies to
+crates which opt into workspace lint inheritance. Examples are workspace
+members and must not silently fall outside that policy.
+
+## Decision
+
+Pin formatting to `nightly-2026-08-07`:
+
+- `Makefile` sets `FMT_TOOLCHAIN ?= nightly-2026-08-07` and uses it for
+  `make fmt` and `make check-fmt`.
+- CI installs that toolchain with
+  `rustup toolchain install nightly-2026-08-07 --profile minimal --component rustfmt`
+  before running `make check-fmt`.
+- Contributors and editor integrations use the same dated nightly formatter;
+  stable `cargo fmt` is not a substitute.
+
+Every workspace crate, including examples, declares:
+
+```toml
+[lints]
+workspace = true
+```
+
+This keeps the root lint policy authoritative and prevents new workspace
+members from silently weakening the repository's quality gates.
+
+## Consequences
+
+- A formatter-date change is a deliberate repository-wide tooling change and
+  must update the Makefile, CI installation, and contributor instructions
+  together.
+- A contributor must install one additional Rust toolchain for formatting, but
+  ordinary builds, tests, and lint commands continue to use the stable
+  toolchain from `rust-toolchain.toml`.
+- New workspace members inherit the root lint and Rustdoc policy by default;
+  local exceptions must remain narrow and justified.

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -95,6 +95,8 @@
 - [ADR 015: name the step-return override outcome][adr-015] records the
   decision to return `InsertOutcome` from `StepContext::insert_value` instead of
   `Option<Box<dyn Any>>`.
+- [ADR 016: pin the nightly rustfmt toolchain][adr-016] records the formatting
+  toolchain and workspace lint-inheritance decision.
 
 ## Execution plans
 
@@ -111,6 +113,7 @@
 [adr-013]: adr-013-adopt-whitaker-no-unwrap-or-else-panic.md
 [adr-014]: adr-014-retain-users-guide-link-validator.md
 [adr-015]: adr-015-insert-outcome-for-step-return-overrides.md
+[adr-016]: adr-016-pinned-nightly-rustfmt.md
 [complexity-guide]: complexity-antipatterns-and-refactoring-strategies.md
 [cucumber-async]: cucumber-rs-migration-and-async-patterns.md
 [dependency-injection]: reliable-testing-in-rust-via-dependency-injection.md

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1363,6 +1363,21 @@ findings, so exclusions are the only sanctioned escape hatch for
 legitimately-ambient code such as test-support crates and integration test
 crates.
 
+
+#### Fixture-expansion lint allowance
+
+`crates/rstest-bdd-test-macros` owns the narrow `unused_braces` allowance
+needed for `rstest` fixture expansion. Apply its
+`#[rstest_bdd_test_macros::allow_fixture_expansion_lints]` attribute
+immediately above `#[fixture]` in workspace test code. It emits the allowance
+only for that fixture and pairs it with Clippy's conditional `allow_attributes`
+expectation.
+
+The crate is a test-only development dependency: production crates and
+non-fixture test helpers must not depend on it. Do not extend the attribute to
+other lints or apply it to arbitrary functions; add a separately justified,
+scoped mechanism if another macro expansion needs one.
+
 When maintaining the pin:
 
 1. Update `WHITAKER_INSTALLER_VERSION` in `.github/workflows/ci.yml`; the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -128,6 +128,47 @@ and promotes every Rustdoc warning to an error. `--workspace` checks every
 member crate, while `--no-deps` keeps the gate focused on documentation owned
 by this repository.
 
+
+## Rust formatting and workspace lints (ADR-016)
+
+The repository's formatter configuration is the root
+[`.rustfmt.toml`](../.rustfmt.toml). It enables unstable options, including
+`unstable_features`, import grouping, comment wrapping, and single-line
+function formatting. Stable `rustfmt` ignores those options and can propose a
+different workspace-wide reformat, so it must not be used for repository
+formatting.
+
+Install the pinned formatter toolchain before running formatting commands:
+
+```bash
+rustup toolchain install nightly-2026-08-07 --profile minimal --component rustfmt
+```
+
+The Makefile sets `FMT_TOOLCHAIN` to `nightly-2026-08-07` and runs
+`$(CARGO) +$(FMT_TOOLCHAIN) fmt`. Use `make fmt` to apply formatting and
+`make check-fmt` to verify it. Editor integrations and format-on-save must
+invoke the same dated nightly `rustfmt`, rather than the stable formatter
+selected by `rust-toolchain.toml`.
+
+CI installs this toolchain explicitly and runs `make check-fmt` in the tools
+lane. Keep the installation command, `FMT_TOOLCHAIN`, and editor configuration
+in sync when changing the pinned date. This policy is recorded in
+[ADR-016](adr-016-pinned-nightly-rustfmt.md).
+
+The root `Cargo.toml` owns the workspace Clippy, Rust, and Rustdoc lint policy.
+Every workspace member, including each example, must inherit it by declaring
+the following in its `Cargo.toml`:
+
+```toml
+[lints]
+workspace = true
+```
+
+Do not replace workspace inheritance with a copied lint table. New lint
+exceptions must be narrow, justified, and kept in the appropriate source or
+workspace configuration so that `make lint` and `make typecheck` exercise the
+same policy across libraries, test-support crates, and examples.
+
 `make test` separately compiles and runs documentation examples for every
 workspace crate with all features enabled:
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -128,7 +128,6 @@ and promotes every Rustdoc warning to an error. `--workspace` checks every
 member crate, while `--no-deps` keeps the gate focused on documentation owned
 by this repository.
 
-
 ## Rust formatting and workspace lints (ADR-016)
 
 The repository's formatter configuration is the root
@@ -1404,7 +1403,6 @@ findings, so exclusions are the only sanctioned escape hatch for
 legitimately-ambient code such as test-support crates and integration test
 crates.
 
-
 #### Fixture-expansion lint allowance
 
 `crates/rstest-bdd-test-macros` owns the narrow `unused_braces` allowance
@@ -1529,12 +1527,11 @@ lets the router install the prepared capability. Discovery and root-opening
 failures are logged and remain non-fatal, so initialization still returns its
 normal result. Did-save notifications received while the workspace capability
 is being prepared are replayed in arrival order on the router task after
-`WorkspaceReadyEvent` installs the capability.
-The pending queue coalesces newer saves for the same URI and is bounded to 128
-distinct notifications and 4 MiB of combined URI and source text. A save that
-would exceed either limit is dropped and recorded as a deferred-save outcome;
-the queue therefore cannot retain unbounded editor input while preparation is
-blocked.
+`WorkspaceReadyEvent` installs the capability. The pending queue coalesces
+newer saves for the same URI and is bounded to 128 distinct notifications and 4
+MiB of combined URI and source text. A save that would exceed either limit is
+dropped and recorded as a deferred-save outcome; the queue therefore cannot
+retain unbounded editor input while preparation is blocked.
 
 `ServerState::index_feature_file` owns the disk boundary: it reads through
 `WorkspaceRoot` and then passes the resulting text to `index_feature_source`.

--- a/docs/execplans/10-2-7-gpui-bulk-migration-cookbook.md
+++ b/docs/execplans/10-2-7-gpui-bulk-migration-cookbook.md
@@ -42,8 +42,7 @@ Success is visible in five ways:
 1. `docs/users-guide.md` contains an expanded "Bulk-migration cookbook"
    subsection that documents sharing the *step library* (not only the state
    scaffolding), is framed as the beta shape that v0.6.0 final shrinks, bridges
-   the
-   GPUI specifics to published `gpui 0.2.2`, and points at the executable
+   the GPUI specifics to published `gpui 0.2.2`, and points at the executable
    reference.
 2. A new executable reference suite proves one shared step library is reused by
    two scenarios across two feature files, with **zero** step definitions in
@@ -118,9 +117,9 @@ The rejected alternative — a second feature-gated GPUI suite with two
 window-opening binaries — was declined because it re-proves the
 harness-agnostic sharing mechanism at high cost, hand-builds boilerplate that
 roadmap items 10.3.1/10.3.2 replace as v0.6.0 final work, trips the dead-code
-lint, and would be built
-by copying `stateful_window.rs` wholesale (Constraint 2 forbids refactoring
-it), i.e. the anti-duplication exemplar would itself be duplication.
+lint, and would be built by copying `stateful_window.rs` wholesale (Constraint
+2 forbids refactoring it), i.e. the anti-duplication exemplar would itself be
+duplication.
 
 Confirm at approval: harness-agnostic executable proof plus GPUI prose
 cross-linked to `stateful_window.rs` (recommended), versus a new GPUI-specific
@@ -353,8 +352,8 @@ Stop and escalate (document in Decision Log, await direction) when:
   proof in `rstest-bdd`, not a new feature-gated GPUI suite. Rationale: the
   reuse property is harness-agnostic and already precedented by
   `noop_steps.rs`; a GPUI suite re-proves it at high cost, hand-builds
-  thread-local boilerplate that 10.3.1/10.3.2 delete for v0.6.0 final, trips the
-  dead-code lint, targets vendored gpui for a published-gpui audience, and
+  thread-local boilerplate that 10.3.1/10.3.2 delete for v0.6.0 final, trips
+  the dead-code lint, targets vendored gpui for a published-gpui audience, and
   would be built by copying `stateful_window.rs` (which Constraint 2 forbids
   refactoring), making the anti-duplication exemplar out of duplication. The
   GPUI half is already proven by `stateful_window.rs`; the cookbook prose
@@ -824,13 +823,13 @@ agnostic runtime shared-step-library proof in `rstest-bdd` (built on shipped
 agnostic, the GPUI half is already proven by `stateful_window.rs`, and a GPUI
 suite would hand-build boilerplate that roadmap 10.3.1/10.3.2 shrink in v0.6.0
 final, trip the dead-code lint, target vendored gpui for a published-gpui
-audience, and duplicate
-`stateful_window.rs`. Corrected the Red stage to a stepless-module runtime
-`StepNotFound` (was an incoherent missing-module compile error). Added a
-`cargo clean -p rstest-bdd` cache guard for the feature-file rebuild foot-gun,
-a "named tests must appear" acceptance guard, the qualified `#[from]` form and
-`pub` requirement, the published-gpui bridge, the "beta shape, shrinks in
-v0.6.0 final" framing, and dead-code/doc-parity-script constraints.
+audience, and duplicate `stateful_window.rs`. Corrected the Red stage to a
+stepless-module runtime `StepNotFound` (was an incoherent missing-module
+compile error). Added a `cargo clean -p rstest-bdd` cache guard for the
+feature-file rebuild foot-gun, a "named tests must appear" acceptance guard,
+the qualified `#[from]` form and `pub` requirement, the published-gpui bridge,
+the "beta shape, shrinks in v0.6.0 final" framing, and
+dead-code/doc-parity-script constraints.
 
 Revision 3 (2026-07-06). Added Constraint 9 — every cookbook example must be
 test-backed (a runtime test, the now-required trybuild compile-pass fixture, or

--- a/docs/execplans/9-2-3-tokio-compatibility-alias.md
+++ b/docs/execplans/9-2-3-tokio-compatibility-alias.md
@@ -215,8 +215,8 @@ Implementation details:
 
 - Run targeted tests proving current async runtime behaviour remains green.
 - Add or adjust unit tests in
-  `crates/rstest-bdd-macros/src/macros/scenarios/macro_args/tests/mod.rs` to define
-  expected alias-resolution semantics.
+  `crates/rstest-bdd-macros/src/macros/scenarios/macro_args/tests/mod.rs` to
+  define expected alias-resolution semantics.
 - Where useful, add codegen-level unit checks in
   `crates/rstest-bdd-macros/src/codegen/scenario/tests.rs` to ensure attribute
   generation remains compatible for runtime-based async scenarios.

--- a/docs/execplans/adopt-v0-6-0-beta2-feedback.md
+++ b/docs/execplans/adopt-v0-6-0-beta2-feedback.md
@@ -165,8 +165,8 @@ Thresholds that trigger escalation when breached.
   (no artefact change) and a relative-path `include_str!` resolved from the
   call-site span remain candidates subject to its portability constraints; the
   roadmap 11.3.1 follow-up must select one. The regression test remains
-  portability-aware and runs in its own process against an isolated target
-  or temporary directory, so concurrent tests cannot share build state.
+  portability-aware and runs in its own process against an isolated target or
+  temporary directory, so concurrent tests cannot share build state.
 
 - Risk: ADR-008 remains in `Proposed` status while roadmap items 9.7.1–9.7.4
   shipped "under maintainer authorization". Touching the harness-led-defaults
@@ -402,13 +402,12 @@ Doggylump, Dinolump):
 All four observable outcomes from `Purpose / big picture` are met:
 
 1. **Roadmap records every new or re-scoped work item.** Added items
-   10.2.4–10.2.7
-   (gpui-version banner + mapping table, lint-clean playbook variant, nextest
-   interaction note, bulk-migration cookbook), re-scoped 10.3.1/10.3.2 (naming
-   the correct `ScenarioStore<T>` / `GpuiScenarioStore` types and cleanup-guard
-   fixture macro, with pull-forward scheduling notes), added item 10.3.3 to
-   step 10.3 (feature-file rebuild fix), and amended Phase 12 intro and 12.1.1
-   to record the committed direction and reference ADR-012.
+   10.2.4–10.2.7 (gpui-version banner + mapping table, lint-clean playbook
+   variant, nextest interaction note, bulk-migration cookbook), re-scoped
+   10.3.1/10.3.2 (naming the correct `ScenarioStore<T>` / `GpuiScenarioStore`
+   types and cleanup-guard fixture macro, with pull-forward scheduling notes),
+   added item 10.3.3 to step 10.3 (feature-file rebuild fix), and amended Phase
+   12 intro and 12.1.1 to record the committed direction and reference ADR-012.
 
 2. **Design document `§2.7.6.x` corrected and extended.** Added a which-gpui
    banner and vendored-to-published mapping table in `§2.7.6.2`, ADR references

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -865,8 +865,8 @@ changing the public trait contracts.
   `docs/users-guide.md`. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.2.
   Delivered 2026-07-06: expanded the user-guide "Bulk-migration cookbook" to
   share the whole step library (given/when/then plus the state scaffolding) in
-  one `#[path]`-included module per crate, framed as the beta shape that
-  v0.6.0 final (10.3.1/10.3.2) shrinks, with inventory-per-binary and `pub`/
+  one `#[path]`-included module per crate, framed as the beta shape that v0.6.0
+  final (10.3.1/10.3.2) shrinks, with inventory-per-binary and `pub`/
   subdirectory rationale, the module-qualified `#[from(...)]` form, and the
   GPUI specialization bridged to published `gpui 0.2.2` via the mapping table
   and cross-linked to `stateful_window.rs`. Backed by a harness-agnostic
@@ -890,8 +890,8 @@ changing the public trait contracts.
   lint-clean `let ... else { panic!(...) }` invariant form. Finish line: the
   published snippets compile against crates.io `gpui 0.2.2`, the vendored and
   published variants are visibly paired, and a drift gate covers both. Design
-  Doc: `docs/rstest-bdd-design.md` §2.7.6.2. Origin:
-  `leynos/rstest-bdd#575` and the gauss v0.6.0-beta3 adoption report.
+  Doc: `docs/rstest-bdd-design.md` §2.7.6.2. Origin: `leynos/rstest-bdd#575`
+  and the gauss v0.6.0-beta3 adoption report.
 
 > **Note (dual-track maintenance):** items 10.2.4 and 10.2.5 introduce a
 > vendored-to-published mapping table that must be kept in sync with any
@@ -912,10 +912,10 @@ superseded by ADR-012 before implementation, so the release is ready when
 feature-file edits cannot leave users running stale scenarios.
 
 - [x] 10.3.1. **Superseded by 12.1.3 before implementation.** ADR-011 proposed
-  a generic `ScenarioStore<T>` core (in `rstest-bdd`) to replace
-  per-scenario thread-local `RefCell` boilerplate; it would expose `set`, `with`,
-  `with_mut`, `take`, and `reset` operations and wrap the two-sided reset
-  protocol, alongside a GPUI-specific `GpuiScenarioStore` re-export in
+  a generic `ScenarioStore<T>` core (in `rstest-bdd`) to replace per-scenario
+  thread-local `RefCell` boilerplate; it would expose `set`, `with`, `with_mut`,
+  `take`, and `reset` operations and wrap the two-sided reset protocol,
+  alongside a GPUI-specific `GpuiScenarioStore` re-export in
   `rstest-bdd-harness-gpui`. These helpers did not ship; ADR-012 instead landed
   framework-managed scenario storage and cleanup, so the v0.6.x thread-local
   interim pattern is retired by the v0.7.0 lifecycle contract rather than by a
@@ -926,19 +926,19 @@ feature-file edits cannot leave users running stale scenarios.
   a cleanup-guard fixture-generating macro in `rstest-bdd-harness-gpui` to
   produce the `ScenarioStateCleanup` `Drop` guard and the
   `#[fixture] fn scenario_state_cleanup()` function, so GPUI scenarios could
-  adopt the two-sided reset protocol with a single macro call. The macro did not
-  ship; ADR-012 instead made cleanup of framework-owned scenario storage part of
-  the v0.7.0 lifecycle contract, which the existing cleanup-probe suite pins
-  across success, assertion failure, and skip. ADR:
+  adopt the two-sided reset protocol with a single macro call. The macro did
+  not ship; ADR-012 instead made cleanup of framework-owned scenario storage
+  part of the v0.7.0 lifecycle contract, which the existing cleanup-probe suite
+  pins across success, assertion failure, and skip. ADR:
   `docs/adr-011-first-party-scenario-state-and-cleanup.md`. Design Doc:
   `docs/rstest-bdd-design.md` §2.7.6.4. (Doggylump)
 - [ ] 10.3.3. Editing only a `.feature` file triggers a rebuild of the scenario
   binary. The `#[scenario]`/`scenarios!` expansion registers each bound feature
-  file as a Cargo rebuild dependency without embedding an absolute path into the
-  compiled artefact, and a portability-aware regression test proves a
-  `.feature`-only edit forces recompilation and a fresh test failure. The fix is
-  non-breaking: no existing call site changes. Finish line: the regression test
-  fails against the current `std::fs`-read macro and passes after the fix;
+  file as a Cargo rebuild dependency without embedding an absolute path into
+  the compiled artefact, and a portability-aware regression test proves a
+  `.feature`-only edit forces recompilation and a fresh test failure. The fix
+  is non-breaking: no existing call site changes. Finish line: the regression
+  test fails against the current `std::fs`-read macro and passes after the fix;
   required `trybuild` compile-pass and compile-fail fixtures pin the emitted
   binding and the missing-`.feature` diagnostic; a redacted `insta` snapshot
   with semantic assertions pins any touched diagnostic wording; no absolute
@@ -1050,8 +1050,8 @@ an assertion cannot disappear behind macro classification or generated code.
   returns `Err`, spelled `Result`, `StepResult`, an alias explicitly marked
   `result`, and a genuine value alias; no `Err` case is boxed and discarded as
   an opaque payload. ADR: `docs/adr-002-stable-step-return-classification.md`.
-  Design Doc: `docs/rstest-bdd-design.md` §2.1. Origin:
-  `leynos/rstest-bdd#573` and the gauss v0.6.0-beta3 validation matrix.
+  Design Doc: `docs/rstest-bdd-design.md` §2.1. Origin: `leynos/rstest-bdd#573`
+  and the gauss v0.6.0-beta3 validation matrix.
 - [ ] 11.3.2. Harness-generated tests consume the result of fallible scenario
   functions, including under `GpuiHarness`, without triggering
   `unused_must_use` under `-D warnings`. Unit-returning scenarios continue to
@@ -1061,8 +1061,8 @@ an assertion cannot disappear behind macro classification or generated code.
   with `Result<(), E>` scenario bodies under denied warnings; runtime tests
   prove scenario-body and step errors both fail the test. ADR:
   `docs/adr-006-fallible-scenario-functions.md`. Design Doc:
-  `docs/rstest-bdd-design.md` §§2.7.2-2.7.4. Origin:
-  `leynos/rstest-bdd#574` and the gauss v0.6.0-beta3 validation matrix.
+  `docs/rstest-bdd-design.md` §§2.7.2-2.7.4. Origin: `leynos/rstest-bdd#574`
+  and the gauss v0.6.0-beta3 validation matrix.
 
 > **Note (ADR-008 follow-up):** roadmap items 9.7.1–9.7.4 shipped the
 > harness-led attribute defaults under maintainer authorization, but
@@ -1083,9 +1083,8 @@ an assertion cannot disappear behind macro classification or generated code.
   durable-handle patterns to framework-managed scenario-boundary cleanup.
   Finish line: runtime unit tests prove concurrent distinct mutable borrows
   succeed, same-fixture conflicts fail, generated-wrapper tests cover harness
-  context plus world state, and the migration guide carries the mapping
-  table. ADR:
-  `docs/adr-012-guard-based-stepcontext-borrowing.md`. Design Doc:
+  context plus world state, and the migration guide carries the mapping table.
+  ADR: `docs/adr-012-guard-based-stepcontext-borrowing.md`. Design Doc:
   `docs/rstest-bdd-design.md` §2.7.6.5. (Pandalump, Telefono)
 - [x] 12.1.2. `FixtureRefMut` exposes a stable, opaque public API that preserves
   value-accessor methods while hiding internal enum and representation details.
@@ -1096,13 +1095,12 @@ an assertion cannot disappear behind macro classification or generated code.
   (Telefono)
 - [x] 12.1.3. A stable world lifecycle contract guarantees fresh
   framework-owned scenario storage, after-scenario cleanup, and cleanup on
-  failure or skip, so users can model scenario state without thread-local
-  reset conventions: the framework automatically constructs the
-  `StepContext` and drops framework-owned fixture cells at the scenario
-  boundary (success, failure, and skip), with no caller-managed reset. The
-  migration guide explains how v0.6 workarounds map to the v0.7 lifecycle.
-  Prerequisite: 12.1.1. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.5.
-  Finish line:
+  failure or skip, so users can model scenario state without thread-local reset
+  conventions: the framework automatically constructs the `StepContext` and
+  drops framework-owned fixture cells at the scenario boundary (success,
+  failure, and skip), with no caller-managed reset. The migration guide
+  explains how v0.6 workarounds map to the v0.7 lifecycle. Prerequisite:
+  12.1.1. Design Doc: `docs/rstest-bdd-design.md` §2.7.6.5. Finish line:
   lifecycle tests pass for success, assertion failure, and skip, and the
   migration guide includes the v0.6-to-v0.7 mapping. (Doggylump)
 

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -1614,8 +1614,8 @@ underlying `HarnessError` detail.
 
 A gauss migration on v0.6.0-beta3 showed that the outer generated GPUI test
 body did not consume a fallible scenario's `Result`, producing
-`unused_must_use` under `-D warnings`. This is a generated-wrapper defect, not a
-reason to weaken the fallible-scenario contract: every harness path must
+`unused_must_use` under `-D warnings`. This is a generated-wrapper defect, not
+a reason to weaken the fallible-scenario contract: every harness path must
 consume or propagate the scenario result. Unit-returning scenario functions
 already propagate fallible step errors and remain the simpler shape when the
 user body does not itself need `?` (ADR-006; roadmap 11.3.2).
@@ -2007,14 +2007,14 @@ interaction.
 > that enforces `no_unwrap_or_else_panic`, and the user guide carries the
 > executable `let … else { panic!(…) }` shape mirrored by the regression suite.
 
-The mapping table is necessary but not sufficient for downstream adoption.
-The gauss v0.6.0-beta3 trial confirmed that the harness and published
-`gpui 0.2.2` share one compatible `TestAppContext` type, while translating the
-vendored-only `given` and `when` snippets still imposed avoidable work.
-Roadmap 10.2.8 therefore adds compile-checked published variants for those
-steps. It also records that Clippy treats step functions and helpers as
-ordinary functions, so `allow-expect-in-tests` does not exempt them from
-`expect_used`; the lint-clean invariant form remains `let … else { panic!(…) }`.
+The mapping table is necessary but not sufficient for downstream adoption. The
+gauss v0.6.0-beta3 trial confirmed that the harness and published `gpui 0.2.2`
+share one compatible `TestAppContext` type, while translating the vendored-only
+`given` and `when` snippets still imposed avoidable work. Roadmap 10.2.8
+therefore adds compile-checked published variants for those steps. It also
+records that Clippy treats step functions and helpers as ordinary functions, so
+`allow-expect-in-tests` does not exempt them from `expect_used`; the lint-clean
+invariant form remains `let … else { panic!(…) }`.
 
 The recommended v0.6-compatible shape keeps only durable handles in resettable
 scenario state. In schematic form (vendored gpui API):
@@ -2092,8 +2092,8 @@ The user guide's "Bulk-migration cookbook" subsection documents the shape and
 bridges its GPUI snippets to published `gpui 0.2.2` through the vendored-to-
 published mapping table. This handwritten shared block is superseded by the
 v0.7.0 guard-based model (ADR-012); `ScenarioStore<T>` and the cleanup-guard
-fixture macro were proposed under ADR-011 (roadmap 10.3.1 and 10.3.2) but
-never shipped.
+fixture macro were proposed under ADR-011 (roadmap 10.3.1 and 10.3.2) but never
+shipped.
 
 ##### 2.7.6.3 v0.6.0-beta2 quick wins
 
@@ -2125,12 +2125,12 @@ The release strategy is therefore split by compatibility risk:
 ##### 2.7.6.4 v0.6.1 early-life support helpers
 
 - **v0.6.1 early-life support:** add semver-compatible helper APIs. Candidate
-  additions include an explicit harness-context parameter marker, a prelude
-  for common integration imports, a typed borrow-error enum, and
-  generated-wrapper coverage for mutable harness context plus scenario
-  state. A first-party scenario-state helper (`ScenarioStore<T>` in
-  `rstest-bdd`, `GpuiScenarioStore` in `rstest-bdd-harness-gpui`) and a
-  cleanup-guard fixture macro were proposed under
+  additions include an explicit harness-context parameter marker, a prelude for
+  common integration imports, a typed borrow-error enum, and generated-wrapper
+  coverage for mutable harness context plus scenario state. A first-party
+  scenario-state helper (`ScenarioStore<T>` in `rstest-bdd`,
+  `GpuiScenarioStore` in `rstest-bdd-harness-gpui`) and a cleanup-guard fixture
+  macro were proposed under
   [ADR-011](adr-011-first-party-scenario-state-and-cleanup.md) but were
   superseded by ADR-012 before implementation and never shipped.
 
@@ -2828,13 +2828,13 @@ Syntactic classification must never turn a fallible step into a false green.
 The gauss v0.6.0-beta3 trial demonstrated the unsafe case: a local
 `TestSupportResult<()>` alias returned `Err`, the macro classified it as a
 value, and the scenario passed after boxing the error as an unused payload.
-Spelling `Result<(), E>` or using `StepResult` failed correctly, independent
-of whether the scenario function returned `()` or `Result<(), E>`. Because a
-named return type can also be a legitimate value alias, the macro cannot
-simply classify every unresolved path as a result. The stable contract must
-instead require or diagnose an explicit `result`/`value` choice where
-classification is unresolved, with regression coverage for both fallible and
-genuine-value aliases (ADR-002; roadmap 11.3.1).
+Spelling `Result<(), E>` or using `StepResult` failed correctly, independent of
+whether the scenario function returned `()` or `Result<(), E>`. Because a named
+return type can also be a legitimate value alias, the macro cannot simply
+classify every unresolved path as a result. The stable contract must instead
+require or diagnose an explicit `result`/`value` choice where classification is
+unresolved, with regression coverage for both fallible and genuine-value
+aliases (ADR-002; roadmap 11.3.1).
 
 The following diagrams illustrate how the wrapper captures step outputs and how
 later steps consume overrides from the context.

--- a/docs/rstest-bdd-design.md
+++ b/docs/rstest-bdd-design.md
@@ -736,9 +736,16 @@ sequenceDiagram
   end
 ```
 
-Continuous integration verifies Markdown formatting and diagram rendering.
-Every pull request runs `make fmt`, `make markdownlint`, and `make nixie`; the
-job fails if formatting or Mermaid rendering errors are detected.
+Continuous integration verifies Rust and Markdown formatting and diagram
+rendering. The tools lane installs the pinned `nightly-2026-08-07` `rustfmt`
+toolchain and runs `make check-fmt`; contributors use `make fmt` with the same
+`FMT_TOOLCHAIN` rather than stable `cargo fmt`. Every workspace member,
+including examples, declares `[lints] workspace = true` so the root Clippy,
+Rust, and Rustdoc policy applies consistently. The remaining documentation
+checks run `make markdownlint` and `make nixie`; the job fails if any
+formatting or Mermaid rendering check fails. See
+[ADR-016](adr-016-pinned-nightly-rustfmt.md) for the accepted toolchain and
+lint-inheritance decision.
 
 Because registration occurs as the compiler encounters each attribute, step
 definitions must appear earlier in a module than any `#[scenario]` that uses

--- a/docs/rstest-bdd-language-server-design.md
+++ b/docs/rstest-bdd-language-server-design.md
@@ -434,8 +434,8 @@ state.
 including the fallback used when Cargo discovery fails, `ServerState` owns the
 validated `cap_std::fs_utf8::Dir` for that root. Only disk-backed feature saves
 use this capability, resolving paths relative to the root before reading.
-Did-save notifications that supply source text are indexed from that
-in-memory text and do not read from disk.
+Did-save notifications that supply source text are indexed from that in-memory
+text and do not read from disk.
 
 **Project Structure:** The `rstest-bdd-server` crate will live in the same
 workspace as `rstest-bdd`. It can depend on `rstest-bdd` or its sub-crates

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -28,9 +28,27 @@ Each `Cargo.toml` declares `rust-version = "1.85"`, so `cargo` will refuse to
 compile the project on older compilers. The workspace uses the Rust 2024
 edition.
 
-`rstest-bdd` builds on stable Rust. The repository pins a stable toolchain for
-development via `rust-toolchain.toml` so contributors get consistent `rustfmt`
-and `clippy` behaviour.
+`rstest-bdd` builds, tests, and lints on stable Rust. The repository pins that
+toolchain through `rust-toolchain.toml`, so ordinary `cargo` and Clippy
+commands use stable Rust.
+
+### Formatting toolchain
+
+The workspace's `.rustfmt.toml` uses unstable formatting options. `make fmt` and
+`make check-fmt` therefore select the dated nightly formatter named by
+`FMT_TOOLCHAIN` in the Makefile, while every other Cargo invocation stays on
+stable. Install the matching formatter after installing the stable toolchain:
+
+```sh
+rustup toolchain install nightly-2026-08-07 --profile minimal --component rustfmt
+```
+
+Use `make fmt` rather than stable `cargo fmt`. Configure editor format-on-save
+to invoke `rustup run nightly-2026-08-07 rustfmt`, with any editor-specific
+arguments needed to pass the current file on standard input and read the
+formatted output from standard output. For rust-analyzer clients, set
+`rust-analyzer.rustfmt.overrideCommand` to that command array. This keeps local
+edits aligned with `make check-fmt` and CI.
 
 Step definitions may be synchronous functions (`fn`) or asynchronous functions (
 `async fn`). The framework no longer depends on the `async-trait` crate to

--- a/examples/gpui-counter/Cargo.toml
+++ b/examples/gpui-counter/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.6.0-beta4"
 edition.workspace = true
 publish = false
 rust-version.workspace = true
+lints.workspace = true
 
 [lints]
 workspace = true

--- a/examples/gpui-counter/Cargo.toml
+++ b/examples/gpui-counter/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dev-dependencies]
 gpui.workspace = true
 rstest = { workspace = true }
+rstest-bdd-test-macros.workspace = true
 rstest-bdd.workspace = true
 rstest-bdd-harness-gpui.workspace = true
 rstest-bdd-macros.workspace = true

--- a/examples/gpui-counter/src/lib.rs
+++ b/examples/gpui-counter/src/lib.rs
@@ -49,14 +49,10 @@ impl CounterApp {
 
     /// Returns the current counter value.
     #[must_use]
-    pub fn value(&self) -> i32 {
-        self.value.get()
-    }
+    pub fn value(&self) -> i32 { self.value.get() }
 
     /// Replaces the stored counter value with the provided amount.
-    pub fn set_value(&self, amount: i32) {
-        self.value.set(amount);
-    }
+    pub fn set_value(&self, amount: i32) { self.value.set(amount); }
 
     /// Increases the counter by `amount`, saturating at `i32::MAX`.
     ///
@@ -86,9 +82,7 @@ impl CounterApp {
     /// app.record_gpui_context();
     /// assert!(app.has_observed_gpui_context());
     /// ```
-    pub fn record_gpui_context(&self) {
-        self.has_observed_gpui_context.set(true);
-    }
+    pub fn record_gpui_context(&self) { self.has_observed_gpui_context.set(true); }
 
     /// Returns whether a GPUI test context has been observed.
     ///
@@ -101,9 +95,7 @@ impl CounterApp {
     /// assert!(!app.has_observed_gpui_context());
     /// ```
     #[must_use]
-    pub fn has_observed_gpui_context(&self) -> bool {
-        self.has_observed_gpui_context.get()
-    }
+    pub fn has_observed_gpui_context(&self) -> bool { self.has_observed_gpui_context.get() }
 }
 
 /// Clamps an `i64` value to the `i32` range.
@@ -121,12 +113,15 @@ fn saturate_to_i32(value: i64) -> i32 {
 mod tests {
     //! Tests for `CounterApp` behaviour.
 
-    use super::CounterApp;
     use rstest::{fixture, rstest};
+
+    use super::CounterApp;
 
     #[fixture]
     fn counter() -> CounterApp {
-        CounterApp::new(0)
+        let app = CounterApp::new(0);
+        std::hint::black_box(&app);
+        app
     }
 
     #[rstest]

--- a/examples/gpui-counter/src/lib.rs
+++ b/examples/gpui-counter/src/lib.rs
@@ -117,6 +117,7 @@ mod tests {
 
     use super::CounterApp;
 
+    #[rstest_bdd_test_macros::allow_fixture_expansion_lints]
     #[fixture]
     fn counter() -> CounterApp {
         let app = CounterApp::new(0);

--- a/examples/gpui-counter/tests/counter.rs
+++ b/examples/gpui-counter/tests/counter.rs
@@ -10,23 +10,19 @@ use rstest_bdd_macros::{given, scenario, then, when};
 
 #[fixture]
 fn app() -> CounterApp {
-    CounterApp::new(0)
+    let app = CounterApp::new(0);
+    std::hint::black_box(&app);
+    app
 }
 
 #[given("a counter starting at {start:i32}")]
-fn a_counter_starting_at(app: &CounterApp, start: i32) {
-    app.set_value(start);
-}
+fn a_counter_starting_at(app: &CounterApp, start: i32) { app.set_value(start); }
 
 #[when("I increment the counter by {amount:u32}")]
-fn increment_counter(app: &CounterApp, amount: u32) {
-    app.increment(amount);
-}
+fn increment_counter(app: &CounterApp, amount: u32) { app.increment(amount); }
 
 #[when("I decrement the counter by {amount:u32}")]
-fn decrement_counter(app: &CounterApp, amount: u32) {
-    app.decrement(amount);
-}
+fn decrement_counter(app: &CounterApp, amount: u32) { app.decrement(amount); }
 
 #[when("I record the GPUI test context")]
 fn record_gpui_test_context(

--- a/examples/gpui-counter/tests/counter.rs
+++ b/examples/gpui-counter/tests/counter.rs
@@ -8,6 +8,7 @@ use gpui_counter::CounterApp;
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn app() -> CounterApp {
     let app = CounterApp::new(0);

--- a/examples/japanese-ledger/Cargo.toml
+++ b/examples/japanese-ledger/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.6.0-beta4"
 edition.workspace = true
 publish = false
 rust-version.workspace = true
+lints.workspace = true
 
 [lints]
 workspace = true

--- a/examples/japanese-ledger/Cargo.toml
+++ b/examples/japanese-ledger/Cargo.toml
@@ -13,5 +13,6 @@ workspace = true
 
 [dev-dependencies]
 rstest = { workspace = true }
+rstest-bdd-test-macros.workspace = true
 rstest-bdd.workspace = true
 rstest-bdd-macros.workspace = true

--- a/examples/japanese-ledger/src/lib.rs
+++ b/examples/japanese-ledger/src/lib.rs
@@ -89,6 +89,7 @@ mod tests {
         }
     }
 
+    #[rstest_bdd_test_macros::allow_fixture_expansion_lints]
     #[fixture]
     fn ledger() -> HouseholdLedger {
         let ledger = HouseholdLedger::new();

--- a/examples/japanese-ledger/src/lib.rs
+++ b/examples/japanese-ledger/src/lib.rs
@@ -33,32 +33,22 @@ pub struct HouseholdLedger {
 impl HouseholdLedger {
     /// Creates a ledger whose balance starts at zero yen.
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
-    }
+    pub fn new() -> Self { Self::default() }
 
     /// Returns the current balance in yen.
     #[must_use]
-    pub fn balance(&self) -> i32 {
-        self.balance.get()
-    }
+    pub fn balance(&self) -> i32 { self.balance.get() }
 
     /// Replaces the stored balance with the provided amount.
-    pub fn set_balance(&self, amount: i32) {
-        self.balance.set(amount);
-    }
+    pub fn set_balance(&self, amount: i32) { self.balance.set(amount); }
 
     /// Records an incoming amount by increasing the balance.
     /// Saturates at `i32::MAX` when the addition would overflow.
-    pub fn apply_income(&self, amount: i32) {
-        self.adjust(amount);
-    }
+    pub fn apply_income(&self, amount: i32) { self.adjust(amount); }
 
     /// Records an expense by decreasing the balance.
     /// Saturates at `i32::MIN` when the subtraction would underflow.
-    pub fn apply_expense(&self, amount: i32) {
-        self.adjust(-amount);
-    }
+    pub fn apply_expense(&self, amount: i32) { self.adjust(-amount); }
 
     fn adjust(&self, delta: i32) {
         let current = self.balance.get();
@@ -75,8 +65,9 @@ impl HouseholdLedger {
 mod tests {
     //! Behavioural tests for the household ledger example.
 
-    use super::HouseholdLedger;
     use rstest::{fixture, rstest};
+
+    use super::HouseholdLedger;
 
     /// Represents a high-level ledger interaction used by the feature
     /// scenarios. Using a dedicated type keeps the scenario test inputs terse
@@ -100,7 +91,9 @@ mod tests {
 
     #[fixture]
     fn ledger() -> HouseholdLedger {
-        HouseholdLedger::new()
+        let ledger = HouseholdLedger::new();
+        std::hint::black_box(&ledger);
+        ledger
     }
 
     /// Replays the declarative ledger steps so each case mirrors a Gherkin

--- a/examples/japanese-ledger/tests/ledger.rs
+++ b/examples/japanese-ledger/tests/ledger.rs
@@ -10,23 +10,19 @@ use rstest_bdd_macros::{given, scenario, then, when};
 
 #[fixture]
 fn ledger() -> HouseholdLedger {
-    HouseholdLedger::new()
+    let ledger = HouseholdLedger::new();
+    std::hint::black_box(&ledger);
+    ledger
 }
 
 #[given("残高は{start:i32}である")]
-fn starting_balance(ledger: &HouseholdLedger, start: i32) {
-    ledger.set_balance(start);
-}
+fn starting_balance(ledger: &HouseholdLedger, start: i32) { ledger.set_balance(start); }
 
 #[when("残高に{income:i32}を加える")]
-fn apply_income(ledger: &HouseholdLedger, income: i32) {
-    ledger.apply_income(income);
-}
+fn apply_income(ledger: &HouseholdLedger, income: i32) { ledger.apply_income(income); }
 
 #[when("残高から{expense:i32}を引く")]
-fn apply_expense(ledger: &HouseholdLedger, expense: i32) {
-    ledger.apply_expense(expense);
-}
+fn apply_expense(ledger: &HouseholdLedger, expense: i32) { ledger.apply_expense(expense); }
 
 #[then("残高は{expected:i32}である")]
 fn assert_balance(ledger: &HouseholdLedger, expected: i32) {

--- a/examples/japanese-ledger/tests/ledger.rs
+++ b/examples/japanese-ledger/tests/ledger.rs
@@ -8,6 +8,7 @@ use japanese_ledger::HouseholdLedger;
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn ledger() -> HouseholdLedger {
     let ledger = HouseholdLedger::new();

--- a/examples/todo-cli/Cargo.toml
+++ b/examples/todo-cli/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.6.0-beta4"
 edition.workspace = true
 publish = false
 rust-version.workspace = true
+lints.workspace = true
 
 [lints]
 workspace = true

--- a/examples/todo-cli/Cargo.toml
+++ b/examples/todo-cli/Cargo.toml
@@ -15,6 +15,7 @@ eyre = "0.6"
 
 [dev-dependencies]
 rstest = { workspace = true }
+rstest-bdd-test-macros.workspace = true
 rstest-bdd.workspace = true
 rstest-bdd-harness.workspace = true
 rstest-bdd-macros.workspace = true

--- a/examples/todo-cli/src/lib.rs
+++ b/examples/todo-cli/src/lib.rs
@@ -18,9 +18,7 @@ pub struct TodoList {
 impl TodoList {
     /// Create a new, empty to-do list.
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
-    }
+    pub fn new() -> Self { Self::default() }
 
     /// Add a task with the given description.
     pub fn add<S: Into<String>>(&mut self, description: S) {
@@ -73,7 +71,5 @@ impl TodoList {
 
     /// Check whether the list is empty.
     #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.tasks.is_empty()
-    }
+    pub fn is_empty(&self) -> bool { self.tasks.is_empty() }
 }

--- a/examples/todo-cli/src/main.rs
+++ b/examples/todo-cli/src/main.rs
@@ -1,8 +1,6 @@
 //! Command-line interface for the `todo-cli` example.
 //! Tasks live only in memory; each invocation starts with an empty to-do list.
-
-use clap::builder::ValueParser;
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, builder::ValueParser};
 use eyre::{Result, WrapErr};
 use std::io::Write;
 use todo_cli::TodoList;

--- a/examples/todo-cli/src/main.rs
+++ b/examples/todo-cli/src/main.rs
@@ -1,8 +1,9 @@
 //! Command-line interface for the `todo-cli` example.
 //! Tasks live only in memory; each invocation starts with an empty to-do list.
+use std::io::Write;
+
 use clap::{Parser, Subcommand, builder::ValueParser};
 use eyre::{Result, WrapErr};
-use std::io::Write;
 use todo_cli::TodoList;
 
 /// Trim and reject blank-only task descriptions.

--- a/examples/todo-cli/tests/cli.rs
+++ b/examples/todo-cli/tests/cli.rs
@@ -1,10 +1,10 @@
 //! Integration tests exercising the `todo-cli` binary.
 
+use std::{env, path::PathBuf};
+
 use assert_cmd::Command;
 use predicates::prelude::*;
 use rstest_bdd_harness::binary_test_support::{BinaryName, locate_or_build_binary};
-use std::env;
-use std::path::PathBuf;
 
 fn locate_or_build_todo_cli_cmd() -> Result<Command, Box<dyn std::error::Error>> {
     let root = workspace_root();
@@ -13,9 +13,7 @@ fn locate_or_build_todo_cli_cmd() -> Result<Command, Box<dyn std::error::Error>>
         .map_err(|e| -> Box<dyn std::error::Error> { Box::new(e) })
 }
 
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
-}
+fn workspace_root() -> PathBuf { PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..") }
 
 #[test]
 fn add_succeeds() -> Result<(), Box<dyn std::error::Error>> {

--- a/examples/todo-cli/tests/todo.rs
+++ b/examples/todo-cli/tests/todo.rs
@@ -54,9 +54,7 @@ impl IntoIterator for TaskEntries {
     type Item = String;
     type IntoIter = std::vec::IntoIter<String>;
 
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
+    fn into_iter(self) -> Self::IntoIter { self.0.into_iter() }
 }
 
 #[derive(Debug)]
@@ -88,7 +86,8 @@ impl TryFrom<Vec<Vec<String>>> for StatusEntries {
                 "no" | "n" | "false" => false,
                 _ => {
                     return Err(format!(
-                        "datatable row {}: second column must be one of yes/y/true or no/n/false; got: {:?}",
+                        "datatable row {}: second column must be one of yes/y/true or no/n/false; \
+                         got: {:?}",
                         index + 1,
                         done_cell
                     ));
@@ -101,9 +100,7 @@ impl TryFrom<Vec<Vec<String>>> for StatusEntries {
 }
 
 impl From<StatusEntries> for Vec<(String, bool)> {
-    fn from(entries: StatusEntries) -> Self {
-        entries.0
-    }
+    fn from(entries: StatusEntries) -> Self { entries.0 }
 }
 
 #[given("an empty to-do list")]

--- a/examples/todo-cli/tests/todo.rs
+++ b/examples/todo-cli/tests/todo.rs
@@ -6,6 +6,7 @@ use todo_cli::TodoList;
 
 // Keep this fixture as a one-liner so the reviewer-requested style persists.
 #[rustfmt::skip]
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn todo_list() -> TodoList { return TodoList::new(); }
 

--- a/examples/tokio-reminders/Cargo.toml
+++ b/examples/tokio-reminders/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.6.0-beta4"
 edition.workspace = true
 publish = false
 rust-version.workspace = true
+lints.workspace = true
 
 [lints]
 workspace = true

--- a/examples/tokio-reminders/Cargo.toml
+++ b/examples/tokio-reminders/Cargo.toml
@@ -15,6 +15,7 @@ tokio.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
+rstest-bdd-test-macros.workspace = true
 rstest-bdd.workspace = true
 rstest-bdd-harness-tokio.workspace = true
 rstest-bdd-macros.workspace = true

--- a/examples/tokio-reminders/src/lib.rs
+++ b/examples/tokio-reminders/src/lib.rs
@@ -77,9 +77,7 @@ impl ReminderService {
     /// assert_eq!(service.pending_reminder_count(), 0);
     /// ```
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
-    }
+    pub fn new() -> Self { Self::default() }
 
     /// Schedules a reminder for later delivery on Tokio's local task queue.
     ///
@@ -189,16 +187,17 @@ impl ReminderService {
     /// let service = ReminderService::new();
     /// service.schedule_reminder("Ada");
     /// service.flush().await?;
-    /// assert_eq!(service.delivered_reminders(), vec!["Reminder sent to Ada".to_string()]);
+    /// assert_eq!(
+    ///     service.delivered_reminders(),
+    ///     vec!["Reminder sent to Ada".to_string()]
+    /// );
     /// # Ok::<(), tokio_reminders::ReminderServiceError>(())
     /// # })?;
     /// # Ok(())
     /// # }
     /// ```
     #[must_use]
-    pub fn delivered_reminders(&self) -> Vec<String> {
-        self.delivered.borrow().clone()
-    }
+    pub fn delivered_reminders(&self) -> Vec<String> { self.delivered.borrow().clone() }
 
     /// Returns the number of reminders still waiting to be flushed.
     ///
@@ -223,9 +222,7 @@ impl ReminderService {
     /// # }
     /// ```
     #[must_use]
-    pub fn pending_reminder_count(&self) -> usize {
-        self.pending.borrow().len()
-    }
+    pub fn pending_reminder_count(&self) -> usize { self.pending.borrow().len() }
 
     /// Returns the queued reminder recipients in scheduling order.
     ///
@@ -243,7 +240,10 @@ impl ReminderService {
     /// let service = ReminderService::new();
     /// service.schedule_reminder("Ada");
     /// service.schedule_reminder("Grace");
-    /// assert_eq!(service.pending_recipients(), vec!["Ada".to_string(), "Grace".to_string()]);
+    /// assert_eq!(
+    ///     service.pending_recipients(),
+    ///     vec!["Ada".to_string(), "Grace".to_string()]
+    /// );
     /// # Ok::<(), tokio_reminders::ReminderServiceError>(())
     /// # })?;
     /// # Ok(())
@@ -265,17 +265,22 @@ mod tests {
 
     use std::rc::Rc;
 
-    use super::{PendingReminder, ReminderService, ReminderTask};
     use rstest::{fixture, rstest};
+
+    use super::{PendingReminder, ReminderService, ReminderTask};
 
     #[fixture]
     fn local_set() -> tokio::task::LocalSet {
-        tokio::task::LocalSet::new()
+        let local_set = tokio::task::LocalSet::new();
+        std::hint::black_box(&local_set);
+        local_set
     }
 
     #[fixture]
     fn service() -> ReminderService {
-        ReminderService::new()
+        let service = ReminderService::new();
+        std::hint::black_box(&service);
+        service
     }
 
     #[rstest]

--- a/examples/tokio-reminders/src/lib.rs
+++ b/examples/tokio-reminders/src/lib.rs
@@ -269,6 +269,7 @@ mod tests {
 
     use super::{PendingReminder, ReminderService, ReminderTask};
 
+    #[rstest_bdd_test_macros::allow_fixture_expansion_lints]
     #[fixture]
     fn local_set() -> tokio::task::LocalSet {
         let local_set = tokio::task::LocalSet::new();
@@ -276,6 +277,7 @@ mod tests {
         local_set
     }
 
+    #[rstest_bdd_test_macros::allow_fixture_expansion_lints]
     #[fixture]
     fn service() -> ReminderService {
         let service = ReminderService::new();

--- a/examples/tokio-reminders/tests/reminders.rs
+++ b/examples/tokio-reminders/tests/reminders.rs
@@ -7,6 +7,7 @@ use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 use tokio_reminders::ReminderService;
 
+#[rstest_bdd_test_macros::allow_fixture_expansion_lints]
 #[fixture]
 fn service() -> ReminderService {
     let service = ReminderService::new();

--- a/examples/tokio-reminders/tests/reminders.rs
+++ b/examples/tokio-reminders/tests/reminders.rs
@@ -9,7 +9,9 @@ use tokio_reminders::ReminderService;
 
 #[fixture]
 fn service() -> ReminderService {
-    ReminderService::new()
+    let service = ReminderService::new();
+    std::hint::black_box(&service);
+    service
 }
 
 #[given("a reminder service")]

--- a/vendor/gpui-macros/src/lib.rs
+++ b/vendor/gpui-macros/src/lib.rs
@@ -3,7 +3,14 @@
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{
-    Error, FnArg, ItemFn, PatType, Signature, Type, TypeReference, parse::Nothing,
+    Error,
+    FnArg,
+    ItemFn,
+    PatType,
+    Signature,
+    Type,
+    TypeReference,
+    parse::Nothing,
     parse_macro_input,
 };
 

--- a/vendor/gpui/src/lib.rs
+++ b/vendor/gpui/src/lib.rs
@@ -25,13 +25,9 @@ enum AttemptAction {
 }
 
 impl AttemptAction {
-    const fn is_success(&self) -> bool {
-        matches!(self, Self::Success)
-    }
+    const fn is_success(&self) -> bool { matches!(self, Self::Success) }
 
-    const fn is_retry(&self) -> bool {
-        matches!(self, Self::Retry)
-    }
+    const fn is_retry(&self) -> bool { matches!(self, Self::Retry) }
 
     fn into_panic(self) -> Box<dyn Any + Send> {
         match self {
@@ -50,15 +46,11 @@ pub struct TestDispatcher {
 impl TestDispatcher {
     /// Creates a dispatcher for the supplied deterministic seed.
     #[must_use]
-    pub const fn new(seed: u64) -> Self {
-        Self { seed }
-    }
+    pub const fn new(seed: u64) -> Self { Self { seed } }
 
     /// Returns the deterministic seed associated with this dispatcher.
     #[must_use]
-    pub const fn seed(&self) -> u64 {
-        self.seed
-    }
+    pub const fn seed(&self) -> u64 { self.seed }
 
     /// Drives queued work until the dispatcher is idle.
     pub fn run_until_parked(&self) {}
@@ -71,9 +63,7 @@ pub struct BackgroundExecutor;
 impl BackgroundExecutor {
     /// Creates an executor associated with the supplied dispatcher.
     #[must_use]
-    pub fn new(_dispatcher: Arc<TestDispatcher>) -> Self {
-        Self
-    }
+    pub fn new(_dispatcher: Arc<TestDispatcher>) -> Self { Self }
 
     /// Blocks on an async test future.
     pub fn block_test<F>(&self, future: F) -> F::Output
@@ -110,33 +100,23 @@ impl TestAppContext {
 
     /// Creates a single-context instance seeded with `0`.
     #[must_use]
-    pub fn single() -> Self {
-        Self::build(TestDispatcher::new(0), None)
-    }
+    pub fn single() -> Self { Self::build(TestDispatcher::new(0), None) }
 
     /// Returns the originating test function name when available.
     #[must_use]
-    pub const fn test_function_name(&self) -> Option<&'static str> {
-        self.fn_name
-    }
+    pub const fn test_function_name(&self) -> Option<&'static str> { self.fn_name }
 
     /// Returns the dispatcher associated with this context.
     #[must_use]
-    pub const fn dispatcher(&self) -> &TestDispatcher {
-        &self.dispatcher
-    }
+    pub const fn dispatcher(&self) -> &TestDispatcher { &self.dispatcher }
 
     /// Returns the background executor associated with this context.
     #[must_use]
-    pub fn executor(&self) -> BackgroundExecutor {
-        self.executor.clone()
-    }
+    pub fn executor(&self) -> BackgroundExecutor { self.executor.clone() }
 
     /// Reports whether a path prompt was observed during the test run.
     #[must_use]
-    pub const fn did_prompt_for_new_path(&self) -> bool {
-        false
-    }
+    pub const fn did_prompt_for_new_path(&self) -> bool { false }
 
     /// Registers cleanup to run when the test context shuts down.
     pub fn on_quit(&mut self, _callback: impl FnOnce() + 'static) {}
@@ -154,9 +134,7 @@ impl TestAppContext {
 
     /// Returns the window handles known to this test context.
     #[must_use]
-    pub fn windows(&self) -> Vec<AnyWindowHandle> {
-        self.windows.handles()
-    }
+    pub fn windows(&self) -> Vec<AnyWindowHandle> { self.windows.handles() }
 
     /// Tears down the test context. This shim has no extra cleanup.
     pub fn quit(&self) {}

--- a/vendor/gpui/src/test_window.rs
+++ b/vendor/gpui/src/test_window.rs
@@ -12,7 +12,6 @@
 //! so stale handles, foreign context handles, and cross-window entity access
 //! fail instead of mutating unrelated test state.
 
-use crate::TestAppContext;
 use std::{
     any::Any,
     cell::{RefCell, RefMut},
@@ -23,6 +22,8 @@ use std::{
     rc::Rc,
     sync::atomic::{AtomicU64, Ordering},
 };
+
+use crate::TestAppContext;
 
 static NEXT_REGISTRY_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -72,9 +73,7 @@ impl WindowRegistry {
         (entity, visual_context)
     }
 
-    pub(crate) fn handles(&self) -> Vec<AnyWindowHandle> {
-        self.inner.borrow().windows.clone()
-    }
+    pub(crate) fn handles(&self) -> Vec<AnyWindowHandle> { self.inner.borrow().windows.clone() }
 
     pub(crate) fn contains(&self, window: AnyWindowHandle) -> bool {
         self.inner.borrow().windows.contains(&window)
@@ -132,15 +131,11 @@ pub struct Entity<T> {
 impl<T> Entity<T> {
     /// Returns the stable identifier backing this test handle.
     #[must_use]
-    pub const fn id(&self) -> u64 {
-        self.id
-    }
+    pub const fn id(&self) -> u64 { self.id }
 }
 
 impl<T> Clone for Entity<T> {
-    fn clone(&self) -> Self {
-        *self
-    }
+    fn clone(&self) -> Self { *self }
 }
 
 impl<T> Copy for Entity<T> {}
@@ -155,9 +150,7 @@ pub struct AnyWindowHandle {
 impl AnyWindowHandle {
     /// Returns the stable identifier backing this test window handle.
     #[must_use]
-    pub const fn id(&self) -> u64 {
-        self.id
-    }
+    pub const fn id(&self) -> u64 { self.id }
 }
 
 /// Error returned when a visual-context entity operation cannot find a handle.
@@ -199,9 +192,7 @@ impl VisualTestContext {
 
     /// Returns the durable handle for this visual context's window.
     #[must_use]
-    pub const fn window_handle(&self) -> AnyWindowHandle {
-        self.window
-    }
+    pub const fn window_handle(&self) -> AnyWindowHandle { self.window }
 
     /// Mutates an entity when the handle identifies a value of the expected type.
     pub fn update_entity<T>(


### PR DESCRIPTION
Pin nightly rustfmt for the workspace
unstable formatting options, install
it in CI, and apply the resulting mechanical source reformat.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

## References

- [Lody session](https://lody.ai/leynos/sessions/a5ef24d7-a1dc-4d26-a51c-a04abf3a52ee)
