### PR TITLE
Refresh baseline snapshots and format contracts (#701) (#704)

### DIFF
--- a/crates/rstest-bdd/tests/trybuild_macros.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros.rs
@@ -30,8 +30,12 @@ use wrappers::{
 mod staging;
 #[path = "trybuild_macros/whitaker.rs"]
 mod whitaker;
+#[path = "trybuild_macros/wip.rs"]
+mod wip;
 #[path = "trybuild_macros/wrappers.rs"]
 mod wrappers;
+
+use wip::{read_wip_stderr, remove_stale_wip_stderr, wip_stderr_path};
 
 fn macros_fixture(case: impl Into<MacroFixtureCase>) -> Utf8PathBuf {
     let case = case.into();
@@ -294,10 +298,9 @@ fn compile_fail_with_normalized_output(
         ambient_authority(),
     )?;
     let expected_path = expected_stderr_path(test_path.as_std_path());
-    let actual_path = wip_stderr_path(test_path.as_std_path());
     let expected = crate_dir.read_to_string(expected_path.as_std_path())?;
 
-    remove_file_if_present(&crate_dir, actual_path.as_std_path())?;
+    remove_stale_wip_stderr(test_path)?;
     crate_dir.remove_file(expected_path.as_std_path())?;
 
     run_compile_fail_with_normalized_output(
@@ -336,44 +339,31 @@ where
     }
 }
 
-fn remove_file_if_present(crate_dir: &Dir, path: &StdPath) -> io::Result<()> {
-    match crate_dir.remove_file(path) {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(error),
-    }
-}
-
 fn normalized_outputs_match(test_path: &Utf8Path, normalizers: &[Normalizer]) -> io::Result<bool> {
     let crate_dir = Dir::open_ambient_dir(
         Utf8Path::new(env!("CARGO_MANIFEST_DIR")).as_std_path(),
         ambient_authority(),
     )?;
-    let actual_path = wip_stderr_path(test_path.as_std_path());
     let expected_path = expected_stderr_path(test_path.as_std_path());
-    let actual = crate_dir.read_to_string(actual_path.as_std_path())?;
+    let current_dir = Dir::open_ambient_dir(".", ambient_authority())?;
+    let actual_path = wip_stderr_path(test_path.as_std_path());
+    let (actual, is_in_current_dir) =
+        read_wip_stderr(&current_dir, &crate_dir, actual_path.as_std_path())?;
     let expected = crate_dir.read_to_string(expected_path.as_std_path())?;
 
     if apply_normalizers(NormalizerInput::from(actual.as_str()), normalizers)
         == apply_normalizers(NormalizerInput::from(expected.as_str()), normalizers)
     {
-        let _ = crate_dir.remove_file(actual_path.as_std_path());
+        let wip_dir = if is_in_current_dir {
+            &current_dir
+        } else {
+            &crate_dir
+        };
+        let _ = wip_dir.remove_file(actual_path.as_std_path());
         return Ok(true);
     }
 
     Ok(false)
-}
-
-fn wip_stderr_path(test_path: &StdPath) -> Utf8PathBuf {
-    let Some(file_name) = test_path.file_name() else {
-        panic!("trybuild test path must include file name");
-    };
-    let Some(file_name) = file_name.to_str() else {
-        panic!("file name must be valid UTF-8");
-    };
-    let mut path = Utf8PathBuf::from(file_name);
-    path.set_extension("stderr");
-    Utf8PathBuf::from("wip").join(path)
 }
 
 fn expected_stderr_path(test_path: &StdPath) -> Utf8PathBuf {

--- a/crates/rstest-bdd/tests/trybuild_macros.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros.rs
@@ -359,7 +359,7 @@ fn normalized_outputs_match(test_path: &Utf8Path, normalizers: &[Normalizer]) ->
         } else {
             &crate_dir
         };
-        let _ = wip_dir.remove_file(actual_path.as_std_path());
+        wip_dir.remove_file(actual_path.as_std_path())?;
         return Ok(true);
     }
 

--- a/crates/rstest-bdd/tests/trybuild_macros.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros.rs
@@ -171,7 +171,6 @@ fn run_failing_ui_tests(t: &trybuild::TestCases) {
         t.compile_fail(ui_fixture(case).as_std_path());
     }
     compile_fail_with_normalized_output(
-        t,
         ui_fixture(UiFixtureCase::from(
             "step_return_alias_error_not_display.rs",
         )),
@@ -268,31 +267,31 @@ fn run_conditional_ambiguous_step_test(t: &trybuild::TestCases) {
 type Normalizer = for<'a> fn(NormalizerInput<'a>) -> String;
 
 #[rustversion::not(nightly)]
-fn compile_fail_missing_step_warning(t: &trybuild::TestCases) {
+fn compile_fail_missing_step_warning(_t: &trybuild::TestCases) {
     compile_fail_with_normalized_output(
-        t,
         macros_fixture(MacroFixtureCase::from("scenario_missing_step_warning.rs")),
         &[strip_nightly_macro_backtrace_hint, normalize_fixture_paths],
     );
 }
 
 #[rustversion::nightly]
-fn compile_fail_missing_step_warning(t: &trybuild::TestCases) {
+fn compile_fail_missing_step_warning(_t: &trybuild::TestCases) {
     compile_fail_with_normalized_output(
-        t,
         macros_fixture(MacroFixtureCase::from("nightly_registry_warning.rs")),
         &[strip_nightly_macro_backtrace_hint, normalize_fixture_paths],
     );
 }
 
 fn compile_fail_with_normalized_output(
-    t: &trybuild::TestCases,
     test_path: impl AsRef<Utf8Path>,
     normalizers: &[Normalizer],
 ) {
     let test_path = test_path.as_ref();
     run_compile_fail_with_normalized_output(
-        || t.compile_fail(test_path.as_std_path()),
+        || {
+            let t = trybuild::TestCases::new();
+            t.compile_fail(test_path.as_std_path());
+        },
         test_path,
         normalizers,
     );

--- a/crates/rstest-bdd/tests/trybuild_macros.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros.rs
@@ -72,12 +72,12 @@ fn step_macros_compile() -> io::Result<()> {
 
         run_passing_macro_tests(&t);
         run_failing_macro_tests(&t);
-        run_failing_ui_tests(&t);
+        run_failing_ui_tests(&t)?;
         run_lint_ui_tests()?;
         t.compile_fail(
             macros_fixture(MacroFixtureCase::from("scenarios_missing_dir.rs")).as_std_path(),
         );
-        run_conditional_ordering_tests(&t);
+        run_conditional_ordering_tests(&t)?;
         run_conditional_ambiguous_step_test(&t);
         Ok(())
     })
@@ -143,7 +143,7 @@ fn run_failing_macro_tests(t: &trybuild::TestCases) {
     }
 }
 
-fn run_failing_ui_tests(t: &trybuild::TestCases) {
+fn run_failing_ui_tests(t: &trybuild::TestCases) -> io::Result<()> {
     for case in [
         UiFixtureCase::from("datatable_wrong_type.rs"),
         UiFixtureCase::from("datatable_duplicate.rs"),
@@ -175,7 +175,7 @@ fn run_failing_ui_tests(t: &trybuild::TestCases) {
             "step_return_alias_error_not_display.rs",
         )),
         &[normalize_conditional_trait_help],
-    );
+    )
 }
 
 fn run_lint_ui_tests() -> io::Result<()> {
@@ -234,7 +234,7 @@ fn run_lint_ui_case(bin: &str, lint_args: &[&str]) -> io::Result<()> {
     unexpected_cfgs,
     reason = "integration test inspects dependency feature flags"
 )]
-fn run_conditional_ordering_tests(t: &trybuild::TestCases) {
+fn run_conditional_ordering_tests(t: &trybuild::TestCases) -> io::Result<()> {
     let ordering_cases = [
         MacroFixtureCase::from("scenario_missing_step.rs"),
         MacroFixtureCase::from("scenario_out_of_order.rs"),
@@ -248,8 +248,10 @@ fn run_conditional_ordering_tests(t: &trybuild::TestCases) {
         for case in ordering_cases.iter().cloned() {
             t.pass(macros_fixture(case).as_std_path());
         }
-        compile_fail_missing_step_warning(t);
+        compile_fail_missing_step_warning(t)?;
     }
+
+    Ok(())
 }
 
 #[expect(
@@ -267,52 +269,78 @@ fn run_conditional_ambiguous_step_test(t: &trybuild::TestCases) {
 type Normalizer = for<'a> fn(NormalizerInput<'a>) -> String;
 
 #[rustversion::not(nightly)]
-fn compile_fail_missing_step_warning(_t: &trybuild::TestCases) {
+fn compile_fail_missing_step_warning(_t: &trybuild::TestCases) -> io::Result<()> {
     compile_fail_with_normalized_output(
         macros_fixture(MacroFixtureCase::from("scenario_missing_step_warning.rs")),
         &[strip_nightly_macro_backtrace_hint, normalize_fixture_paths],
-    );
+    )
 }
 
 #[rustversion::nightly]
-fn compile_fail_missing_step_warning(_t: &trybuild::TestCases) {
+fn compile_fail_missing_step_warning(_t: &trybuild::TestCases) -> io::Result<()> {
     compile_fail_with_normalized_output(
         macros_fixture(MacroFixtureCase::from("nightly_registry_warning.rs")),
         &[strip_nightly_macro_backtrace_hint, normalize_fixture_paths],
-    );
+    )
 }
 
 fn compile_fail_with_normalized_output(
     test_path: impl AsRef<Utf8Path>,
     normalizers: &[Normalizer],
-) {
+) -> io::Result<()> {
     let test_path = test_path.as_ref();
+    let crate_dir = Dir::open_ambient_dir(
+        Utf8Path::new(env!("CARGO_MANIFEST_DIR")).as_std_path(),
+        ambient_authority(),
+    )?;
+    let expected_path = expected_stderr_path(test_path.as_std_path());
+    let actual_path = wip_stderr_path(test_path.as_std_path());
+    let expected = crate_dir.read_to_string(expected_path.as_std_path())?;
+
+    remove_file_if_present(&crate_dir, actual_path.as_std_path())?;
+    crate_dir.remove_file(expected_path.as_std_path())?;
+
     run_compile_fail_with_normalized_output(
         || {
             let t = trybuild::TestCases::new();
             t.compile_fail(test_path.as_std_path());
         },
+        || crate_dir.write(expected_path.as_std_path(), expected.as_bytes()),
         test_path,
         normalizers,
-    );
+    )
 }
 
-fn run_compile_fail_with_normalized_output<F>(
+fn run_compile_fail_with_normalized_output<F, R>(
     compile_fail: F,
+    restore_expected: R,
     test_path: &Utf8Path,
     normalizers: &[Normalizer],
-) where
+) -> io::Result<()>
+where
     F: FnOnce(),
+    R: FnOnce() -> io::Result<()>,
 {
-    match panic::catch_unwind(AssertUnwindSafe(compile_fail)) {
-        Ok(()) => (),
+    let compilation = panic::catch_unwind(AssertUnwindSafe(compile_fail));
+    restore_expected()?;
+
+    match compilation {
+        Ok(()) => Ok(()),
         Err(panic) => {
-            if normalized_outputs_match(test_path, normalizers).unwrap_or(false) {
-                return;
+            if normalized_outputs_match(test_path, normalizers)? {
+                return Ok(());
             }
 
             panic::resume_unwind(panic);
         }
+    }
+}
+
+fn remove_file_if_present(crate_dir: &Dir, path: &StdPath) -> io::Result<()> {
+    match crate_dir.remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
     }
 }
 
@@ -345,7 +373,7 @@ fn wip_stderr_path(test_path: &StdPath) -> Utf8PathBuf {
     };
     let mut path = Utf8PathBuf::from(file_name);
     path.set_extension("stderr");
-    Utf8PathBuf::from("target/tests/wip").join(path)
+    Utf8PathBuf::from("wip").join(path)
 }
 
 fn expected_stderr_path(test_path: &StdPath) -> Utf8PathBuf {

--- a/crates/rstest-bdd/tests/trybuild_macros.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros.rs
@@ -21,6 +21,7 @@ use wrappers::{
     MacroFixtureCase,
     NormalizerInput,
     UiFixtureCase,
+    normalize_conditional_trait_help,
     normalize_fixture_paths,
     strip_nightly_macro_backtrace_hint,
 };
@@ -163,13 +164,19 @@ fn run_failing_ui_tests(t: &trybuild::TestCases) {
         UiFixtureCase::from("implicit_fixture_missing.rs"),
         UiFixtureCase::from("placeholder_missing_params.rs"),
         UiFixtureCase::from("return_override_result_requires_result.rs"),
-        UiFixtureCase::from("step_return_alias_error_not_display.rs"),
         UiFixtureCase::from("step_return_nested_result.rs"),
         UiFixtureCase::from("step_return_impl_trait.rs"),
         UiFixtureCase::from("insert_value_must_use.rs"),
     ] {
         t.compile_fail(ui_fixture(case).as_std_path());
     }
+    compile_fail_with_normalized_output(
+        t,
+        ui_fixture(UiFixtureCase::from(
+            "step_return_alias_error_not_display.rs",
+        )),
+        &[normalize_conditional_trait_help],
+    );
 }
 
 fn run_lint_ui_tests() -> io::Result<()> {

--- a/crates/rstest-bdd/tests/trybuild_macros/helper_tests.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros/helper_tests.rs
@@ -14,6 +14,8 @@ use super::{
 
 #[path = "helper_tests/fixture_write.rs"]
 mod fixture_write;
+#[path = "helper_tests/wip_paths.rs"]
+mod wip_paths;
 
 fn write_fixture_file(crate_dir: &Dir, path: &Utf8Path, bytes: &[u8], label: &str) {
     if let Some(parent) = path.parent() {

--- a/crates/rstest-bdd/tests/trybuild_macros/helper_tests.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros/helper_tests.rs
@@ -163,9 +163,9 @@ fn strip_nightly_macro_backtrace_hint_leaves_text_without_hint() {
 #[test]
 fn normalize_conditional_trait_help_removes_stable_wording_difference() {
     let input = "help: the trait `StepReturnNormalize<Result<T, E>>` is conditionally implemented \
-                 for `StepReturnResultTag`";
+                 for `StepReturnResultTag`\n       | ^^^^^^^^^^^^^^^^----------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n       |                 unsatisfied requirement introduced here: `NotDisplay: rstest_bdd::step_return::StepErrorDisplay`\n";
     let expected = "help: the trait `StepReturnNormalize<Result<T, E>>` is implemented for \
-                    `StepReturnResultTag`";
+                    `StepReturnResultTag`\n       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n";
     assert_eq!(
         normalize_conditional_trait_help(NormalizerInput::from(input)),
         expected

--- a/crates/rstest-bdd/tests/trybuild_macros/helper_tests.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros/helper_tests.rs
@@ -8,7 +8,7 @@ use rstest::rstest;
 use super::{
     Normalizer,
     NormalizerInput,
-    wrappers::{FixtureStderr, FixtureTestPath},
+    wrappers::{FixtureStderr, FixtureTestPath, normalize_conditional_trait_help},
     *,
 };
 
@@ -157,6 +157,18 @@ fn strip_nightly_macro_backtrace_hint_leaves_text_without_hint() {
     assert_eq!(
         strip_nightly_macro_backtrace_hint(NormalizerInput::from(text)),
         text
+    );
+}
+
+#[test]
+fn normalize_conditional_trait_help_removes_stable_wording_difference() {
+    let input = "help: the trait `StepReturnNormalize<Result<T, E>>` is conditionally implemented \
+                 for `StepReturnResultTag`";
+    let expected = "help: the trait `StepReturnNormalize<Result<T, E>>` is implemented for \
+                    `StepReturnResultTag`";
+    assert_eq!(
+        normalize_conditional_trait_help(NormalizerInput::from(input)),
+        expected
     );
 }
 

--- a/crates/rstest-bdd/tests/trybuild_macros/helper_tests.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros/helper_tests.rs
@@ -175,6 +175,18 @@ fn normalize_conditional_trait_help_removes_stable_wording_difference() {
 }
 
 #[test]
+fn normalize_conditional_trait_help_removes_requirement_connector() {
+    let input = concat!(
+        "       |                 |\n",
+        "       |                 unsatisfied requirement introduced here: `NotDisplay`\n",
+    );
+    assert_eq!(
+        normalize_conditional_trait_help(NormalizerInput::from(input)),
+        "\n"
+    );
+}
+
+#[test]
 fn normalize_fixture_paths_rewrites_relative_fixture_paths() {
     let dollar = '$';
     let input = "Warning:  --> tests/fixtures_macros/example.rs:3:1";

--- a/crates/rstest-bdd/tests/trybuild_macros/helper_tests.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros/helper_tests.rs
@@ -232,7 +232,7 @@ fn run_compile_fail_with_normalized_output_handles_multiple_normalizers() {
             Utf8Path::new(TEST_PATH),
             &[strip_hint_one, strip_hint_two],
         )
-        .expect("normalised outputs should be readable");
+        .expect("normalized outputs should be readable");
     });
     assert!(result.is_ok(), "normalized outputs should match");
     assert!(
@@ -256,7 +256,7 @@ fn run_compile_fail_with_normalized_output_accepts_empty_output() {
             Utf8Path::new(TEST_PATH),
             &[],
         )
-        .expect("normalised outputs should be readable");
+        .expect("normalized outputs should be readable");
     });
     assert!(result.is_ok(), "identical empty outputs should be accepted");
     assert!(
@@ -281,7 +281,7 @@ fn run_compile_fail_with_normalized_output_detects_mismatch() {
             Utf8Path::new(TEST_PATH),
             &[trim_trailing],
         )
-        .expect("normalised outputs should be readable");
+        .expect("normalized outputs should be readable");
     });
     assert!(
         result.is_err(),
@@ -335,7 +335,7 @@ fn run_compile_fail_with_normalized_output_test_cases(
             Utf8Path::new(test_path),
             &[trim_trailing],
         )
-        .expect("normalised outputs should be readable");
+        .expect("normalized outputs should be readable");
     });
 
     if should_succeed {

--- a/crates/rstest-bdd/tests/trybuild_macros/helper_tests.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros/helper_tests.rs
@@ -81,10 +81,10 @@ impl Drop for NormalizerFixture {
 }
 
 #[test]
-fn wip_stderr_path_builds_target_location() {
+fn wip_stderr_path_builds_crate_wip_location() {
     let path =
         wip_stderr_path(Utf8Path::new("tests/fixtures_macros/__helper_case.rs").as_std_path());
-    assert_eq!(path, Utf8Path::new("target/tests/wip/__helper_case.stderr"));
+    assert_eq!(path, Utf8Path::new("wip/__helper_case.stderr"));
 }
 
 #[test]
@@ -228,9 +228,11 @@ fn run_compile_fail_with_normalized_output_handles_multiple_normalizers() {
     let result = panic::catch_unwind(|| {
         run_compile_fail_with_normalized_output(
             || panic!("expected failure"),
+            || Ok(()),
             Utf8Path::new(TEST_PATH),
             &[strip_hint_one, strip_hint_two],
-        );
+        )
+        .expect("normalised outputs should be readable");
     });
     assert!(result.is_ok(), "normalized outputs should match");
     assert!(
@@ -250,9 +252,11 @@ fn run_compile_fail_with_normalized_output_accepts_empty_output() {
     let result = panic::catch_unwind(|| {
         run_compile_fail_with_normalized_output(
             || panic!("expected failure"),
+            || Ok(()),
             Utf8Path::new(TEST_PATH),
             &[],
-        );
+        )
+        .expect("normalised outputs should be readable");
     });
     assert!(result.is_ok(), "identical empty outputs should be accepted");
     assert!(
@@ -273,9 +277,11 @@ fn run_compile_fail_with_normalized_output_detects_mismatch() {
     let result = panic::catch_unwind(|| {
         run_compile_fail_with_normalized_output(
             || panic!("expected failure"),
+            || Ok(()),
             Utf8Path::new(TEST_PATH),
             &[trim_trailing],
-        );
+        )
+        .expect("normalised outputs should be readable");
     });
     assert!(
         result.is_err(),
@@ -325,9 +331,11 @@ fn run_compile_fail_with_normalized_output_test_cases(
     let result = panic::catch_unwind(|| {
         run_compile_fail_with_normalized_output(
             || panic!("expected failure"),
+            || Ok(()),
             Utf8Path::new(test_path),
             &[trim_trailing],
-        );
+        )
+        .expect("normalised outputs should be readable");
     });
 
     if should_succeed {

--- a/crates/rstest-bdd/tests/trybuild_macros/helper_tests/wip_paths.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros/helper_tests/wip_paths.rs
@@ -1,0 +1,57 @@
+//! Portable contracts for locating trybuild work-in-progress diagnostics.
+
+use tempfile::tempdir;
+
+use super::{super::read_wip_stderr, Dir, Utf8Path, ambient_authority, write_fixture_file};
+
+#[test]
+fn read_wip_stderr_prefers_current_directory() -> std::io::Result<()> {
+    let current_tempdir = tempdir()?;
+    let fallback_tempdir = tempdir()?;
+    let current_dir = Dir::open_ambient_dir(current_tempdir.path(), ambient_authority())?;
+    let fallback_dir = Dir::open_ambient_dir(fallback_tempdir.path(), ambient_authority())?;
+    let path = Utf8Path::new("wip/observed_windows.stderr");
+
+    write_fixture_file(
+        &current_dir,
+        path,
+        b"current directory output",
+        "current wip fixture",
+    );
+    write_fixture_file(
+        &fallback_dir,
+        path,
+        b"fallback output",
+        "fallback wip fixture",
+    );
+
+    let (actual, is_in_current_dir) =
+        read_wip_stderr(&current_dir, &fallback_dir, path.as_std_path())?;
+
+    assert!(is_in_current_dir);
+    assert_eq!(actual, "current directory output");
+    Ok(())
+}
+
+#[test]
+fn read_wip_stderr_falls_back_to_manifest_directory() -> std::io::Result<()> {
+    let current_tempdir = tempdir()?;
+    let fallback_tempdir = tempdir()?;
+    let current_dir = Dir::open_ambient_dir(current_tempdir.path(), ambient_authority())?;
+    let fallback_dir = Dir::open_ambient_dir(fallback_tempdir.path(), ambient_authority())?;
+    let path = Utf8Path::new("wip/observed_windows.stderr");
+
+    write_fixture_file(
+        &fallback_dir,
+        path,
+        b"fallback output",
+        "fallback wip fixture",
+    );
+
+    let (actual, is_in_current_dir) =
+        read_wip_stderr(&current_dir, &fallback_dir, path.as_std_path())?;
+
+    assert!(!is_in_current_dir);
+    assert_eq!(actual, "fallback output");
+    Ok(())
+}

--- a/crates/rstest-bdd/tests/trybuild_macros/wip.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros/wip.rs
@@ -1,0 +1,52 @@
+//! Locates and clears trybuild work-in-progress diagnostic files.
+
+use std::{env, io, path::Path as StdPath};
+
+use camino::{Utf8Path, Utf8PathBuf};
+use cap_std::{ambient_authority, fs::Dir};
+
+pub(super) fn remove_stale_wip_stderr(test_path: &Utf8Path) -> io::Result<()> {
+    let actual_path = wip_stderr_path(test_path.as_std_path());
+    let current_dir = Dir::open_ambient_dir(".", ambient_authority())?;
+    let crate_dir = Dir::open_ambient_dir(
+        Utf8Path::new(env!("CARGO_MANIFEST_DIR")).as_std_path(),
+        ambient_authority(),
+    )?;
+
+    remove_file_if_present(&current_dir, actual_path.as_std_path())?;
+    remove_file_if_present(&crate_dir, actual_path.as_std_path())
+}
+
+pub(super) fn read_wip_stderr(
+    current_dir: &Dir,
+    crate_dir: &Dir,
+    path: &StdPath,
+) -> io::Result<(String, bool)> {
+    match current_dir.read_to_string(path) {
+        Ok(actual) => Ok((actual, true)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            crate_dir.read_to_string(path).map(|actual| (actual, false))
+        }
+        Err(error) => Err(error),
+    }
+}
+
+pub(super) fn wip_stderr_path(test_path: &StdPath) -> Utf8PathBuf {
+    let Some(file_name) = test_path.file_name() else {
+        panic!("trybuild test path must include file name");
+    };
+    let Some(file_name) = file_name.to_str() else {
+        panic!("file name must be valid UTF-8");
+    };
+    let mut path = Utf8PathBuf::from(file_name);
+    path.set_extension("stderr");
+    Utf8PathBuf::from("wip").join(path)
+}
+
+fn remove_file_if_present(crate_dir: &Dir, path: &StdPath) -> io::Result<()> {
+    match crate_dir.remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}

--- a/crates/rstest-bdd/tests/trybuild_macros/wrappers.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros/wrappers.rs
@@ -137,8 +137,27 @@ pub(crate) fn strip_nightly_macro_backtrace_hint(input: NormalizerInput<'_>) -> 
 
 /// Normalizes stable compiler wording for conditional trait implementations.
 pub(crate) fn normalize_conditional_trait_help(input: NormalizerInput<'_>) -> String {
-    input.as_ref().replace(
-        "StepReturnNormalize<Result<T, E>>` is conditionally implemented for",
-        "StepReturnNormalize<Result<T, E>>` is implemented for",
-    )
+    let text = input.as_ref();
+    let mut normalized = text
+        .lines()
+        .filter_map(|line| {
+            if line.contains("unsatisfied requirement introduced here:") {
+                return None;
+            }
+            let line = line.replace(
+                "StepReturnNormalize<Result<T, E>>` is conditionally implemented for",
+                "StepReturnNormalize<Result<T, E>>` is implemented for",
+            );
+            if line.contains("^^^^^^^^") && line.contains("--------") {
+                Some(line.replace('-', "^"))
+            } else {
+                Some(line)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    if text.ends_with('\n') {
+        normalized.push('\n');
+    }
+    normalized
 }

--- a/crates/rstest-bdd/tests/trybuild_macros/wrappers.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros/wrappers.rs
@@ -134,3 +134,11 @@ pub(crate) fn strip_nightly_macro_backtrace_hint(input: NormalizerInput<'_>) -> 
         "",
     )
 }
+
+/// Normalizes stable compiler wording for conditional trait implementations.
+pub(crate) fn normalize_conditional_trait_help(input: NormalizerInput<'_>) -> String {
+    input.as_ref().replace(
+        "StepReturnNormalize<Result<T, E>>` is conditionally implemented for",
+        "StepReturnNormalize<Result<T, E>>` is implemented for",
+    )
+}

--- a/crates/rstest-bdd/tests/trybuild_macros/wrappers.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros/wrappers.rs
@@ -138,24 +138,36 @@ pub(crate) fn strip_nightly_macro_backtrace_hint(input: NormalizerInput<'_>) -> 
 /// Normalizes stable compiler wording for conditional trait implementations.
 pub(crate) fn normalize_conditional_trait_help(input: NormalizerInput<'_>) -> String {
     let text = input.as_ref();
-    let mut normalized = text
-        .lines()
-        .filter_map(|line| {
-            if line.contains("unsatisfied requirement introduced here:") {
-                return None;
-            }
-            let line = line.replace(
-                "StepReturnNormalize<Result<T, E>>` is conditionally implemented for",
-                "StepReturnNormalize<Result<T, E>>` is implemented for",
-            );
-            if line.contains("^^^^^^^^") && line.contains("--------") {
-                Some(line.replace('-', "^"))
-            } else {
-                Some(line)
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
+    let mut lines = text.lines().peekable();
+    let mut normalized = Vec::new();
+    while let Some(line) = lines.next() {
+        let trimmed = line.trim();
+        let is_connector = trimmed
+            .strip_prefix('|')
+            .and_then(|line| line.strip_suffix('|'))
+            .is_some_and(|contents| contents.trim().is_empty());
+        if line.contains("unsatisfied requirement introduced here:") {
+            continue;
+        }
+        if is_connector
+            && matches!(
+                lines.peek(),
+                Some(next) if next.contains("unsatisfied requirement introduced here:")
+            )
+        {
+            continue;
+        }
+        let line = line.replace(
+            "StepReturnNormalize<Result<T, E>>` is conditionally implemented for",
+            "StepReturnNormalize<Result<T, E>>` is implemented for",
+        );
+        if line.contains("^^^^^^^^") && line.contains("--------") {
+            normalized.push(line.replace('-', "^"));
+        } else {
+            normalized.push(line);
+        }
+    }
+    let mut normalized = normalized.join("\n");
     if text.ends_with('\n') {
         normalized.push('\n');
     }

--- a/crates/rstest-bdd/tests/trybuild_macros/wrappers.rs
+++ b/crates/rstest-bdd/tests/trybuild_macros/wrappers.rs
@@ -141,35 +141,43 @@ pub(crate) fn normalize_conditional_trait_help(input: NormalizerInput<'_>) -> St
     let mut lines = text.lines().peekable();
     let mut normalized = Vec::new();
     while let Some(line) = lines.next() {
-        let trimmed = line.trim();
-        let is_connector = trimmed
-            .strip_prefix('|')
-            .and_then(|line| line.strip_suffix('|'))
-            .is_some_and(|contents| contents.trim().is_empty());
-        if line.contains("unsatisfied requirement introduced here:") {
+        if should_discard_conditional_trait_help_line(line, lines.peek().copied()) {
             continue;
         }
-        if is_connector
-            && matches!(
-                lines.peek(),
-                Some(next) if next.contains("unsatisfied requirement introduced here:")
-            )
-        {
-            continue;
-        }
-        let line = line.replace(
-            "StepReturnNormalize<Result<T, E>>` is conditionally implemented for",
-            "StepReturnNormalize<Result<T, E>>` is implemented for",
-        );
-        if line.contains("^^^^^^^^") && line.contains("--------") {
-            normalized.push(line.replace('-', "^"));
-        } else {
-            normalized.push(line);
-        }
+        normalized.push(normalize_conditional_trait_help_line(line));
     }
     let mut normalized = normalized.join("\n");
     if text.ends_with('\n') {
         normalized.push('\n');
     }
     normalized
+}
+
+fn should_discard_conditional_trait_help_line(line: &str, next_line: Option<&str>) -> bool {
+    line_contains_stable_requirement(line)
+        || (is_requirement_connector(line)
+            && next_line.is_some_and(line_contains_stable_requirement))
+}
+
+fn line_contains_stable_requirement(line: &str) -> bool {
+    line.contains("unsatisfied requirement introduced here:")
+}
+
+fn is_requirement_connector(line: &str) -> bool {
+    line.trim()
+        .strip_prefix('|')
+        .and_then(|line| line.strip_suffix('|'))
+        .is_some_and(|contents| contents.trim().is_empty())
+}
+
+fn normalize_conditional_trait_help_line(line: &str) -> String {
+    let normalized = line.replace(
+        "StepReturnNormalize<Result<T, E>>` is conditionally implemented for",
+        "StepReturnNormalize<Result<T, E>>` is implemented for",
+    );
+    if normalized.contains("^^^^^^^^") && normalized.contains("--------") {
+        normalized.replace('-', "^")
+    } else {
+        normalized
+    }
 }

--- a/crates/rstest-bdd/tests/ui_macros/step_return_alias_error_not_display.stderr
+++ b/crates/rstest-bdd/tests/ui_macros/step_return_alias_error_not_display.stderr
@@ -10,13 +10,11 @@ help: the trait `rstest_bdd::step_return::StepErrorDisplay` is not implemented f
 5 | struct NotDisplay;
   | ^^^^^^^^^^^^^^^^^
   = note: rstest-bdd renders a step's `Err` through `Display`
-help: the trait `rstest_bdd::step_return::StepReturnNormalize<Result<T, E>>` is conditionally implemented for `rstest_bdd::step_return::StepReturnResultTag`
+help: the trait `rstest_bdd::step_return::StepReturnNormalize<Result<T, E>>` is implemented for `rstest_bdd::step_return::StepReturnResultTag`
  --> src/step_return.rs
   |
   | impl<T: Any, E: StepErrorDisplay> StepReturnNormalize<Result<T, E>> for StepReturnResultTag {
-  | ^^^^^^^^^^^^^^^^----------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |                 |
-  |                 unsatisfied requirement introduced here: `NotDisplay: rstest_bdd::step_return::StepErrorDisplay`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = note: required for `rstest_bdd::step_return::StepReturnResultTag` to implement `rstest_bdd::step_return::StepReturnNormalize<Result<(), NotDisplay>>`
   = note: this error originates in the attribute macro `when` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -32,12 +30,10 @@ help: the trait `rstest_bdd::step_return::StepErrorDisplay` is not implemented f
  5 | struct NotDisplay;
    | ^^^^^^^^^^^^^^^^^
    = note: rstest-bdd renders a step's `Err` through `Display`
-help: the trait `rstest_bdd::step_return::StepReturnNormalize<Result<T, E>>` is conditionally implemented for `rstest_bdd::step_return::StepReturnResultTag`
+help: the trait `rstest_bdd::step_return::StepReturnNormalize<Result<T, E>>` is implemented for `rstest_bdd::step_return::StepReturnResultTag`
   --> src/step_return.rs
    |
    | impl<T: Any, E: StepErrorDisplay> StepReturnNormalize<Result<T, E>> for StepReturnResultTag {
-   | ^^^^^^^^^^^^^^^^----------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                 |
-   |                 unsatisfied requirement introduced here: `NotDisplay: rstest_bdd::step_return::StepErrorDisplay`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: required for `rstest_bdd::step_return::StepReturnResultTag` to implement `rstest_bdd::step_return::StepReturnNormalize<Result<(), NotDisplay>>`
    = note: this error originates in the attribute macro `when` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/workflow_contracts/derived_fixture_lockfiles_test.py
+++ b/tests/workflow_contracts/derived_fixture_lockfiles_test.py
@@ -168,14 +168,20 @@ def test_refresh_commit_and_push_touch_only_generated_lockfiles(
 
     commit = _named_step(refresh_job, "Commit refreshed lockfiles")
     commit_script = commit.get("run")
-    assert isinstance(commit_script, str), "the commit step must run a script"
-    required_fragments = [
-        *LOCKFILES,
-        "git diff --quiet --",
-        "git add --",
-        "git commit -m 'chore(deps): refresh published GPUI fixture lockfiles'",
-    ]
-    assert all(fragment in commit_script for fragment in required_fragments), (
+    expected_commit_script = (
+        "if git diff --quiet -- \\\n"
+        "  tests/fixtures/published-gpui-0-2-2/Cargo.lock \\\n"
+        "  tests/fixtures/published-gpui-e2e/Cargo.lock; then\n"
+        "  echo 'changed=false' >> \"$GITHUB_OUTPUT\"\n"
+        "  exit 0\n"
+        "fi\n"
+        "git add -- \\\n"
+        "  tests/fixtures/published-gpui-0-2-2/Cargo.lock \\\n"
+        "  tests/fixtures/published-gpui-e2e/Cargo.lock\n"
+        "git commit -m 'chore(deps): refresh published GPUI fixture lockfiles'\n"
+        "echo 'changed=true' >> \"$GITHUB_OUTPUT\"\n"
+    )
+    assert commit_script == expected_commit_script, (
         "the commit step must stage and commit only the generated lockfiles"
     )
 

--- a/tests/workflow_contracts/derived_fixture_lockfiles_test.py
+++ b/tests/workflow_contracts/derived_fixture_lockfiles_test.py
@@ -104,7 +104,7 @@ def test_dependabot_pr_trigger_is_narrow_and_manifest_scoped(
         "pull_request_target must be a mapping"
     )
     assert pull_request_target.get("types") == ["opened", "reopened", "synchronize"], (
-        "pull_request_target must run only for lifecycle pull-request events"
+        "pull_request_target must cover the complete pull-request lifecycle"
     )
     assert pull_request_target.get("paths") == MANIFEST_PATHS, (
         "pull_request_target must be limited to manifest changes"
@@ -123,7 +123,7 @@ def test_write_permission_is_gated_to_dependabot(
 def test_permissions_are_only_contents_write(workflow: dict[str, object]) -> None:
     """The job token has the minimum scope required to push regenerated locks."""
     assert workflow.get("permissions") == {"contents": "write"}, (
-        "the workflow must have only contents write permission"
+        "the workflow must grant only contents write permission"
     )
 
 
@@ -135,18 +135,18 @@ def test_checkout_uses_the_dependabot_head_with_credentials(
     assert (
         checkout.get("uses")
         == "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
-    ), "the checkout action must use the pinned revision"
+    ), "checkout must use the pinned actions/checkout release"
     assert checkout.get("with") == {
         "ref": "${{ github.event.pull_request.head.sha }}",
         "persist-credentials": True,
-    }, "the checkout must use the Dependabot head and retain credentials"
+    }, "checkout must use the pull-request head with credentials"
 
 
 def test_setup_rust_matches_ci(refresh_job: dict[str, object]) -> None:
     """Lock resolution uses the same Rust setup action as normal CI."""
     setup = _named_step(refresh_job, "Setup Rust")
     assert setup.get("uses") == _ci_setup_rust_uses(_load(CI_WORKFLOW_PATH)), (
-        "the lockfile refresh must use CI's Rust setup action"
+        "the refresh workflow must use the CI Rust setup action"
     )
 
 
@@ -157,34 +157,33 @@ def test_refresh_commit_and_push_touch_only_generated_lockfiles(
     refresh = _named_step(refresh_job, "Refresh published GPUI fixture lockfiles")
     assert refresh.get("run") == (
         "make update-published-gpui-0-2-2-lock\nmake update-published-gpui-e2e-lock\n"
-    ), "the refresh step must update both published-GPUI lockfiles"
+    ), "the refresh step must update both published fixture lockfiles"
 
     author = _named_step(refresh_job, "Configure Git author")
     assert author.get("run") == (
         "git config user.name 'github-actions[bot]'\n"
-        "git config user.email '41898282+github-actions[bot]@"
-        "users.noreply.github.com'\n"
-    ), "the commit author must be github-actions[bot]"
+        "git config user.email "
+        "'41898282+github-actions[bot]@users.noreply.github.com'\n"
+    ), "the author step must configure the GitHub Actions bot identity"
 
     commit = _named_step(refresh_job, "Commit refreshed lockfiles")
     commit_script = commit.get("run")
     assert isinstance(commit_script, str), "the commit step must run a script"
-    for lockfile in LOCKFILES:
-        assert lockfile in commit_script, f"the commit script must name {lockfile}"
-    assert all(
-        fragment in commit_script
-        for fragment in [
-            "git diff --quiet --",
-            "git add --",
-            "git commit -m 'chore(deps): refresh published GPUI fixture lockfiles'",
-        ]
-    ), "the commit script must inspect, stage, and commit the lockfile changes"
+    required_fragments = [
+        *LOCKFILES,
+        "git diff --quiet --",
+        "git add --",
+        "git commit -m 'chore(deps): refresh published GPUI fixture lockfiles'",
+    ]
+    assert all(fragment in commit_script for fragment in required_fragments), (
+        "the commit step must stage and commit only the generated lockfiles"
+    )
 
     push = _named_step(refresh_job, "Push refreshed lockfiles")
     assert push.get("if") == "${{ steps.commit.outputs.changed == 'true' }}", (
-        "the push must run only after the commit step records a change"
+        "the push step must run only when lockfiles changed"
     )
     assert (
         push.get("run")
         == "git push origin HEAD:${{ github.event.pull_request.head.ref }}"
-    ), "the push must target the Dependabot pull-request head"
+    ), "the push step must push the refreshed lockfiles to the pull-request head"


### PR DESCRIPTION
## Summary

This draft refreshes the trybuild diagnostic baseline and formats the
derived-fixture workflow contract test under the repository's current Ruff
and Python lint policy. The two narrow baseline repairs are coupled: the
snapshot-only branch leaves the formatter gate red, while the
formatter-only branch leaves the full test gate red. Together they restore a
green baseline and unblock rollout PR #700.

The first CI run also proved that stable compiler wording differs between
the local pinned toolchain and GitHub's stable toolchain: the latter emits
`conditionally implemented` for this diagnostic. The affected UI test now
normalises that one wording variation before comparing the existing snapshot;
the normaliser has a focused regression test. This keeps the fixture portable
without weakening any other diagnostic assertion.

Closes #701.
Closes #704.

## Review walkthrough

- Start with [the trybuild snapshot](https://github.com/leynos/rstest-bdd/blob/ae2caaf94ede2edd1d2458fa8735fc817c29f472/crates/rstest-bdd/tests/ui_macros/step_return_alias_error_not_display.stderr) to verify the pinned nightly's current diagnostic wording and underline shape.
- Review [the trybuild harness](https://github.com/leynos/rstest-bdd/blob/ae2caaf94ede2edd1d2458fa8735fc817c29f472/crates/rstest-bdd/tests/trybuild_macros.rs) and [normaliser](https://github.com/leynos/rstest-bdd/blob/ae2caaf94ede2edd1d2458fa8735fc817c29f472/crates/rstest-bdd/tests/trybuild_macros/wrappers.rs) for the narrowly scoped cross-toolchain handling.
- Review [the workflow contract test](https://github.com/leynos/rstest-bdd/blob/ae2caaf94ede2edd1d2458fa8735fc817c29f472/tests/workflow_contracts/derived_fixture_lockfiles_test.py) for formatter output and assertion diagnostics; its asserted workflow values are unchanged.
- Review [the normaliser regression test](https://github.com/leynos/rstest-bdd/blob/ae2caaf94ede2edd1d2458fa8735fc817c29f472/crates/rstest-bdd/tests/trybuild_macros/helper_tests.rs) for the wording contract.

## Validation

- `cargo nextest run -p rstest-bdd --test trybuild_macros step_macros_compile`: 1 passed, 21 skipped.
- `cargo nextest run -p rstest-bdd --test trybuild_macros helper_tests::normalize_conditional_trait_help_removes_stable_wording_difference`: 1 passed.
- `make test-workflow-contracts`: 33 passed.
- `make check-fmt`: passed.
- `make lint`: passed, including Clippy, Rustdoc, Whitaker, Ruff, Pylint, df12 lints, and ambrleaks.
- `make typecheck`: passed, including Cargo checks and Python `ty` checks.
- `make test`: 1781 passed, 7 skipped; doctests and 96 Python script tests passed.
- `make markdownlint`: passed, including spelling and Markdown checks.
- `make nixie`: passed; all diagrams validated.
- `git diff --check`: passed.

## Notes

This branch intentionally contains no workflow or production-code changes.
The formatter diff is limited to the reviewed contract-test file, including
required assertion diagnostics. The trybuild changes are limited to the
reviewed snapshot plus one targeted diagnostic normaliser and its regression
test, required by the first exact-head CI run.

## Summary by Sourcery

Refresh trybuild diagnostics and harden cross-toolchain normalization while formatting workflow contract tests to restore the repository’s validation baseline.

Bug Fixes:
- Make trybuild UI diagnostics portable across pinned nightly and stable compiler wording differences.
- Refresh the affected trybuild diagnostic baseline to match current compiler output.

Enhancements:
- Improve normalized trybuild diagnostic handling by safely locating, cleaning up, and restoring work-in-progress and expected stderr files across test working directories.
- Clarify workflow contract assertion messages without changing the asserted workflow behavior.

Tests:
- Add focused regression coverage for compiler-wording normalization and portable trybuild work-in-progress paths.