### PR TITLE
Size the trybuild compile budget for a cold cache

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,8 +2,13 @@
 # Kill any test once it crosses 60s.
 slow-timeout = { period = "60s", terminate-after = 1, grace-period = "5s" }
 
-# Accommodate cargo-spawning tests that deliberately run one at a time.
-global-timeout = "20m"
+# Accommodate cargo-spawning tests that deliberately run one at a time. This
+# must exceed the largest per-test budget below, or the run dies before the
+# test it was raised for can finish: a 20 minute compile budget under a
+# 20 minute global timeout rescues nothing. The cold run that motivated the
+# larger budget finished its whole suite in 813 s with the slow test at 387 s,
+# so a worst-case cold compile puts the suite near 27 minutes.
+global-timeout = "40m"
 
 [test-groups.cargo-spawning]
 # Tests that shell out to `cargo` contend for the package-cache lock and for
@@ -23,8 +28,17 @@ test-group = "cargo-spawning"
 # tree; on cold caches this can legitimately exceed the default 60 s limit.
 # Allow the full fixture set to rebuild without treating slow, healthy compiler
 # work as a hung test.
+#
+# The budget is sized for a genuinely cold compiler cache, which is what a
+# trunk run meets after a cache eviction or a key change. Measured on
+# `ubicloud-standard-2` for `rstest-bdd::trybuild_macros step_macros_compile`:
+# it exceeded the former 10 minute budget on run 33871787845's first attempt
+# with nothing in sccache, took 386.8 s on the rerun with 297 objects in
+# scope, and 200.5 s and 186.1 s on runs 33884577115 and 33888769029 against
+# a full generation. A passing test never spends the budget, so the larger
+# figure costs nothing except on the run it rescues.
 filter = "binary_id(rstest-bdd-harness-tokio::macro_compile) | binary_id(rstest-bdd-harness-gpui::macro_compile) | binary_id(rstest-bdd::trybuild_macros) | binary_id(rstest-bdd-server::workspace_discovery_compile)"
-slow-timeout = { period = "10m", terminate-after = 1, grace-period = "5s" }
+slow-timeout = { period = "20m", terminate-after = 1, grace-period = "5s" }
 test-group = "cargo-spawning"
 
 [profile.long]

--- a/crates/rstest-bdd/tests/nextest_config.rs
+++ b/crates/rstest-bdd/tests/nextest_config.rs
@@ -106,13 +106,17 @@ fn workspace_root() -> Result<PathBuf, io::Error> {
     Ok(workspace_root.to_path_buf())
 }
 
-fn default_global_timeout(configuration: &Value) -> Result<&str, io::Error> {
+fn default_profile_key<'a>(configuration: &'a Value, key: &str) -> Option<&'a Value> {
     configuration
         .get("profile")
         .and_then(Value::as_table)
         .and_then(|profiles| profiles.get("default"))
         .and_then(Value::as_table)
