### PR TITLE
Add invariant tests and correct follow-up comments from PR #691 (#697)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -489,7 +489,10 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         uses: leynos/shared-actions/.github/actions/generate-coverage@f6d4d5f549655c118f86f371b8d55c200d3efa50
         env:
-          RUN_RUST_CARGO_WAIT_TIMEOUT: '1800'
+          # Cold instrumented builds plus the doctest pass can exceed the
+          # action's 1800s budget; stay explicit so a future default cannot
+          # quietly shorten this lane.
+          RUN_RUST_CARGO_WAIT_TIMEOUT: '4500'
           # Tests that snapshot a child process's stderr must see the same
           # panic-hook output on every lane. An instrumented build retains
           # debuginfo, so a backtrace would otherwise appear here and not on
@@ -519,9 +522,13 @@ jobs:
         uses: leynos/shared-actions/.github/actions/generate-coverage@f6d4d5f549655c118f86f371b8d55c200d3efa50
         continue-on-error: true
         env:
-          # Windows coverage runs (build plus doctests) exceed the shared
-          # action's 600s per-invocation default; give them headroom.
-          RUN_RUST_CARGO_WAIT_TIMEOUT: '1800'
+          # Windows coverage runs (build plus doctests) outgrew the shared
+          # action's 1800s default: a cold instrumented build spends most of
+          # that budget compiling before the doctest pass starts. 4500 gives
+          # the cold path headroom while the watchdog still catches a hang,
+          # and stays explicit so a future default cannot quietly change
+          # these lanes.
+          RUN_RUST_CARGO_WAIT_TIMEOUT: '4500'
           # Match the Linux lane so stderr snapshots stay deterministic.
           RUST_BACKTRACE: '0'
         with:
@@ -539,9 +546,13 @@ jobs:
         uses: leynos/shared-actions/.github/actions/generate-coverage@f6d4d5f549655c118f86f371b8d55c200d3efa50
         continue-on-error: true
         env:
-          # Windows coverage runs (build plus doctests) exceed the shared
-          # action's 600s per-invocation default; give them headroom.
-          RUN_RUST_CARGO_WAIT_TIMEOUT: '1800'
+          # Windows coverage runs (build plus doctests) outgrew the shared
+          # action's 1800s default: a cold instrumented build spends most of
+          # that budget compiling before the doctest pass starts. 4500 gives
+          # the cold path headroom while the watchdog still catches a hang,
+          # and stays explicit so a future default cannot quietly change
+          # these lanes.
+          RUN_RUST_CARGO_WAIT_TIMEOUT: '4500'
           # Match the Linux lane so stderr snapshots stay deterministic.
           RUST_BACKTRACE: '0'
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     # Ubicloud runners register as just-in-time self-hosted runners, so the
     # six-hour hosted limit does not apply. Bound the job explicitly.
-    timeout-minutes: 90
+    timeout-minutes: 190
     permissions:
       contents: read
     env:
@@ -489,7 +489,14 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         uses: leynos/shared-actions/.github/actions/generate-coverage@77ea10341249024e22ec5d9069e3caa7596e0d4f
         env:
-          RUN_RUST_CARGO_WAIT_TIMEOUT: '4500'
+          # The cargo watchdog, one of four tiers that can end a run. It
+          # must cover the 75 m nextest global-timeout in
+          # .config/nextest.toml, the 20 m a test already running may
+          # still take when that expires, and the build inside the same
+          # cargo invocation. Below that, a cold run is killed before
+          # nextest can use the budget it was given. See "Test timeouts:
+          # four tiers, outermost last" in docs/developers-guide.md.
+          RUN_RUST_CARGO_WAIT_TIMEOUT: '6600'
           # Tests that snapshot a child process's stderr must see the same
           # panic-hook output on every lane. An instrumented build retains
           # debuginfo, so a backtrace would otherwise appear here and not on
@@ -519,11 +526,13 @@ jobs:
         uses: leynos/shared-actions/.github/actions/generate-coverage@77ea10341249024e22ec5d9069e3caa7596e0d4f
         continue-on-error: true
         env:
-          # Windows coverage runs (build plus doctests) needed headroom over
-          # the shared action's default; 4500 gives the cold sccache store the
-          # same budget as the Linux lane. It stays explicit so a future
-          # default cannot quietly shorten these lanes.
-          RUN_RUST_CARGO_WAIT_TIMEOUT: '4500'
+          # Windows coverage runs (build plus doctests) needed headroom
+          # over the shared action's default, and take the same budget as
+          # the Linux lane, sized by the rule in "Test timeouts: four
+          # tiers, outermost last" in docs/developers-guide.md. It stays
+          # explicit so a future default cannot quietly shorten these
+          # lanes.
+          RUN_RUST_CARGO_WAIT_TIMEOUT: '6600'
           # Match the Linux lane so stderr snapshots stay deterministic.
           RUST_BACKTRACE: '0'
         with:
@@ -541,11 +550,13 @@ jobs:
         uses: leynos/shared-actions/.github/actions/generate-coverage@77ea10341249024e22ec5d9069e3caa7596e0d4f
         continue-on-error: true
         env:
-          # Windows coverage runs (build plus doctests) needed headroom over
-          # the shared action's default; 4500 gives the cold sccache store the
-          # same budget as the Linux lane. It stays explicit so a future
-          # default cannot quietly shorten these lanes.
-          RUN_RUST_CARGO_WAIT_TIMEOUT: '4500'
+          # Windows coverage runs (build plus doctests) needed headroom
+          # over the shared action's default, and take the same budget as
+          # the Linux lane, sized by the rule in "Test timeouts: four
+          # tiers, outermost last" in docs/developers-guide.md. It stays
+          # explicit so a future default cannot quietly shorten these
+          # lanes.
+          RUN_RUST_CARGO_WAIT_TIMEOUT: '6600'
           # Match the Linux lane so stderr snapshots stay deterministic.
           RUST_BACKTRACE: '0'
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -489,7 +489,7 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         uses: leynos/shared-actions/.github/actions/generate-coverage@77ea10341249024e22ec5d9069e3caa7596e0d4f
         env:
-          RUN_RUST_CARGO_WAIT_TIMEOUT: '1800'
+          RUN_RUST_CARGO_WAIT_TIMEOUT: '4500'
           # Tests that snapshot a child process's stderr must see the same
           # panic-hook output on every lane. An instrumented build retains
           # debuginfo, so a backtrace would otherwise appear here and not on
@@ -520,10 +520,10 @@ jobs:
         continue-on-error: true
         env:
           # Windows coverage runs (build plus doctests) needed headroom over
-          # the shared action's old 600s default. From this pin 1800 is that
-          # default, so this now restates it rather than raising it; it stays
-          # explicit so a future default cannot quietly shorten these lanes.
-          RUN_RUST_CARGO_WAIT_TIMEOUT: '1800'
+          # the shared action's default; 4500 gives the cold sccache store the
+          # same budget as the Linux lane. It stays explicit so a future
+          # default cannot quietly shorten these lanes.
+          RUN_RUST_CARGO_WAIT_TIMEOUT: '4500'
           # Match the Linux lane so stderr snapshots stay deterministic.
           RUST_BACKTRACE: '0'
         with:
@@ -542,10 +542,10 @@ jobs:
         continue-on-error: true
         env:
           # Windows coverage runs (build plus doctests) needed headroom over
