### PR TITLE
Repin generate-coverage so a pull request stops moving the baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,7 +487,7 @@ jobs:
       # llvm-cov's nextest path cannot execute doc tests.
       - name: Test and Measure Coverage (Linux)
         if: ${{ runner.os == 'Linux' }}
-        uses: leynos/shared-actions/.github/actions/generate-coverage@f6d4d5f549655c118f86f371b8d55c200d3efa50
+        uses: leynos/shared-actions/.github/actions/generate-coverage@77ea10341249024e22ec5d9069e3caa7596e0d4f
         env:
           RUN_RUST_CARGO_WAIT_TIMEOUT: '1800'
           # Tests that snapshot a child process's stderr must see the same
@@ -516,11 +516,13 @@ jobs:
       - name: Test and Measure Coverage (Windows, default features)
         if: ${{ runner.os == 'Windows' && matrix.features == '' }}
         # Merged shared-actions whole-workspace coverage revision.
-        uses: leynos/shared-actions/.github/actions/generate-coverage@f6d4d5f549655c118f86f371b8d55c200d3efa50
+        uses: leynos/shared-actions/.github/actions/generate-coverage@77ea10341249024e22ec5d9069e3caa7596e0d4f
         continue-on-error: true
         env:
-          # Windows coverage runs (build plus doctests) exceed the shared
-          # action's 600s per-invocation default; give them headroom.
+          # Windows coverage runs (build plus doctests) needed headroom over
+          # the shared action's old 600s default. From this pin 1800 is that
+          # default, so this now restates it rather than raising it; it stays
+          # explicit so a future default cannot quietly shorten these lanes.
           RUN_RUST_CARGO_WAIT_TIMEOUT: '1800'
           # Match the Linux lane so stderr snapshots stay deterministic.
           RUST_BACKTRACE: '0'
@@ -536,11 +538,13 @@ jobs:
       - name: Test and Measure Coverage (Windows, strict validation)
         if: ${{ runner.os == 'Windows' && matrix.features != '' }}
         # Merged shared-actions whole-workspace coverage revision.
-        uses: leynos/shared-actions/.github/actions/generate-coverage@f6d4d5f549655c118f86f371b8d55c200d3efa50
+        uses: leynos/shared-actions/.github/actions/generate-coverage@77ea10341249024e22ec5d9069e3caa7596e0d4f
         continue-on-error: true
         env:
-          # Windows coverage runs (build plus doctests) exceed the shared
-          # action's 600s per-invocation default; give them headroom.
+          # Windows coverage runs (build plus doctests) needed headroom over
+          # the shared action's old 600s default. From this pin 1800 is that
+          # default, so this now restates it rather than raising it; it stays
+          # explicit so a future default cannot quietly shorten these lanes.
           RUN_RUST_CARGO_WAIT_TIMEOUT: '1800'
           # Match the Linux lane so stderr snapshots stay deterministic.
           RUST_BACKTRACE: '0'

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -150,9 +150,16 @@ A former `coverage-main.yml` ran a fifth job whose platform, feature set, and
 driver matched the Linux lane. Once `ci.yml` gained its `push` trigger the two
 executed the same suite on every merge, so that workflow is gone and its two
 distinct behaviours moved into the surviving lane: it writes the ratchet
-baseline on every run, and it uploads to CodeScene on trunk while pull requests
-run the changed-line check. CodeScene accepts an upload only for an analysed
-branch, which is why the two modes are separate steps.
+baseline, and it uploads to CodeScene on trunk while pull requests run the
+changed-line check. CodeScene accepts an upload only for an analysed branch,
+which is why the two modes are separate steps.
+
+The baseline is written only on a push to `main`. Every run restores it and
+measures against it, but a pull request, and a manual dispatch, publish
+nothing. That guard lives in the pinned shared action rather than in this
+workflow. Before it, each pull request advanced the baseline it was then
+measured against, which a green run cannot show: a ratchet comparing a branch
+against itself passes while coverage falls.
 
 Two Linux steps look like test runs but are not part of the workspace suite and
 stay. `make test-workflow-contracts` exercises the Python contracts in this

