### PR TITLE
Record why the shared sccache wiring stays off and what the disk budget is

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,14 @@ jobs:
 
       - name: Setup Rust
         # Merged shared-actions PR #421 cache-provider revision.
+        #
+        # `use-sccache: 'false'` is load-bearing on the Linux lanes, not a
+        # duplicate of the installer below. The action's sccache wiring
+        # re-exports ACTIONS_CACHE_SERVICE_V2=on with GitHub's results URL and
+        # token to GITHUB_ENV as its last act, which clobbers the credential
+        # re-export for every later step; the server then addresses GitHub's
+        # results service and every write fails. Measured on
+        # ubicloud-standard-2. Do not set this to 'true'.
         uses: leynos/shared-actions/.github/actions/setup-rust@5daae0a332441d170d88ca648c9e71f0bbe96cb3
         with:
           toolchain: ${{ matrix.rust-toolchain }}

--- a/docs/adr-013-adopt-whitaker-no-unwrap-or-else-panic.md
+++ b/docs/adr-013-adopt-whitaker-no-unwrap-or-else-panic.md
@@ -291,8 +291,8 @@ listing held 385 `sccache/*` objects under this branch's scope, verified on
 2026-09-03 at 23:15 UTC with `ubi gh leynos/rstest-bdd list-cache-entries`.
 
 The shared Rust setup is called with `use-sccache: false` on every lane, and on
-Linux that is the decision, not an omission: the action's `sccache` wiring re-exports
-`ACTIONS_CACHE_SERVICE_V2=on` with GitHub's results URL and token to
+Linux that is the decision, not an omission: the action's `sccache` wiring
+re-exports `ACTIONS_CACHE_SERVICE_V2=on` with GitHub's results URL and token to
 `GITHUB_ENV` as its last act, clobbering the re-export for later steps and
 sending every write to the wrong service. The Windows lane has no backend of
 that kind at all, so it uses the workspace directory that the cache step

--- a/docs/adr-013-adopt-whitaker-no-unwrap-or-else-panic.md
+++ b/docs/adr-013-adopt-whitaker-no-unwrap-or-else-panic.md
@@ -288,9 +288,14 @@ rather than that proxy, and every write failed against it: 6,934 of 6,934 on
 the last run that used it. After the change the same workload reported 2,372
 hits, a 34 percent hit rate, and 5 write errors in 4,601, and the Ubicloud
 listing held 385 `sccache/*` objects under this branch's scope, verified on
-2026-09-03 at 23:15 UTC with `ubi gh leynos/rstest-bdd list-cache-entries`. The
-Windows lane has no such backend, because the shared Rust setup is called with
-`use-sccache: false`, so it uses the workspace directory that the cache step
+2026-09-03 at 23:15 UTC with `ubi gh leynos/rstest-bdd list-cache-entries`.
+
+The shared Rust setup is called with `use-sccache: false` on every lane, and on
+Linux that is the decision, not an omission: the action's `sccache` wiring re-exports
+`ACTIONS_CACHE_SERVICE_V2=on` with GitHub's results URL and token to
+`GITHUB_ENV` as its last act, clobbering the re-export for later steps and
+sending every write to the wrong service. The Windows lane has no backend of
+that kind at all, so it uses the workspace directory that the cache step
 owns. Setting the `RSTEST_BDD_SCCACHE_LOCAL` repository variable moves the
 Linux lanes onto that same local directory as a documented fallback. Check the
 first `main` run with `ubi gh leynos/rstest-bdd list-cache-entries` to confirm

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -56,6 +56,26 @@ free disk to both the job log and the job summary, even when the job fails.
 Escalate to `ubicloud-standard-4`, and set the vCPU constant to 4, only if the
 sampler shows the reclaimed shape still peaking within 5 GB of a full disk.
 
+The reclaimed lane has never come close to that. Five consecutive runs on
+2026-09-04, three on the pull request and two dispatched on trunk, measured:
+
+| Run | Peak used disk | Least free disk | Peak memory |
+| --- | --- | --- | --- |
+| 33853939331 | 60,315 MiB | 12,995 MiB | 1,911 MiB |
+| 33862077644 | 60,312 MiB | 12,998 MiB | 1,789 MiB |
+| 33866984348 | 60,244 MiB | 13,066 MiB | 2,007 MiB |
+| 33884577115 | 60,875 MiB | 12,435 MiB | 1,932 MiB |
+| 33888769029 | 60,875 MiB | 12,435 MiB | 1,975 MiB |
+
+*Table: sampler peaks on `ubicloud-standard-2` after the discard step landed.*
+
+Each of those runs reclaimed about 10 GB, taking the root filesystem from
+83 percent to 69 percent full immediately before the publish build. The trees
+measured 5.7 GB for the instrumented coverage tree, 1.9 GB for the
+published-GPUI end-to-end fixture, 1.6 GB for `target/debug`, and 993 MB for
+the 0.2.2 fixture. Discarding the coverage tree alone would have left most of
+the pressure in place.
+
 `ubicloud-standard-2` is registered in `.github/actionlint.yaml` under
 `self-hosted-runner.labels`. GitHub-hosted labels need no registration, and the
 contracts require the registered set to match the labels the matrix names.
