### PR TITLE
Document the four test timeouts, and stop the outermost pre-empting them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     # Ubicloud runners register as just-in-time self-hosted runners, so the
     # six-hour hosted limit does not apply. Bound the job explicitly.
-    timeout-minutes: 90
+    timeout-minutes: 170
     permissions:
       contents: read
     env:
@@ -489,7 +489,14 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         uses: leynos/shared-actions/.github/actions/generate-coverage@77ea10341249024e22ec5d9069e3caa7596e0d4f
         env:
-          RUN_RUST_CARGO_WAIT_TIMEOUT: '4500'
+          # The cargo watchdog, one of four tiers that can end a run. It
+          # must cover the 75 m nextest global-timeout in
+          # .config/nextest.toml, the 20 m a test already running may
+          # still take when that expires, and the build inside the same
+          # cargo invocation. Below that, a cold run is killed before
+          # nextest can use the budget it was given. See "Test timeouts:
+          # four tiers, outermost last" in docs/developers-guide.md.
+          RUN_RUST_CARGO_WAIT_TIMEOUT: '6600'
           # Tests that snapshot a child process's stderr must see the same
           # panic-hook output on every lane. An instrumented build retains
           # debuginfo, so a backtrace would otherwise appear here and not on
@@ -519,11 +526,13 @@ jobs:
         uses: leynos/shared-actions/.github/actions/generate-coverage@77ea10341249024e22ec5d9069e3caa7596e0d4f
         continue-on-error: true
         env:
-          # Windows coverage runs (build plus doctests) needed headroom over
-          # the shared action's default; 4500 gives the cold sccache store the
-          # same budget as the Linux lane. It stays explicit so a future
-          # default cannot quietly shorten these lanes.
-          RUN_RUST_CARGO_WAIT_TIMEOUT: '4500'
+          # Windows coverage runs (build plus doctests) needed headroom
+          # over the shared action's default, and take the same budget as
+          # the Linux lane, sized by the rule in "Test timeouts: four
+          # tiers, outermost last" in docs/developers-guide.md. It stays
+          # explicit so a future default cannot quietly shorten these
+          # lanes.
+          RUN_RUST_CARGO_WAIT_TIMEOUT: '6600'
           # Match the Linux lane so stderr snapshots stay deterministic.
           RUST_BACKTRACE: '0'
         with:
@@ -541,11 +550,13 @@ jobs:
         uses: leynos/shared-actions/.github/actions/generate-coverage@77ea10341249024e22ec5d9069e3caa7596e0d4f
         continue-on-error: true
         env:
-          # Windows coverage runs (build plus doctests) needed headroom over
-          # the shared action's default; 4500 gives the cold sccache store the
-          # same budget as the Linux lane. It stays explicit so a future
-          # default cannot quietly shorten these lanes.
-          RUN_RUST_CARGO_WAIT_TIMEOUT: '4500'
+          # Windows coverage runs (build plus doctests) needed headroom
+          # over the shared action's default, and take the same budget as
+          # the Linux lane, sized by the rule in "Test timeouts: four
+          # tiers, outermost last" in docs/developers-guide.md. It stays
+          # explicit so a future default cannot quietly shorten these
+          # lanes.
+          RUN_RUST_CARGO_WAIT_TIMEOUT: '6600'
           # Match the Linux lane so stderr snapshots stay deterministic.
           RUST_BACKTRACE: '0'
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     # Ubicloud runners register as just-in-time self-hosted runners, so the
     # six-hour hosted limit does not apply. Bound the job explicitly.
-    timeout-minutes: 170
+    timeout-minutes: 190
     permissions:
       contents: read
     env:

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -565,7 +565,7 @@ so it is worth knowing which is which and in what order they can fire.
 | Per-test `slow-timeout` | one test | `.config/nextest.toml` | 60 s default, 20 m for the trybuild binaries |
 | nextest `global-timeout` | the whole test run | `.config/nextest.toml` | 75 m |
 | Cargo watchdog | one `cargo` invocation, wall clock | `RUN_RUST_CARGO_WAIT_TIMEOUT` on the coverage steps in `ci.yml` | 6,600 s (110 m) |
