### PR TITLE
Canonicalize Markdown formatting

### DIFF
--- a/docs/adr-018-parser-neutral-scenario-execution.md
+++ b/docs/adr-018-parser-neutral-scenario-execution.md
@@ -19,9 +19,9 @@ generates the remaining scenario orchestration code.
 
 The generated scenario loop currently owns policy that is not intrinsically
 Gherkin-specific. It executes steps in order, inserts step return values into
-`StepContext`, stops after a failure or skip, records skipped work, and converts
-terminal failures into panics for the Rust test harness. This policy exists as
-quoted generated code rather than as a public runtime function.
+`StepContext`, stops after a failure or skip, records skipped work, and
+converts terminal failures into panics for the Rust test harness. This policy
+exists as quoted generated code rather than as a public runtime function.
 
 Trymark proposes a standalone Markdown frontend for literate behavioural tests.
 The stock Trymark executable must run in repositories that contain no
@@ -37,8 +37,8 @@ that accepts an already-parsed scenario would let frontends supply steps
 without translating them into temporary Gherkin or generated Rust source.
 
 The decision is whether rstest-bdd should expose parser-neutral scenario
-orchestration as a supported runtime API, and how to do so without weakening the
-existing Gherkin and rstest integrations.
+orchestration as a supported runtime API, and how to do so without weakening
+the existing Gherkin and rstest integrations.
 
 ## Decision drivers
 
@@ -88,8 +88,8 @@ existing Gherkin and rstest integrations.
 1. The parser-neutral plan contains no `gherkin` Abstract Syntax Tree (AST),
    Markdown, Trymark, Clap, process, snapshot, or reporter types.
 2. The runtime runner does not panic for an ordinary scenario failure. It
-   returns a typed outcome. Panics from step handlers remain represented through
-   the existing step-error machinery.
+   returns a typed outcome. Panics from step handlers remain represented
+   through the existing step-error machinery.
 3. The initial change is additive. Existing step macros, scenario macros,
    `execute_step`, and `execute_step_async` continue to work.
 4. The procedural macro crate delegates canonical scenario-loop policy to the
@@ -149,8 +149,8 @@ Markdown.
 ### Option E: extract a new shared core crate immediately
 
 The project could first move the registry, context, execution, plan, and runner
-into a new `rstest-bdd-core` crate, with Gherkin and rstest integrations layered
-above it.
+into a new `rstest-bdd-core` crate, with Gherkin and rstest integrations
+layered above it.
 
 Deferred. The conceptual split may become useful, particularly if the existing
 runtime's `gherkin` dependency proves undesirable for standalone consumers.
@@ -158,22 +158,23 @@ Doing it before the public runner exists combines two architectural changes and
 makes review harder. The first implementation should add the boundary inside
 `rstest-bdd`; later evidence can justify extraction.
 
-| Topic | Independent engine | Temporary Gherkin or Rust | Parser-neutral runner | Immediate core crate |
-| --- | --- | --- | --- | --- |
-| One execution policy | No | Partly | Yes | Yes |
-| Source fidelity | Yes | No | Yes | Yes |
-| No Rust setup for stock Trymark | Yes | No | Yes | Yes |
-| Change to rstest-bdd | None | Small frontend workaround | Focused runtime API | Large package refactor |
-| Risk of semantic drift | High | Medium | Low | Low |
-| Initial implementation cost | Medium | Medium | Medium | High |
+| Topic                           | Independent engine | Temporary Gherkin or Rust | Parser-neutral runner | Immediate core crate   |
+| ------------------------------- | ------------------ | ------------------------- | --------------------- | ---------------------- |
+| One execution policy            | No                 | Partly                    | Yes                   | Yes                    |
+| Source fidelity                 | Yes                | No                        | Yes                   | Yes                    |
+| No Rust setup for stock Trymark | Yes                | No                        | Yes                   | Yes                    |
+| Change to rstest-bdd            | None               | Small frontend workaround | Focused runtime API   | Large package refactor |
+| Risk of semantic drift          | High               | Medium                    | Low                   | Low                    |
+| Initial implementation cost     | Medium             | Medium                    | Medium                | High                   |
 
 _Table 1: Trade-offs between the considered execution architectures._
 
 ## Decision outcome and proposed direction
 
