### PR TITLE
Synchronize Dependabot fixture scans

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,9 @@ updates:
       - "/crates/rstest-bdd/tests/fixtures_macros"
       - "/crates/rstest-bdd/tests/ui_macros"
       - "/crates/rstest-bdd/tests/ui_lints"
+    groups:
+      cargo-by-dependency:
+        group-by: dependency-name
     open-pull-requests-limit: 5
     labels:
       - "dependencies"

--- a/crates/cargo-bdd/tests/fixtures/minimal/Cargo.toml
+++ b/crates/cargo-bdd/tests/fixtures/minimal/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rstest-bdd-cli-fixture"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.85"
 
 [dependencies]
 inventory = "0.3"

--- a/crates/rstest-bdd/tests/fixtures_macros/Cargo.toml
+++ b/crates/rstest-bdd/tests/fixtures_macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rstest-bdd-macros-fixtures"
 version = "0.0.0"
 edition = "2024"
+rust-version = "1.85"
 publish = false
 
 [dependencies]

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -635,6 +635,22 @@ If a workflow's behaviour genuinely depends on a feature only present from a
 particular commit onwards, express that as a comment or a changelog note, not
 as a test assertion on the SHA string.
 
+### Cargo update grouping
+
+The Cargo Dependabot entry scans the workspace root and the standalone fixture
+packages in `crates/cargo-bdd/tests/fixtures/minimal`,
+`crates/rstest-bdd/tests/fixtures_macros`, `crates/rstest-bdd/tests/ui_macros`,
+and `crates/rstest-bdd/tests/ui_lints`. Its `cargo-by-dependency` group uses
+`group-by: dependency-name` so that, when Cargo can resolve one compatible
+version, Dependabot updates that dependency across every scanned directory in a
+single pull request.
+
+Each standalone fixture manifest must declare the workspace MSRV with
+`rust-version = "1.85"`. Keep these declarations synchronized with
+`workspace.package.rust-version` when the repository MSRV changes; otherwise,
+the fixture resolvers can accept different dependency versions and split a
+cross-directory update.
+
 ## Spelling policy
 
 `make spelling` enforces en-GB-oxendict spelling over tracked text with the


### PR DESCRIPTION
## Summary

This branch groups Cargo Dependabot updates by dependency name across the
workspace and standalone fixtures, so a single update PR keeps common
dependencies in lockstep. It gives the two previously undeclared fixtures the
workspace's Rust 1.85 MSRV and documents the policy so later fixture changes
preserve a common resolver baseline.

## Review walkthrough

- Start with [.github/dependabot.yml](https://github.com/leynos/rstest-bdd/blob/synchronize-dependabot-fixture-scans/.github/dependabot.yml#L22) to verify the one cross-directory Cargo group.
- Review [the minimal fixture manifest](https://github.com/leynos/rstest-bdd/blob/synchronize-dependabot-fixture-scans/crates/cargo-bdd/tests/fixtures/minimal/Cargo.toml#L1) and [the macro fixture manifest](https://github.com/leynos/rstest-bdd/blob/synchronize-dependabot-fixture-scans/crates/rstest-bdd/tests/fixtures_macros/Cargo.toml#L1) to verify their MSRV matches the workspace.
- Finish with [the developer guide](https://github.com/leynos/rstest-bdd/blob/synchronize-dependabot-fixture-scans/docs/developers-guide.md#L638) for the maintenance rule governing future Cargo fixture scans.

## Validation

- `git diff --check`: passed.
- `cargo metadata --manifest-path crates/cargo-bdd/tests/fixtures/minimal/Cargo.toml --no-deps --format-version 1`: passed.
- `make check-fmt`, `make lint`, `make typecheck`, `make test`,
  `make markdownlint`, and `make nixie`: passed.

## References

- [Lody session](https://lody.ai/leynos/sessions/23f27fc6-f850-456e-9e3d-f8c0cf8a4ac3)