-| Job `timeout-minutes` | the whole job | `ci.yml`, job level | 170 m |
+| Job `timeout-minutes` | the whole job | `ci.yml`, job level | 190 m |
 
 Each tier must sit above the one before it. If the watchdog sits below the
 nextest global timeout, as it did until this was written, the run is killed
@@ -595,9 +595,12 @@ the 15 minutes is generous on purpose.
 The job timer starts when the job starts, long before coverage and long after it
 finishes. On the Linux lane, formatting, linting, type checking and the
 published-GPUI end-to-end scenario run first, and the publish dry run follows.
-Measured on run 33971821695: 14 m 03 s before coverage and 36 m 41 s after, so
-just under 51 minutes of the job lies outside the watchdog's window. The job
-ceiling is therefore 110 m + 55 m = 165 m, rounded to 170. A job ceiling merely
+Measured across runs rather than one: 14 m 03 s before coverage and 36 m 41 s
+after on run 33971821695, against 37 m 34 s before and 30 m 59 s after on the
+cold run that carried this change, where the published-GPUI fixture check and
+end-to-end scenario took 8 m 19 s and 13 m 07 s rather than about three minutes
+each. Just over 68 minutes of that job lay outside the watchdog's window. The
+ceiling is therefore 110 m + 75 m = 185 m, rounded to 190. A job ceiling merely
 above the watchdog would cancel the run before the watchdog could report it, and
 a cancellation discards the log that would have explained the overrun.
 
@@ -631,6 +634,13 @@ The Linux coverage step was measured on `ubicloud-standard-2`:
 | 33966133264 | 11 m 20 s | warm |
 | 33975538044 | 22 m 16 s | typical |
 | 33971821695 | 30 m 33 s | cold |
+| this change's own run | 42 m 02 s | cold |
+
+That last row is why the earlier numbers were not enough. Each of the first
+three was the coldest run available when it was taken, and each was beaten. At
+1,800 s this run would have been killed with twelve minutes of work left; the
+job itself took 1 h 50 m, so the former 90 minute ceiling would have cancelled
+it even with a larger watchdog in place.
 
 A dependabot bump to `syn` on 2026-09-05 served 9 % of Rust compile requests
 from the cache and was killed by the watchdog at 1,800 s with 1,894 of 1,897

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -535,9 +535,12 @@ The file sets the timeout policy for the test suite:
   group (`max-threads = 1`), so `cargo-bdd::cli`, the four trybuild binaries,
   and `rstest-bdd::feature_rebuild_invalidation` run one at a time instead of
   contending for CPU with concurrent `cargo` builds. Their worst-case serial
-  budget is 180 s + (20 m × 4) + (600 s × 3) = 6,180 s (103 m), which is why
-  the global timeout above it is set at the run level rather than the group
-  level; the group bound only serializes execution, it does not cap it.
+  budget is 180 s + (20 m × 4) + (600 s × 3) = 6,180 s (103 m). That figure is
+  a bound, not an expectation: it assumes every member of the group exhausts
+  its own allowance in the same run, which has never happened. The 75 m
+  `global-timeout` is deliberately below it, because a run that genuinely took
+  103 minutes would be a fault worth failing rather than waiting out. The group
+  bound only serializes execution; it does not cap it.
 
 The feature-rebuild fixture-manifest rewriter is the sole owner of TOML
 basic-string encoding for its rewritten absolute dependency paths. It must
@@ -550,6 +553,100 @@ Windows; use a TOML serializer for any broader configuration-writing need.
 When adding a test binary that shells out to `cargo`, extend the relevant
 override's `filter` expression rather than raising the default `slow-timeout`:
 the tight default is what surfaces genuinely hung tests quickly.