-rstest-bdd will expose parser-neutral scenario execution from its runtime crate.
-The Gherkin macros will become one frontend over that API. Trymark can become a
-second frontend while shipping as an independent repository and executable.
+rstest-bdd will expose parser-neutral scenario execution from its runtime
+crate. The Gherkin macros will become one frontend over that API. Trymark can
+become a second frontend while shipping as an independent repository and
+executable.
 
 ### Scenario plan
 
@@ -182,11 +183,11 @@ shape remains an implementation detail to settle through a focused API spike,
 but it must support borrowed static data from generated tests and owned dynamic
 data from external parsers.
 
-The first plan contract includes tags and `allow_skipped`; they are not deferred
-to a later policy object. The representation must support both generated
-borrowed static sources and external owned sources. Its final ownership shape,
-field names, and type names remain free to evolve until the Stage 1
-compatibility review.
+The first plan contract includes tags and `allow_skipped`; they are not
+deferred to a later policy object. The representation must support both
+generated borrowed static sources and external owned sources. Its final
+ownership shape, field names, and type names remain free to evolve until the
+Stage 1 compatibility review.
 
 The following snippet is illustrative only. It does not establish final public
 field or type names, lifetime syntax, or ownership representation:
@@ -266,15 +267,15 @@ in the plan, in plan order. After a terminal skip or failure, every remaining
 invocation is recorded as `Bypassed`; diagnostics or reporter configuration
 must not change this sequence.
 
-`SourceLocation` consists of a path, a one-based line, and an optional one-based
-column measured in Unicode scalar values. Locations are never added to
+`SourceLocation` consists of a path, a one-based line, and an optional
+one-based column measured in Unicode scalar values. Locations are never added to
 `ExecutionError` and are never inferred by parsing error strings.
 
 The runner surface will provide synchronous and asynchronous forms:
 
 The first runner accepts a per-run `ScenarioScope` lifecycle token, not a bare