--- a/tests/workflow_contracts/ratchet_publication_test.py
+++ b/tests/workflow_contracts/ratchet_publication_test.py
@@ -38,10 +38,17 @@ GENERATE_COVERAGE = (
 RATCHET_LANE = "Test and Measure Coverage (Linux)"
 
 
-def _coverage_steps() -> list[dict[str, typ.Any]]:
+@pytest.fixture(scope="module")
+def workflow() -> dict[str, typ.Any]:
+    """Return the parsed workflow, read once for the module."""
+    document = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assert isinstance(document, dict), "the workflow must parse to a mapping"
+    return document
+
+
+@pytest.fixture(scope="module")
+def coverage_steps(workflow: dict[str, typ.Any]) -> list[dict[str, typ.Any]]:
     """Return every step invoking the shared coverage action."""
-    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
-    assert isinstance(workflow, dict), "the workflow must parse to a mapping"
     jobs = workflow.get("jobs")
     assert isinstance(jobs, dict), "the workflow must declare a jobs mapping"
     found = [
@@ -56,13 +63,27 @@ def _coverage_steps() -> list[dict[str, typ.Any]]:
     return found
 
 
-def test_every_coverage_step_shares_the_guarded_revision() -> None:
+def _ratcheting_steps(
+    coverage_steps: list[dict[str, typ.Any]],
+) -> dict[str, dict[str, typ.Any]]:
+    """Return every coverage step that enables the ratchet, keyed by name."""
+    return {
+        str(step.get("name")): step
+        for step in coverage_steps
+        if isinstance(step.get("with"), dict)
+        and step["with"].get("with-ratchet") == "true"
+    }
+
+
+def test_every_coverage_step_shares_the_guarded_revision(
+    coverage_steps: list[dict[str, typ.Any]],
+) -> None:
     """One pin, and it must be the one that carries the guard.
 
     Two lanes on different revisions would be worse than one stale pin: the
     behaviour would depend on which lane a reader happened to check.
     """
-    pinned = {str(step.get("uses")) for step in _coverage_steps()}
+    pinned = {str(step.get("uses")) for step in coverage_steps}
 
     assert pinned == {GENERATE_COVERAGE}, (
         f"every coverage step must be pinned to {GENERATE_COVERAGE}, found "
@@ -70,34 +91,50 @@ def test_every_coverage_step_shares_the_guarded_revision() -> None:
     )
 
 
-def test_the_ratchet_lane_takes_the_guarded_default() -> None:
+def test_one_lane_ratchets_and_it_is_the_documented_one(
+    coverage_steps: list[dict[str, typ.Any]],
+) -> None:
+    """Only one step may write the baseline, and it must be the known one.
+
+    Checking the expected lane alone would prove only that it exists. A second
+    lane enabling the ratchet would be another baseline writer, and could opt
+    itself out of the guard without this contract noticing.
+    """
+    ratcheting = _ratcheting_steps(coverage_steps)
+
+    assert set(ratcheting) == {RATCHET_LANE}, (
+        f"exactly one coverage step may enable the ratchet, and it must be "
+        f"{RATCHET_LANE!r}; found {sorted(ratcheting)}"
+    )
+
+
+def test_no_ratcheting_lane_opts_out_of_the_guard(
+    coverage_steps: list[dict[str, typ.Any]],
+) -> None:
     """Leaving ``publish-baseline`` unset is what keeps a pull request out.
 
-    Setting it to ``always`` here would restore exactly the behaviour this pin
-    exists to remove.
+    Setting it to ``always`` would restore exactly the behaviour this pin
+    exists to remove. Asserted over every ratcheting lane, so a lane added
+    later cannot quietly become a second writer.
     """
-    lanes = [step for step in _coverage_steps() if step.get("name") == RATCHET_LANE]
-    assert len(lanes) == 1, f"expected one {RATCHET_LANE!r} step, found {len(lanes)}"
-    inputs = lanes[0].get("with")
-    assert isinstance(inputs, dict), f"{RATCHET_LANE} must declare inputs"
-
-    assert inputs.get("with-ratchet") == "true", (
-        f"{RATCHET_LANE} must enable the ratchet, or the guard governs nothing"
-    )
-    assert "publish-baseline" not in inputs, (
-        f"{RATCHET_LANE} sets publish-baseline={inputs.get('publish-baseline')!r}; "
-        f"a pull request would then advance the baseline it is measured against"
-    )
+    for name, step in _ratcheting_steps(coverage_steps).items():
+        inputs = step["with"]
+        assert "publish-baseline" not in inputs, (
+            f"{name} sets publish-baseline={inputs.get('publish-baseline')!r}; "
+            f"a pull request would then advance the baseline it is measured "
+            f"against"
+        )
 
 
 @pytest.mark.parametrize("trigger", ["push", "pull_request"])
-def test_the_workflow_still_runs_where_the_guard_expects_it(trigger: str) -> None:
+def test_the_workflow_still_runs_where_the_guard_expects_it(
+    workflow: dict[str, typ.Any], trigger: str
+) -> None:
     """The guard publishes on a push to main, so that trigger must exist.
 
     Without it no run could ever publish, and the ratchet would compare every
     pull request against a baseline that had stopped advancing.
     """
-    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
     # PyYAML parses the bare `on:` key as the boolean True.
     triggers = workflow.get("on", workflow.get(True))
     assert isinstance(triggers, dict), "the workflow must declare an on: mapping"
@@ -105,10 +142,12 @@ def test_the_workflow_still_runs_where_the_guard_expects_it(trigger: str) -> Non
     assert trigger in triggers, f"the workflow must still run on {trigger}"
 
 
-def test_trunk_pushes_are_restricted_to_main() -> None:
+def test_trunk_pushes_are_restricted_to_main(
+    workflow: dict[str, typ.Any],
+) -> None:
     """The guard names refs/heads/main, so the trigger must not widen it."""
-    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
     triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict), "the workflow must declare an on: mapping"
     push = triggers["push"]
     assert isinstance(push, dict), "the push trigger must declare branches"
 

--- a/tests/workflow_contracts/ratchet_publication_test.py
+++ b/tests/workflow_contracts/ratchet_publication_test.py
@@ -1,0 +1,117 @@
+"""Contract for which runs may publish the coverage ratchet baseline.
+
+A ratchet is only a ratchet while the baseline it compares against comes from
+somewhere a pull request cannot reach. Before the pinned revision the shared
+action published from every run that reached its save step, so a pull request
+advanced the baseline it was then measured against, and a ``workflow_dispatch``
+replaced whatever generation it was measuring.
+
+None of that is visible from a green run. A ratchet comparing each pull request
+against itself passes exactly as one comparing against trunk does, and it goes
+on passing while coverage falls.
+
+The pin is therefore asserted by value here, unlike the shape assertions in
+``codescene_coverage_test.py``: the guarantee arrived in a particular revision,
+so a bump has to update this constant and make someone confirm the new revision
+still keeps a pull request from publishing.
+
+This repository needs no opt-in. Its `ci.yml` runs on pushes to `main`, which
+is what the action's default guard requires, so the Linux lane leaves
+``publish-baseline`` unset and takes it.
+"""
+
+import typing as typ
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "ci.yml"
+
+#: The revision that guards the baseline save on a push to refs/heads/main.
+GENERATE_COVERAGE = (
+    "leynos/shared-actions/.github/actions/generate-coverage@"
+    "77ea10341249024e22ec5d9069e3caa7596e0d4f"
+)
+
+#: The lane that enables the ratchet, and so the only one the guard governs.
+RATCHET_LANE = "Test and Measure Coverage (Linux)"
+
+
+def _coverage_steps() -> list[dict[str, typ.Any]]:
+    """Return every step invoking the shared coverage action."""
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict), "the workflow must parse to a mapping"
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "the workflow must declare a jobs mapping"
+    found = [
+        step
+        for definition in jobs.values()
+        if isinstance(definition, dict)
+        for step in definition.get("steps") or []
+        if isinstance(step, dict)
+        and "generate-coverage@" in str(step.get("uses") or "")
+    ]
+    assert found, "the workflow must invoke the shared coverage action"
+    return found
+
+
+def test_every_coverage_step_shares_the_guarded_revision() -> None:
+    """One pin, and it must be the one that carries the guard.
+
+    Two lanes on different revisions would be worse than one stale pin: the
+    behaviour would depend on which lane a reader happened to check.
+    """
+    pinned = {str(step.get("uses")) for step in _coverage_steps()}
+
+    assert pinned == {GENERATE_COVERAGE}, (
+        f"every coverage step must be pinned to {GENERATE_COVERAGE}, found "
+        f"{sorted(pinned)}"
+    )
+
+
+def test_the_ratchet_lane_takes_the_guarded_default() -> None:
+    """Leaving ``publish-baseline`` unset is what keeps a pull request out.
+
+    Setting it to ``always`` here would restore exactly the behaviour this pin
+    exists to remove.
+    """
+    lanes = [step for step in _coverage_steps() if step.get("name") == RATCHET_LANE]
+    assert len(lanes) == 1, f"expected one {RATCHET_LANE!r} step, found {len(lanes)}"
+    inputs = lanes[0].get("with")
+    assert isinstance(inputs, dict), f"{RATCHET_LANE} must declare inputs"
+
+    assert inputs.get("with-ratchet") == "true", (
+        f"{RATCHET_LANE} must enable the ratchet, or the guard governs nothing"
+    )
+    assert "publish-baseline" not in inputs, (
+        f"{RATCHET_LANE} sets publish-baseline={inputs.get('publish-baseline')!r}; "
+        f"a pull request would then advance the baseline it is measured against"
+    )
+
+
+@pytest.mark.parametrize("trigger", ["push", "pull_request"])
+def test_the_workflow_still_runs_where_the_guard_expects_it(trigger: str) -> None:
+    """The guard publishes on a push to main, so that trigger must exist.
+
+    Without it no run could ever publish, and the ratchet would compare every
+    pull request against a baseline that had stopped advancing.
+    """
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    # PyYAML parses the bare `on:` key as the boolean True.
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict), "the workflow must declare an on: mapping"
+
+    assert trigger in triggers, f"the workflow must still run on {trigger}"
+
+
+def test_trunk_pushes_are_restricted_to_main() -> None:
+    """The guard names refs/heads/main, so the trigger must not widen it."""
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    triggers = workflow.get("on", workflow.get(True))
+    push = triggers["push"]
+    assert isinstance(push, dict), "the push trigger must declare branches"
+
+    assert push.get("branches") == ["main"], (
+        f"the push trigger must be restricted to main, got {push.get('branches')!r}"
+    )