+
+## Test timeouts: four tiers, outermost last
+
+Four independent timers can end a test run, and they are set in four different
+places. A run that dies without an obvious cause is nearly always one of them,
+so it is worth knowing which is which and in what order they can fire.
+
+| Tier | What it bounds | Where it is set | Current value |
+| --- | --- | --- | --- |
+| Per-test `slow-timeout` | one test | `.config/nextest.toml` | 60 s default, 20 m for the trybuild binaries |
+| nextest `global-timeout` | the whole test run | `.config/nextest.toml` | 75 m |
+| Cargo watchdog | one `cargo` invocation, wall clock | `RUN_RUST_CARGO_WAIT_TIMEOUT` on the coverage steps in `ci.yml` | 6,600 s (110 m) |
+| Job `timeout-minutes` | the whole job | `ci.yml`, job level | 170 m |
+
+Each tier must sit above the one before it. If the watchdog sits below the
+nextest global timeout, as it did until this was written, the run is killed
+before the budget nextest was given can be used, and the failure looks like an
+infrastructure problem rather than a slow test.
+
+### The clocks do not start together
+
+Comparing the configured numbers is not enough because two of the four timers
+start at different moments and cover different work.
+
+The watchdog starts when `cargo` starts, so it covers the build as well as the
+test run. nextest's global timeout starts only once tests begin. A watchdog
+merely larger than the global timeout is still pre-empting it whenever the build
+takes longer than the difference between them.
+
+The far end matters as well. A test already running when the global timeout
+expires is allowed to finish, so a run can outlast that budget by the longest
+per-test allowance, 20 minutes here. Whether that tail is ever reached or not,
+allowing for it costs nothing, because the watchdog only fires on an overrun.
+
+The watchdog is therefore sized as the global timeout, plus the running-test
+tail, plus a cold-build allowance: 75 m + 20 m + 15 m = 110 m. The build phase
+inside `cargo` measured 3 m 31 s on run 33966769942 with a nearly cold cache, so
+the 15 minutes is generous on purpose.
+
+The job timer starts when the job starts, long before coverage and long after it
+finishes. On the Linux lane, formatting, linting, type checking and the
+published-GPUI end-to-end scenario run first, and the publish dry run follows.
+Measured on run 33971821695: 14 m 03 s before coverage and 36 m 41 s after, so
+just under 51 minutes of the job lies outside the watchdog's window. The job
+ceiling is therefore 110 m + 55 m = 165 m, rounded to 170. A job ceiling merely
+above the watchdog would cancel the run before the watchdog could report it, and
+a cancellation discards the log that would have explained the overrun.
+
+### The cargo watchdog is the tier nobody expects
+
+The first three tiers are nextest's and the repository's. The watchdog belongs
+to the shared `generate-coverage` action, which wraps the `cargo` invocation and
+kills it after a wall-clock budget. It defaults to 1,800 s and it is easy to
+forget, because nothing in `.config/nextest.toml` mentions it.
+
+When it fires the step prints:
+
+```text
+::error::cargo did not exit within 6600s; killing. This is a budget, not a
+detected hang: raise the cargo-wait-timeout input, or
+RUN_RUST_CARGO_WAIT_TIMEOUT, if the build is legitimately slower. A cold
+sccache store makes the first run on a branch compile everything inside this
+budget.
+```
+
+The message is worth taking at its word. Nothing was detected as hung. A budget
+expired, and on a cold compiler cache that is the expected outcome rather than a
+symptom.
+
+### What the current values are sized against
+
+The Linux coverage step was measured on `ubicloud-standard-2`:
+
+| Run | Step duration | Cache |
+| --- | --- | --- |
+| 33966133264 | 11 m 20 s | warm |
+| 33975538044 | 22 m 16 s | typical |
+| 33971821695 | 30 m 33 s | cold |
+
+A dependabot bump to `syn` on 2026-09-05 served 9 % of Rust compile requests
+from the cache and was killed by the watchdog at 1,800 s with 1,894 of 1,897
+tests complete. The run immediately before it took 1,833 s and passed, because
+the watchdog times `cargo` rather than the step. At 1,800 s the lane was not
+close to its budget, it was straddling it, and whether a run survived was
+decided by a few seconds of job setup.
+
+`timeout_ordering_test.py` asserts the ordering by value, including the two
+allowances above, so a change to any one tier that inverts it fails on the pull
+request rather than in a run three weeks later. The job ceiling is compared per
+job rather than against the tightest budget in the file because an unrelated
+job's ceiling has nothing to say about this one. It also requires every step
+that invokes the shared coverage action to set the watchdog explicitly: a step
+that loses its override inherits the action's 1,800 s default, which is how this
+went wrong in the first place.
 
 ## `#[serial]`, `#[file_serial]`, and nextest test-groups
 