@@ -169,8 +189,20 @@ proxy, and every `sccache` write failed against it. Clearing
 that this reaches Ubicloud is `sccache/*` entries under the branch scope in
 `ubi gh leynos/rstest-bdd list-cache-entries`.
 
-The Windows lane has no such backend, because the shared Rust setup is called
-with `use-sccache: false` and nothing else wires one. It uses the workspace
+The shared Rust setup is called with `use-sccache: false` on every lane, and
+on the Linux lanes that is load-bearing rather than incidental. Measured on
+`ubicloud-standard-2`, a later `run:` step does see the credentials the
+re-export publishes; what breaks the backend is the shared action's own
+`sccache` wiring. Its last act re-exports `ACTIONS_CACHE_SERVICE_V2=on`
+together with GitHub's results URL and token to `GITHUB_ENV`, which clobbers
+the re-export for every step that follows, so the `sccache` server then
+addresses GitHub's results service and its writes fail. Keeping that step out
+of the job is what makes the backend reach Ubicloud. Do not set
+`use-sccache: true` here on the assumption that the workflow's own installer
+is merely a duplicate.
+
+The Windows lane has no backend of that kind, because nothing else wires
+one. It uses the workspace
 directory, restored and saved by the cache action with a `restore-keys` prefix.
 Setting the `RSTEST_BDD_SCCACHE_LOCAL` repository variable moves the Linux
 lanes onto that same local directory, which is the documented fallback if the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -201,9 +201,9 @@ of the job is what makes the backend reach Ubicloud. Do not set
 `use-sccache: true` here on the assumption that the workflow's own installer
 is merely a duplicate.
 
-The Windows lane has no backend of that kind, because nothing else wires
-one. It uses the workspace
-directory, restored and saved by the cache action with a `restore-keys` prefix.
+The Windows lane has no backend of that kind because nothing else wires one. It
+uses the workspace directory, restored and saved by the cache action with a
+`restore-keys` prefix.
 Setting the `RSTEST_BDD_SCCACHE_LOCAL` repository variable moves the Linux
 lanes onto that same local directory, which is the documented fallback if the
 backend ever stops reaching Ubicloud. The compiler-cache step is guarded so


### PR DESCRIPTION
## Why

Two corrections to what PR #710 left in the documentation, both from
measurements taken after it merged.

The guide and ADR-013 explained `use-sccache: false` as a fact about the
Windows lane. Every lane passes it, and on Linux it is the decision rather
than an omission. A reader could reasonably conclude the workflow's own
checksum-verified installer merely duplicates the shared action and flip the
input to `true`, which would silently break the backend.

The lane's disk budget was described but never quantified, so the 5 GB
escalation threshold had no measured distance to compare against.

## What

- State the measured mechanism in the guide, in the ADR addendum, and as a
  comment at the `Setup Rust` step where someone would change the input. On
  `ubicloud-standard-2` a later `run:` step does see the re-exported
  credentials; the shared action's sccache step re-exports
  `ACTIONS_CACHE_SERVICE_V2=on` with GitHub's results URL and token to
  `GITHUB_ENV` as its last act, clobbering the re-export for every step that
  follows, after which the server addresses GitHub's results service and its
  writes fail.
- Add the sampler table to the guide: five consecutive runs on 2026-09-04,
  three on #710 and two dispatched on trunk, with the sizes of the four trees
  the discard step reclaims.

## Evidence

| Run | Peak used disk | Least free disk | Peak memory |
| --- | --- | --- | --- |
| 33853939331 | 60,315 MiB | 12,995 MiB | 1,911 MiB |
| 33862077644 | 60,312 MiB | 12,998 MiB | 1,789 MiB |
| 33866984348 | 60,244 MiB | 13,066 MiB | 2,007 MiB |
| 33884577115 | 60,875 MiB | 12,435 MiB | 1,932 MiB |
| 33888769029 | 60,875 MiB | 12,435 MiB | 1,975 MiB |

Peaks span 631 MiB across the five, and the least free disk never fell below
12,435 MiB against a 5 GB escalation threshold. No workflow behaviour changes:
the only `ci.yml` edit is a comment.

## Validation

`make test-workflow-contracts`, `make markdownlint`, `make spelling`,
`make nixie`, and `actionlint .github/workflows/ci.yml` all pass. No Rust
changed.

https://claude.ai/code/session_01QrjNTnTwM7FmWXe5KFPMPY

## Summary by Sourcery

Document the measured reasons for keeping shared sccache disabled and quantify the reclaimed lane’s resource headroom.

Enhancements:
- Document why shared sccache integration remains disabled across lanes and warn against enabling it on Linux.
- Document measured disk and memory usage for the reclaimed runner lane, including the sizes of the cleanup targets and distance from the escalation threshold.

CI:
- Add an explanatory comment to the Rust setup step without changing workflow behavior.

Documentation:
- Update the developer guide and ADR-013 with the sccache credential-clobbering rationale, local fallback context, and runner resource measurements.