-`&mut StepContext`. The scope is consumed once and cannot be reused. It owns the
-lifecycle and cleanup guard around the otherwise caller-backed context.
+`&mut StepContext`. The scope is consumed once and cannot be reused. It owns
+the lifecycle and cleanup guard around the otherwise caller-backed context.
 
 ```rust,no_run
 pub fn run_scenario(
@@ -310,19 +311,19 @@ arrays and adapters, but it must not carry an independent result-handling loop.
 ### Skip parity
 
 A successfully skipped step remains `Skipped` in every configuration. Its
-`forced_failure` value is exactly `!allow_skipped && fail_on_skipped`.
-The runner resolves `fail_on_skipped` once per run, using programmatic
+`forced_failure` value is exactly `!allow_skipped && fail_on_skipped`. The
+runner resolves `fail_on_skipped` once per run, using programmatic
 configuration first, then `RSTEST_BDD_FAIL_ON_SKIPPED`, and finally `false`.
 Both runner forms use that resolved value. Macro-generated tests and external
 frontends must use the same resolution rather than implementing separate
 skip-failure policy.
 
 | `allow_skipped` | `fail_on_skipped` | Step outcome | `forced_failure` |
-| --- | --- | --- | --- |
-| `false` | `false` | `Skipped` | `false` |
-| `false` | `true` | `Skipped` | `true` |
-| `true` | `false` | `Skipped` | `false` |
-| `true` | `true` | `Skipped` | `false` |
+| --------------- | ----------------- | ------------ | ---------------- |
+| `false`         | `false`           | `Skipped`    | `false`          |
+| `false`         | `true`            | `Skipped`    | `true`           |
+| `true`          | `false`           | `Skipped`    | `false`          |
+| `true`          | `true`            | `Skipped`    | `false`          |
 
 The verification suite must execute and assert all four rows. They are part of
 the parity contract, including when an aggregate caller later treats a forced
@@ -333,14 +334,14 @@ skip as a failure.
 Once a scenario scope begins, cleanup and the after-scenario hook run exactly
 once on every listed terminal path:
 
-| Path | Step execution | After/cleanup | Primary outcome |
-| --- | --- | --- | --- |
-| Before-hook failure | No steps run | Exactly once | Before failure wins |
-| Step pass | Eligible steps continue | Exactly once | Step results decide |
-| Step skip | Later steps are bypassed | Exactly once | Normal skip remains terminal |
-| Step failure | Later steps are bypassed | Exactly once | Step failure wins |
-| Resolution or fixture failure | Later steps are bypassed | Exactly once | Resolution/fixture failure wins |
-| Panic or unwind | Execution stops as applicable | Exactly once | Panic/step failure wins |
+| Path                          | Step execution                | After/cleanup | Primary outcome                 |
+| ----------------------------- | ----------------------------- | ------------- | ------------------------------- |
+| Before-hook failure           | No steps run                  | Exactly once  | Before failure wins             |
+| Step pass                     | Eligible steps continue       | Exactly once  | Step results decide             |
+| Step skip                     | Later steps are bypassed      | Exactly once  | Normal skip remains terminal    |
+| Step failure                  | Later steps are bypassed      | Exactly once  | Step failure wins               |
+| Resolution or fixture failure | Later steps are bypassed      | Exactly once  | Resolution/fixture failure wins |
+| Panic or unwind               | Execution stops as applicable | Exactly once  | Panic/step failure wins         |
 
 An after/cleanup failure is retained as a secondary cleanup diagnostic when a
 primary before or step failure exists. When there is no primary failure,
@@ -446,14 +447,14 @@ failures. The two paths must agree before macro migration.
 
 Change macro output to build a plan and call the runtime API. Remove the old
 result-handling loop after parity tests pass. Retain only thin generated
-adapters for fixture setup, harness integration, outline values, and translation
-to the Rust test harness.
+adapters for fixture setup, harness integration, outline values, and
+translation to the Rust test harness.
 
 ### Stage 4: validate an external frontend
 
-Use Trymark, or a small conformance frontend if Trymark is not yet available, to
-parse scenarios at runtime and execute standard linked steps. This stage proves
-that the API is genuinely parser-neutral rather than merely a rearranged
+Use Trymark, or a small conformance frontend if Trymark is not yet available,
+to parse scenarios at runtime and execute standard linked steps. This stage
+proves that the API is genuinely parser-neutral rather than merely a rearranged
 Gherkin implementation.
 
 A later release may deprecate Gherkin-specific runtime field names or extract a

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -377,10 +377,10 @@ tests for the table checker live in
 
 `docs/users-guide.md` carries a "Published gpui 0.2.2 stateful step variants"
 subsection whose snippets target the crates.io `gpui` crate rather than the
-`vendor/gpui` shim. `tests/fixtures/published-gpui-0-2-2/` is a
-compile-checked mirror of those snippets, so the published call shapes cannot
-silently drift from the guide. Compare the vendored snippets, which are
-mirrored by the executable regression suite
+`vendor/gpui` shim. `tests/fixtures/published-gpui-0-2-2/` is a compile-checked
+mirror of those snippets, so the published call shapes cannot silently drift
+from the guide. Compare the vendored snippets, which are mirrored by the
+executable regression suite
 `crates/rstest-bdd-harness-gpui/tests/stateful_window.rs`.
 
 Run the check with:
@@ -398,34 +398,33 @@ check-published-gpui: ## Compile the published gpui 0.2.2 documentation fixture
 		tests/fixtures/published-gpui-0-2-2/Cargo.toml
 ```
 
-The fixture declares its own empty `[workspace]` table so that `gpui`
-resolves from crates.io rather than inheriting the root workspace's path
-dependency. The root `Cargo.toml` pins the shim:
+The fixture declares its own empty `[workspace]` table so that `gpui` resolves
+from crates.io rather than inheriting the root workspace's path dependency. The
+root `Cargo.toml` pins the shim:
 
 ```toml
 gpui = { version = "0.2.2", path = "vendor/gpui", default-features = false, features = ["test-support"] }
 ```
 
-so any crate inside the root workspace would otherwise pull it in.
-One consequence: because `rstest-bdd-harness-gpui` depends on
+so any crate inside the root workspace would otherwise pull it in. One
+consequence: because `rstest-bdd-harness-gpui` depends on
 `gpui.workspace = true` (the shim), the fixture cannot use `GpuiHarness`; it
 declares bare `#[given]`/`#[when]`/`#[then]` steps that take
 `#[from(rstest_bdd_harness_context)] context: &mut gpui::TestAppContext`
 directly.
 
 The fixture commits its own `tests/fixtures/published-gpui-0-2-2/Cargo.lock`,
