### PR TITLE
Enforce private documentation across the workspace (#677)

### DIFF
--- a/vendor/gpui-macros/Cargo.toml
+++ b/vendor/gpui-macros/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 license = "Apache-2.0"
 description = "Stable-compatible GPUI test macro shim for rstest-bdd."
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 

--- a/vendor/gpui-macros/src/lib.rs
+++ b/vendor/gpui-macros/src/lib.rs
@@ -101,13 +101,19 @@ pub fn test(args: TokenStream, input: TokenStream) -> TokenStream {
 /// Generated statements and arguments that isolate each injected test context.
 ///
 /// Keeping creation and teardown alongside their corresponding argument list
-/// ensures the expansion drains and closes every context that it constructs.
+/// lets the expansion drain and close each context after the generated test
+/// body returns normally. A panic while evaluating the body or its result
+/// skips these post-call statements; retry orchestration remains owned by
+/// `gpui::run_test`.
 struct ContextSetup {
     /// Statements that construct the mutable contexts before the test body.
     setup: Vec<proc_macro2::TokenStream>,
     /// Borrowed context arguments passed to the annotated test function.
     args: Vec<proc_macro2::TokenStream>,
-    /// Statements that drain and close contexts after the test body returns.
+    /// Statements that drain and close contexts after a normal body return.
+    ///
+    /// A panic before these statements execute bypasses this generated
+    /// cleanup sequence.
     teardown: Vec<proc_macro2::TokenStream>,
 }
 
@@ -115,6 +121,17 @@ struct ContextSetup {
 ///
 /// The generated wrapper needs concrete context bindings, so generic functions
 /// and receiver parameters have no sound expansion in this limited test API.
+///
+/// # Examples
+///
+/// A concrete context parameter is accepted:
+///
+/// ```rust,ignore
+/// let signature: syn::Signature = syn::parse_quote!(
+///     fn renders_a_view(context: &gpui::TestAppContext)
+/// );
+/// assert!(validate_signature(&signature).is_ok());
+/// ```
 fn validate_signature(signature: &Signature) -> syn::Result<()> {
     if !signature.generics.params.is_empty() {
         return Err(Error::new_spanned(
@@ -180,8 +197,11 @@ fn validate_context_reference(reference: &TypeReference) -> syn::Result<()> {
 
 /// Generate context construction, argument borrowing, and deterministic teardown.
 ///
-/// Every supplied context is drained before and after it is quit, preventing
-/// pending tasks from leaking between attempts in the generated test wrapper.
+/// When the generated test body returns normally, each supplied context is
+/// drained before and after it is quit, preventing pending tasks from leaking
+/// between retry attempts. Because the wrapper invokes the test body before
+/// these statements, a panic skips this post-call teardown; this helper does
+/// not install an unwind guard, and retry handling remains in `run_test`.
 fn build_context_setup(
     signature: &Signature,
     declared_name: &syn::Ident,

--- a/vendor/gpui-macros/src/lib.rs
+++ b/vendor/gpui-macros/src/lib.rs
@@ -98,12 +98,23 @@ pub fn test(args: TokenStream, input: TokenStream) -> TokenStream {
     expanded.into()
 }
 
+/// Generated statements and arguments that isolate each injected test context.
+///
+/// Keeping creation and teardown alongside their corresponding argument list
+/// ensures the expansion drains and closes every context that it constructs.
 struct ContextSetup {
+    /// Statements that construct the mutable contexts before the test body.
     setup: Vec<proc_macro2::TokenStream>,
+    /// Borrowed context arguments passed to the annotated test function.
     args: Vec<proc_macro2::TokenStream>,
+    /// Statements that drain and close contexts after the test body returns.
     teardown: Vec<proc_macro2::TokenStream>,
 }
 
+/// Reject signature forms the shim cannot execute while preserving error spans.
+///
+/// The generated wrapper needs concrete context bindings, so generic functions
+/// and receiver parameters have no sound expansion in this limited test API.
 fn validate_signature(signature: &Signature) -> syn::Result<()> {
     if !signature.generics.params.is_empty() {
         return Err(Error::new_spanned(
@@ -126,6 +137,10 @@ fn validate_signature(signature: &Signature) -> syn::Result<()> {
     Ok(())
 }
 
+/// Confirm that one injected parameter is a reference to the test context.
+///
+/// This intentionally rejects arbitrary references because every argument is
+/// supplied by a newly constructed `gpui::TestAppContext`.
 fn validate_argument(argument: &PatType) -> syn::Result<()> {
     let Type::Reference(reference) = argument.ty.as_ref() else {
         return Err(Error::new_spanned(
@@ -137,6 +152,10 @@ fn validate_argument(argument: &PatType) -> syn::Result<()> {
     validate_context_reference(reference)
 }
 
+/// Validate the terminal type name of a context reference at its source span.
+///
+/// The shim accepts qualified context paths, but reports the offending type
+/// directly when the final segment cannot be provided by its generated setup.
 fn validate_context_reference(reference: &TypeReference) -> syn::Result<()> {
     let Type::Path(path) = reference.elem.as_ref() else {
         return Err(Error::new_spanned(
@@ -159,6 +178,10 @@ fn validate_context_reference(reference: &TypeReference) -> syn::Result<()> {
     }
 }
 
+/// Generate context construction, argument borrowing, and deterministic teardown.
+///
+/// Every supplied context is drained before and after it is quit, preventing
+/// pending tasks from leaking between attempts in the generated test wrapper.
 fn build_context_setup(
     signature: &Signature,
     declared_name: &syn::Ident,

--- a/vendor/gpui/Cargo.toml
+++ b/vendor/gpui/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 license = "Apache-2.0"
 description = "Stable-compatible GPUI test support shim for rstest-bdd."
 
+[lints]
+workspace = true
+
 [features]
 default = []
 test-support = []

--- a/vendor/gpui/src/lib.rs
+++ b/vendor/gpui/src/lib.rs
@@ -18,17 +18,24 @@ pub use test_window::{AnyWindowHandle, Entity, EntityError, VisualTestContext};
 
 mod test_window;
 
+/// Classifies one protected test invocation for the retry controller.
 enum AttemptAction {
+    /// The test body completed without unwinding.
     Success,
+    /// The panic is eligible for another attempt.
     Retry,
+    /// The final panic payload must resume after the failure callback runs.
     ResumeUnwind(Box<dyn Any + Send>),
 }
 
 impl AttemptAction {
+    /// Reports whether this action completes the seed successfully.
     const fn is_success(&self) -> bool { matches!(self, Self::Success) }
 
+    /// Reports whether the controller should repeat the current seed.
     const fn is_retry(&self) -> bool { matches!(self, Self::Retry) }
 
+    /// Extracts the panic payload retained exclusively by a terminal failure.
     fn into_panic(self) -> Box<dyn Any + Send> {
         match self {
             Self::ResumeUnwind(error) => error,
@@ -40,6 +47,7 @@ impl AttemptAction {
 /// Minimal dispatcher value passed through `run_test`.
 #[derive(Clone, Debug, Default)]
 pub struct TestDispatcher {
+    /// Deterministic input used to identify the active test attempt.
     seed: u64,
 }
 
@@ -80,9 +88,13 @@ impl BackgroundExecutor {
 /// Lightweight test context made available to GPUI-backed scenario execution.
 #[derive(Clone, Debug)]
 pub struct TestAppContext {
+    /// Dispatcher retained so views and generated teardown share the attempt seed.
     dispatcher: TestDispatcher,
+    /// Executor used when an expanded test function is asynchronous.
     executor: BackgroundExecutor,
+    /// Original test name, retained for assertions made inside generated contexts.
     fn_name: Option<&'static str>,
+    /// Windows and entities owned exclusively by this test context.
     windows: test_window::WindowRegistry,
 }
 
@@ -155,6 +167,17 @@ where
 }
 
 /// Runs a GPUI-style test closure for the supplied seeds and retry policy.
+///
+/// The retry diagnostics deliberately go directly to the test process because
+/// this minimal shim does not install a global tracing subscriber.
+#[expect(
+    clippy::print_stdout,
+    reason = "retry progress must remain visible without a global tracing subscriber"
+)]
+#[expect(
+    clippy::print_stderr,
+    reason = "seed diagnostics must remain visible when a test eventually panics"
+)]
 pub fn run_test(
     num_iterations: usize,
     explicit_seeds: &[u64],
@@ -192,6 +215,10 @@ pub fn run_test(
     }
 }
 
+/// Run one attempt under unwind capture and classify the retry decision.
+///
+/// Only the final failure retains its payload, so callers can run their
+/// callback before resuming the original panic without changing its value.
 fn classify_attempt(
     seed: u64,
     attempt: usize,
@@ -210,6 +237,10 @@ fn classify_attempt(
     }
 }
 
+/// Resolve the complete seed sequence and whether seed labels aid diagnostics.
+///
+/// Environment overrides take precedence over explicit seeds to mirror GPUI's
+/// reproducible test-run contract.
 fn calculate_seeds(
     iterations: u64,
     explicit_seeds: &[u64],
@@ -222,12 +253,21 @@ fn calculate_seeds(
     (seeds.into_iter(), is_multiple_runs)
 }
 
+/// Resolve the iteration count while preserving at least one test execution.
 fn resolve_iterations(default_iterations: u64) -> u64 {
     parse_env_u64("ITERATIONS")
         .unwrap_or(default_iterations)
         .max(1)
 }
 
+/// Parse an optional unsigned environment override without failing the test run.
+///
+/// Invalid values are diagnosed to stderr because this shim has no logging
+/// subscriber and must make a discarded override observable to the developer.
+#[expect(
+    clippy::print_stderr,
+    reason = "invalid environment overrides must be visible without global logging"
+)]
 fn parse_env_u64(key: &str) -> Option<u64> {
     let value = env::var(key).ok()?;
     match value.parse() {
@@ -239,6 +279,7 @@ fn parse_env_u64(key: &str) -> Option<u64> {
     }
 }
 
+/// Select deterministic seeds, giving an environment override precedence.
 fn select_seeds(iterations: u64, explicit_seeds: &[u64], env_seed: Option<u64>) -> Vec<u64> {
     if let Some(seed) = env_seed {
         return build_seed_range(seed, iterations);
@@ -253,18 +294,25 @@ fn select_seeds(iterations: u64, explicit_seeds: &[u64], env_seed: Option<u64>) 
     seeds
 }
 
+/// Build a non-empty consecutive seed range, truncating safely on overflow.
+///
+/// The truncation warning is emitted directly because silently wrapping would
+/// make a failing run unreproducible.
+#[expect(
+    clippy::print_stderr,
+    reason = "seed-range truncation must be visible without global logging"
+)]
 fn build_seed_range(start: u64, iterations: u64) -> Vec<u64> {
     let mut seeds = Vec::new();
     for offset in 0..iterations.max(1) {
-        match start.checked_add(offset) {
-            Some(seed) => seeds.push(seed),
-            None => {
-                eprintln!(
-                    "seed range overflowed for start={start} and iterations={iterations}; \
-                     truncating generated seeds"
-                );
-                break;
-            }
+        if let Some(seed) = start.checked_add(offset) {
+            seeds.push(seed);
+        } else {
+            eprintln!(
+                "seed range overflowed for start={start} and iterations={iterations}; truncating \
+                 generated seeds"
+            );
+            break;
         }
     }
 

--- a/vendor/gpui/src/lib.rs
+++ b/vendor/gpui/src/lib.rs
@@ -264,16 +264,32 @@ fn resolve_iterations(default_iterations: u64) -> u64 {
 ///
 /// Invalid values are diagnosed to stderr because this shim has no logging
 /// subscriber and must make a discarded override observable to the developer.
+fn parse_env_u64(key: &str) -> Option<u64> { parse_env_u64_value(key, env::var(key)) }
+
+/// Parse a fallible environment lookup as an optional unsigned override.
+///
+/// A missing variable is deliberately optional, whereas an invalid Unicode or
+/// numeric value is discarded after its diagnostic makes the configuration
+/// mistake visible to the test author.
 #[expect(
     clippy::print_stderr,
     reason = "invalid environment overrides must be visible without global logging"
 )]
-fn parse_env_u64(key: &str) -> Option<u64> {
-    let value = env::var(key).ok()?;
-    match value.parse() {
-        Ok(parsed) => Some(parsed),
-        Err(error) => {
-            eprintln!("ignoring invalid {key} value {value:?}: {error}");
+fn parse_env_u64_value(key: &str, value: Result<String, env::VarError>) -> Option<u64> {
+    match value {
+        Ok(value) => match value.parse() {
+            Ok(parsed) => Some(parsed),
+            Err(error) => {
+                eprintln!("ignoring invalid {key} value {value:?}: {error}");
+                None
+            }
+        },
+        Err(env::VarError::NotPresent) => None,
+        Err(env::VarError::NotUnicode(value)) => {
+            eprintln!(
+                "ignoring invalid {key} value {}: value is not valid Unicode",
+                value.display()
+            );
             None
         }
     }
@@ -321,4 +337,21 @@ fn build_seed_range(start: u64, iterations: u64) -> Vec<u64> {
     }
 
     seeds
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests the environment-override boundary without mutating process state.
+
+    use std::{env::VarError, ffi::OsString};
+
+    use super::parse_env_u64_value;
+
+    /// Treats an injected non-Unicode lookup failure as an invalid override.
+    #[test]
+    fn discards_non_unicode_environment_override() {
+        let value = VarError::NotUnicode(OsString::from("invalid-byte-sequence"));
+
+        assert_eq!(parse_env_u64_value("SEED", Err(value)), None);
+    }
 }

--- a/vendor/gpui/src/test_window.rs
+++ b/vendor/gpui/src/test_window.rs
@@ -25,10 +25,13 @@ use std::{
 
 use crate::TestAppContext;
 
+/// Allocates process-unique registry identities for rejecting foreign handles.
 static NEXT_REGISTRY_ID: AtomicU64 = AtomicU64::new(1);
 
+/// Owns the mutable window/entity state for one `TestAppContext`.
 #[derive(Clone, Debug)]
 pub(crate) struct WindowRegistry {
+    /// Shared interior state so visual contexts retain access after construction.
     inner: Rc<RefCell<WindowRegistryState>>,
 }
 
@@ -41,6 +44,10 @@ impl Default for WindowRegistry {
 }
 
 impl WindowRegistry {
+    /// Allocate a window/entity pair before invoking the view constructor.
+    ///
+    /// Reserving both identifiers first lets the constructor retain a visual
+    /// context that can address the newly created window.
     pub(crate) fn add_window_view<T>(
         &self,
         build_view: impl FnOnce(&mut VisualTestContext) -> T,
@@ -73,12 +80,18 @@ impl WindowRegistry {
         (entity, visual_context)
     }
 
+    /// Return a snapshot of handles owned by this registry.
     pub(crate) fn handles(&self) -> Vec<AnyWindowHandle> { self.inner.borrow().windows.clone() }
 
+    /// Report whether a handle belongs to this registry's window set.
     pub(crate) fn contains(&self, window: AnyWindowHandle) -> bool {
         self.inner.borrow().windows.contains(&window)
     }
 
+    /// Store a view under the window and typed handle allocated for it.
+    ///
+    /// Callers must have allocated both values from this registry; later reads
+    /// verify that ownership before downcasting the erased value.
     fn insert_entity<T>(&self, window: AnyWindowHandle, entity: Entity<T>, view: T)
     where
         T: 'static,
@@ -93,22 +106,32 @@ impl WindowRegistry {
     }
 }
 
+/// Type-erased entity storage paired with its owning window.
 #[derive(Debug)]
 struct StoredEntity {
+    /// Window permitted to access this value.
     window: AnyWindowHandle,
+    /// Runtime-erased view value, downcast only through a matching `Entity<T>`.
     value: Box<dyn Any>,
 }
 
+/// Mutable bookkeeping for the windows and entities of one test context.
 #[derive(Debug)]
 struct WindowRegistryState {
+    /// Process-unique provenance used to reject foreign handles.
     registry_id: u64,
+    /// Last entity identity issued by this registry.
     next_entity_id: u64,
+    /// Last window identity issued by this registry.
     next_window_id: u64,
+    /// Handles returned to callers in creation order.
     windows: Vec<AnyWindowHandle>,
+    /// Type-erased entity values indexed by their stable identity.
     entities: HashMap<u64, StoredEntity>,
 }
 
 impl WindowRegistryState {
+    /// Initialise empty state with a unique registry provenance identity.
     fn new() -> Self {
         Self {
             registry_id: NEXT_REGISTRY_ID.fetch_add(1, Ordering::Relaxed),
@@ -123,8 +146,11 @@ impl WindowRegistryState {
 /// Durable typed handle for an entity stored in a GPUI test window.
 #[derive(Debug)]
 pub struct Entity<T> {
+    /// Registry that created this handle and therefore owns its entity value.
     registry_id: u64,
+    /// Stable identity used as the entity-store key.
     id: u64,
+    /// Retains the entity's compile-time type without storing a `T` value.
     _marker: PhantomData<fn() -> T>,
 }
 
@@ -143,7 +169,9 @@ impl<T> Copy for Entity<T> {}
 /// Type-erased durable handle for a GPUI test window.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct AnyWindowHandle {
+    /// Registry that created this handle and therefore owns its window.
     registry_id: u64,
+    /// Stable identity used to distinguish windows within the registry.
     id: u64,
 }
 
@@ -157,7 +185,10 @@ impl AnyWindowHandle {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum EntityError {
     /// The entity handle does not identify an entity of the expected type.
-    NotFound { id: u64 },
+    NotFound {
+        /// Stable identifier from the handle that could not be resolved.
+        id: u64,
+    },
 }
 
 impl fmt::Display for EntityError {
@@ -176,7 +207,9 @@ impl Error for EntityError {}
 /// Window-bound visual context reconstructed during GPUI tests.
 #[derive(Clone, Debug)]
 pub struct VisualTestContext {
+    /// Window to which all reads and writes through this context are confined.
     window: AnyWindowHandle,
+    /// Shared state that validates registry and window ownership before access.
     registry: Rc<RefCell<WindowRegistryState>>,
 }
 
@@ -195,6 +228,11 @@ impl VisualTestContext {
     pub const fn window_handle(&self) -> AnyWindowHandle { self.window }
 
     /// Mutates an entity when the handle identifies a value of the expected type.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EntityError::NotFound`] when the handle comes from another
+    /// registry or window, or when it identifies a different concrete type.
     pub fn update_entity<T>(
         &mut self,
         entity: Entity<T>,
@@ -227,10 +265,12 @@ impl VisualTestContext {
             .map(read)
     }
 
+    /// Bind a visual context to one known window and its registry state.
     fn new(window: AnyWindowHandle, registry: Rc<RefCell<WindowRegistryState>>) -> Self {
         Self { window, registry }
     }
 
+    /// Borrow a typed entity only when its registry and window match this context.
     fn entity_mut<T>(&mut self, entity: Entity<T>) -> Option<RefMut<'_, T>>
     where
         T: 'static,

--- a/vendor/gpui/src/test_window.rs
+++ b/vendor/gpui/src/test_window.rs
@@ -131,7 +131,7 @@ struct WindowRegistryState {
 }
 
 impl WindowRegistryState {
-    /// Initialise empty state with a unique registry provenance identity.
+    /// Initialize empty state with a unique registry provenance identity.
     fn new() -> Self {
         Self {
             registry_id: NEXT_REGISTRY_ID.fetch_add(1, Ordering::Relaxed),


### PR DESCRIPTION
## Summary

This branch extends the existing workspace denial of
`clippy::missing_docs_in_private_items` to the local GPUI shim and its
proc-macro crate. It documents the private generated-context lifecycle,
entity provenance, erased-storage boundary, and seed/retry contracts exposed
when those packages adopt the shared lint policy.

Closes #677.

## Review walkthrough

- Start with [vendor/gpui/Cargo.toml](https://github.com/leynos/rstest-bdd/blob/issue-677-deny-missing-documentation-on-private-items-across-the-workspace/vendor/gpui/Cargo.toml#L9) and [vendor/gpui-macros/Cargo.toml](https://github.com/leynos/rstest-bdd/blob/issue-677-deny-missing-documentation-on-private-items-across-the-workspace/vendor/gpui-macros/Cargo.toml#L9) to see both local workspace members inherit the canonical lint policy.
- Review [vendor/gpui-macros/src/lib.rs](https://github.com/leynos/rstest-bdd/blob/issue-677-deny-missing-documentation-on-private-items-across-the-workspace/vendor/gpui-macros/src/lib.rs#L101) for source-span validation and generated context setup/teardown semantics.
- Then review [vendor/gpui/src/test_window.rs](https://github.com/leynos/rstest-bdd/blob/issue-677-deny-missing-documentation-on-private-items-across-the-workspace/vendor/gpui/src/test_window.rs#L28) and [vendor/gpui/src/lib.rs](https://github.com/leynos/rstest-bdd/blob/issue-677-deny-missing-documentation-on-private-items-across-the-workspace/vendor/gpui/src/lib.rs#L169) for ownership invariants and narrowly scoped test-process diagnostic expectations.

## Validation

- `make check-fmt`: passed
- `make typecheck`: passed
- `make lint`: passed, including `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `make test`: passed; 1,748 Nextest tests, doctests, and 69 Python tests passed

## References

- Issue: https://github.com/leynos/rstest-bdd/issues/677
- Lody session: https://lody.ai/leynos/sessions/7f8a494c-9e21-4813-aacc-92334df9105c

## Summary by Sourcery

Enforce private-item documentation across the local GPUI workspace crates while clarifying their internal API contracts.

Enhancements:
- Apply the shared private-documentation lint policy to the local GPUI and GPUI proc-macro workspace members.
- Document private GPUI lifecycle, ownership, storage, provenance, and seed/retry contracts required by the stricter lint policy.