### PR TITLE
Repin the mutation caller past two failures it could not report

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@794e4801babcf68065c660fdf4781ad62be5d061
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@2b04a1ac2f4bfeb75804b44b46acf29a23c8d595
     with:
       # The workspace's mutable source lives under crates/; the root
       # Cargo.toml is a virtual manifest with no src/. paths: "crates/"


### PR DESCRIPTION
## What this changes

One line: the `mutation-cargo.yml` pin moves from `794e480` to `8b3130b0`. Nothing else is touched.

## Two upstream fixes ride on it

**The mutants job was failing during cleanup.** The reusable workflow moves its own checkout out of the workspace so it does not pollute the tree under test, and GitHub re-reads a local action's `action.yml` when it runs that action's post step. The action was no longer there, so the job died at "Post Setup Rust". `leynos/shared-actions#460` restores the checkout as the job's last regular step.

**Empty runs were reporting clean passes.** `cargo mutants` exits `0` both when every mutant was caught and when it found none, and the workflow recorded both as `all mutants caught`. `leynos/shared-actions#462` gives an empty run its own outcome and fails it, unless the caller sets `allow-no-mutants: true`.

That second one changes nothing here, and the reason is to this repository's credit. Four consumer lanes were passing on nothing, all of them because `cargo mutants` mutates only the current package unless told otherwise. This caller already passes `--test-workspace=true`, so its runs find mutants: 168 on the last executed job.

## This does not make the lane green

That same job failed on the unmutated baseline, for a reason local to this repository and filed as `#721`. A test builds a fixture with a nested `cargo test --no-run`, which runs offline under the mutation harness and cannot fetch a crate that is not in the local registry:

```
fixture baseline build failed: no `compiler-artifact` with a test-binary `executable`
was reported by `cargo test --no-run --message-format=json`; child output:
error: failed to download `proc-macro-error-attr3 v3.1.0`
Caused by:
  attempting to make an HTTP request, but --offline was specified
```

Nothing here touches that, and the lane will still fail until it is addressed.

## What else the ref carries

The pin is a ref, so it brings every upstream change between the two commits, including `setup-rust` across nine of them. For this lane that means a different compiler cache: sccache was installed but never exported as the wrapper, so it did no work, alongside an archived target tree; now it is exported as `RUSTC_WRAPPER` on the GitHub Actions backend with no target archive. This repository is three commits further back than the other consumers, so it takes the largest step.

## Verification

`make test-workflow-contracts` passes at 70 tests. The contract asserts the shape of the pin, a 40-character hex SHA on the right reusable workflow path, rather than a particular value.

## Summary by Sourcery

Repin the mutation-testing workflow to incorporate upstream reliability and caching improvements.

Bug Fixes:
- Update the mutation-testing workflow to consume upstream fixes for cleanup failures and accurate handling of empty mutation runs.

Enhancements:
- Refresh the reusable mutation workflow pin, bringing in upstream workflow and Rust setup improvements.

CI:
- Repin the mutation-testing job to a newer immutable shared-workflow revision.

Tests:
- Verify the workflow contract tests continue to pass with the updated pin.