-separate from the root workspace lockfile, and the target passes `--locked`,
-so the check is reproducible and a dependency bump has to be an explicit,
-reviewed lockfile change rather than a silent resolution drift.
+separate from the root workspace lockfile, and the target passes `--locked`, so
+the check is reproducible and a dependency bump has to be an explicit, reviewed
+lockfile change rather than a silent resolution drift.
 
-The check is deliberately `cargo check` only: the fixture is never executed,
-so the `assert_eq!` calls inside its steps document the expected published
-semantics but do not run. The real crates.io `gpui` pulls in the full
-graphics and windowing stack (`blade-graphics`, Wayland and X11 client
-libraries, `cosmic-text`, `bindgen`), none of which CI provisions; the
-`vendor/gpui` shim exists exactly so the executable suite can run without
-them. Anyone changing the fixture should treat compilation, not assertion, as
-the gate.
+The check is deliberately `cargo check` only: the fixture is never executed, so
+the `assert_eq!` calls inside its steps document the expected published
+semantics but do not run. The real crates.io `gpui` pulls in the full graphics
+and windowing stack (`blade-graphics`, Wayland and X11 client libraries,
+`cosmic-text`, `bindgen`), none of which CI provisions; the `vendor/gpui` shim
+exists exactly so the executable suite can run without them. Anyone changing
+the fixture should treat compilation, not assertion, as the gate.
 
 Unlike the GPUI mapping-table check described above, this is a dedicated CI
 step invoked directly, not part of `make lint` or `make test`. It runs as a
@@ -437,8 +436,8 @@ standalone step in `.github/workflows/ci.yml`:
   run: make check-published-gpui
 ```
 
-Consequently it does not run in a plain local `make lint`; developers
-touching the published snippets should run it by hand.
+Consequently it does not run in a plain local `make lint`; developers touching
+the published snippets should run it by hand.
 
 ## `#[serial]`/nextest matrix validation (`scripts/check_serial_nextest_matrix.py`)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -891,26 +891,25 @@ changing the public trait contracts.
   published snippets compile against crates.io `gpui 0.2.2`, the vendored and
   published variants are visibly paired, and a drift gate covers both. Design
   Doc: `docs/rstest-bdd-design.md` §2.7.6.2. Origin: `leynos/rstest-bdd#575`
-  and the gauss v0.6.0-beta3 adoption report.
-  Delivered 2026-08-12: the user guide pairs a `Published gpui 0.2.2 stateful
-  step variants` subsection with the vendored playbook, cross-linked in both
-  directions, covering `given`, `when`, and `then`; the v0.6.0 migration guide
-  carries the compact downstream translation. The snippets are proved by a
-  nested-workspace fixture (`tests/fixtures/published-gpui-0-2-2/`) that
-  resolves `gpui 0.2.2` from crates.io rather than the workspace's vendored
-  path dependency, and whose bindings force the published return shapes
-  (`update_entity`/`read_entity` yield `R` directly, not `Result<R, _>`).
-  Drift is gated on two sides: `scripts/check_gpui_mapping_table.py` under
-  `make lint` covers the vendored-to-published mapping table, and
-  `make check-published-gpui` compiles the fixture with `--locked` under
-  `-D warnings`, wired into CI. The fixture is also under `make fmt` and
-  `make check-fmt`, which do not otherwise reach a nested workspace.
-  Caveat: the fixture is compile-only. An executable published-GPUI scenario
-  is blocked because `rstest-bdd-harness-gpui` binds the vendored shim via
-  `gpui.workspace = true`, so `GpuiHarness` is unavailable to a published-gpui
-  workspace; that remains open. Validation: `make check-fmt`, `make lint`,
-  `make typecheck`, `make test`, `make markdownlint`, and
-  `make check-published-gpui` passed.
+  and the gauss v0.6.0-beta3 adoption report. Delivered 2026-08-12: the user
+  guide pairs a `Published gpui 0.2.2 stateful step variants` subsection with
+  the vendored playbook, cross-linked in both directions, covering `given`,
+  `when`, and `then`; the v0.6.0 migration guide carries the compact downstream
+  translation. The snippets are proved by a nested-workspace fixture
+  (`tests/fixtures/published-gpui-0-2-2/`) that resolves `gpui 0.2.2` from
+  crates.io rather than the workspace's vendored path dependency, and whose
+  bindings force the published return shapes (`update_entity`/`read_entity`
+  yield `R` directly, not `Result<R, _>`). Drift is gated on two sides:
+  `scripts/check_gpui_mapping_table.py` under `make lint` covers the
+  vendored-to-published mapping table, and `make check-published-gpui` compiles
+  the fixture with `--locked` under `-D warnings`, wired into CI. The fixture
+  is also under `make fmt` and `make check-fmt`, which do not otherwise reach a
+  nested workspace. Caveat: the fixture is compile-only. An executable
+  published-GPUI scenario is blocked because `rstest-bdd-harness-gpui` binds
+  the vendored shim via `gpui.workspace = true`, so `GpuiHarness` is
+  unavailable to a published-gpui workspace; that remains open. Validation:
+  `make check-fmt`, `make lint`, `make typecheck`, `make test`,
+  `make markdownlint`, and `make check-published-gpui` passed.
 
 > **Note (dual-track maintenance):** items 10.2.4 and 10.2.5 introduce a
 > vendored-to-published mapping table that must be kept in sync with any