### PR DESCRIPTION
## What

Repins all three `generate-coverage` steps in `ci.yml` from `f6d4d5f5` to
`77ea1034`, the revision that stops a pull request publishing the ratchet
baseline it is measured against.

## Why it matters here

Before `77ea1034` the shared action published a baseline from every run that
reached its save step: it was guarded on `success()` and on the ratchet being
enabled, and on nothing else.

The Linux lane sets `with-ratchet: 'true'` and runs on `pull_request`, so every
pull request advanced the baseline it was then measured against. A
`workflow_dispatch` replaced whatever generation it was measuring.

None of that shows in a green run. A ratchet comparing each pull request
against itself passes exactly as one comparing against trunk does, and goes on
passing while coverage falls.

## No opt-in needed

From this pin the save requires a push to `refs/heads/main`. `ci.yml` already
runs on pushes to `main` — that trigger exists so the cache writer can publish a
trusted generation — so the Linux lane leaves `publish-baseline` unset and takes
the guarded default. Nothing else in the repository publishes a baseline.

## The watchdog default also moved

The same revision raises the cargo watchdog default from 600 to 1800 seconds,
which is exactly what the two Windows lanes were setting by hand. Their
`RUN_RUST_CARGO_WAIT_TIMEOUT: '1800'` entries stay: a default is not a promise,
and keeping them explicit means a future default cannot quietly shorten those
lanes. What changed is their comments, which described 1800 as headroom over a
600 second default that no longer exists.