--- a/tests/workflow_contracts/timeout_ordering_test.py
+++ b/tests/workflow_contracts/timeout_ordering_test.py
@@ -52,10 +52,13 @@ COVERAGE_ACTION: typ.Final[str] = "shared-actions/.github/actions/generate-cover
 COLD_BUILD_ALLOWANCE_SECONDS: typ.Final[float] = 15 * 60.0
 
 #: Everything in the job that is not the coverage step. The job timer
-#: covers it; the watchdog does not. Measured at 14 m 03 s before and
-#: 36 m 41 s after on run 33971821695, the latter almost entirely the
-#: publish dry run.
-NON_COVERAGE_ALLOWANCE_SECONDS: typ.Final[float] = 55 * 60.0
+#: covers it; the watchdog does not. Taken from the worst of several
+#: runs rather than one: 14 m 03 s before and 36 m 41 s after on run
+#: 33971821695, against 37 m 34 s before and 30 m 59 s after on this
+#: branch's own cold run, where the published-GPUI fixture check and
+#: end-to-end scenario ran at 8 m 19 s and 13 m 07 s rather than about
+#: three minutes each. 75 minutes covers the worse pair with room.
+NON_COVERAGE_ALLOWANCE_SECONDS: typ.Final[float] = 75 * 60.0
 
 #: ``30s``, ``5m``, ``20 m``: the durations nextest accepts here.
 _DURATION: typ.Final[re.Pattern[str]] = re.compile(

--- a/tests/workflow_contracts/timeout_ordering_test.py
+++ b/tests/workflow_contracts/timeout_ordering_test.py
@@ -1,0 +1,348 @@
+"""Contract for the four timers that can end a test run.
+
+Four independent budgets bound a coverage lane, and each is set in a
+different place: a per-test ``slow-timeout`` and a whole-run
+``global-timeout`` in ``.config/nextest.toml``, a wall-clock watchdog on
+the ``cargo`` invocation in the workflow, and the job's own
+``timeout-minutes``. They only work if each sits above the one inside it.
+
+The ordering was inverted for months. The watchdog defaulted to 1,800 s
+while nextest was configured for a 75 m run, so a cold compile was killed
+by the outer timer before the inner one had spent a third of its budget,
+and the failure read as an infrastructure fault rather than as a slow
+build. Nothing in ``.config/nextest.toml`` mentions the watchdog, and
+nothing in the workflow mentioned nextest, so the two could drift apart
+without either side noticing.
+
+Two of the four timers do not start together, which the ordering has to
+allow for. The watchdog starts when ``cargo`` starts, and covers the
+build as well as the test run; nextest's global timeout starts only once
+tests begin. The job timer starts when the job starts, long before
+coverage and long before the work that follows it. Comparing the
+configured numbers alone would call an inverted lane correct, so the
+allowances below are measured rather than assumed.
+
+See "Test timeouts: four tiers, outermost last" in
+``docs/developers-guide.md``.
+"""
+
+import re
+import typing as typ
+
+import pytest
+import yaml
+from workflow_support import ROOT
+
+if typ.TYPE_CHECKING:
+    from pathlib import Path
+
+NEXTEST_CONFIG: typ.Final[Path] = ROOT / ".config" / "nextest.toml"
+CI_WORKFLOW: typ.Final[Path] = ROOT / ".github" / "workflows" / "ci.yml"
+
+#: The environment variable the shared coverage action reads.
+WATCHDOG_VARIABLE: typ.Final[str] = "RUN_RUST_CARGO_WAIT_TIMEOUT"
+
+#: The action whose steps must declare a watchdog budget.
+COVERAGE_ACTION: typ.Final[str] = "shared-actions/.github/actions/generate-coverage"
+
+#: Build time inside the `cargo` invocation, before nextest starts its
+#: own clock. The watchdog covers it; the global timeout does not.
+#: Measured at 3 m 31 s on run 33966769942 with a nearly cold compiler
+#: cache; 15 minutes is that with room to spare.
+COLD_BUILD_ALLOWANCE_SECONDS: typ.Final[float] = 15 * 60.0
+
+#: Everything in the job that is not the coverage step. The job timer
+#: covers it; the watchdog does not. Measured at 14 m 03 s before and
+#: 36 m 41 s after on run 33971821695, the latter almost entirely the
+#: publish dry run.
+NON_COVERAGE_ALLOWANCE_SECONDS: typ.Final[float] = 55 * 60.0
+
+#: ``30s``, ``5m``, ``20 m``: the durations nextest accepts here.
+_DURATION: typ.Final[re.Pattern[str]] = re.compile(
+    r"^\s*(?P<value>\d+(?:\.\d+)?)\s*(?P<unit>ms|s|m|h)\s*$"
+)
+
+_UNIT_SECONDS: typ.Final[dict[str, float]] = {
+    "ms": 0.001,
+    "s": 1.0,
+    "m": 60.0,
+    "h": 3600.0,
+}
+
+
+def _seconds(duration: str) -> float:
+    """Convert a nextest duration to seconds.
+
+    Parameters
+    ----------
+    duration : str
+        A duration as nextest spells it, such as ``"75m"``.
+
+    Returns
+    -------
+    float
+        The duration in seconds.
+    """
+    match = _DURATION.match(duration)
+    assert match is not None, f"unrecognized nextest duration {duration!r}"
+    return float(match["value"]) * _UNIT_SECONDS[match["unit"]]
+
+
+@pytest.fixture(scope="module")
+def nextest_config() -> str:
+    """Return the nextest configuration file's text.
+
+    Returns
+    -------
+    str
+        The file's contents.
+    """
+    return NEXTEST_CONFIG.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def ci_workflow() -> dict[str, typ.Any]:
+    """Return the parsed CI workflow.
+
+    Returns
+    -------
+    dict[str, typ.Any]
+        The parsed workflow document.
+    """
+    return yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def global_timeout(nextest_config: str) -> float:
+    """Return the default profile's ``global-timeout`` in seconds.
+
+    Read textually rather than through a TOML parser, because the value
+    must be matched to the profile it belongs to and the file declares
+    more than one profile.
+
+    Parameters
+    ----------
+    nextest_config : str
+        The nextest configuration file's text.
+
+    Returns
+    -------
+    float
+        The default profile's whole-run budget, in seconds.
+    """
+    blocks = re.split(r"^\[profile\.", nextest_config, flags=re.MULTILINE)
+    default = next((block for block in blocks if block.startswith("default]")), None)
+    assert default is not None, (
+        "nextest.toml must declare a [profile.default] section; the ordering "
+        "contract has nothing to compare against without one"
+    )
+    match = re.search(r'^global-timeout\s*=\s*"([^"]+)"', default, re.MULTILINE)
+    assert match is not None, (
+        "[profile.default] must set global-timeout; without it the whole-run "
+        "budget is unbounded and the watchdog becomes the only limit"
+    )
+    return _seconds(match[1])
+
+
+@pytest.fixture(scope="module")
+def largest_slow_timeout(nextest_config: str) -> float:
+    """Return the longest single-test allowance in seconds.
+
+    Parameters
+    ----------
+    nextest_config : str
+        The nextest configuration file's text.
+
+    Returns
+    -------
+    float
+        The longest per-test budget.
+    """
+    periods = re.findall(r'period\s*=\s*"([^"]+)"', nextest_config)
+    assert periods, "nextest.toml must set at least one slow-timeout period"
+    return max(_seconds(period) for period in periods)
+
+
+class CoverageLane(typ.NamedTuple):
+    """One coverage step, with the job budget that encloses it.
+
+    Attributes
+    ----------
+    job : str
+        The job the step belongs to.
+    step : str
+        The step's declared name.
+    watchdog : float | None
+        The step's watchdog budget in seconds, or ``None`` when it sets
+        none and so inherits the action's default.
+    job_timeout : float | None
+        The enclosing job's ``timeout-minutes`` in seconds, or ``None``
+        when the job declares none.
+    """
+
+    job: str
+    step: str
+    watchdog: float | None
+    job_timeout: float | None
+
+    def __str__(self) -> str:
+        """Return a location suitable for a failure message.
+
+        Returns
+        -------
+        str
+            ``job:step`` for this lane.
+        """
+        return f"{self.job}:{self.step!r}"
+
+
+def _optional_seconds(value: object) -> float | None:
+    """Return a ``timeout-minutes`` value in seconds, or None.
+
+    Parameters
+    ----------
+    value : object
+        The declared value, or ``None`` when the job declares none.
+
+    Returns
+    -------
+    float | None
+        The budget in seconds.
+    """
+    return None if value is None else float(str(value)) * 60.0
+
+
+@pytest.fixture(scope="module")
+def lanes(ci_workflow: dict[str, typ.Any]) -> tuple[CoverageLane, ...]:
+    """Return every coverage lane, each with its own job's ceiling.
+
+    Every coverage step is included, not only those that set the
+    watchdog, so a step that loses its override is visible as ``None``
+    rather than absent. An absent entry would make the ordering tests
+    skip it silently and restore the default that caused the regression.
+
+    The job ceiling travels with the lane rather than being taken as the
+    tightest in the file: an unrelated job's budget has nothing to say
+    about this one, and comparing them would either fail an
+    honestly-sized job or force unrelated budgets to move together.
+
+    Parameters
+    ----------
+    ci_workflow : dict[str, typ.Any]
+        The parsed CI workflow.
+
+    Returns
+    -------
+    tuple[CoverageLane, ...]
+        One entry per coverage step.
+    """
+    lanes: list[CoverageLane] = []
+    for job_name, job in ci_workflow["jobs"].items():
+        for step in job.get("steps", []):
+            if COVERAGE_ACTION not in str(step.get("uses", "")):
+                continue
+            raw = (step.get("env") or {}).get(WATCHDOG_VARIABLE)
+            lanes.append(
+                CoverageLane(
+                    job=str(job_name),
+                    step=str(step.get("name", "")) or str(job_name),
+                    watchdog=None if raw is None else float(str(raw)),
+                    job_timeout=_optional_seconds(job.get("timeout-minutes")),
+                )
+            )
+    return tuple(lanes)
+
+
+def test_every_coverage_step_declares_a_watchdog_budget(
+    lanes: tuple[CoverageLane, ...],
+) -> None:
+    """The default is invisible, so every step must write it down.
+
+    Leaving the action's 1,800 s default in place is how this went
+    wrong: a budget nobody set, mentioned nowhere, killing runs that
+    were merely cold. Checking that some step sets it would not do;
+    one step losing its override is enough to bring the fault back.
+    """
+    assert lanes, (
+        f"ci.yml must invoke {COVERAGE_ACTION}; this contract has nothing to "
+        f"assert against otherwise"
+    )
+    missing = [str(lane) for lane in lanes if lane.watchdog is None]
+    assert not missing, (
+        f"these coverage steps do not set {WATCHDOG_VARIABLE} and so inherit "
+        f"the action's undocumented 1,800 s default: {missing}"
+    )
+
+
+def test_the_watchdog_covers_the_nextest_budget_and_the_build(
+    lanes: tuple[CoverageLane, ...],
+    global_timeout: float,
+    largest_slow_timeout: float,
+) -> None:
+    """Tier three must not pre-empt tier two.
+
+    The two clocks do not start together. The watchdog starts with
+    ``cargo`` and covers the build; nextest's global timeout starts only
+    once tests begin. A watchdog merely above the global timeout is
+    still pre-empting it whenever the build takes longer than the
+    difference, so the build allowance is part of the comparison.
+
+    The far end matters too. A test already running when the global
+    timeout expires is allowed to finish, so the run can outlast that
+    budget by the longest per-test allowance. Whether that tail is ever
+    reached or not, allowing for it costs nothing: the watchdog only
+    fires on an overrun.
+    """
+    required = global_timeout + largest_slow_timeout + COLD_BUILD_ALLOWANCE_SECONDS
+    for lane in lanes:
+        assert lane.watchdog is not None, str(lane)
+        assert lane.watchdog >= required, (
+            f"{lane} sets {WATCHDOG_VARIABLE}={lane.watchdog:.0f}s, below the "
+            f"{required:.0f}s needed to cover the {global_timeout:.0f}s nextest "
+            f"budget, the {largest_slow_timeout:.0f}s a test already running may "
+            f"still take, and {COLD_BUILD_ALLOWANCE_SECONDS:.0f}s of cold build; "
+            f"a cold run would be killed before nextest's own budget expired"
+        )
+
+
+def test_the_nextest_global_timeout_sits_above_the_largest_slow_timeout(
+    global_timeout: float,
+    largest_slow_timeout: float,
+) -> None:
+    """Tier two must not pre-empt tier one.
+
+    A global timeout below the longest per-test allowance kills the run
+    before the test that allowance exists for can finish.
+    """
+    assert global_timeout > largest_slow_timeout, (
+        f"the {global_timeout:.0f}s global-timeout is not above the "
+        f"{largest_slow_timeout:.0f}s largest per-test slow-timeout; the run "
+        f"would end before that test could use its budget"
+    )
+
+
+def test_the_job_timeout_covers_the_watchdog_and_the_rest_of_the_job(
+    lanes: tuple[CoverageLane, ...],
+) -> None:
+    """Tier four must not pre-empt tier three.
+
+    The job timer starts when the job starts, not when coverage does.
+    Formatting, linting, the published-GPUI scenario and the publish dry
+    run all sit outside the watchdog's window but inside the job's, so a
+    job timeout merely above the watchdog still cancels the run before
+    the watchdog can report it, and a cancellation discards the log that
+    would have explained the overrun.
+    """
+    for lane in lanes:
+        assert lane.watchdog is not None, str(lane)
+        assert lane.job_timeout is not None, (
+            f"{lane} runs cargo under a {lane.watchdog:.0f}s watchdog in a job "
+            f"with no timeout-minutes; the outermost tier is missing"
+        )
+        required = lane.watchdog + NON_COVERAGE_ALLOWANCE_SECONDS
+        assert lane.job_timeout >= required, (
+            f"{lane} has a job timeout of {lane.job_timeout:.0f}s, below the "
+            f"{required:.0f}s needed to cover its {lane.watchdog:.0f}s watchdog "
+            f"plus {NON_COVERAGE_ALLOWANCE_SECONDS:.0f}s of measured work "
+            f"outside it; an overrun would be cancelled rather than reported"
+        )


### PR DESCRIPTION
## What happened

A dependabot bump to `syn` (`#696`) had its Linux coverage step killed at 1,800 s with 1,894 of 1,897 tests complete. The compiler cache served 9 % of Rust requests, so nearly everything was rebuilt.

The budget that killed it is not nextest's. It belongs to the shared `generate-coverage` action, which wraps the `cargo` invocation and kills it after a wall-clock budget, defaulting to 1,800 s. `ci.yml` set it to 1,800 explicitly with no comment, and the developers' guide never mentioned it at all. The guide does describe nextest's 75 minute global timeout and the 20 minute allowance for the trybuild binaries, and says in as many words that a cold compile is healthy compiler work rather than a hung test. All true, and all pre-empted by a fourth timer nothing documented.

## The ordering was inverted

Four timers can end a run, and each must sit above the one inside it.

| Tier | Bounds | Set in | Before | After |
| --- | --- | --- | --- | --- |
| per-test `slow-timeout` | one test | `.config/nextest.toml` | 20 m | unchanged |
| nextest `global-timeout` | the run | `.config/nextest.toml` | 75 m | unchanged |
| cargo watchdog | one `cargo` call | `ci.yml` | 1,800 s (30 m) | 5,400 s (90 m) |
| job `timeout-minutes` | the job | `ci.yml` | 90 m | 100 m |

The watchdog sat at 30 minutes underneath a 75 minute budget, so a cold run was killed before nextest had spent half of what it was given, and the error named `cargo` rather than the test still running.

## What the measurements say

Linux coverage step durations on `ubicloud-standard-2`:

| Run | Duration | Cache |
| --- | --- | --- |
| 33966133264 | 11 m 20 s | warm |
| 33975538044 | 22 m 16 s | typical |
| 33971821695 | 30 m 33 s | cold |

The last line is the one that matters. That run took 1,833 s against an 1,800 s budget and passed, because the watchdog times `cargo` rather than the step. The lane was not close to its limit, it was straddling it, and whether a run survived was decided by a few seconds of job setup.

## The guide's arithmetic was also wrong

It gave the cargo-spawning group's worst-case serial budget as 180 s + (20 m × 4) + (600 s × 3) = 6,180 s, or 103 minutes, and then called the 75 minute global timeout "above it". Seventy-five is not above one hundred and three.

The figure is a bound assuming every group member exhausts its own allowance in the same run, which has never happened. The guide now says so, and says the global timeout is deliberately set below it because a run that genuinely took 103 minutes would be a fault worth failing rather than waiting out.

## Verification

`tests/workflow_contracts/timeout_ordering_test.py` reads `.config/nextest.toml` and `ci.yml` and asserts the ordering by value, so a change to any tier that inverts it fails on the pull request rather than in a run three weeks later. Four mutations, each caught:

| Mutation | Result |
| --- | --- |
| watchdog restored to 1,800 s | 3 failed |
| job ceiling restored to 90 m | 3 failed |
| watchdog deleted entirely | 1 failed |
| global timeout dropped below the largest per-test allowance | 1 failed |

`make test-workflow-contracts` passes at 78 tests, formatting is clean, and markdownlint reports zero errors across 117 files.

## Scope

This is the first of a set. The same watchdog reaches roughly sixty repositories through `generate-coverage`; two have the inverted ordering, this one and chutoro, whose 40 minute nextest budget sits under the same 30 minute default without the repository setting the value at all.

## Summary by Sourcery

Align CI timeout tiers so cold coverage runs can use their full test budgets and validate the ordering automatically.

New Features:
- Document the four test timeout tiers, their scopes, and the required ordering in the developers guide.
- Add workflow contract tests that validate timeout ordering and require explicit watchdog budgets for every coverage lane.

Bug Fixes:
- Prevent coverage runs from being terminated by the cargo watchdog before nextest's test and build budgets are exhausted.
- Prevent job-level timeouts from cancelling coverage runs before watchdog failures can be reported.

Enhancements:
- Increase Linux and Windows coverage watchdog budgets to 6,600 seconds and raise the enclosing job timeout to 190 minutes.
- Correct the documented arithmetic and rationale for the cargo-spawning test group's timeout bound.

CI:
- Align coverage and job timeout settings so outer timers provide sufficient headroom for inner timers and non-coverage job work.

Documentation:
- Explain how the four timers start, what work they cover, and how their current values are sized.

Tests:
- Add regression coverage for missing watchdog settings, insufficient watchdog headroom, invalid nextest timeout ordering, and insufficient job ceilings.