-          # the shared action's old 600s default. From this pin 1800 is that
-          # default, so this now restates it rather than raising it; it stays
-          # explicit so a future default cannot quietly shorten these lanes.
-          RUN_RUST_CARGO_WAIT_TIMEOUT: '1800'
+          # the shared action's default; 4500 gives the cold sccache store the
+          # same budget as the Linux lane. It stays explicit so a future
+          # default cannot quietly shorten these lanes.
+          RUN_RUST_CARGO_WAIT_TIMEOUT: '4500'
           # Match the Linux lane so stderr snapshots stay deterministic.
           RUST_BACKTRACE: '0'
         with:

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@794e4801babcf68065c660fdf4781ad62be5d061
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@2b04a1ac2f4bfeb75804b44b46acf29a23c8d595
     with:
       # The workspace's mutable source lives under crates/; the root
       # Cargo.toml is a virtual manifest with no src/. paths: "crates/"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,6 +824,7 @@ name = "gpui-counter"
 version = "0.6.0-beta4"
 dependencies = [
  "gpui",
+ "proptest",
  "rstest",
  "rstest-bdd",
  "rstest-bdd-harness-gpui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1799,7 +1799,7 @@ dependencies = [
  "rstest-bdd-test-macros",
  "rustc_version",
  "serial_test 2.0.0",
- "syn 2.0.119",
+ "syn 3.0.4",
  "temp-env",
  "tempfile",
  "thiserror 2.0.20",
@@ -1846,7 +1846,7 @@ dependencies = [
  "rstest-bdd-test-macros",
  "serde",
  "serde_json",
- "syn 2.0.119",
+ "syn 3.0.4",
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
@@ -1863,7 +1863,7 @@ version = "0.6.0-beta4"
 dependencies = [
  "quote",
  "rstest",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,9 +361,9 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
-version = "0.6.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+checksum = "1af709f1f33454bf52eadfc8c78b3b9ef9cb26fb54d16dc9cd9a7299f899fd1b"
 dependencies = [
  "unicode-segmentation",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ derive_more = { version = "2.1", features = ["deref", "from", "into_iterator"] }
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
 cfg-if = "^1.0.4"
-convert_case = "0.6"
+convert_case = "0.12"
 rstest = "0.26.1"
 insta = "1.47.2"
 macrotest = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ regex = "1.12.2"
 thiserror = "2.0"
 derive_more = { version = "2.1", features = ["deref", "from", "into_iterator"] }
 quote = "1"
-syn = { version = "2", features = ["full", "extra-traits"] }
+syn = { version = "3", features = ["full", "extra-traits", "visit"] }
 cfg-if = "^1.0.4"
 convert_case = "0.12"
 rstest = "0.26.1"

--- a/crates/cargo-bdd/tests/fixtures/minimal/Cargo.lock
+++ b/crates/cargo-bdd/tests/fixtures/minimal/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
-version = "0.6.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+checksum = "1af709f1f33454bf52eadfc8c78b3b9ef9cb26fb54d16dc9cd9a7299f899fd1b"
 dependencies = [
  "unicode-segmentation",
 ]

--- a/crates/cargo-bdd/tests/fixtures/minimal/Cargo.lock
+++ b/crates/cargo-bdd/tests/fixtures/minimal/Cargo.lock
@@ -839,7 +839,7 @@ dependencies = [
  "rstest-bdd-patterns",
  "rstest-bdd-policy",
  "rustc_version",
- "syn 2.0.119",
+ "syn 3.0.4",
  "thiserror 2.0.20",
  "walkdir",
 ]

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/emit/identifiers.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/emit/identifiers.rs
@@ -138,7 +138,7 @@ pub(super) fn next_wrapper_id() -> usize { COUNTER.fetch_add(1, Ordering::Relaxe
 
 #[cfg(test)]
 mod tests {
-    //! Serialised tests for the process-wide wrapper-ID counter.
+    //! Serialized tests for the process-wide wrapper-ID counter.
     //!
     //! `COUNTER` is process-wide state, so allocation and reset must never
     //! overlap other tests that touch it. Every test here is `#[serial]`,

--- a/crates/rstest-bdd-macros/src/codegen/wrapper/emit/identifiers.rs
+++ b/crates/rstest-bdd-macros/src/codegen/wrapper/emit/identifiers.rs
@@ -3,7 +3,13 @@
 //! Generates the internal wrapper, pattern, and fixture identifiers used by
 //! emitted step wrappers. The identifiers are sanitized to ASCII to avoid
 //! generating invalid symbols when step function names contain Unicode.
-//! A global counter ensures uniqueness across all generated wrappers.
+//!
+//! [`COUNTER`] owns global wrapper-ID uniqueness across all generated
+//! wrappers in the process. Allocation through [`next_wrapper_id`] and the
+//! test-only reset through [`reset_wrapper_counter_for_tests`] share the same
+//! narrow, test-aware mechanism: the reset exists solely for tests, is
+//! compiled out of production builds, and callers must run under
+//! `#[serial]` so parallel tests cannot race on the process-wide state.
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -12,7 +18,11 @@ use quote::format_ident;
 
 use crate::utils::ident::sanitize_ident;
 
-/// Internal shared state used by the macros implementation.
+/// Process-wide source of wrapper-ID uniqueness.
+///
+/// Every emitted wrapper suffix is allocated from this counter, so the value
+/// it hands out must be unique for the lifetime of the process. The
+/// test-only reset below is the sole writer other than [`next_wrapper_id`].
 static COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 /// Identifiers for sync and async wrapper components.
@@ -30,35 +40,16 @@ pub(in crate::codegen::wrapper::emit) struct WrapperIdents {
     pub(in crate::codegen::wrapper::emit) pattern_ident: proc_macro2::Ident,
 }
 
-/// Resets the wrapper identifier counter to zero.
+/// Resets the wrapper identifier counter to zero for a test.
 ///
-/// This function is intended **only for test code** to ensure deterministic
-/// identifier generation across test runs. Production code must never call
-/// this function.
+/// This function exists **only for test code** so tests observe a
+/// deterministic identifier sequence. Production code must never call it.
 ///
 /// # Thread Safety
 ///
-/// Rust tests run in parallel by default. Tests that call this function must
-/// be serialized to avoid non-deterministic identifier generation. Use one of:
-///
-/// - The `#[serial]` attribute from the `serial_test` crate
-/// - The `--test-threads=1` flag when running tests
-/// - A shared mutex guard to coordinate access
-///
-/// # Example
-///
-/// ```ignore
-/// use serial_test::serial;
-///
-/// #[test]
-/// #[serial]
-/// fn wrapper_identifiers_are_deterministic() {
-///     reset_wrapper_counter_for_tests();
-///     // First call returns 0, second returns 1, etc.
-///     assert_eq!(next_wrapper_id(), 0);
-///     assert_eq!(next_wrapper_id(), 1);
-/// }
-/// ```
+/// Rust tests run in parallel by default, and the counter is process-wide.
+/// Every caller must run under `#[serial]` (see the tests in this module and
+/// the codegen equivalence tests) so allocation and reset never race.
 #[cfg(test)]
 pub(crate) fn reset_wrapper_counter_for_tests() {
     // Use SeqCst ordering (rather than Relaxed used in production) to ensure
@@ -144,3 +135,36 @@ pub(in crate::codegen::wrapper::emit) fn generate_wrapper_signature(
 /// assert_eq!(second, first + 1);
 /// ```
 pub(super) fn next_wrapper_id() -> usize { COUNTER.fetch_add(1, Ordering::Relaxed) }
+
+#[cfg(test)]
+mod tests {
+    //! Serialised tests for the process-wide wrapper-ID counter.
+    //!
+    //! `COUNTER` is process-wide state, so allocation and reset must never
+    //! overlap other tests that touch it. Every test here is `#[serial]`,
+    //! matching the protocol used by the codegen equivalence tests.
+
+    use serial_test::serial;
+
+    use super::{next_wrapper_id, reset_wrapper_counter_for_tests};
+
+    /// Resetting yields a deterministic sequence starting from zero.
+    #[test]
+    #[serial]
+    fn reset_wrapper_counter_restart_ids_from_zero() {
+        reset_wrapper_counter_for_tests();
+        assert_eq!(next_wrapper_id(), 0);
+        assert_eq!(next_wrapper_id(), 1);
+        assert_eq!(next_wrapper_id(), 2);
+    }
+
+    /// A later reset restarts the sequence rather than resuming it.
+    #[test]
+    #[serial]
+    fn reset_wrapper_counter_can_be_reapplied() {
+        reset_wrapper_counter_for_tests();
+        assert_eq!(next_wrapper_id(), 0);
+        reset_wrapper_counter_for_tests();
+        assert_eq!(next_wrapper_id(), 0);
+    }
+}

--- a/crates/rstest-bdd-server/src/indexing/rust/mod.rs
+++ b/crates/rstest-bdd-server/src/indexing/rust/mod.rs
@@ -209,8 +209,9 @@ fn index_step_function(
     let expects_table = parameters.iter().any(|param| param.is_datatable);
     let expects_docstring = parameters.iter().any(|param| param.is_docstring);
 
-    // Extract span from the step attribute (syn uses 1-based line numbers).
-    // Line/column numbers in practice will never exceed u32::MAX, so truncation is safe.
+    // Extract the span from the step attribute. `syn` reports 1-based line
+    // numbers; the conversion below turns them into zero-based `u32` values,
+    // and any conversion overflow saturates at `u32::MAX`.
     let attribute_span = extract_attribute_span(step_attribute.attr, &item_fn.sig, source);
 
     Ok(Some(IndexedStepDefinition {

--- a/crates/rstest-bdd-server/src/indexing/rust/type_render.rs
+++ b/crates/rstest-bdd-server/src/indexing/rust/type_render.rs
@@ -24,7 +24,7 @@ use syn::{Expr, GenericArgument, Path, PathArguments, ReturnType, Type, TypePara
 pub(super) fn render_type(ty: &Type) -> String {
     match ty {
         Type::Path(type_path) => render_path(&type_path.path),
-        Type::BareFn(bare_fn) => render_bare_fn(bare_fn),
+        Type::FnPtr(fn_ptr) => render_fn_ptr(fn_ptr),
         Type::Reference(type_ref) => render_reference(type_ref),
         Type::Tuple(tuple) => render_tuple(tuple),
         Type::Slice(slice) => format!("[{}]", render_type(&slice.elem)),
@@ -36,11 +36,13 @@ pub(super) fn render_type(ty: &Type) -> String {
         Type::Group(group) => render_type(&group.elem),
         Type::Ptr(ptr) => {
             let mut rendered = String::from("*");
-            rendered.push_str(if ptr.mutability.is_some() {
-                "mut "
-            } else {
-                "const "
-            });
+            rendered.push_str(
+                if matches!(ptr.mutability, syn::PointerMutability::Mut(_)) {
+                    "mut "
+                } else {
+                    "const "
+                },
+            );
             rendered.push_str(&render_type(&ptr.elem));
             rendered
         }
@@ -103,7 +105,7 @@ fn render_fn_prefix(unsafety: Option<&syn::token::Unsafe>, abi: Option<&syn::Abi
 }
 
 /// Render variadic parameters suffix if present.
-fn render_variadic(variadic: Option<&syn::BareVariadic>, has_inputs: bool) -> String {
+fn render_variadic(variadic: Option<&syn::FnPtrVariadic>, has_inputs: bool) -> String {
     if variadic.is_some() {
         if has_inputs {
             ", ...".to_owned()
@@ -115,14 +117,14 @@ fn render_variadic(variadic: Option<&syn::BareVariadic>, has_inputs: bool) -> St
     }
 }
 
-/// Render a bare function type (`fn(..) -> ..`).
+/// Render a function pointer type (`fn(..) -> ..`).
 ///
 /// This composes the unsafety and ABI prefix (`unsafe`, `extern "..."`), the
 /// input parameter list (including variadics), and the return type.
-fn render_bare_fn(bare_fn: &syn::TypeBareFn) -> String {
-    let mut rendered = render_fn_prefix(bare_fn.unsafety.as_ref(), bare_fn.abi.as_ref());
+fn render_fn_ptr(fn_ptr: &syn::TypeFnPtr) -> String {
+    let mut rendered = render_fn_prefix(fn_ptr.unsafety.as_ref(), fn_ptr.abi.as_ref());
     rendered.push_str("fn(");
-    let inputs = bare_fn
+    let inputs = fn_ptr
         .inputs
         .iter()
         .map(|arg| render_type(&arg.ty))
@@ -130,14 +132,14 @@ fn render_bare_fn(bare_fn: &syn::TypeBareFn) -> String {
         .join(", ");
     rendered.push_str(&inputs);
     rendered.push_str(&render_variadic(
-        bare_fn.variadic.as_ref(),
-        !bare_fn.inputs.is_empty(),
+        fn_ptr.variadic.as_ref(),
+        !fn_ptr.inputs.is_empty(),
     ));
     rendered.push(')');
 
-    if let ReturnType::Type(_, ty) = &bare_fn.output {
+    if let ReturnType::Type(_, ty) = &fn_ptr.output {
         rendered.push_str(" -> ");
-        rendered.push_str(&render_type(ty));
+        rendered.push_str(&render_type(ty.as_ref()));
     }
 
     rendered
@@ -151,7 +153,7 @@ fn render_trait_object(trait_object: &syn::TypeTraitObject) -> String {
         .map(|bound| match bound {
             TypeParamBound::Trait(trait_bound) => {
                 let mut rendered = String::new();
-                if let syn::TraitBoundModifier::Maybe(_) = trait_bound.modifier {
+                if trait_bound.maybe.is_some() {
                     rendered.push('?');
                 }
                 rendered.push_str(&render_path(&trait_bound.path));
@@ -208,12 +210,12 @@ fn render_path_arguments(arguments: &PathArguments) -> String {
             let inputs = parenthesized
                 .inputs
                 .iter()
-                .map(render_type)
+                .map(|arg| render_type(&arg.ty))
                 .collect::<Vec<_>>()
                 .join(", ");
             let output = match &parenthesized.output {
                 ReturnType::Default => String::new(),
-                ReturnType::Type(_, ty) => format!(" -> {}", render_type(ty)),
+                ReturnType::Type(_, ty) => format!(" -> {}", render_type(ty.as_ref())),
             };
             format!("({inputs}){output}")
         }
@@ -317,13 +319,20 @@ mod tests {
             &parse_quote!(dyn std::fmt::Debug + Send + 'static),
             "dyn std::fmt::Debug + Send + 'static",
         );
+        // `Fn(u8) -> u16` reaches the renderer as parenthesized generic
+        // arguments on a trait-object bound (a bare `Fn(..)` type does not
+        // parse).
+        assert_renders(
+            &parse_quote!(Box<dyn Fn(u8) -> u16>),
+            "Box<dyn Fn(u8) -> u16>",
+        );
     }
 
     #[test]
     fn renders_trait_object_maybe_modifier() {
         let mut ty: syn::TypeTraitObject = parse_quote!(dyn Sized);
         let mut bound: syn::TraitBound = parse_quote!(Sized);
-        bound.modifier = syn::TraitBoundModifier::Maybe(syn::token::Question::default());
+        bound.maybe = Some(syn::token::Question::default());
         ty.bounds = std::iter::once(syn::TypeParamBound::Trait(bound)).collect();
         assert_eq!(render_trait_object(&ty), "dyn ?Sized");
     }
@@ -331,6 +340,7 @@ mod tests {
     #[test]
     fn renders_trait_object_with_no_bounds_as_placeholder() {
         let ty = syn::TypeTraitObject {
+            attrs: Vec::new(),
             dyn_token: Option::default(),
             bounds: syn::punctuated::Punctuated::default(),
         };

--- a/crates/rstest-bdd/tests/fixtures/feature_addition/Cargo.lock
+++ b/crates/rstest-bdd/tests/fixtures/feature_addition/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
-version = "0.6.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+checksum = "1af709f1f33454bf52eadfc8c78b3b9ef9cb26fb54d16dc9cd9a7299f899fd1b"
 dependencies = [
  "unicode-segmentation",
 ]

--- a/crates/rstest-bdd/tests/fixtures/feature_addition/Cargo.lock
+++ b/crates/rstest-bdd/tests/fixtures/feature_addition/Cargo.lock
@@ -881,7 +881,7 @@ dependencies = [
  "rstest-bdd-patterns",
  "rstest-bdd-policy",
  "rustc_version",
- "syn 2.0.119",
+ "syn 3.0.4",
  "thiserror 2.0.20",
  "walkdir",
 ]

--- a/crates/rstest-bdd/tests/fixtures/rebuild_invalidation/Cargo.lock
+++ b/crates/rstest-bdd/tests/fixtures/rebuild_invalidation/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
-version = "0.6.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+checksum = "1af709f1f33454bf52eadfc8c78b3b9ef9cb26fb54d16dc9cd9a7299f899fd1b"
 dependencies = [
  "unicode-segmentation",
 ]

--- a/crates/rstest-bdd/tests/fixtures/rebuild_invalidation/Cargo.lock
+++ b/crates/rstest-bdd/tests/fixtures/rebuild_invalidation/Cargo.lock
@@ -870,7 +870,7 @@ dependencies = [
  "rstest-bdd-patterns",
  "rstest-bdd-policy",
  "rustc_version",
- "syn 2.0.119",
+ "syn 3.0.4",
  "thiserror 2.0.20",
  "walkdir",
 ]

--- a/crates/rstest-bdd/tests/ui_lints/Cargo.lock
+++ b/crates/rstest-bdd/tests/ui_lints/Cargo.lock
@@ -798,7 +798,7 @@ dependencies = [
  "rstest-bdd-patterns",
  "rstest-bdd-policy",
  "rustc_version",
- "syn 2.0.119",
+ "syn 3.0.4",
  "thiserror 2.0.20",
  "walkdir",
 ]

--- a/crates/rstest-bdd/tests/ui_lints/Cargo.lock
+++ b/crates/rstest-bdd/tests/ui_lints/Cargo.lock
@@ -139,9 +139,9 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
-version = "0.6.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+checksum = "1af709f1f33454bf52eadfc8c78b3b9ef9cb26fb54d16dc9cd9a7299f899fd1b"
 dependencies = [
  "unicode-segmentation",
 ]

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -535,9 +535,12 @@ The file sets the timeout policy for the test suite:
   group (`max-threads = 1`), so `cargo-bdd::cli`, the four trybuild binaries,
   and `rstest-bdd::feature_rebuild_invalidation` run one at a time instead of
   contending for CPU with concurrent `cargo` builds. Their worst-case serial
-  budget is 180 s + (20 m × 4) + (600 s × 3) = 6,180 s (103 m), which is why
-  the global timeout above it is set at the run level rather than the group
-  level; the group bound only serializes execution, it does not cap it.
+  budget is 180 s + (20 m × 4) + (600 s × 3) = 6,180 s (103 m). That figure is
+  a bound, not an expectation: it assumes every member of the group exhausts
+  its own allowance in the same run, which has never happened. The 75 m
+  `global-timeout` is deliberately below it, because a run that genuinely took
+  103 minutes would be a fault worth failing rather than waiting out. The group
+  bound only serializes execution; it does not cap it.
 
 The feature-rebuild fixture-manifest rewriter is the sole owner of TOML
 basic-string encoding for its rewritten absolute dependency paths. It must
@@ -550,6 +553,110 @@ Windows; use a TOML serializer for any broader configuration-writing need.
 When adding a test binary that shells out to `cargo`, extend the relevant
 override's `filter` expression rather than raising the default `slow-timeout`:
 the tight default is what surfaces genuinely hung tests quickly.
+
+## Test timeouts: four tiers, outermost last
+
+Four independent timers can end a test run, and they are set in four different
+places. A run that dies without an obvious cause is nearly always one of them,
+so it is worth knowing which is which and in what order they can fire.
+
+| Tier | What it bounds | Where it is set | Current value |
+| --- | --- | --- | --- |
+| Per-test `slow-timeout` | one test | `.config/nextest.toml` | 60 s default, 20 m for the trybuild binaries |
+| nextest `global-timeout` | the whole test run | `.config/nextest.toml` | 75 m |
+| Cargo watchdog | one `cargo` invocation, wall clock | `RUN_RUST_CARGO_WAIT_TIMEOUT` on the coverage steps in `ci.yml` | 6,600 s (110 m) |
+| Job `timeout-minutes` | the whole job | `ci.yml`, job level | 190 m |
+
+Each tier must sit above the one before it. If the watchdog sits below the
+nextest global timeout, as it did until this was written, the run is killed
+before the budget nextest was given can be used, and the failure looks like an
+infrastructure problem rather than a slow test.
+
+### The clocks do not start together
+
+Comparing the configured numbers is not enough because two of the four timers
+start at different moments and cover different work.
+
+The watchdog starts when `cargo` starts, so it covers the build as well as the
+test run. nextest's global timeout starts only once tests begin. A watchdog
+merely larger than the global timeout is still pre-empting it whenever the build
+takes longer than the difference between them.
+
+The far end matters as well. A test already running when the global timeout
+expires is allowed to finish, so a run can outlast that budget by the longest
+per-test allowance, 20 minutes here. Whether that tail is ever reached or not,
+allowing for it costs nothing, because the watchdog only fires on an overrun.
+
+The watchdog is therefore sized as the global timeout, plus the running-test
+tail, plus a cold-build allowance: 75 m + 20 m + 15 m = 110 m. The build phase
+inside `cargo` measured 3 m 31 s on run 33966769942 with a nearly cold cache, so
+the 15 minutes is generous on purpose.
+
+The job timer starts when the job starts, long before coverage and long after it
+finishes. On the Linux lane, formatting, linting, type checking and the
+published-GPUI end-to-end scenario run first, and the publish dry run follows.
+Measured across runs rather than one: 14 m 03 s before coverage and 36 m 41 s
+after on run 33971821695, against 37 m 34 s before and 30 m 59 s after on the
+cold run that carried this change, where the published-GPUI fixture check and
+end-to-end scenario took 8 m 19 s and 13 m 07 s rather than about three minutes
+each. Just over 68 minutes of that job lay outside the watchdog's window. The
+ceiling is therefore 110 m + 75 m = 185 m, rounded to 190. A job ceiling merely
+above the watchdog would cancel the run before the watchdog could report it, and
+a cancellation discards the log that would have explained the overrun.
+
+### The cargo watchdog is the tier nobody expects
+
+The first three tiers are nextest's and the repository's. The watchdog belongs
+to the shared `generate-coverage` action, which wraps the `cargo` invocation and
+kills it after a wall-clock budget. It defaults to 1,800 s and it is easy to
+forget, because nothing in `.config/nextest.toml` mentions it.
+
+When it fires the step prints:
+
+```text
+::error::cargo did not exit within 6600s; killing. This is a budget, not a
+detected hang: raise the cargo-wait-timeout input, or
+RUN_RUST_CARGO_WAIT_TIMEOUT, if the build is legitimately slower. A cold
+sccache store makes the first run on a branch compile everything inside this
+budget.
+```
+
+The message is worth taking at its word. Nothing was detected as hung. A budget
+expired, and on a cold compiler cache that is the expected outcome rather than a
+symptom.
+
+### What the current values are sized against
+
+The Linux coverage step was measured on `ubicloud-standard-2`:
+
+| Run | Step duration | Cache |
+| --- | --- | --- |
+| 33966133264 | 11 m 20 s | warm |
+| 33975538044 | 22 m 16 s | typical |
+| 33971821695 | 30 m 33 s | cold |
+| this change's own run | 42 m 02 s | cold |
+
+That last row is why the earlier numbers were not enough. Each of the first
+three was the coldest run available when it was taken, and each was beaten. At
+1,800 s this run would have been killed with twelve minutes of work left; the
+job itself took 1 h 50 m, so the former 90 minute ceiling would have cancelled
+it even with a larger watchdog in place.
+
+A dependabot bump to `syn` on 2026-09-05 served 9 % of Rust compile requests
+from the cache and was killed by the watchdog at 1,800 s with 1,894 of 1,897
+tests complete. The run immediately before it took 1,833 s and passed, because
+the watchdog times `cargo` rather than the step. At 1,800 s the lane was not
+close to its budget, it was straddling it, and whether a run survived was
+decided by a few seconds of job setup.
+
+`timeout_ordering_test.py` asserts the ordering by value, including the two
+allowances above, so a change to any one tier that inverts it fails on the pull
+request rather than in a run three weeks later. The job ceiling is compared per
+job rather than against the tightest budget in the file because an unrelated
+job's ceiling has nothing to say about this one. It also requires every step
+that invokes the shared coverage action to set the watchdog explicitly: a step
+that loses its override inherits the action's 1,800 s default, which is how this
+went wrong in the first place.
 
 ## `#[serial]`, `#[file_serial]`, and nextest test-groups
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1226,6 +1226,25 @@ product are unnecessary because repeated combinations reach the same branches,
 while randomized `syn` syntax adds no semantic states or useful shrinking
 oracle.
 
+### Property tests in the gpui-counter example
+
+The gpui-counter example checks its delta arithmetic with property tests in
+`examples/gpui-counter/src/prop_tests.rs`, a `#[cfg(test)]` module declared
+from `examples/gpui-counter/src/lib.rs`. The crate requires the workspace
+`proptest` development dependency (`proptest.workspace = true` under
+`[dev-dependencies]` in `examples/gpui-counter/Cargo.toml`). The tests run
+with `cargo test -p gpui-counter` and execute as part of the normal workspace
+test suite; `.config/nextest.toml` has no gpui-counter override, so they run
+under the default 60 s slow-timeout with no configuration needed.
+
+The property tests verify the `i64` -> `i32` saturation invariant of
+`saturate_to_i32`: values above `i32::MAX` saturate to `i32::MAX`, values
+below `i32::MIN` saturate to `i32::MIN`, in-range values convert unchanged,
+and every result stays inside the `i32` range. The boundary strategies start
+above `i32::MAX` and end below `i32::MIN`, so the saturation regions are
+exercised densely without relying on random draws landing there; the exact
+boundary values are pinned by deterministic cases added in the same change.
+
 ### Bulk-migration cookbook reference suite
 
 The user guide's "Bulk-migration cookbook" subsection is backed by a

--- a/examples/gpui-counter/Cargo.toml
+++ b/examples/gpui-counter/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dev-dependencies]
 gpui.workspace = true
+proptest.workspace = true
 rstest = { workspace = true }
 rstest-bdd-test-macros.workspace = true
 rstest-bdd.workspace = true

--- a/examples/gpui-counter/src/lib.rs
+++ b/examples/gpui-counter/src/lib.rs
@@ -51,10 +51,14 @@ impl CounterApp {
 
     /// Returns the current counter value.
     #[must_use]
-    pub fn value(&self) -> i32 { self.value.get() }
+    pub fn value(&self) -> i32 {
+        self.value.get()
+    }
 
     /// Replaces the stored counter value with the provided amount.
-    pub fn set_value(&self, amount: i32) { self.value.set(amount); }
+    pub fn set_value(&self, amount: i32) {
+        self.value.set(amount);
+    }
 
     /// Increases the counter by `amount`, saturating at `i32::MAX`.
     ///
@@ -84,7 +88,9 @@ impl CounterApp {
     /// app.record_gpui_context();
     /// assert!(app.has_observed_gpui_context());
     /// ```
-    pub fn record_gpui_context(&self) { self.has_observed_gpui_context.set(true); }
+    pub fn record_gpui_context(&self) {
+        self.has_observed_gpui_context.set(true);
+    }
 
     /// Returns whether a GPUI test context has been observed.
     ///
@@ -97,7 +103,9 @@ impl CounterApp {
     /// assert!(!app.has_observed_gpui_context());
     /// ```
     #[must_use]
-    pub fn has_observed_gpui_context(&self) -> bool { self.has_observed_gpui_context.get() }
+    pub fn has_observed_gpui_context(&self) -> bool {
+        self.has_observed_gpui_context.get()
+    }
 }
 
 /// Clamps an `i64` value to the `i32` range.
@@ -108,6 +116,9 @@ fn saturate_to_i32(value: i64) -> i32 {
         Err(_) => i32::MAX,
     }
 }
+
+#[cfg(test)]
+mod prop_tests;
 
 #[cfg(test)]
 mod tests {

--- a/examples/gpui-counter/src/lib.rs
+++ b/examples/gpui-counter/src/lib.rs
@@ -51,14 +51,10 @@ impl CounterApp {
 
     /// Returns the current counter value.
     #[must_use]
-    pub fn value(&self) -> i32 {
-        self.value.get()
-    }
+    pub fn value(&self) -> i32 { self.value.get() }
 
     /// Replaces the stored counter value with the provided amount.
-    pub fn set_value(&self, amount: i32) {
-        self.value.set(amount);
-    }
+    pub fn set_value(&self, amount: i32) { self.value.set(amount); }
 
     /// Increases the counter by `amount`, saturating at `i32::MAX`.
     ///
@@ -88,9 +84,7 @@ impl CounterApp {
     /// app.record_gpui_context();
     /// assert!(app.has_observed_gpui_context());
     /// ```
-    pub fn record_gpui_context(&self) {
-        self.has_observed_gpui_context.set(true);
-    }
+    pub fn record_gpui_context(&self) { self.has_observed_gpui_context.set(true); }
 
     /// Returns whether a GPUI test context has been observed.
     ///
@@ -103,9 +97,7 @@ impl CounterApp {
     /// assert!(!app.has_observed_gpui_context());
     /// ```
     #[must_use]
-    pub fn has_observed_gpui_context(&self) -> bool {
-        self.has_observed_gpui_context.get()
-    }
+    pub fn has_observed_gpui_context(&self) -> bool { self.has_observed_gpui_context.get() }
 }
 
 /// Clamps an `i64` value to the `i32` range.

--- a/examples/gpui-counter/src/prop_tests.rs
+++ b/examples/gpui-counter/src/prop_tests.rs
@@ -1,0 +1,47 @@
+//! Property-based invariants for [`saturate_to_i32`].
+//!
+//! The clamping behaviour must hold for the complete `i64` input domain:
+//! values above `i32::MAX` saturate to `i32::MAX`, values below `i32::MIN`
+//! saturate to `i32::MIN`, and in-range values convert unchanged. Every
+//! result must also stay inside the `i32` range.
+
+use proptest::prelude::*;
+
+use super::saturate_to_i32;
+
+proptest! {
+    /// Any `i64` input must clamp exactly like an independent boundary
+    /// reference, and the result must remain a valid `i32`.
+    #[test]
+    fn clamps_to_i32_range(value in any::<i64>()) {
+        // Independent reference: explicit boundary checks instead of
+        // restating the production `TryFrom`-based expression.
+        let expected = if value > i64::from(i32::MAX) {
+            i32::MAX
+        } else if value < i64::from(i32::MIN) {
+            i32::MIN
+        } else {
+            // In range, so the conversion cannot fail.
+            i32::try_from(value).expect("value is within i32 range")
+        };
+
+        let result = saturate_to_i32(value);
+
+        // Result matches the clamp reference.
+        prop_assert_eq!(result, expected);
+        // Result always lies within the `i32` bounds.
+        prop_assert!((i32::MIN..=i32::MAX).contains(&result));
+    }
+
+    /// The upper saturation edge returns exactly `i32::MAX`.
+    #[test]
+    fn saturates_at_upper_boundary(value in (i64::from(i32::MAX) + 1)..=i64::MAX) {
+        prop_assert_eq!(saturate_to_i32(value), i32::MAX);
+    }
+
+    /// The lower saturation edge returns exactly `i32::MIN`.
+    #[test]
+    fn saturates_at_lower_boundary(value in i64::MIN..=(i64::from(i32::MIN) - 1)) {
+        prop_assert_eq!(saturate_to_i32(value), i32::MIN);
+    }
+}

--- a/examples/gpui-counter/src/prop_tests.rs
+++ b/examples/gpui-counter/src/prop_tests.rs
@@ -9,21 +9,46 @@ use proptest::prelude::*;
 
 use super::saturate_to_i32;
 
+/// Independent reference for the saturation invariant.
+///
+/// Deliberately uses explicit boundary comparisons rather than restating the
+/// production `TryFrom`-based expression, so the property tests the documented
+/// behaviour instead of a second copy of the implementation.
+fn reference_clamp(value: i64) -> i32 {
+    if value > i64::from(i32::MAX) {
+        i32::MAX
+    } else if value < i64::from(i32::MIN) {
+        i32::MIN
+    } else {
+        // The boundary branches above handled every out-of-range value, so
+        // the conversion cannot fail here.
+        let Ok(converted) = i32::try_from(value) else {
+            unreachable!("value is within the i32 range")
+        };
+        converted
+    }
+}
+
+/// The exact `i32` boundaries convert to themselves.
+#[test]
+fn i32_boundaries_convert_unchanged() {
+    assert_eq!(saturate_to_i32(i64::from(i32::MAX)), i32::MAX);
+    assert_eq!(saturate_to_i32(i64::from(i32::MIN)), i32::MIN);
+}
+
+/// One step beyond either boundary saturates deterministically.
+#[test]
+fn values_beyond_i32_boundaries_saturate() {
+    assert_eq!(saturate_to_i32(i64::from(i32::MAX) + 1), i32::MAX);
+    assert_eq!(saturate_to_i32(i64::from(i32::MIN) - 1), i32::MIN);
+}
+
 proptest! {
     /// Any `i64` input must clamp exactly like an independent boundary
     /// reference, and the result must remain a valid `i32`.
     #[test]
     fn clamps_to_i32_range(value in any::<i64>()) {
-        // Independent reference: explicit boundary checks instead of
-        // restating the production `TryFrom`-based expression.
-        let expected = if value > i64::from(i32::MAX) {
-            i32::MAX
-        } else if value < i64::from(i32::MIN) {
-            i32::MIN
-        } else {
-            // In range, so the conversion cannot fail.
-            i32::try_from(value).expect("value is within i32 range")
-        };
+        let expected = reference_clamp(value);
 
         let result = saturate_to_i32(value);
 

--- a/tests/fixtures/published-gpui-0-2-2/Cargo.lock
+++ b/tests/fixtures/published-gpui-0-2-2/Cargo.lock
@@ -4869,7 +4869,7 @@ dependencies = [
  "rstest-bdd-patterns",
  "rstest-bdd-policy",
  "rustc_version",
- "syn 2.0.119",
+ "syn 3.0.5",
  "thiserror 2.0.20",
  "walkdir",
 ]

--- a/tests/fixtures/published-gpui-0-2-2/Cargo.lock
+++ b/tests/fixtures/published-gpui-0-2-2/Cargo.lock
@@ -245,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
+checksum = "515a1f282e33d55983c499d7e9e87082e81cbc32974825bf9032f928392d5844"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -423,7 +423,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -744,7 +744,7 @@ checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -884,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1046,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+checksum = "2fe67f2944eef52fc7b106b8c9450d243a88701a0c065f7f57235e76abaed7df"
 dependencies = [
  "compression-core",
  "deflate64",
@@ -1058,9 +1058,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+checksum = "6e8ccc4ea9f6acc32d102c0f6d471d11d913ad15f20c04de743374861fa1d414"
 
 [[package]]
 name = "concurrent-queue"
@@ -1105,9 +1105,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "convert_case"
-version = "0.6.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+checksum = "1af709f1f33454bf52eadfc8c78b3b9ef9cb26fb54d16dc9cd9a7299f899fd1b"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1516,7 +1516,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1588,7 +1588,7 @@ dependencies = [
  "cc",
  "memchr",
  "rustc_version",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
  "vswhom",
  "winreg",
 ]
@@ -1800,9 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "flate2"
@@ -1972,7 +1972,7 @@ checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2106,7 +2106,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3177,9 +3177,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3292,9 +3292,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
 dependencies = [
  "libc",
 ]
@@ -3545,9 +3545,9 @@ checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "wasi",
@@ -3977,9 +3977,9 @@ dependencies = [
 
 [[package]]
 name = "open"
-version = "5.4.2"
+version = "5.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade3be4664bc1ef537ce133015f04c176b737815c2ba9fd60edf212d6e90dd55"
+checksum = "7c603ab8300cf18bc3b14146b19fe3dfcc4843ae5a400cd0e7a30b95aa366634"
 dependencies = [
  "is-wsl",
  "libc",
@@ -4743,7 +4743,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4857,7 +4857,7 @@ dependencies = [
  "camino",
  "cap-std",
  "cfg-if",
- "convert_case 0.6.0",
+ "convert_case 0.12.0",
  "gherkin",
  "newt-hype",
  "proc-macro-crate",
@@ -5130,7 +5130,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -5240,7 +5240,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -5251,7 +5251,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -5298,7 +5298,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -5438,9 +5438,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "smawk"
@@ -5733,9 +5733,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5917,7 +5917,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -5982,9 +5982,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -6018,14 +6018,14 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls",
  "tokio",
@@ -6080,9 +6080,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -6501,9 +6501,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.13.2"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068e763e8279de7ab94b6afebded2cb701678af094feb1c12ccb061b4783c1be"
+checksum = "2799ffb329a792ecfd902b71306c8a815a6ef1c0470fa9953a6aa4d4cecbe511"
 dependencies = [
  "value-bag-serde1",
  "value-bag-sval2",
@@ -6511,9 +6511,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag-serde1"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27780e3aec98b13ac796bc0d5770205ee6e976d1ccb33a52da70b73ff0ff880d"
+checksum = "0941feceafbe7a8f59ea1096d45b97002884a41306315ad797b3684b63a81d8c"
 dependencies = [
  "erased-serde",
  "serde_core",
@@ -6522,9 +6522,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag-sval2"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c093d229c7ead9974b640e61170976e0eff3dac447cf6792c645f0b7f28b3de"
+checksum = "839752af8179287d27eb2b94164641b1ede9e60ab7424163388dc21ebd0508cd"
 dependencies = [
  "sval",
  "sval_buffer",
@@ -6609,9 +6609,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6622,9 +6622,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.77"
+version = "0.4.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6632,9 +6632,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6642,22 +6642,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
@@ -6774,9 +6774,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7550,7 +7550,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -7799,7 +7799,7 @@ checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -7863,7 +7863,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
  "zvariant_utils",
 ]
 
@@ -7876,6 +7876,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 3.0.4",
+ "syn 3.0.5",
  "winnow 1.0.4",
 ]

--- a/tests/fixtures/published-gpui-e2e/Cargo.lock
+++ b/tests/fixtures/published-gpui-e2e/Cargo.lock
@@ -4919,7 +4919,7 @@ dependencies = [
  "rstest-bdd-patterns",
  "rstest-bdd-policy",
  "rustc_version",
- "syn 2.0.119",
+ "syn 3.0.5",
  "thiserror 2.0.20",
  "walkdir",
 ]

--- a/tests/fixtures/published-gpui-e2e/Cargo.lock
+++ b/tests/fixtures/published-gpui-e2e/Cargo.lock
@@ -245,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
+checksum = "515a1f282e33d55983c499d7e9e87082e81cbc32974825bf9032f928392d5844"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -423,7 +423,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -744,7 +744,7 @@ checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -884,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1046,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+checksum = "2fe67f2944eef52fc7b106b8c9450d243a88701a0c065f7f57235e76abaed7df"
 dependencies = [
  "compression-core",
  "deflate64",
@@ -1058,9 +1058,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+checksum = "6e8ccc4ea9f6acc32d102c0f6d471d11d913ad15f20c04de743374861fa1d414"
 
 [[package]]
 name = "concurrent-queue"
@@ -1105,9 +1105,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "convert_case"
-version = "0.6.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+checksum = "1af709f1f33454bf52eadfc8c78b3b9ef9cb26fb54d16dc9cd9a7299f899fd1b"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1529,7 +1529,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1601,7 +1601,7 @@ dependencies = [
  "cc",
  "memchr",
  "rustc_version",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
  "vswhom",
  "winreg",
 ]
@@ -1813,9 +1813,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "flate2"
@@ -1985,7 +1985,7 @@ checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2119,7 +2119,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3196,9 +3196,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3311,9 +3311,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
 dependencies = [
  "libc",
 ]
@@ -3564,9 +3564,9 @@ checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "wasi",
@@ -3996,9 +3996,9 @@ dependencies = [
 
 [[package]]
 name = "open"
-version = "5.4.2"
+version = "5.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade3be4664bc1ef537ce133015f04c176b737815c2ba9fd60edf212d6e90dd55"
+checksum = "7c603ab8300cf18bc3b14146b19fe3dfcc4843ae5a400cd0e7a30b95aa366634"
 dependencies = [
  "is-wsl",
  "libc",
@@ -4766,7 +4766,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4907,7 +4907,7 @@ dependencies = [
  "camino",
  "cap-std",
  "cfg-if",
- "convert_case 0.6.0",
+ "convert_case 0.12.0",
  "gherkin",
  "newt-hype",
  "proc-macro-crate",
@@ -5198,7 +5198,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -5308,7 +5308,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -5319,7 +5319,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -5366,7 +5366,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -5531,9 +5531,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "smawk"
@@ -5826,9 +5826,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6010,7 +6010,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -6075,9 +6075,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -6111,14 +6111,14 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls",
  "tokio",
@@ -6173,9 +6173,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -6594,9 +6594,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.13.2"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068e763e8279de7ab94b6afebded2cb701678af094feb1c12ccb061b4783c1be"
+checksum = "2799ffb329a792ecfd902b71306c8a815a6ef1c0470fa9953a6aa4d4cecbe511"
 dependencies = [
  "value-bag-serde1",
  "value-bag-sval2",
@@ -6604,9 +6604,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag-serde1"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27780e3aec98b13ac796bc0d5770205ee6e976d1ccb33a52da70b73ff0ff880d"
+checksum = "0941feceafbe7a8f59ea1096d45b97002884a41306315ad797b3684b63a81d8c"
 dependencies = [
  "erased-serde",
  "serde_core",
@@ -6615,9 +6615,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag-sval2"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c093d229c7ead9974b640e61170976e0eff3dac447cf6792c645f0b7f28b3de"
+checksum = "839752af8179287d27eb2b94164641b1ede9e60ab7424163388dc21ebd0508cd"
 dependencies = [
  "sval",
  "sval_buffer",
@@ -6702,9 +6702,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6715,9 +6715,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.77"
+version = "0.4.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6725,9 +6725,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6735,22 +6735,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
@@ -6867,9 +6867,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7643,7 +7643,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -7892,7 +7892,7 @@ checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -7956,7 +7956,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
  "zvariant_utils",
 ]
 
@@ -7969,6 +7969,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 3.0.4",
+ "syn 3.0.5",
  "winnow 1.0.4",
 ]

--- a/tests/workflow_contracts/codescene_coverage_test.py
+++ b/tests/workflow_contracts/codescene_coverage_test.py
@@ -58,6 +58,7 @@ EXPECTED_CODESCENE_INPUTS = {
     "access-token": "${{ env.CS_ACCESS_TOKEN }}",
     "installer-checksum": "${{ vars.CODESCENE_CLI_SHA256 }}",
 }
+EXPECTED_CARGO_WAIT_TIMEOUT = "4500"
 
 
 def _load() -> dict[str, object]:
@@ -125,6 +126,29 @@ def test_linux_generator_emits_the_canonical_report(
     )
     assert generator.get("with") == EXPECTED_GENERATOR_INPUTS, (
         "the Linux generator must preserve its canonical report and ratchet inputs"
+    )
+
+
+@pytest.mark.parametrize(
+    ("step_name", "lane"),
+    [
+        ("Test and Measure Coverage (Linux)", "Linux"),
+        ("Test and Measure Coverage (Windows, default features)", "Windows"),
+        ("Test and Measure Coverage (Windows, strict validation)", "Windows"),
+    ],
+)
+def test_coverage_steps_budget_a_cold_instrumented_build(
+    build_test_steps: list[dict[str, object]],
+    step_name: str,
+    lane: str,
+) -> None:
+    """Each coverage lane must budget the watchdog for a cold instrumented build."""
+    step = _named_step(build_test_steps, step_name)
+    env = step.get("env")
+    assert isinstance(env, dict), f"the {lane} coverage step must declare env"
+    assert env.get("RUN_RUST_CARGO_WAIT_TIMEOUT") == EXPECTED_CARGO_WAIT_TIMEOUT, (
+        f"the {lane} coverage step must size the cargo watchdog for a cold "
+        "sccache store; the watchdog exists to catch a hang, not a cold build"
     )
 
 

--- a/tests/workflow_contracts/codescene_coverage_test.py
+++ b/tests/workflow_contracts/codescene_coverage_test.py
@@ -58,6 +58,7 @@ EXPECTED_CODESCENE_INPUTS = {
     "access-token": "${{ env.CS_ACCESS_TOKEN }}",
     "installer-checksum": "${{ vars.CODESCENE_CLI_SHA256 }}",
 }
+EXPECTED_CARGO_WAIT_TIMEOUT = "6600"
 
 
 def _load() -> dict[str, object]:
@@ -125,6 +126,29 @@ def test_linux_generator_emits_the_canonical_report(
     )
     assert generator.get("with") == EXPECTED_GENERATOR_INPUTS, (
         "the Linux generator must preserve its canonical report and ratchet inputs"
+    )
+
+
+@pytest.mark.parametrize(
+    ("step_name", "lane"),
+    [
+        ("Test and Measure Coverage (Linux)", "Linux"),
+        ("Test and Measure Coverage (Windows, default features)", "Windows"),
+        ("Test and Measure Coverage (Windows, strict validation)", "Windows"),
+    ],
+)
+def test_coverage_steps_budget_a_cold_instrumented_build(
+    build_test_steps: list[dict[str, object]],
+    step_name: str,
+    lane: str,
+) -> None:
+    """Each coverage lane must budget the watchdog for a cold instrumented build."""
+    step = _named_step(build_test_steps, step_name)
+    env = step.get("env")
+    assert isinstance(env, dict), f"the {lane} coverage step must declare env"
+    assert env.get("RUN_RUST_CARGO_WAIT_TIMEOUT") == EXPECTED_CARGO_WAIT_TIMEOUT, (
+        f"the {lane} coverage step must size the cargo watchdog for a cold "
+        "sccache store; the watchdog exists to catch a hang, not a cold build"
     )
 
 

--- a/tests/workflow_contracts/timeout_ordering_test.py
+++ b/tests/workflow_contracts/timeout_ordering_test.py
@@ -1,0 +1,351 @@
+"""Contract for the four timers that can end a test run.
+
+Four independent budgets bound a coverage lane, and each is set in a
+different place: a per-test ``slow-timeout`` and a whole-run
+``global-timeout`` in ``.config/nextest.toml``, a wall-clock watchdog on
+the ``cargo`` invocation in the workflow, and the job's own
+``timeout-minutes``. They only work if each sits above the one inside it.
+
+The ordering was inverted for months. The watchdog defaulted to 1,800 s
+while nextest was configured for a 75 m run, so a cold compile was killed
+by the outer timer before the inner one had spent a third of its budget,
+and the failure read as an infrastructure fault rather than as a slow
+build. Nothing in ``.config/nextest.toml`` mentions the watchdog, and
+nothing in the workflow mentioned nextest, so the two could drift apart
+without either side noticing.
+
+Two of the four timers do not start together, which the ordering has to
+allow for. The watchdog starts when ``cargo`` starts, and covers the
+build as well as the test run; nextest's global timeout starts only once
+tests begin. The job timer starts when the job starts, long before
+coverage and long before the work that follows it. Comparing the
+configured numbers alone would call an inverted lane correct, so the
+allowances below are measured rather than assumed.
+
+See "Test timeouts: four tiers, outermost last" in
+``docs/developers-guide.md``.
+"""
+
+import re
+import typing as typ
+
+import pytest
+import yaml
+from workflow_support import ROOT
+
+if typ.TYPE_CHECKING:
+    from pathlib import Path
+
+NEXTEST_CONFIG: typ.Final[Path] = ROOT / ".config" / "nextest.toml"
+CI_WORKFLOW: typ.Final[Path] = ROOT / ".github" / "workflows" / "ci.yml"
+
+#: The environment variable the shared coverage action reads.
+WATCHDOG_VARIABLE: typ.Final[str] = "RUN_RUST_CARGO_WAIT_TIMEOUT"
+
+#: The action whose steps must declare a watchdog budget.
+COVERAGE_ACTION: typ.Final[str] = "shared-actions/.github/actions/generate-coverage"
+
+#: Build time inside the `cargo` invocation, before nextest starts its
+#: own clock. The watchdog covers it; the global timeout does not.
+#: Measured at 3 m 31 s on run 33966769942 with a nearly cold compiler
+#: cache; 15 minutes is that with room to spare.
+COLD_BUILD_ALLOWANCE_SECONDS: typ.Final[float] = 15 * 60.0
+
+#: Everything in the job that is not the coverage step. The job timer
+#: covers it; the watchdog does not. Taken from the worst of several
+#: runs rather than one: 14 m 03 s before and 36 m 41 s after on run
+#: 33971821695, against 37 m 34 s before and 30 m 59 s after on this
+#: branch's own cold run, where the published-GPUI fixture check and
+#: end-to-end scenario ran at 8 m 19 s and 13 m 07 s rather than about
+#: three minutes each. 75 minutes covers the worse pair with room.
+NON_COVERAGE_ALLOWANCE_SECONDS: typ.Final[float] = 75 * 60.0
+
+#: ``30s``, ``5m``, ``20 m``: the durations nextest accepts here.
+_DURATION: typ.Final[re.Pattern[str]] = re.compile(
+    r"^\s*(?P<value>\d+(?:\.\d+)?)\s*(?P<unit>ms|s|m|h)\s*$"
+)
+
+_UNIT_SECONDS: typ.Final[dict[str, float]] = {
+    "ms": 0.001,
+    "s": 1.0,
+    "m": 60.0,
+    "h": 3600.0,
+}
+
+
+def _seconds(duration: str) -> float:
+    """Convert a nextest duration to seconds.
+
+    Parameters
+    ----------
+    duration : str
+        A duration as nextest spells it, such as ``"75m"``.
+
+    Returns
+    -------
+    float
+        The duration in seconds.
+    """
+    match = _DURATION.match(duration)
+    assert match is not None, f"unrecognized nextest duration {duration!r}"
+    return float(match["value"]) * _UNIT_SECONDS[match["unit"]]
+
+
+@pytest.fixture(scope="module")
+def nextest_config() -> str:
+    """Return the nextest configuration file's text.
+
+    Returns
+    -------
+    str
+        The file's contents.
+    """
+    return NEXTEST_CONFIG.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def ci_workflow() -> dict[str, typ.Any]:
+    """Return the parsed CI workflow.
+
+    Returns
+    -------
+    dict[str, typ.Any]
+        The parsed workflow document.
+    """
+    return yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def global_timeout(nextest_config: str) -> float:
+    """Return the default profile's ``global-timeout`` in seconds.
+
+    Read textually rather than through a TOML parser, because the value
+    must be matched to the profile it belongs to and the file declares
+    more than one profile.
+
+    Parameters
+    ----------
+    nextest_config : str
+        The nextest configuration file's text.
+
+    Returns
+    -------
+    float
+        The default profile's whole-run budget, in seconds.
+    """
+    blocks = re.split(r"^\[profile\.", nextest_config, flags=re.MULTILINE)
+    default = next((block for block in blocks if block.startswith("default]")), None)
+    assert default is not None, (
+        "nextest.toml must declare a [profile.default] section; the ordering "
+        "contract has nothing to compare against without one"
+    )
+    match = re.search(r'^global-timeout\s*=\s*"([^"]+)"', default, re.MULTILINE)
+    assert match is not None, (
+        "[profile.default] must set global-timeout; without it the whole-run "
+        "budget is unbounded and the watchdog becomes the only limit"
+    )
+    return _seconds(match[1])
+
+
+@pytest.fixture(scope="module")
+def largest_slow_timeout(nextest_config: str) -> float:
+    """Return the longest single-test allowance in seconds.
+
+    Parameters
+    ----------
+    nextest_config : str
+        The nextest configuration file's text.
+
+    Returns
+    -------
+    float
+        The longest per-test budget.
+    """
+    periods = re.findall(r'period\s*=\s*"([^"]+)"', nextest_config)
+    assert periods, "nextest.toml must set at least one slow-timeout period"
+    return max(_seconds(period) for period in periods)
+
+
+class CoverageLane(typ.NamedTuple):
+    """One coverage step, with the job budget that encloses it.
+
+    Attributes
+    ----------
+    job : str
+        The job the step belongs to.
+    step : str
+        The step's declared name.
+    watchdog : float | None
+        The step's watchdog budget in seconds, or ``None`` when it sets
+        none and so inherits the action's default.
+    job_timeout : float | None
+        The enclosing job's ``timeout-minutes`` in seconds, or ``None``
+        when the job declares none.
+    """
+
+    job: str
+    step: str
+    watchdog: float | None
+    job_timeout: float | None
+
+    def __str__(self) -> str:
+        """Return a location suitable for a failure message.
+
+        Returns
+        -------
+        str
+            ``job:step`` for this lane.
+        """
+        return f"{self.job}:{self.step!r}"
+
+
+def _optional_seconds(value: object) -> float | None:
+    """Return a ``timeout-minutes`` value in seconds, or None.
+
+    Parameters
+    ----------
+    value : object
+        The declared value, or ``None`` when the job declares none.
+
+    Returns
+    -------
+    float | None
+        The budget in seconds.
+    """
+    return None if value is None else float(str(value)) * 60.0
+
+
+@pytest.fixture(scope="module")
+def lanes(ci_workflow: dict[str, typ.Any]) -> tuple[CoverageLane, ...]:
+    """Return every coverage lane, each with its own job's ceiling.
+
+    Every coverage step is included, not only those that set the
+    watchdog, so a step that loses its override is visible as ``None``
+    rather than absent. An absent entry would make the ordering tests
+    skip it silently and restore the default that caused the regression.
+
+    The job ceiling travels with the lane rather than being taken as the
+    tightest in the file: an unrelated job's budget has nothing to say
+    about this one, and comparing them would either fail an
+    honestly-sized job or force unrelated budgets to move together.
+
+    Parameters
+    ----------
+    ci_workflow : dict[str, typ.Any]
+        The parsed CI workflow.
+
+    Returns
+    -------
+    tuple[CoverageLane, ...]
+        One entry per coverage step.
+    """
+    lanes: list[CoverageLane] = []
+    for job_name, job in ci_workflow["jobs"].items():
+        for step in job.get("steps", []):
+            if COVERAGE_ACTION not in str(step.get("uses", "")):
+                continue
+            raw = (step.get("env") or {}).get(WATCHDOG_VARIABLE)
+            lanes.append(
+                CoverageLane(
+                    job=str(job_name),
+                    step=str(step.get("name", "")) or str(job_name),
+                    watchdog=None if raw is None else float(str(raw)),
+                    job_timeout=_optional_seconds(job.get("timeout-minutes")),
+                )
+            )
+    return tuple(lanes)
+
+
+def test_every_coverage_step_declares_a_watchdog_budget(
+    lanes: tuple[CoverageLane, ...],
+) -> None:
+    """The default is invisible, so every step must write it down.
+
+    Leaving the action's 1,800 s default in place is how this went
+    wrong: a budget nobody set, mentioned nowhere, killing runs that
+    were merely cold. Checking that some step sets it would not do;
+    one step losing its override is enough to bring the fault back.
+    """
+    assert lanes, (
+        f"ci.yml must invoke {COVERAGE_ACTION}; this contract has nothing to "
+        f"assert against otherwise"
+    )
+    missing = [str(lane) for lane in lanes if lane.watchdog is None]
+    assert not missing, (
+        f"these coverage steps do not set {WATCHDOG_VARIABLE} and so inherit "
+        f"the action's undocumented 1,800 s default: {missing}"
+    )
+
+
+def test_the_watchdog_covers_the_nextest_budget_and_the_build(
+    lanes: tuple[CoverageLane, ...],
+    global_timeout: float,
+    largest_slow_timeout: float,
+) -> None:
+    """Tier three must not pre-empt tier two.
+
+    The two clocks do not start together. The watchdog starts with
+    ``cargo`` and covers the build; nextest's global timeout starts only
+    once tests begin. A watchdog merely above the global timeout is
+    still pre-empting it whenever the build takes longer than the
+    difference, so the build allowance is part of the comparison.
+
+    The far end matters too. A test already running when the global
+    timeout expires is allowed to finish, so the run can outlast that
+    budget by the longest per-test allowance. Whether that tail is ever
+    reached or not, allowing for it costs nothing: the watchdog only
+    fires on an overrun.
+    """
+    required = global_timeout + largest_slow_timeout + COLD_BUILD_ALLOWANCE_SECONDS
+    for lane in lanes:
+        assert lane.watchdog is not None, str(lane)
+        assert lane.watchdog >= required, (
+            f"{lane} sets {WATCHDOG_VARIABLE}={lane.watchdog:.0f}s, below the "
+            f"{required:.0f}s needed to cover the {global_timeout:.0f}s nextest "
+            f"budget, the {largest_slow_timeout:.0f}s a test already running may "
+            f"still take, and {COLD_BUILD_ALLOWANCE_SECONDS:.0f}s of cold build; "
+            f"a cold run would be killed before nextest's own budget expired"
+        )
+
+
+def test_the_nextest_global_timeout_sits_above_the_largest_slow_timeout(
+    global_timeout: float,
+    largest_slow_timeout: float,
+) -> None:
+    """Tier two must not pre-empt tier one.
+
+    A global timeout below the longest per-test allowance kills the run
+    before the test that allowance exists for can finish.
+    """
+    assert global_timeout > largest_slow_timeout, (
+        f"the {global_timeout:.0f}s global-timeout is not above the "
+        f"{largest_slow_timeout:.0f}s largest per-test slow-timeout; the run "
+        f"would end before that test could use its budget"
+    )
+
+
+def test_the_job_timeout_covers_the_watchdog_and_the_rest_of_the_job(
+    lanes: tuple[CoverageLane, ...],
+) -> None:
+    """Tier four must not pre-empt tier three.
+
+    The job timer starts when the job starts, not when coverage does.
+    Formatting, linting, the published-GPUI scenario and the publish dry
+    run all sit outside the watchdog's window but inside the job's, so a
+    job timeout merely above the watchdog still cancels the run before
+    the watchdog can report it, and a cancellation discards the log that
+    would have explained the overrun.
+    """
+    for lane in lanes:
+        assert lane.watchdog is not None, str(lane)
+        assert lane.job_timeout is not None, (
+            f"{lane} runs cargo under a {lane.watchdog:.0f}s watchdog in a job "
+            f"with no timeout-minutes; the outermost tier is missing"
+        )
+        required = lane.watchdog + NON_COVERAGE_ALLOWANCE_SECONDS
+        assert lane.job_timeout >= required, (
+            f"{lane} has a job timeout of {lane.job_timeout:.0f}s, below the "
+            f"{required:.0f}s needed to cover its {lane.watchdog:.0f}s watchdog "
+            f"plus {NON_COVERAGE_ALLOWANCE_SECONDS:.0f}s of measured work "
+            f"outside it; an overrun would be cancelled rather than reported"
+        )


### PR DESCRIPTION
Closes #697

## Summary

- Add `proptest`-based invariant tests for `saturate_to_i32` in the
  `gpui-counter` example, comparing the result against an independently
  expressed clamp reference, asserting every result stays within the
  `i32` bounds, and covering both conversion boundaries.
- Keep the process-wide wrapper-ID counter and restore a safe test
  reset protocol: `reset_wrapper_counter_for_tests` is now wired into
  real `#[serial]` tests, and the module documents that the counter
  owns global wrapper-ID uniqueness with allocation and reset sharing
  the same narrow, test-aware mechanism.
- Correct the span-conversion comment in the Rust indexer: source line
  numbers convert to zero-based `u32` values and conversion overflow
  saturates at `u32::MAX`; the stale claim that truncation is safe is
  removed.

## Validation

- `cargo test -p gpui-counter --lib` (9 tests, including 3 new property tests)
- `cargo test -p rstest-bdd-macros` (504 unit tests, including the 2 new
  serialised counter tests)
- `cargo test -p rstest-bdd-server` (197 library tests plus integration suites)
- `cargo test --workspace` (136 test suites, all passing)
- `cargo clippy -p gpui-counter -p rstest-bdd-macros -p rstest-bdd-server --all-targets --all-features`
- `cargo +nightly-2026-08-07 fmt --all -- --check`
- `coderabbit review --agent --base origin/main` (0 findings)

## References

- [Lody session](https://lody.ai/leynos/sessions/7e3a6b7e-3f6a-4615-a46c-7d74e138da03)
- [PR #691 review comment](https://github.com/leynos/rstest-bdd/pull/691#issuecomment-5480774041)

## Summary by Sourcery

Strengthen invariant and workflow timeout coverage while updating macro compatibility and CI budgets for reliable full-workspace validation.

New Features:
- Add property-based invariant coverage for `saturate_to_i32`, including exact and out-of-range boundary cases.
- Add workflow contract tests that enforce timeout ordering and explicit coverage watchdog budgets.

Bug Fixes:
- Update Rust type rendering for the syn 3 syntax model and correct span-conversion documentation.

Enhancements:
- Document the process-wide wrapper-ID counter and enforce serialized reset behavior with dedicated tests.
- Increase CI coverage and job time budgets to accommodate cold builds and the complete test-timeout hierarchy.

Build:
- Upgrade the workspace to syn 3 and convert_case 0.12, updating related lockfiles and development dependencies.

CI:
- Update the mutation-testing shared workflow reference and align Linux and Windows coverage watchdog settings.

Documentation:
- Document the four-tier test timeout policy and property-testing guidance for the gpui-counter example.

Tests:
- Add serialized wrapper-counter tests and syn 3 rendering coverage.