@@ -1208,8 +1207,8 @@ external-frontends rely on. See
 proposed direction).
 
 - [ ] 13.1.1. Add parser-neutral `ScenarioPlan`, `StepInvocation`, source, and
-  structured terminal-outcome types plus synchronous and asynchronous runners
-  in `rstest-bdd`.
+  structured terminal-outcome types plus synchronous and asynchronous runners in
+  `rstest-bdd`.
   - Requires 12.1.1 and 12.1.3.
   - Keep `gherkin`, Markdown, Trymark, process, snapshot, and reporter types
     out of the public plan and outcome surface.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1332,11 +1332,11 @@ typed view entity plus a visual context. The vendored fork returns
 `(Entity<T>, &mut VisualTestContext)`. `Entity<T>` is the typed, durable handle
 to the stored view, and `VisualTestContext::window_handle()` returns the
 `AnyWindowHandle` that identifies the window itself. Both handles remain valid
-across steps. `VisualTestContext`, by contrast, is tied to the
-`TestAppContext` it was created against and must not be stored across steps: a
-later step receives a fresh `&mut TestAppContext` from the harness. Stateful
-steps therefore store `Entity<T>` and `AnyWindowHandle` only, and rebuild a
-fresh `VisualTestContext` inside each step that needs visual interaction.
+across steps. `VisualTestContext`, by contrast, is tied to the `TestAppContext`
+it was created against and must not be stored across steps: a later step
+receives a fresh `&mut TestAppContext` from the harness. Stateful steps
+therefore store `Entity<T>` and `AnyWindowHandle` only, and rebuild a fresh
+`VisualTestContext` inside each step that needs visual interaction.
 
 ##### Reset protocol
 
@@ -1379,11 +1379,10 @@ test-group matrix.
 #### Worked example
 
 The scenario-state and vendored call-site snippets below mirror the regression