-        .and_then(|default_profile| default_profile.get("global-timeout"))
+        .and_then(|default_profile| default_profile.get(key))
+}
+
+fn default_global_timeout(configuration: &Value) -> Result<&str, io::Error> {
+    default_profile_key(configuration, "global-timeout")
         .and_then(Value::as_str)
         .ok_or_else(|| {
             io::Error::other("nextest configuration must set profile.default.global-timeout")
@@ -144,12 +148,7 @@ fn duration_seconds(duration: &str) -> Result<u64, io::Error> {
 }
 
 fn default_overrides(configuration: &Value) -> Result<&[Value], io::Error> {
-    let overrides = configuration
-        .get("profile")
-        .and_then(Value::as_table)
-        .and_then(|profiles| profiles.get("default"))
-        .and_then(Value::as_table)
-        .and_then(|default_profile| default_profile.get("overrides"))
+    let overrides = default_profile_key(configuration, "overrides")
         .and_then(Value::as_array)
         .ok_or_else(|| {
             io::Error::other("nextest configuration must contain profile.default.overrides")

--- a/crates/rstest-bdd/tests/nextest_config.rs
+++ b/crates/rstest-bdd/tests/nextest_config.rs
@@ -45,10 +45,22 @@ fn trybuild_nextest_override_preserves_timeout_contract() -> Result<(), Box<dyn 
         .and_then(Value::as_table)
         .expect("trybuild nextest override must contain a slow-timeout table");
 
+    let period = slow_timeout
+        .get("period")
+        .and_then(Value::as_str)
+        .ok_or_else(|| io::Error::other("trybuild nextest override must name a period"))?;
     assert_eq!(
-        slow_timeout.get("period").and_then(Value::as_str),
-        Some("10m"),
-        "trybuild nextest override must allow a 10-minute slow timeout",
+        period, "20m",
+        "trybuild nextest override must allow a 20-minute slow timeout, which is what a cold \
+         compiler cache costs this fixture tree",
+    );
+
+    let global_timeout = default_global_timeout(&configuration)?;
+    assert!(
+        duration_seconds(global_timeout)? > duration_seconds(period)?,
+        "the default profile's global timeout ({global_timeout}) must exceed the trybuild slow \
+         timeout ({period}); otherwise nextest kills the run before the test the budget exists \
+         for can finish, and raising the budget alone rescues nothing",
     );
     assert_eq!(
         slow_timeout
@@ -92,6 +104,43 @@ fn workspace_root() -> Result<PathBuf, io::Error> {
         })?;
 
     Ok(workspace_root.to_path_buf())
+}
+
+fn default_global_timeout(configuration: &Value) -> Result<&str, io::Error> {
+    configuration
+        .get("profile")
+        .and_then(Value::as_table)
+        .and_then(|profiles| profiles.get("default"))
+        .and_then(Value::as_table)
+        .and_then(|default_profile| default_profile.get("global-timeout"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            io::Error::other("nextest configuration must set profile.default.global-timeout")
+        })
+}
+
+fn duration_seconds(duration: &str) -> Result<u64, io::Error> {
+    let unit_start = duration
+        .find(|character: char| !character.is_ascii_digit())
+        .ok_or_else(|| io::Error::other(format!("duration {duration} names no unit")))?;
+    let (value, unit) = duration.split_at(unit_start);
+    let value: u64 = value
+        .parse()
+        .map_err(|_| io::Error::other(format!("duration {duration} names no count")))?;
+    let multiplier = match unit {
+        "s" => 1,
+        "m" => 60,
+        "h" => 3_600,
+        _ => {
+            return Err(io::Error::other(format!(
+                "duration {duration} uses unit {unit}"
+            )));
+        }
+    };
+
+    value
+        .checked_mul(multiplier)
+        .ok_or_else(|| io::Error::other(format!("duration {duration} overflows")))
 }
 
 fn default_overrides(configuration: &Value) -> Result<&[Value], io::Error> {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## Unreleased
 
 - Raised the nextest compile budget for the trybuild-based tests from ten to
-  twenty minutes, and the default profile's global timeout from twenty to
-  forty minutes so the larger per-test budget can be spent. A CI run with a
-  cold compiler cache exceeded the old budget while healthily compiling the
-  fixture dependency tree; the same test takes about three minutes once the
-  cache is warm. A passing test never spends the budget.
+  twenty minutes, and the default profile's global timeout from twenty to forty
+  minutes so the larger per-test budget can be spent. A CI run with a cold
+  compiler cache exceeded the old budget while healthily compiling the fixture
+  dependency tree; the same test takes about three minutes once the cache is
+  warm. A passing test never spends the budget.
 
 - Scenarios that previously passed may now correctly fail: unhinted steps that
   return a local alias of `Result<T, E>` now propagate `Err` rather than boxing

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Raised the nextest compile budget for the trybuild-based tests from ten to
+  twenty minutes, and the default profile's global timeout from twenty to
+  forty minutes so the larger per-test budget can be spent. A CI run with a
+  cold compiler cache exceeded the old budget while healthily compiling the
+  fixture dependency tree; the same test takes about three minutes once the
+  cache is warm. A passing test never spends the budget.
+
 - Scenarios that previously passed may now correctly fail: unhinted steps that
   return a local alias of `Result<T, E>` now propagate `Err` rather than boxing
   it as a payload. `Ok(T)` injects `T`, and `E` must implement `Display`.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -498,20 +498,28 @@ workspace root; this is the only nextest configuration file the runner loads.
 The file sets the timeout policy for the test suite:
 
 - The default profile kills any test that runs past a 60 s `slow-timeout`
-  (`terminate-after = 1`, 5 s grace period) and applies a 20 m `global-timeout`
+  (`terminate-after = 1`, 5 s grace period) and applies a 40 m `global-timeout`
   to the whole run. This allows the cargo-spawning group to run its bounded
-  tests one at a time without exhausting the whole-suite budget.
+  tests one at a time without exhausting the whole-suite budget. The global
+  timeout must stay above the largest per-test budget below, or the run is
+  killed before the test that budget exists for can finish;
+  `trybuild_nextest_override_preserves_timeout_contract` enforces the
+  ordering.
 - A `[[profile.default.overrides]]` entry raises the `slow-timeout` to 180 s
   for `cargo-bdd::cli`, whose smoke tests spawn `cargo` to build fixture crates
   and can legitimately exceed 60 s on cold caches.
-- A second override raises the `slow-timeout` further, to 10 minutes, for the
+- A second override raises the `slow-timeout` further, to 20 minutes, for the
   trybuild-based compile-test binaries:
   `rstest-bdd-harness-tokio::macro_compile`,
   `rstest-bdd-harness-gpui::macro_compile`, `rstest-bdd::trybuild_macros`, and
   `rstest-bdd-server::workspace_discovery_compile`. These tests invoke
-  `cargo build` against a large dependency tree. The 10-minute allowance
-  permits the full fixture set to rebuild on a cold cache without treating
-  slow, healthy compiler work as a hung test. The strict 60 s default remains
+  `cargo build` against a large dependency tree, so their runtime tracks
+  compiler-cache warmth rather than anything about the tests. Measured on
+  `ubicloud-standard-2`, `step_macros_compile` exceeded the former 10-minute
+  allowance with nothing in `sccache`, took 386.8 s with a partial cache, and
+  about 190 s against a full one. The 20-minute allowance permits the full
+  fixture set to rebuild on a cold cache without treating slow, healthy
+  compiler work as a hung test. The strict 60 s default remains
   in force elsewhere, and these tests stay in the `cargo-spawning` group so all
   four run serially.
 - Both overrides also place their binaries in a `cargo-spawning` test group
@@ -571,7 +579,7 @@ Mitigation:
 - `.config/nextest.toml` raises the `slow-timeout` for the trybuild
   compile-test binaries (including both `macro_compile` binaries,
   `rstest-bdd::trybuild_macros`, and
-  `rstest-bdd-server::workspace_discovery_compile`) to 10 minutes as a
+  `rstest-bdd-server::workspace_discovery_compile`) to 20 minutes as a
   local-development safety net. This does not fix the deadlock; it only delays
   termination to allow the build to complete on fast machines.
 - `.config/nextest.toml` also places the `cargo-bdd::cli` and trybuild


### PR DESCRIPTION
## Why

`rstest-bdd::trybuild_macros step_macros_compile` shells out to cargo and
compiles a large fixture dependency tree, so its runtime tracks compiler-cache
warmth rather than anything about the test. Measured on `ubicloud-standard-2`:

| Run | sccache state | Duration |
| --- | --- | --- |
| 33871787845, first attempt | cold | exceeded the 600 s budget |
| 33871787845, rerun | 297 objects in scope | 386.8 s |
| 33884577115 | full generation | 200.5 s |
| 33888769029 | full generation | 186.1 s |

The first of those was the cold writer on `main` immediately after #710
merged. A trunk run meets the cold case whenever a cache is evicted or a key
changes, which is exactly when there is no saved generation to recover from,
and the failure costs a whole rerun.

## What

- Raise the trybuild override's `slow-timeout` from ten to twenty minutes.
- Raise the default profile's `global-timeout` from twenty to forty minutes.

The second is not optional. A twenty minute per-test budget under a twenty
minute global timeout rescues nothing, because the run is killed before the
test it was raised for can finish. The cold run completed its whole suite in
813 s with the slow test at 387 s, so a worst-case cold compile puts the suite
near twenty-seven minutes. Forty leaves headroom while the job's own
ninety-minute limit still bounds everything.

`crates/rstest-bdd/tests/nextest_config.rs` already pinned the override at ten
minutes, so the first push turned that contract red. Its expectation moves to
twenty, and it gains the invariant the first attempt missed: the global
timeout must exceed the largest per-test budget. The check parses both
durations rather than pinning a second literal, so either value can move as
long as the ordering holds.

A passing test never spends its budget, so neither change costs anything
except on the run it rescues. Nothing else is touched.

## Validation

`make markdownlint`, `make spelling` and `make test-workflow-contracts` pass.
`cargo nextest list -E 'binary_id(rstest-bdd::trybuild_macros)'` parses the
configuration and lists the test, so the override is well formed. No Rust
source changed.

## Summary by Sourcery

Increase nextest timeout budgets to accommodate cold-cache trybuild compilation runs.

Bug Fixes:
- Prevent cold-cache trybuild compilation tests from being terminated before they can complete by increasing their per-test and suite-wide timeout budgets.

Enhancements:
- Make the timeout contract test verify that the default global timeout exceeds the largest per-test timeout.
- Document the expanded timeout policy and its rationale for cold compiler caches.

Documentation:
- Update the changelog and developer guide to reflect the 20-minute trybuild budget and 40-minute global timeout.

Tests:
- Update nextest configuration tests to expect the larger trybuild timeout and validate timeout ordering.