### PR TITLE
Adopt shared Namespace Linux runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - namespace-profile-default

--- a/.github/workflows/delayed-pr-comment.yml
+++ b/.github/workflows/delayed-pr-comment.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   delay_and_comment:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-default
     permissions:
       pull-requests: write   # needed to post comments
     steps:

--- a/.github/workflows/delayed-pr-comment.yml
+++ b/.github/workflows/delayed-pr-comment.yml
@@ -5,24 +5,44 @@ on:
       pr_number:
         description: 'PR number to comment on'
         required: true
+        type: number
       delay_minutes:
         description: 'Minutes to wait before commenting'
         required: true
+        type: number
       message:
         description: 'Comment body'
         required: true
+        type: string
+
+permissions: {}
 
 jobs:
   delay_and_comment:
     runs-on: namespace-profile-default
+    timeout-minutes: 65
     permissions:
       pull-requests: write   # needed to post comments
     steps:
       - name: Convert minutes to seconds
         id: calc
-        run: echo "secs=$(( ${{ github.event.inputs.delay_minutes }} * 60 ))" >> "$GITHUB_OUTPUT"
+        env:
+          DELAY_MINUTES: ${{ github.event.inputs.delay_minutes }}
+        run: |
+          set -euo pipefail
+          case "$DELAY_MINUTES" in
+            ''|*[!0-9]*)
+              echo 'delay_minutes must be a whole number' >&2
+              exit 1
+              ;;
+          esac
+          if (( 10#$DELAY_MINUTES < 1 || 10#$DELAY_MINUTES > 60 )); then
+            echo 'delay_minutes must be between 1 and 60' >&2
+            exit 1
+          fi
+          echo "secs=$(( 10#$DELAY_MINUTES * 60 ))" >> "$GITHUB_OUTPUT"
       - name: Wait requested time
-        run: sleep ${{ steps.calc.outputs.secs }}
+        run: sleep "${{ steps.calc.outputs.secs }}"
         shell: bash
       - name: Comment PR
         uses: thollander/actions-comment-pull-request@v3

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -4,7 +4,6 @@ For engineers and contributors working on the rstest-bdd codebase.  This guide
 covers workspace tooling, test infrastructure, macro internals, and the
 patterns used across crates — it is not a user-facing tutorial.
 
-
 ## GitHub Actions runner profiles
 
 The delayed pull-request comment job uses the shared uncached

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -4,6 +4,21 @@ For engineers and contributors working on the rstest-bdd codebase.  This guide
 covers workspace tooling, test infrastructure, macro internals, and the
 patterns used across crates — it is not a user-facing tutorial.
 
+
+## GitHub Actions runner profiles
+
+The delayed pull-request comment job uses the shared uncached
+`namespace-profile-default` runner (Ubuntu 22.04, amd64, 4 vCPU, and 16 GB).
+Its cache volume is disabled, so the initial adoption slice introduces no new
+cache ownership or cache-write policy.
+
+The main build-and-coverage matrix remains on GitHub-hosted Linux and Windows
+runners. Its Linux legs combine workspace compilation, broad coverage, and
+tooling setup; migrate them only after an equivalent 8-vCPU shared Linux
+profile is available and measured. Windows remains GitHub-hosted because this
+pilot has no shared Windows Namespace profile. Externally owned reusable
+workflows retain their own runner selection.
+
 ## Workspace dependency policy
 
 Keep workspace-local development and crates.io publication on the same manifest

--- a/tests/workflow_contracts/namespace_runners_test.py
+++ b/tests/workflow_contracts/namespace_runners_test.py
@@ -1,4 +1,12 @@
-"""Contract-test rstest-bdd's initial Namespace runner assignment."""
+"""Verify GitHub Actions runner assignments.
+
+Load workflow YAML and check runner contracts for the delayed comment job
+and the build matrix.
+
+Run with:
+
+    pytest tests/workflow_contracts/namespace_runners_test.py
+"""
 
 from __future__ import annotations
 
@@ -23,12 +31,28 @@ def _job(workflow_name: str, job_name: str) -> dict[str, object]:
 
 def test_comment_job_uses_the_shared_uncached_namespace_profile() -> None:
     """Keep the controlled utility-job assignment from drifting."""
-    assert _job("delayed-pr-comment.yml", "delay_and_comment").get("runs-on") == (
+    job = _job("delayed-pr-comment.yml", "delay_and_comment")
+    assert job.get("runs-on") == (
         "namespace-profile-default"
+    ), "delayed-pr-comment.yml:delay_and_comment must use namespace-profile-default"
+    assert job.get("timeout-minutes") == 65, (
+        "delayed-pr-comment.yml:delay_and_comment must bound runner occupancy"
     )
 
 
 def test_build_matrix_remains_platform_controlled() -> None:
     """Keep Windows and capacity-sensitive Linux legs on their current runners."""
     build_test = _job("ci.yml", "build-test")
-    assert build_test.get("runs-on") == "${{ matrix.os }}"
+    assert build_test.get("runs-on") == "${{ matrix.os }}", (
+        "ci.yml:build-test must resolve its runner from matrix.os"
+    )
+    strategy = build_test.get("strategy")
+    assert isinstance(strategy, dict), "ci.yml:build-test must declare strategy"
+    matrix = strategy.get("matrix")
+    assert isinstance(matrix, dict), "ci.yml:build-test must declare a matrix"
+    include = matrix.get("include")
+    assert isinstance(include, list), "ci.yml:build-test matrix must declare include"
+    matrix_oses = {entry.get("os") for entry in include if isinstance(entry, dict)}
+    assert {"ubuntu-latest", "windows-latest"} <= matrix_oses, (
+        "ci.yml:build-test matrix must retain ubuntu-latest and windows-latest"
+    )

--- a/tests/workflow_contracts/namespace_runners_test.py
+++ b/tests/workflow_contracts/namespace_runners_test.py
@@ -54,3 +54,6 @@ def test_build_matrix_remains_platform_controlled() -> None:
     assert {"ubuntu-latest", "windows-latest"} <= matrix_oses, (
         "ci.yml:build-test matrix must retain ubuntu-latest and windows-latest"
     )
+    assert matrix_oses <= {"ubuntu-latest", "windows-latest"}, (
+        "ci.yml:build-test matrix must use only approved GitHub-hosted runners"
+    )

--- a/tests/workflow_contracts/namespace_runners_test.py
+++ b/tests/workflow_contracts/namespace_runners_test.py
@@ -32,9 +32,9 @@ def _job(workflow_name: str, job_name: str) -> dict[str, object]:
 def test_comment_job_uses_the_shared_uncached_namespace_profile() -> None:
     """Keep the controlled utility-job assignment from drifting."""
     job = _job("delayed-pr-comment.yml", "delay_and_comment")
-    assert job.get("runs-on") == (
-        "namespace-profile-default"
-    ), "delayed-pr-comment.yml:delay_and_comment must use namespace-profile-default"
+    assert job.get("runs-on") == ("namespace-profile-default"), (
+        "delayed-pr-comment.yml:delay_and_comment must use namespace-profile-default"
+    )
     assert job.get("timeout-minutes") == 65, (
         "delayed-pr-comment.yml:delay_and_comment must bound runner occupancy"
     )

--- a/tests/workflow_contracts/namespace_runners_test.py
+++ b/tests/workflow_contracts/namespace_runners_test.py
@@ -8,8 +8,6 @@ Run with:
     pytest tests/workflow_contracts/namespace_runners_test.py
 """
 
-from __future__ import annotations
-
 from pathlib import Path
 
 import yaml

--- a/tests/workflow_contracts/namespace_runners_test.py
+++ b/tests/workflow_contracts/namespace_runners_test.py
@@ -1,0 +1,34 @@
+"""Contract-test rstest-bdd's initial Namespace runner assignment."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _job(workflow_name: str, job_name: str) -> dict[str, object]:
+    """Load one named job from a repository workflow."""
+    workflow_path = ROOT / ".github" / "workflows" / workflow_name
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict), f"{workflow_name} must parse to a mapping"
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), f"{workflow_name} must declare jobs"
+    job = jobs.get(job_name)
+    assert isinstance(job, dict), f"{workflow_name} must declare {job_name}"
+    return job
+
+
+def test_comment_job_uses_the_shared_uncached_namespace_profile() -> None:
+    """Keep the controlled utility-job assignment from drifting."""
+    assert _job("delayed-pr-comment.yml", "delay_and_comment").get("runs-on") == (
+        "namespace-profile-default"
+    )
+
+
+def test_build_matrix_remains_platform_controlled() -> None:
+    """Keep Windows and capacity-sensitive Linux legs on their current runners."""
+    build_test = _job("ci.yml", "build-test")
+    assert build_test.get("runs-on") == "${{ matrix.os }}"


### PR DESCRIPTION
## Summary

- move the compatible delayed-comment job to the shared uncached Namespace runner
- document retained broad test-matrix, Windows, and reusable-workflow exceptions
- add actionlint configuration and a runner-assignment contract test

## Validation

- `make test-workflow-contracts`
- `make check-fmt markdownlint typecheck lint`
- `actionlint -ignore shellcheck -config-file .github/actionlint.yaml .github/workflows/*.yml`

## Summary by Sourcery

Adopt the shared uncached Namespace Linux runner for the delayed pull-request comment job while preserving platform-specific build runners and enforcing workflow runner contracts.

Bug Fixes:
- Validate delayed-comment wait durations and reject values outside the supported one-to-60-minute range.

Enhancements:
- Move the delayed pull-request comment job to the shared uncached Namespace Linux runner with a bounded execution timeout.
- Document runner-profile decisions and retained GitHub-hosted runner exceptions.
- Add workflow contracts to prevent unintended runner-assignment changes.

CI:
- Add actionlint configuration for the shared Namespace runner label.

Tests:
- Add contract tests covering the delayed-comment runner and the build matrix's approved GitHub-hosted runners.