-suite at
-`crates/rstest-bdd-harness-gpui/tests/stateful_window.rs` exactly. Treat that
-file as the executable reference: if a snippet here
-drifts from the suite, the suite wins and this section should be updated to
-match. Projects consuming published `gpui 0.2.2` should use the parallel
+suite at `crates/rstest-bdd-harness-gpui/tests/stateful_window.rs` exactly.
+Treat that file as the executable reference: if a snippet here drifts from the
+suite, the suite wins and this section should be updated to match. Projects
+consuming published `gpui 0.2.2` should use the parallel
 [published call-site variants](#published-gpui-022-stateful-step-variants)
 instead.
 
@@ -1593,10 +1592,10 @@ fn fresh_gpui_window_is_opened(
 The published reconstruction constructor returns `VisualTestContext` by value.
 Its entity methods take the entity by reference: `update_entity`'s callback
 receives `&mut Context<T>` as its second argument, whereas `read_entity`'s
-callback receives `&App`. Their `AppContext::Result<R>` alias is `R`,
-so assertions compare the returned values directly rather than unwrapping
-`Option` or `Result`. Unlike the vendored helper, the published helper clones
-the stored entity because published `Entity<T>` is `Clone`, not `Copy`:
+callback receives `&App`. Their `AppContext::Result<R>` alias is `R`, so
+assertions compare the returned values directly rather than unwrapping `Option`
+or `Result`. Unlike the vendored helper, the published helper clones the stored
+entity because published `Entity<T>` is `Clone`, not `Copy`:
 
 ```rust,ignore
 use gpui::AppContext as _;

--- a/docs/v0-6-0-migration-guide.md
+++ b/docs/v0-6-0-migration-guide.md
@@ -496,9 +496,8 @@ of the user guide is the in-depth reference; the steps below mirror its outline:
 5. **Rebuild `VisualTestContext` per step.** Replace any stored
    `VisualTestContext` field with the durable handles, and in each subsequent
    step reconstruct the visual context with
-   `gpui::VisualTestContext::from_window(window, cx)`. The vendored gpui
-   return is `Option<VisualTestContext>`; treat `None` as an invariant
-   violation:
+   `gpui::VisualTestContext::from_window(window, cx)`. The vendored gpui return
+   is `Option<VisualTestContext>`; treat `None` as an invariant violation:
 
    ```rust,ignore
    let Some(visual_cx) = gpui::VisualTestContext::from_window(window, cx) else {
@@ -669,8 +668,8 @@ fn when_shell_receives_input(
 Guard-based borrowing removes the `E0499`/`E0502` obstacle to holding `cx` and
 `world` at once, but it does not make a stored `VisualTestContext` valid. That
 value is tied to the `TestAppContext` it was built against, and each step
-receives a fresh one, so `UiWorld` still keeps only the durable
-`Entity<T>` and `AnyWindowHandle` and rebuilds the visual context per step, as
+receives a fresh one, so `UiWorld` still keeps only the durable `Entity<T>` and
+`AnyWindowHandle` and rebuilds the visual context per step, as
 [Rebuild `VisualTestContext` per step](#migrate-a-stateful-gpui-test) requires.
 
 ## Migration checklist
@@ -762,8 +761,7 @@ fn given_shell_open(
 ```
 
 The rejection here comes from the two `&mut` fixture parameters, not from the
-body: the snippet already stores only durable handles, as the playbook
-requires.
+body: the snippet already stores only durable handles, as the playbook requires.
 
 The same constraint is not GPUI-specific. This non-GPUI shape is also rejected
 when both parameters come from the same `StepContext`.


### PR DESCRIPTION
## Summary

This draft base branch isolates the canonical `make fmt` output for five
pre-existing Markdown documents. It preserves their wording and meaning while
keeping the type-directed step-return implementation in #681 reviewable.

## Review walkthrough

- Start with [the parser-neutral execution ADR](https://github.com/leynos/rstest-bdd/blob/11-3-1-document-formatting/docs/adr-018-parser-neutral-scenario-execution.md#L1) for representative prose and table alignment.
- Review [the developers' guide](https://github.com/leynos/rstest-bdd/blob/11-3-1-document-formatting/docs/developers-guide.md#L1) and [the users' guide](https://github.com/leynos/rstest-bdd/blob/11-3-1-document-formatting/docs/users-guide.md#L1) for canonical paragraph wrapping.
- Finish with [the roadmap](https://github.com/leynos/rstest-bdd/blob/11-3-1-document-formatting/docs/roadmap.md#L1) and [the migration guide](https://github.com/leynos/rstest-bdd/blob/11-3-1-document-formatting/docs/v0-6-0-migration-guide.md#L1), which receive the remaining reflow.

## Validation

- `make check-fmt`: passed.
- `make markdownlint`: passed.
- `make nixie`: passed.
- `coderabbit review --agent`: 0 findings across five files.

## Notes

- A word-level diff found no changed words; this branch retains the formatter's canonical representation.
- This PR is the base for #681 and carries no behavioural or API change.

## References

- [Stacked implementation PR #681](https://github.com/leynos/rstest-bdd/pull/681)
- Lody session: https://lody.ai/leynos/sessions/29b14d61-d38d-4cc2-a64c-b257716885d0