## Contract

`tests/workflow_contracts/ratchet_publication_test.py` asserts:

- every coverage step shares one pin, and it is the revision carrying the
  guard. Two lanes on different revisions would be worse than one stale pin,
  because the behaviour would depend on which lane a reader checked;
- the ratchet lane enables the ratchet and does not set `publish-baseline`,
  since setting it to `always` would restore precisely the behaviour this pin
  removes;
- the `push` trigger the guard depends on is still present and still restricted
  to `main`. Without it no run could publish and the baseline would stop
  advancing.

The pin is asserted by value rather than by shape, unlike the Dependabot-owned
assertions in `codescene_coverage_test.py`, because the guarantee arrived in a
particular revision. A bump has to update the constant, which is the point.

`codescene_coverage_test.py` already asserts the Linux lane's `with` block by
exact equality, so it independently catches `publish-baseline` appearing there.

## Validation

`make check-fmt`, `lint-python`, `typecheck`, `markdownlint`, and the workflow
contract suite: 69 passed.

## Summary by Sourcery

Pin coverage generation to the guarded shared-action revision and enforce the ratchet publication contract.

Bug Fixes:
- Prevent pull requests and manual workflow runs from publishing the coverage ratchet baseline they are measured against.

Enhancements:
- Pin all coverage-generation lanes to the shared action revision that restricts baseline publication to pushes on main.
- Document the guarded baseline publication behavior and updated coverage watchdog default.

Documentation:
- Clarify that coverage baselines are written only from pushes to main and that pull requests measure against the trusted baseline.

Tests:
- Add workflow contract tests covering the shared action pin, ratchet lane configuration, required triggers, and main-only push restrictions.