### PR TITLE
Synchronize smoke LSP definition indexing (#699)

### DIFF
--- a/crates/rstest-bdd-server/tests/smoke_lsp/main.rs
+++ b/crates/rstest-bdd-server/tests/smoke_lsp/main.rs
@@ -164,6 +164,7 @@ impl ServerHandle {
 struct TestFiles {
     feature_path: PathBuf,
     rust_path: PathBuf,
+    feature_uri: lsp_types::Url,
     rust_uri: lsp_types::Url,
 }
 
@@ -196,26 +197,23 @@ fn create_test_files(dir: &Path) -> TestFiles {
     )
     .expect("write rust steps");
 
+    let feature_uri = lsp_types::Url::from_file_path(&feature_path).expect("feature URI");
     let rust_uri = lsp_types::Url::from_file_path(&rust_path).expect("rust URI");
 
     TestFiles {
         feature_path,
         rust_path,
+        feature_uri,
         rust_uri,
     }
 }
 
-/// Send `didSave` for both files and wait for a `publishDiagnostics`
-/// notification confirming that indexing has completed.
+/// Wait until indexing has published diagnostics for one saved document.
 #[expect(
     clippy::expect_used,
     reason = "missing diagnostics notification is a test-fatal condition"
 )]
-fn index_and_wait(stdin: &mut ChildStdin, receiver: &MessageReceiver, files: &TestFiles) {
-    did_save(stdin, &files.feature_path);
-    did_save(stdin, &files.rust_path);
-
-    let expected_uri = files.rust_uri.as_str();
+fn wait_for_indexed_document(receiver: &MessageReceiver, expected_uri: &str) {
     receiver
         .recv_notification_matching(
             |msg| {
@@ -230,6 +228,19 @@ fn index_and_wait(stdin: &mut ChildStdin, receiver: &MessageReceiver, files: &Te
             MAX_RECV_MESSAGES,
         )
         .expect("expected a publishDiagnostics notification after indexing");
+}
+
+/// Index the feature and Rust files in dependency order before navigation.
+///
+/// The feature diagnostic confirms that its step locations are available before
+/// the Rust save builds the matching step registry entry. Each wait matches the
+/// saved document URI, so unrelated diagnostics cannot satisfy the boundary.
+fn index_and_wait(stdin: &mut ChildStdin, receiver: &MessageReceiver, files: &TestFiles) {
+    did_save(stdin, &files.feature_path);
+    wait_for_indexed_document(receiver, files.feature_uri.as_str());
+
+    did_save(stdin, &files.rust_path);
+    wait_for_indexed_document(receiver, files.rust_uri.as_str());
 }
 
 /// Assert that `def_response` contains a non-empty array of locations

--- a/docs/debugging/debugging-plan-2026-09-02-issue-699.md
+++ b/docs/debugging/debugging-plan-2026-09-02-issue-699.md
@@ -133,6 +133,17 @@ ______________________________________________________________________
 - **Escalation trigger**: All hypotheses are falsified; revise this plan using
   the experiment outputs and the failed Windows log.
 
+## Falsification Results
+
+- **H1 falsified**: Direct and deferred save handling preserve the feature then
+  Rust order. The original helper nevertheless left a single, ambiguous
+  readiness boundary. The replacement uses phase-specific acknowledgements.
+- **H2 falsified for this fixture**: Its Rust source indexes successfully,
+  although an unrelated fatal index failure can publish empty diagnostics.
+- **H3 not falsified**: `recv_notification_matching` discards non-matching
+  messages. The replacement must therefore wait for each URI before sending
+  the next dependent save.
+
 ## Notes for Executing Agent
 
 Run only the supplied minimal experiment. Do not run repository-wide gates,

--- a/docs/debugging/debugging-plan-2026-09-02-issue-699.md
+++ b/docs/debugging/debugging-plan-2026-09-02-issue-699.md
@@ -1,0 +1,140 @@
+# Debugging Plan: Synchronize the LSP Definition Smoke Test
+
+**Generated**: 2026-09-02
+**Issue ID**: #699
+**Severity**: CI-blocking test failure
+**Falsification sub-agent**: alchemist
+**Planning agent boundary**: This document was prepared by the planning agent.
+Falsification must be executed by the named sub-agent, not by the planning
+agent.
+
+## Problem Statement
+
+The Windows smoke test sends a definition request after `index_and_wait`, but
+the server sometimes returns `null` rather than a location array. The helper
+sends saves for the feature and Rust files together, then waits only for a Rust
+`publishDiagnostics` notification. That notification must be replaced or
+strengthened with a deterministic protocol that establishes that both indexes
+are available before the definition request is sent.
+
+## Context Summary
+
+| Aspect | Details |
+| --- | --- |
+| First observed | Windows CI run 33584006657 on PR #706 |
+| Reproduction rate | Intermittent; Linux passed, Windows failed |
+| Affected components | `smoke_lsp` synchronization and deferred save replay |
+| Recent changes | The helper was restored, but it sent both saves before waiting |
+
+### Error Artefacts
+
+```plaintext
+smoke_definition_request_returns_locations ... FAILED
+expected array of locations, got: null
+```
+
+### Information Gaps
+
+- The CI runner's internal scheduling is not observable from the failed log.
+- The exact transport-to-router interleaving requires a deterministic local
+  experiment rather than inference from one CI run.
+
+______________________________________________________________________
+
+## Hypotheses
+
+### H1: The two save notifications are handled out of dependency order
+
+**Claim**: The server can process the Rust save and publish its diagnostics
+before it applies the feature save, so waiting for that Rust notification does
+not establish that a matching feature index exists.
+
+**Plausibility**: High — the helper sends both notifications without a
+per-document acknowledgement, while the server starts asynchronous workspace
+preparation and deferred replay.
+
+**Prediction**: If the feature save is acknowledged before the Rust save is
+sent, and the Rust save is then acknowledged, the definition response is
+always a location array.
+
+#### H1 Falsification Plan
+
+| Step | Action | Expected Negative Result |
+| --- | --- | --- |
+| 1 | Inspect the save and deferred-replay paths for a serialization guarantee from the first notification to the second. | A proved ordering guarantee falsifies H1. |
+| 2 | Run the smallest smoke test variant that waits for the feature diagnostic before sending the Rust save. | A `null` response despite both phase acknowledgements falsifies H1. |
+
+**Tooling**: Focused source inspection and the single `smoke_lsp` test target.
+
+**Confidence on falsification**: High. A proven single-router ordering or a
+failed phase-acknowledged test rules out the proposed race.
+
+______________________________________________________________________
+
+### H2: The helper accepts a Rust diagnostic from a failed index
+
+**Claim**: A Rust parse or read failure publishes an empty diagnostic vector,
+and `index_and_wait` treats it as successful indexing even though the step
+registry was not updated.
+
+**Plausibility**: Medium — the fatal Rust-index error path deliberately emits
+an empty `publishDiagnostics` notification.
+
+**Prediction**: A failed Rust index can produce the exact notification that the
+helper currently accepts while `handle_definition` has no step definition.
+
+#### H2 Falsification Plan
+
+| Step | Action | Expected Negative Result |
+| --- | --- | --- |
+| 1 | Inspect the smoke fixture's Rust source and the Rust indexing result path. | A successful index is guaranteed before the accepted notification, falsifying H2. |
+
+**Tooling**: Focused source inspection only; no production edits.
+
+**Confidence on falsification**: High. The fixture and error-path contracts are
+directly inspectable.
+
+______________________________________________________________________
+
+### H3: The notification receiver loses a required protocol message
+
+**Claim**: `recv_notification_matching` consumes non-matching messages, so a
+notification needed to establish readiness is discarded before the request.
+
+**Plausibility**: Low — the definition response uses id-matched reception, but
+the helper intentionally ignores all other notifications.
+
+**Prediction**: A required readiness signal occurs before the accepted Rust
+notification and cannot be recovered by the test harness.
+
+#### H3 Falsification Plan
+
+| Step | Action | Expected Negative Result |
+| --- | --- | --- |
+| 1 | Inspect receiver semantics and emitted diagnostic order for the two saves. | No required signal is discarded, falsifying H3. |
+
+**Tooling**: Focused source inspection only; no production edits.
+
+**Confidence on falsification**: Medium. This rules out loss within the test
+harness, but not server scheduling.
+
+______________________________________________________________________
+
+## Recommended Execution Order
+
+1. **H1** — directly tests the most likely cross-platform race.
+2. **H2** — cheaply rules out a false-positive readiness signal.
+3. **H3** — confirms whether the receiver constrains the replacement protocol.
+
+## Termination Criteria
+
+- **Root cause identified**: One hypothesis survives its falsification attempt
+  and yields a deterministic replacement protocol.
+- **Escalation trigger**: All hypotheses are falsified; revise this plan using
+  the experiment outputs and the failed Windows log.
+
+## Notes for Executing Agent
+
+Run only the supplied minimal experiment. Do not run repository-wide gates,
+modify tracked files, or use sleeps. Report a verdict for each hypothesis with
+the source or test evidence that supports it.

--- a/docs/debugging/debugging-plan-2026-09-02-issue-699.md
+++ b/docs/debugging/debugging-plan-2026-09-02-issue-699.md
@@ -1,4 +1,4 @@
-# Debugging Plan: Synchronize the LSP Definition Smoke Test
+# Debugging plan: Synchronize the LSP definition smoke test
 
 **Generated**: 2026-09-02
 **Issue ID**: #699
@@ -8,7 +8,7 @@
 Falsification must be executed by the named sub-agent, not by the planning
 agent.
 
-## Problem Statement
+## Problem statement
 
 The Windows smoke test sends a definition request after `index_and_wait`, but
 the server sometimes returns `null` rather than a location array. The helper
@@ -17,7 +17,7 @@ sends saves for the feature and Rust files together, then waits only for a Rust
 strengthened with a deterministic protocol that establishes that both indexes
 are available before the definition request is sent.
 
-## Context Summary
+## Context summary
 
 | Aspect | Details |
 | --- | --- |
@@ -26,14 +26,14 @@ are available before the definition request is sent.
 | Affected components | `smoke_lsp` synchronization and deferred save replay |
 | Recent changes | The helper was restored, but it sent both saves before waiting |
 
-### Error Artefacts
+### Error artefacts
 
 ```plaintext
 smoke_definition_request_returns_locations ... FAILED
 expected array of locations, got: null
 ```
 
-### Information Gaps
+### Information gaps
 
 - The CI runner's internal scheduling is not observable from the failed log.
 - The exact transport-to-router interleaving requires a deterministic local
@@ -57,7 +57,7 @@ preparation and deferred replay.
 sent, and the Rust save is then acknowledged, the definition response is
 always a location array.
 
-#### H1 Falsification Plan
+#### H1 falsification plan
 
 | Step | Action | Expected Negative Result |
 | --- | --- | --- |
@@ -83,7 +83,7 @@ an empty `publishDiagnostics` notification.
 **Prediction**: A failed Rust index can produce the exact notification that the
 helper currently accepts while `handle_definition` has no step definition.
 
-#### H2 Falsification Plan
+#### H2 falsification plan
 
 | Step | Action | Expected Negative Result |
 | --- | --- | --- |
@@ -107,7 +107,7 @@ the helper intentionally ignores all other notifications.
 **Prediction**: A required readiness signal occurs before the accepted Rust
 notification and cannot be recovered by the test harness.
 
-#### H3 Falsification Plan
+#### H3 falsification plan
 
 | Step | Action | Expected Negative Result |
 | --- | --- | --- |
@@ -120,20 +120,20 @@ harness, but not server scheduling.
 
 ______________________________________________________________________
 
-## Recommended Execution Order
+## Recommended execution order
 
 1. **H1** — directly tests the most likely cross-platform race.
 2. **H2** — cheaply rules out a false-positive readiness signal.
 3. **H3** — confirms whether the receiver constrains the replacement protocol.
 
-## Termination Criteria
+## Termination criteria
 
 - **Root cause identified**: One hypothesis survives its falsification attempt
   and yields a deterministic replacement protocol.
 - **Escalation trigger**: All hypotheses are falsified; revise this plan using
   the experiment outputs and the failed Windows log.
 
-## Falsification Results
+## Falsification results
 
 - **H1 falsified**: Direct and deferred save handling preserve the feature then
   Rust order. The original helper nevertheless left a single, ambiguous
@@ -144,7 +144,7 @@ ______________________________________________________________________
   messages. The replacement must therefore wait for each URI before sending
   the next dependent save.
 
-## Notes for Executing Agent
+## Notes for executing agent
 
 Run only the supplied minimal experiment. Do not run repository-wide gates,
 modify tracked files, or use sleeps. Report a verdict for each hypothesis with

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1940,9 +1940,13 @@ which `prepare_publish`-only tests cannot observe:
 ## Smoke LSP definition indexing sequence
 
 The definition-location smoke test must complete workspace indexing before it
-sends `textDocument/definition`. `index_and_wait` saves the fixture documents
-and waits for the indexing diagnostics notification, while the client matches
-the resulting JSON-RPC response by request identifier.
+sends `textDocument/definition`. `index_and_wait` saves the feature file, then
+waits for a `textDocument/publishDiagnostics` notification whose URI matches the
+feature document just saved. It then saves the Rust step file and waits for a
+second notification whose URI matches that Rust document. These ordered,
+URI-specific acknowledgements establish that both indexing phases have
+completed; the client then matches the resulting JSON-RPC response by request
+identifier.
 
 For screen readers: The smoke test initializes the language server, waits for
 the feature and Rust step files to be indexed, requests a definition, and
@@ -1956,6 +1960,7 @@ sequenceDiagram
 
     Test->>Server: initialize
     Test->>Server: index_and_wait(feature_file, rust_step_file)
+    Server-->>Client: textDocument/publishDiagnostics(feature_file_uri)
     Server-->>Client: textDocument/publishDiagnostics(rust_file_uri)
     Test->>Server: textDocument/definition
     Server-->>Client: definition response(JSONRPC_id)

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1937,6 +1937,34 @@ which `prepare_publish`-only tests cannot observe:
   suite: an unimplemented/unused step yields a non-empty `publishDiagnostics`,
   and resolving it re-publishes an empty array for the same URI.
 
+
+## Smoke LSP definition indexing sequence
+
+The definition-location smoke test must complete workspace indexing before it
+sends `textDocument/definition`. `index_and_wait` saves the fixture documents
+and waits for the indexing diagnostics notification, while the client matches
+the resulting JSON-RPC response by request identifier.
+
+For screen readers: The smoke test initializes the language server, waits for
+the feature and Rust step files to be indexed, requests a definition, and
+receives the matching definition response through the JSON-RPC client.
+
+```mermaid
+sequenceDiagram
+    participant Test as SmokeTest
+    participant Server as LanguageServer
+    participant Client as JSONRPCClient
+
+    Test->>Server: initialize
+    Test->>Server: index_and_wait(feature_file, rust_step_file)
+    Server-->>Client: textDocument/publishDiagnostics(rust_file_uri)
+    Test->>Server: textDocument/definition
+    Server-->>Client: definition response(JSONRPC_id)
+    Client-->>Test: Match response by JSONRPC_id
+```
+
+_Figure 1: Definition-location smoke-test indexing and response sequence._
+
 ## Bypassed-step recording contract
 
 The runtime records steps that were not executed after a scenario requested a

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1937,7 +1937,6 @@ which `prepare_publish`-only tests cannot observe:
   suite: an unimplemented/unused step yields a non-empty `publishDiagnostics`,
   and resolving it re-publishes an empty array for the same URI.
 
-
 ## Smoke LSP definition indexing sequence
 
 The definition-location smoke test must complete workspace indexing before it
@@ -1963,7 +1962,7 @@ sequenceDiagram
     Client-->>Test: Match response by JSONRPC_id
 ```
 
-_Figure 1: Definition-location smoke-test indexing and response sequence._
+*Figure 1: Definition-location smoke-test indexing and response sequence.*
 
 ## Bypassed-step recording contract
 

--- a/docs/rstest-bdd-language-server-design.md
+++ b/docs/rstest-bdd-language-server-design.md
@@ -1043,14 +1043,13 @@ and asserting correct responses and diagnostics. Three smoke tests validate:
 3. Diagnostic publication for unimplemented feature steps.
 
 The definition-navigation smoke test establishes an indexing completion
-boundary before making its request. After `initialize`, it saves both the
-feature file and the Rust step file, then waits for the
-`textDocument/publishDiagnostics` notification for the Rust file. The existing
-`index_and_wait` helper implements this protocol: the notification is emitted
-after the ordered saves have updated the feature index and step registry. The
-test then sends `textDocument/definition` and receives the response by its
-`JSON-RPC` id, because indexing notifications may still be buffered on the
-wire.
+boundary before making its request. After `initialize`, `index_and_wait` saves
+the feature file and waits for `textDocument/publishDiagnostics` with its exact
+URI. It then saves the Rust step file and waits for the same notification with
+the Rust file URI. The two phase-specific acknowledgements ensure that the
+feature index is present before the step registry is built. The test then sends
+`textDocument/definition` and receives the response by its `JSON-RPC` id,
+because indexing notifications may still be buffered on the wire.
 Tests must not replace this protocol with sleeps, timing assumptions, or
 platform-specific branches. `--debounce-ms 0` avoids an intentional debounce in
 the smoke-test process, but does not prove that asynchronous indexing has

--- a/docs/rstest-bdd-language-server-design.md
+++ b/docs/rstest-bdd-language-server-design.md
@@ -1049,7 +1049,8 @@ feature file and the Rust step file, then waits for the
 `index_and_wait` helper implements this protocol: the notification is emitted
 after the ordered saves have updated the feature index and step registry. The
 test then sends `textDocument/definition` and receives the response by its
-JSON- RPC id, because indexing notifications may still be buffered on the wire.
+`JSON-RPC` id, because indexing notifications may still be buffered on the
+wire.
 Tests must not replace this protocol with sleeps, timing assumptions, or
 platform-specific branches. `--debounce-ms 0` avoids an intentional debounce in
 the smoke-test process, but does not prove that asynchronous indexing has

--- a/docs/rstest-bdd-language-server-design.md
+++ b/docs/rstest-bdd-language-server-design.md
@@ -1042,8 +1042,20 @@ and asserting correct responses and diagnostics. Three smoke tests validate:
 2. Definition request returning correct feature file locations.
 3. Diagnostic publication for unimplemented feature steps.
 
-These tests run as part of the standard CI pipeline (`make test`) and use
-`--debounce-ms 0` to eliminate indexing delay.
+The definition-navigation smoke test establishes an indexing completion
+boundary before making its request. After `initialize`, it saves both the
+feature file and the Rust step file, then waits for the
+`textDocument/publishDiagnostics` notification for the Rust file. The existing
+`index_and_wait` helper implements this protocol: the notification is emitted
+after the ordered saves have updated the feature index and step registry. The
+test then sends `textDocument/definition` and receives the response by its
+JSON- RPC id, because indexing notifications may still be buffered on the wire.
+Tests must not replace this protocol with sleeps, timing assumptions, or
+platform-specific branches. `--debounce-ms 0` avoids an intentional debounce in
+the smoke-test process, but does not prove that asynchronous indexing has
+completed.
+
+These tests run as part of the standard CI pipeline (`make test`).
 
 ### Next phases
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -48,6 +48,28 @@ like these:
 - For cleanup assertions, use lightweight RAII probes with `Drop` side effects
   rather than internal implementation hooks.
 
+
+### LSP smoke-test synchronization
+
+The language-server smoke tests exercise an asynchronous JSON-RPC process, so a
+response can be interleaved with indexing notifications. A definition request
+is valid only after the workspace index contains both the feature step and its
+Rust implementation. Maintain this sequence in definition-navigation tests:
+
+1. Complete the `initialize` handshake.
+2. Save both the feature file and the Rust step file using `index_and_wait`, or
+   an equivalent deterministic helper.
+3. Wait for `textDocument/publishDiagnostics` for the Rust file URI. This is
+   the completion boundary: the ordered saves have been processed, and the
+   feature index and step registry are ready for navigation.
+4. Send `textDocument/definition` and receive its response by JSON-RPC id, so
+   buffered notifications cannot be mistaken for the response.
+
+The completion boundary is a protocol invariant, not a timing hint. Do not use
+sleeps, assumed scheduling delays, or platform-specific branches to make these
+tests pass. Setting `--debounce-ms 0` can remove an intentional debounce, but
+cannot replace the indexing-completion wait.
+
 ## Good and fragile assertions
 
 Good semantic assertions:

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -48,7 +48,6 @@ like these:
 - For cleanup assertions, use lightweight RAII probes with `Drop` side effects
   rather than internal implementation hooks.
 
-
 ### LSP smoke-test synchronization
 
 The language-server smoke tests exercise an asynchronous JSON-RPC process, so a

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -57,11 +57,11 @@ is valid only after the workspace index contains both the feature step and its
 Rust implementation. Maintain this sequence in definition-navigation tests:
 
 1. Complete the `initialize` handshake.
-2. Save both the feature file and the Rust step file using `index_and_wait`, or
-   an equivalent deterministic helper.
-3. Wait for `textDocument/publishDiagnostics` for the Rust file URI. This is
-   the completion boundary: the ordered saves have been processed, and the
-   feature index and step registry are ready for navigation.
+2. Save the feature file and wait for `textDocument/publishDiagnostics` for
+   its exact URI.
+3. Save the Rust step file and wait for `textDocument/publishDiagnostics` for
+   its exact URI. Together, the two URI-matched acknowledgements establish
+   that the feature index and step registry are ready for navigation.
 4. Send `textDocument/definition` and receive its response by JSON-RPC id, so
    buffered notifications cannot be mistaken for the response.
 


### PR DESCRIPTION
## Summary

- Save the feature file and await `publishDiagnostics` for its exact URI before
  sending the dependent Rust save.
- Await the Rust-file diagnostic before issuing `textDocument/definition`, so
  the assertion only exercises definition locations after both indexes are ready.
- Document the URI-specific completion protocol and its no-timing invariant.

Closes #699.

Context: [Configure DF12 Python linting #691 comment](https://github.com/leynos/rstest-bdd/pull/691#issuecomment-5493188674).

## Validation

- `cargo test --workspace --test smoke_lsp --no-default-features --features "rstest-bdd/diagnostics rstest-bdd-server/test-support strict-compile-time-validation"`: passed (6 tests).
- `make check-fmt`, `make lint`, and `make test`: passed (1,826 passed; 7 skipped).
- `make markdownlint` and `make nixie`: passed.
- `coderabbit review --agent`: 0 findings.

## References

- [Lody session](https://lody.ai/leynos/sessions/062c819d-5dd8-4f11-8f5e-81a1825ed807)

## Summary by Sourcery

Synchronize LSP smoke-test indexing before exercising definition navigation.

Bug Fixes:
- Make the LSP definition smoke test reliably wait for feature and Rust indexing before requesting definitions.

Enhancements:
- Use ordered, URI-specific diagnostics acknowledgements as the indexing completion boundary and document the no-timing synchronization protocol.

Documentation:
- Document the LSP smoke-test indexing sequence, JSON-RPC response matching, and prohibition on sleeps or timing-based synchronization.

Tests:
- Synchronize smoke-test saves and diagnostic waits to prevent intermittent definition lookup failures.