### PR TITLE
Correct the termination term: a grace period, not a whole slow-timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,11 +501,12 @@ jobs:
         env:
           # The cargo watchdog, one of four tiers that can end a run. It
           # must cover the 75 m nextest global-timeout in
-          # .config/nextest.toml, the 20 m a test already running may
-          # still take when that expires, and the build inside the same
-          # cargo invocation. Below that, a cold run is killed before
-          # nextest can use the budget it was given. See "Test timeouts:
-          # four tiers, outermost last" in docs/developers-guide.md.
+          # .config/nextest.toml, the grace period nextest takes to
+          # terminate the run once that expires, and the build inside the
+          # same cargo invocation. Below that, a cold run is killed
+          # before nextest can use the budget it was given. See "Test
+          # timeouts: four tiers, outermost last" in
+          # docs/developers-guide.md.
           RUN_RUST_CARGO_WAIT_TIMEOUT: '6600'
           # Tests that snapshot a child process's stderr must see the same
           # panic-hook output on every lane. An instrumented build retains

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -581,15 +581,26 @@ test run. nextest's global timeout starts only once tests begin. A watchdog
 merely larger than the global timeout is still pre-empting it whenever the
 build takes longer than the difference between them.
 
-The far end matters as well. A test already running when the global timeout
-expires is allowed to finish, so a run can outlast that budget by the longest
-per-test allowance, 20 minutes here. Whether that tail is ever reached or not,
-allowing for it costs nothing, because the watchdog only fires on an overrun.
+The far end matters as well, though less than it first appears. Hitting the
+global timeout does not stop the run instantly: nextest follows its ordinary
+termination procedure, signalling the process group on Unix and waiting
+`slow-timeout.grace-period`, five seconds here, before killing it. On Windows
+termination is immediate and the grace period is ignored for timeouts. So the
+allowance is seconds rather than minutes, but it is not zero.
 
-The watchdog is therefore sized as the global timeout, plus the running-test
-tail, plus a cold-build allowance: 75 m + 20 m + 15 m = 110 m. The build phase
-inside `cargo` measured 3 m 31 s on run 33966769942 with a nearly cold cache,
-so the 15 minutes is generous on purpose.
+The watchdog is therefore sized as the global timeout, plus a termination
+allowance of one minute, plus a cold-build allowance: 75 m + 1 m + 15 m, taken
+up to 110 m. The build phase inside `cargo` measured 3 m 31 s on run
+33966769942 with a nearly cold cache, so the 15 minutes is generous on purpose,
+and the extra minutes of rounding cost nothing because the watchdog only fires
+on an overrun.
+
+This paragraph previously claimed that a test already running when the global
+timeout expires is allowed to finish, and sized the middle term at the 20 minute
+trybuild allowance. That was wrong, and it is recorded here rather than quietly
+replaced because the other repositories adopting this contract copy this
+section. The numbers did not change: the value chosen from the wrong premise is
+larger than the corrected rule requires.
 
 The job timer starts when the job starts, long before coverage and long after
 it finishes. On the Linux lane, formatting, linting, type checking and the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -584,9 +584,11 @@ build takes longer than the difference between them.
 The far end matters as well, though less than it first appears. Hitting the
 global timeout does not stop the run instantly: nextest follows its ordinary
 termination procedure, signalling the process group on Unix and waiting
-`slow-timeout.grace-period`, five seconds here, before killing it. On Windows
-termination is immediate and the grace period is ignored for timeouts. So the
-allowance is seconds rather than minutes, but it is not zero.
+`slow-timeout.grace-period`, five seconds here, before killing it. On Windows,
+termination is immediate, and the grace period is ignored for timeouts. So the
+allowance is seconds rather than minutes, but it is not zero, and the contract
+reads it from the configuration so a profile that raises it raises the
+requirement too.
 
 The watchdog is therefore sized as the global timeout, plus a termination
 allowance of one minute, plus a cold-build allowance: 75 m + 1 m + 15 m, taken

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -671,12 +671,12 @@ that loses its override inherits the action's 1,800 s default, which is how
 this went wrong in the first place.
 
 The arithmetic behind those assertions lives in `timeout_budgets.py`, beside
-the contract: reading nextest's duration strings, picking the default profile's
-budget, taking the largest configured grace period against the one minute floor,
-and the watchdog rule itself. It owns that reading for the workflow contracts
-and nothing else, and it takes text rather than paths so a test stays in charge
-of what it is asserting about. A new tier belongs there beside the others rather
-than inline in a contract module.
+the contract: reading nextest's duration strings, picking the default
+profile's budget, taking the largest configured grace period against the
+one-minute floor, and the watchdog rule itself. It owns that reading for the
+workflow contracts and nothing else, and it takes text rather than paths so a
+test stays in charge of what it is asserting about. A new tier belongs there
+beside the others rather than inline in a contract module.
 
 It is separated because the contract alone cannot exercise it. Every
 `grace-period` in `.config/nextest.toml` is five seconds, so the termination

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -591,11 +591,13 @@ reads it from the configuration so a profile that raises it raises the
 requirement too.
 
 The watchdog is therefore sized as the global timeout, plus a termination
-allowance of one minute, plus a cold-build allowance: 75 m + 1 m + 15 m, taken
-up to 110 m. The build phase inside `cargo` measured 3 m 31 s on run
-33966769942 with a nearly cold cache, so the 15 minutes is generous on purpose,
-and the extra minutes of rounding cost nothing because the watchdog only fires
-on an overrun.
+allowance, plus a cold-build allowance: 75 m + 65 s + 15 m, taken up to 110 m.
+The termination allowance is derived, not fixed: the largest configured grace
+period, five seconds here, or nextest's ten-second default when none is named,
+plus a sixty-second margin for the teardown and report writing that follow. The
+build phase inside `cargo` measured 3 m 31 s on run 33966769942 with a nearly
+cold cache, so the 15 minutes is generous on purpose, and the extra minutes of
+rounding cost nothing because the watchdog only fires on an overrun.
 
 This paragraph previously claimed that a test already running when the global
 timeout expires is allowed to finish, and sized the middle term at the 20 minute
@@ -671,13 +673,13 @@ that loses its override inherits the action's 1,800 s default, which is how
 this went wrong in the first place.
 
 The arithmetic behind those assertions lives in `timeout_budgets.py`, beside
-the contract: reading nextest's duration strings, adding the largest configured
-grace period to the teardown margin, and the watchdog rule itself. The
-configuration reading it works from lives in `nextest_config.py`. Between them
-they own that reading for the workflow contracts and nothing else, and both
-take text rather than paths, so a test stays in charge of what it is asserting
-about. A new tier belongs there
-beside the others rather than inline in a contract module.
+the contract: nextest's duration strings and the watchdog rule itself. The
+configuration reading it works from lives in `nextest_config.py`, which
+derives the termination allowance from the largest configured grace period.
+Between them, they own that reading for the workflow contracts and nothing
+else, and both take text rather than paths, so a test stays in charge of what
+it is asserting about. A new tier belongs there beside the others rather than
+inline in a contract module.
 
 It is separated because the contract alone cannot exercise it. Every
 `grace-period` in `.config/nextest.toml` is five seconds, so the contract sees

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -671,11 +671,12 @@ that loses its override inherits the action's 1,800 s default, which is how
 this went wrong in the first place.
 
 The arithmetic behind those assertions lives in `timeout_budgets.py`, beside
-the contract: reading nextest's duration strings, picking the default
-profile's budget, adding the largest configured grace period to the
-teardown margin, and the watchdog rule itself. It owns that reading for the
-workflow contracts and nothing else, and it takes text rather than paths, so a
-test stays in charge of what it is asserting about. A new tier belongs there
+the contract: reading nextest's duration strings, adding the largest configured
+grace period to the teardown margin, and the watchdog rule itself. The
+configuration reading it works from lives in `nextest_config.py`. Between them
+they own that reading for the workflow contracts and nothing else, and both
+take text rather than paths, so a test stays in charge of what it is asserting
+about. A new tier belongs there
 beside the others rather than inline in a contract module.
 
 It is separated because the contract alone cannot exercise it. Every
@@ -685,6 +686,26 @@ one value and would pass with the reading replaced by that constant.
 instead: a grace period above the margin, one below it, one equal to it, none
 at all, several profiles disagreeing, and a watchdog sized the way the
 superseded two-term rule would have sized it.
+
+The configuration is parsed with `tomllib` rather than matched as text. A text
+match finds a key inside a comment, inside a `filter` string, or in a table
+nextest never consults, and reports a budget the runner does not use. The
+commented-out `global-timeout` is the case that matters most, because the
+contract requires that tier to be present: a scraping reader would go on
+reporting a budget somebody had switched off. Parsing also keeps a profile's
+own table apart from its overrides, which is what lets the base allowance be
+asserted on its own: an override bounds the tests its filter matches, and a
+profile whose only `terminate-after` sat in one would leave every unmatched
+test with no bound at all while the largest budget still read comfortable.
+
+`terminate-after` is optional, and nextest treats its absence as no
+termination: the test is reported slow, once per period, and runs on. The
+reading refuses that form rather than counting it as one period. It also counts
+the multiplier, which it did not before: the budget is `period` multiplied by
+`terminate-after`, and every multiplier here is one, so the old reading agreed
+with a correct one against this file and would have been wrong the moment
+somebody raised one. `nextest_config_test.py` drives all of it with
+configurations this repository does not have.
 
 The termination allowance is itself two terms added, not a floor over them:
 the largest configured grace period, or nextest's ten-second default when none

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -670,6 +670,22 @@ that invokes the shared coverage action to set the watchdog explicitly: a step
 that loses its override inherits the action's 1,800 s default, which is how
 this went wrong in the first place.
 
+The arithmetic behind those assertions lives in `timeout_budgets.py`, beside
+the contract: reading nextest's duration strings, picking the default profile's
+budget, taking the largest configured grace period against the one minute floor,
+and the watchdog rule itself. It owns that reading for the workflow contracts
+and nothing else, and it takes text rather than paths so a test stays in charge
+of what it is asserting about. A new tier belongs there beside the others rather
+than inline in a contract module.
+
+It is separated because the contract alone cannot exercise it. Every
+`grace-period` in `.config/nextest.toml` is five seconds, so the termination
+allowance always lands on its floor, and a contract that only ever sees the
+floor would pass with the term deleted. `timeout_budgets_test.py` drives the
+derivations with controlled configurations instead: a grace period above the
+floor, one below it, none at all, several profiles disagreeing, and a watchdog
+sized the way the superseded two-term rule would have sized it.
+
 ## `#[serial]`, `#[file_serial]`, and nextest test-groups
 
 Stateful GPUI scenarios keep `#[serial]` even though this repository's

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -672,19 +672,26 @@ this went wrong in the first place.
 
 The arithmetic behind those assertions lives in `timeout_budgets.py`, beside
 the contract: reading nextest's duration strings, picking the default
-profile's budget, taking the largest configured grace period against the
-one-minute floor, and the watchdog rule itself. It owns that reading for the
-workflow contracts and nothing else, and it takes text rather than paths so a
+profile's budget, adding the largest configured grace period to the
+teardown margin, and the watchdog rule itself. It owns that reading for the
+workflow contracts and nothing else, and it takes text rather than paths, so a
 test stays in charge of what it is asserting about. A new tier belongs there
 beside the others rather than inline in a contract module.
 
 It is separated because the contract alone cannot exercise it. Every
-`grace-period` in `.config/nextest.toml` is five seconds, so the termination
-allowance always lands on its floor, and a contract that only ever sees the
-floor would pass with the term deleted. `timeout_budgets_test.py` drives the
-derivations with controlled configurations instead: a grace period above the
-floor, one below it, none at all, several profiles disagreeing, and a watchdog
-sized the way the superseded two-term rule would have sized it.
+`grace-period` in `.config/nextest.toml` is five seconds, so the contract sees
+one value and would pass with the reading replaced by that constant.
+`timeout_budgets_test.py` drives the derivations with controlled configurations
+instead: a grace period above the margin, one below it, one equal to it, none
+at all, several profiles disagreeing, and a watchdog sized the way the
+superseded two-term rule would have sized it.
+
+The termination allowance is itself two terms added, not a floor over them:
+the largest configured grace period, or nextest's ten-second default when none
+is named, plus a sixty-second margin for the teardown and report writing that
+follow. A floor absorbs every grace period below it, so raising this file's
+five seconds to thirty would demand nothing more of the watchdog above it, and
+the saving would look free until the run it cancelled.
 
 ## `#[serial]`, `#[file_serial]`, and nextest test-groups
 

--- a/tests/workflow_contracts/nextest_config.py
+++ b/tests/workflow_contracts/nextest_config.py
@@ -2,12 +2,10 @@
 
 Separated from ``timeout_budgets`` so the configuration reading and the
 watchdog arithmetic stay legible apart, and so neither module outgrows
-the 400-line limit ``AGENTS.md`` sets.
-
-The configuration is parsed with ``tomllib`` rather than matched as
-text. A text match finds a key inside a comment, inside a ``filter``
-string, or in a table nextest never consults, and reports a budget the
-runner does not use.
+the 400-line limit ``AGENTS.md`` sets. The configuration is parsed with
+``tomllib`` rather than matched as text: a text match finds a key inside
+a comment, inside a ``filter`` string, or in a table nextest never
+consults, and reports a budget the runner does not use.
 """
 
 import tomllib
@@ -31,9 +29,8 @@ def _parsed(config_text: str) -> dict[str, object]:
     """Return the configuration as TOML.
 
     Parsed rather than matched as text, for the reasons the module
-    docstring gives: the commented-out ``global-timeout`` it names is the
-    case that matters most here, because the contract requires that tier
-    to be present.
+    docstring gives. A commented-out ``global-timeout`` is the case that
+    matters most here, because the contract requires that tier present.
 
     Parameters
     ----------
@@ -75,9 +72,8 @@ def _table(value: object) -> dict[str, object]:
 def _budget_tables(config_text: str) -> list[tuple[str, dict[str, object]]]:
     """Return every table nextest reads a per-test budget from.
 
-    Each profile's own table and each of its ``[[overrides]]`` entries,
-    with the dotted path naming it so a failure can say which is at
-    fault.
+    Each profile's own table and each of its ``[[overrides]]`` entries, with
+    the dotted path naming it so a failure can say which is at fault.
 
     Parameters
     ----------
@@ -107,7 +103,9 @@ def _slow_timeouts(config_text: str) -> list[tuple[str, dict[str, object]]]:
 
     Both of nextest's spellings are read. The table form is used as
     written; the scalar shorthand is folded into ``{ period = ... }``
-    before it is returned.
+    before it is returned, and a present value that is neither is refused
+    rather than skipped: nextest loads no such file, and skipping one
+    leaves the readers reporting another entry's budget.
 
     Parameters
     ----------
@@ -119,14 +117,24 @@ def _slow_timeouts(config_text: str) -> list[tuple[str, dict[str, object]]]:
     list of tuple
         The dotted path of the declaring table and the ``slow-timeout``
         it holds, with neither spelling lost.
+
+    Raises
+    ------
+    MalformedSlowTimeoutPeriodError
+        If a declared value is neither a non-empty string nor a table.
     """
     declared: list[tuple[str, dict[str, object]]] = []
     for path, table in _budget_tables(config_text):
         match table.get("slow-timeout"):
-            case str() as period if period:
+            case None | "":
+                # Absent, and the empty string nextest reads as absent.
+                continue
+            case str() as period:
                 declared.append((path, _table({"period": period})))
             case dict() as written:
                 declared.append((path, _table(written)))
+            case value:
+                raise MalformedSlowTimeoutPeriodError(path, value)
     return declared
 
 
@@ -166,9 +174,7 @@ def _terminate_after(table: dict[str, object], where: str) -> int:
 
     nextest types ``terminate-after`` as a whole number of periods
     greater than zero and refuses anything else. Reading one anyway
-    would put a budget on the tier the runner never applies, and a string
-    used to raise a bare ``ValueError`` rather than a shape error naming
-    it.
+    would put a budget on the tier the runner never applies.
 
     Parameters
     ----------
@@ -185,8 +191,7 @@ def _terminate_after(table: dict[str, object], where: str) -> int:
     Raises
     ------
     UnboundedTestError
-        If the key is absent, which nextest reads as no termination at
-        all rather than as a malformed value.
+        If the key is absent, which nextest reads as no termination at all.
     MalformedTerminateAfterError
         If the key holds anything but a whole number above zero.
     """
@@ -236,10 +241,9 @@ def _grace_period(table: dict[str, object], where: str) -> float:
 def global_timeout(config_text: str) -> float:
     r"""Return the default profile's ``global-timeout`` in seconds.
 
-    Read from ``[profile.default]``'s own table. nextest's other
-    profiles inherit it unless they override it, and an ``[[overrides]]``
-    entry cannot carry one, so a value found elsewhere is not the budget
-    in force.
+    Read from ``[profile.default]``'s own table. nextest's other profiles
+    inherit it unless they override it, and an ``[[overrides]]`` entry cannot
+    carry one, so a value found elsewhere is not the budget in force.
 
     Parameters
     ----------
@@ -277,9 +281,8 @@ def bounds_a_single_test(config_text: str, profile: str = "default") -> bool:
 
     An override bounds the tests its filter matches; the profile's own
     bounds the rest. A profile whose only ``terminate-after`` sits in an
-    override leaves every unmatched test running with no bound at all
-    while :func:`largest_slow_timeout` still reports a comfortable
-    number, so the two are read apart.
+    override leaves unmatched tests unbounded while
+    :func:`largest_slow_timeout` still reports a comfortable number.
 
     Parameters
     ----------
@@ -317,10 +320,6 @@ def largest_slow_timeout(config_text: str) -> float:
     The scalar shorthand is read as well, and is unbounded: nextest reads
     ``slow-timeout = "60s"`` as a period with no termination policy,
     exactly as if the table form had left ``terminate-after`` out.
-
-    A ``slow-timeout`` nextest could not read is refused where it is
-    read, and one that terminates nothing is refused rather than counted
-    as a single period.
 
     Parameters
     ----------

--- a/tests/workflow_contracts/nextest_config.py
+++ b/tests/workflow_contracts/nextest_config.py
@@ -15,6 +15,9 @@ import tomllib
 from timeout_budgets import (
     NEXTEST_DEFAULT_GRACE_PERIOD_SECONDS,
     TERMINATION_SAFETY_MARGIN_SECONDS,
+    MalformedGracePeriodError,
+    MalformedSlowTimeoutPeriodError,
+    MalformedTerminateAfterError,
     MissingDefaultProfileError,
     MissingGlobalTimeoutError,
     MissingSlowTimeoutError,
@@ -27,11 +30,10 @@ from timeout_budgets import (
 def _parsed(config_text: str) -> dict[str, object]:
     """Return the configuration as TOML.
 
-    Parsed rather than matched as text. A text match finds a key inside
-    a comment, inside a ``filter`` string, or in a table nextest never
-    consults, and reports a budget the runner does not use. The
-    commented-out ``global-timeout`` is the case that matters most here,
-    because the contract requires that tier to be present.
+    Parsed rather than matched as text, for the reasons the module
+    docstring gives: the commented-out ``global-timeout`` it names is the
+    case that matters most here, because the contract requires that tier
+    to be present.
 
     Parameters
     ----------
@@ -101,7 +103,11 @@ def _budget_tables(config_text: str) -> list[tuple[str, dict[str, object]]]:
 
 
 def _slow_timeouts(config_text: str) -> list[tuple[str, dict[str, object]]]:
-    """Return every ``slow-timeout`` table the configuration declares.
+    """Return every ``slow-timeout`` the configuration declares.
+
+    Both of nextest's spellings are read. The table form is used as
+    written; the scalar shorthand is folded into ``{ period = ... }``
+    before it is returned.
 
     Parameters
     ----------
@@ -112,13 +118,119 @@ def _slow_timeouts(config_text: str) -> list[tuple[str, dict[str, object]]]:
     -------
     list of tuple
         The dotted path of the declaring table and the ``slow-timeout``
-        it holds.
+        it holds, with neither spelling lost.
     """
-    return [
-        (path, _table(table["slow-timeout"]))
-        for path, table in _budget_tables(config_text)
-        if isinstance(table.get("slow-timeout"), dict)
-    ]
+    declared: list[tuple[str, dict[str, object]]] = []
+    for path, table in _budget_tables(config_text):
+        match table.get("slow-timeout"):
+            case str() as period if period:
+                declared.append((path, _table({"period": period})))
+            case dict() as written:
+                declared.append((path, _table(written)))
+    return declared
+
+
+def _period(table: dict[str, object], where: str) -> str:
+    """Return a ``slow-timeout``'s ``period``, refusing one nextest would.
+
+    nextest requires the key in the table form, so a table without one is
+    a configuration error rather than an entry to skip: skipping it would
+    report a missing tier while the file names one the runner will not
+    load.
+
+    Parameters
+    ----------
+    table : dict[str, object]
+        The ``slow-timeout`` table.
+    where : str
+        The dotted path of the declaring table.
+
+    Returns
+    -------
+    str
+        The period as nextest spells it.
+
+    Raises
+    ------
+    MalformedSlowTimeoutPeriodError
+        If the table names no period, or names one that is not a string.
+    """
+    value = table.get("period")
+    if not isinstance(value, str):
+        raise MalformedSlowTimeoutPeriodError(where, value)
+    return value
+
+
+def _terminate_after(table: dict[str, object], where: str) -> int:
+    """Return how many periods nextest lets a slow test run for.
+
+    nextest types ``terminate-after`` as a whole number of periods
+    greater than zero and refuses anything else. Reading one anyway
+    would put a budget on the tier the runner never applies, and a string
+    used to raise a bare ``ValueError`` rather than a shape error naming
+    it.
+
+    Parameters
+    ----------
+    table : dict[str, object]
+        The ``slow-timeout`` table.
+    where : str
+        The dotted path of the declaring table.
+
+    Returns
+    -------
+    int
+        The multiplier, always at least one.
+
+    Raises
+    ------
+    UnboundedTestError
+        If the key is absent, which nextest reads as no termination at
+        all rather than as a malformed value.
+    MalformedTerminateAfterError
+        If the key holds anything but a whole number above zero.
+    """
+    value = table.get("terminate-after")
+    if value is None:
+        raise UnboundedTestError(where)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise MalformedTerminateAfterError(where, value)
+    if value < 1:
+        raise MalformedTerminateAfterError(where, value)
+    return value
+
+
+def _grace_period(table: dict[str, object], where: str) -> float:
+    """Return a ``slow-timeout``'s ``grace-period`` in seconds.
+
+    Absence is not a fault: nextest defaults the key to ten seconds, and
+    that default is the reading. A value that is present and unreadable
+    is a fault, because falling back to the default would size the
+    termination allowance against a number the file does not set.
+
+    Parameters
+    ----------
+    table : dict[str, object]
+        The ``slow-timeout`` table.
+    where : str
+        The dotted path of the declaring table.
+
+    Returns
+    -------
+    float
+        The grace period in seconds.
+
+    Raises
+    ------
+    MalformedGracePeriodError
+        If the key is present but is not a duration string.
+    """
+    value = table.get("grace-period")
+    if value is None:
+        return NEXTEST_DEFAULT_GRACE_PERIOD_SECONDS
+    if not isinstance(value, str):
+        raise MalformedGracePeriodError(where, value)
+    return seconds(value)
 
 
 def global_timeout(config_text: str) -> float:
@@ -180,14 +292,17 @@ def bounds_a_single_test(config_text: str, profile: str = "default") -> bool:
     -------
     bool
         True when that profile's own ``slow-timeout`` sets both a period
-        and ``terminate-after``.
+        and a ``terminate-after`` nextest would accept.
     """
     own = _table(_table(_parsed(config_text).get("profile")).get(profile))
     table = _table(own.get("slow-timeout"))
-    return (
-        isinstance(table.get("period"), str)
-        and table.get("terminate-after") is not None
-    )
+    if not table:
+        return False
+    _period(table, f"profile.{profile}")
+    if table.get("terminate-after") is None:
+        return False
+    _terminate_after(table, f"profile.{profile}")
+    return True
 
 
 def largest_slow_timeout(config_text: str) -> float:
@@ -198,6 +313,14 @@ def largest_slow_timeout(config_text: str) -> float:
     multiplier in this repository is one, so a reading that ignored it
     would agree with a correct one against the real file and be wrong
     the moment somebody raised one.
+
+    The scalar shorthand is read as well, and is unbounded: nextest reads
+    ``slow-timeout = "60s"`` as a period with no termination policy,
+    exactly as if the table form had left ``terminate-after`` out.
+
+    A ``slow-timeout`` nextest could not read is refused where it is
+    read, and one that terminates nothing is refused rather than counted
+    as a single period.
 
     Parameters
     ----------
@@ -213,9 +336,6 @@ def largest_slow_timeout(config_text: str) -> float:
     ------
     MissingSlowTimeoutError
         If the configuration declares no per-test budget.
-    UnboundedTestError
-        If a ``slow-timeout`` names no ``terminate-after``, so nextest
-        never stops the test it reports as slow.
 
     Examples
     --------
@@ -227,12 +347,8 @@ def largest_slow_timeout(config_text: str) -> float:
     """
     budgets: list[float] = []
     for path, table in _slow_timeouts(config_text):
-        period = table.get("period")
-        if not isinstance(period, str):
-            continue
-        if table.get("terminate-after") is None:
-            raise UnboundedTestError(path)
-        budgets.append(seconds(period) * float(str(table["terminate-after"])))
+        period = seconds(_period(table, path))
+        budgets.append(period * _terminate_after(table, path))
     if not budgets:
         raise MissingSlowTimeoutError
     return max(budgets)
@@ -250,11 +366,10 @@ def termination_allowance(config_text: str) -> float:
     second is a fixed margin for the teardown and report writing that
     follow.
 
-    A single floor over the two, which is what this read before, absorbs
-    every grace period below the margin. Raising this file's five
-    seconds to thirty would have demanded nothing more of the watchdog
-    above it, and the saving would have looked free until the run it
-    cancelled.
+    A floor over the two would absorb every grace period below the
+    margin, so raising this file's five seconds would have demanded
+    nothing more of the watchdog above it. A ``grace-period`` nextest
+    could not read is refused where it is read rather than guessed at.
 
     Parameters
     ----------
@@ -277,9 +392,7 @@ def termination_allowance(config_text: str) -> float:
     65.0
     """
     periods = [
-        seconds(grace)
-        for _, table in _slow_timeouts(config_text)
-        if isinstance(grace := table.get("grace-period"), str)
+        _grace_period(table, path) for path, table in _slow_timeouts(config_text)
     ]
     largest = max(periods, default=NEXTEST_DEFAULT_GRACE_PERIOD_SECONDS)
     return largest + TERMINATION_SAFETY_MARGIN_SECONDS

--- a/tests/workflow_contracts/nextest_config.py
+++ b/tests/workflow_contracts/nextest_config.py
@@ -1,0 +1,285 @@
+"""Reading `.config/nextest.toml` as the runner reads it.
+
+Separated from ``timeout_budgets`` so the configuration reading and the
+watchdog arithmetic stay legible apart, and so neither module outgrows
+the 400-line limit ``AGENTS.md`` sets.
+
+The configuration is parsed with ``tomllib`` rather than matched as
+text. A text match finds a key inside a comment, inside a ``filter``
+string, or in a table nextest never consults, and reports a budget the
+runner does not use.
+"""
+
+import tomllib
+
+from timeout_budgets import (
+    NEXTEST_DEFAULT_GRACE_PERIOD_SECONDS,
+    TERMINATION_SAFETY_MARGIN_SECONDS,
+    MissingDefaultProfileError,
+    MissingGlobalTimeoutError,
+    MissingSlowTimeoutError,
+    UnboundedTestError,
+    UnparsableConfigurationError,
+    seconds,
+)
+
+
+def _parsed(config_text: str) -> dict[str, object]:
+    """Return the configuration as TOML.
+
+    Parsed rather than matched as text. A text match finds a key inside
+    a comment, inside a ``filter`` string, or in a table nextest never
+    consults, and reports a budget the runner does not use. The
+    commented-out ``global-timeout`` is the case that matters most here,
+    because the contract requires that tier to be present.
+
+    Parameters
+    ----------
+    config_text : str
+        A nextest configuration file's text.
+
+    Returns
+    -------
+    dict[str, object]
+        The parsed document.
+
+    Raises
+    ------
+    UnparsableConfigurationError
+        If the text is not valid TOML.
+    """
+    try:
+        return tomllib.loads(config_text)
+    except tomllib.TOMLDecodeError as error:
+        raise UnparsableConfigurationError(str(error)) from error
+
+
+def _table(value: object) -> dict[str, object]:
+    """Return a parsed value as a table, or an empty one.
+
+    Parameters
+    ----------
+    value : object
+        Any value ``tomllib`` produced.
+
+    Returns
+    -------
+    dict[str, object]
+        The table, or an empty one when the value is not a table.
+    """
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _budget_tables(config_text: str) -> list[tuple[str, dict[str, object]]]:
+    """Return every table nextest reads a per-test budget from.
+
+    Each profile's own table and each of its ``[[overrides]]`` entries,
+    with the dotted path naming it so a failure can say which is at
+    fault.
+
+    Parameters
+    ----------
+    config_text : str
+        A nextest configuration file's text.
+
+    Returns
+    -------
+    list of tuple
+        The dotted path and the table, in file order.
+    """
+    tables: list[tuple[str, dict[str, object]]] = []
+    for name, raw in _table(_parsed(config_text).get("profile")).items():
+        profile = _table(raw)
+        tables.append((f"profile.{name}", profile))
+        overrides = profile.get("overrides")
+        entries = overrides if isinstance(overrides, list) else []
+        tables.extend(
+            (f"profile.{name}.overrides[{index}]", _table(entry))
+            for index, entry in enumerate(entries)
+        )
+    return tables
+
+
+def _slow_timeouts(config_text: str) -> list[tuple[str, dict[str, object]]]:
+    """Return every ``slow-timeout`` table the configuration declares.
+
+    Parameters
+    ----------
+    config_text : str
+        A nextest configuration file's text.
+
+    Returns
+    -------
+    list of tuple
+        The dotted path of the declaring table and the ``slow-timeout``
+        it holds.
+    """
+    return [
+        (path, _table(table["slow-timeout"]))
+        for path, table in _budget_tables(config_text)
+        if isinstance(table.get("slow-timeout"), dict)
+    ]
+
+
+def global_timeout(config_text: str) -> float:
+    r"""Return the default profile's ``global-timeout`` in seconds.
+
+    Read from ``[profile.default]``'s own table. nextest's other
+    profiles inherit it unless they override it, and an ``[[overrides]]``
+    entry cannot carry one, so a value found elsewhere is not the budget
+    in force.
+
+    Parameters
+    ----------
+    config_text : str
+        A nextest configuration file's text.
+
+    Returns
+    -------
+    float
+        The default profile's whole-run budget, in seconds.
+
+    Raises
+    ------
+    MissingDefaultProfileError
+        If no ``[profile.default]`` section is present.
+    MissingGlobalTimeoutError
+        If that section sets no ``global-timeout``.
+
+    Examples
+    --------
+    >>> global_timeout('[profile.default]\nglobal-timeout = "75m"\n')
+    4500.0
+    """
+    profiles = _table(_parsed(config_text).get("profile"))
+    if "default" not in profiles:
+        raise MissingDefaultProfileError
+    budget = _table(profiles["default"]).get("global-timeout")
+    if not isinstance(budget, str):
+        raise MissingGlobalTimeoutError
+    return seconds(budget)
+
+
+def bounds_a_single_test(config_text: str, profile: str = "default") -> bool:
+    """Return whether a profile's own table terminates a slow test.
+
+    An override bounds the tests its filter matches; the profile's own
+    bounds the rest. A profile whose only ``terminate-after`` sits in an
+    override leaves every unmatched test running with no bound at all
+    while :func:`largest_slow_timeout` still reports a comfortable
+    number, so the two are read apart.
+
+    Parameters
+    ----------
+    config_text : str
+        A nextest configuration file's text.
+    profile : str
+        The profile to read.
+
+    Returns
+    -------
+    bool
+        True when that profile's own ``slow-timeout`` sets both a period
+        and ``terminate-after``.
+    """
+    own = _table(_table(_parsed(config_text).get("profile")).get(profile))
+    table = _table(own.get("slow-timeout"))
+    return (
+        isinstance(table.get("period"), str)
+        and table.get("terminate-after") is not None
+    )
+
+
+def largest_slow_timeout(config_text: str) -> float:
+    r"""Return the longest single-test allowance in seconds.
+
+    nextest warns once per ``period`` and terminates after
+    ``terminate-after`` of them, so the budget is their product. Every
+    multiplier in this repository is one, so a reading that ignored it
+    would agree with a correct one against the real file and be wrong
+    the moment somebody raised one.
+
+    Parameters
+    ----------
+    config_text : str
+        A nextest configuration file's text.
+
+    Returns
+    -------
+    float
+        The longest per-test budget.
+
+    Raises
+    ------
+    MissingSlowTimeoutError
+        If the configuration declares no per-test budget.
+    UnboundedTestError
+        If a ``slow-timeout`` names no ``terminate-after``, so nextest
+        never stops the test it reports as slow.
+
+    Examples
+    --------
+    >>> largest_slow_timeout(
+    ...     '[profile.default]\n'
+    ...     'slow-timeout = { period = "20m", terminate-after = 1 }\n'
+    ... )
+    1200.0
+    """
+    budgets: list[float] = []
+    for path, table in _slow_timeouts(config_text):
+        period = table.get("period")
+        if not isinstance(period, str):
+            continue
+        if table.get("terminate-after") is None:
+            raise UnboundedTestError(path)
+        budgets.append(seconds(period) * float(str(table["terminate-after"])))
+    if not budgets:
+        raise MissingSlowTimeoutError
+    return max(budgets)
+
+
+def termination_allowance(config_text: str) -> float:
+    r"""Return the time nextest may take to stop the run, in seconds.
+
+    Two terms, added rather than maximized over, because they answer
+    different questions. The first is what nextest promises the test:
+    on Unix it signals the process group and waits
+    ``slow-timeout.grace-period`` before killing it, read from the
+    configuration so a profile that raised it raises the requirement
+    too, with nextest's own ten-second default when none is named. The
+    second is a fixed margin for the teardown and report writing that
+    follow.
+
+    A single floor over the two, which is what this read before, absorbs
+    every grace period below the margin. Raising this file's five
+    seconds to thirty would have demanded nothing more of the watchdog
+    above it, and the saving would have looked free until the run it
+    cancelled.
+
+    Parameters
+    ----------
+    config_text : str
+        A nextest configuration file's text.
+
+    Returns
+    -------
+    float
+        The largest configured grace period, or nextest's default, plus
+        the safety margin.
+
+    Examples
+    --------
+    >>> termination_allowance(
+    ...     '[profile.default]\n'
+    ...     'slow-timeout = { period = "60s", terminate-after = 1, '
+    ...     'grace-period = "5s" }\n'
+    ... )
+    65.0
+    """
+    periods = [
+        seconds(grace)
+        for _, table in _slow_timeouts(config_text)
+        if isinstance(grace := table.get("grace-period"), str)
+    ]
+    largest = max(periods, default=NEXTEST_DEFAULT_GRACE_PERIOD_SECONDS)
+    return largest + TERMINATION_SAFETY_MARGIN_SECONDS

--- a/tests/workflow_contracts/nextest_config_test.py
+++ b/tests/workflow_contracts/nextest_config_test.py
@@ -12,8 +12,13 @@ consults. The commented-out `global-timeout` is the case that matters
 most, because the contract requires that tier to be present.
 """
 
+import typing as typ
+
 import nextest_config as reading
 import pytest
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
 
 _DEFAULT_PROFILE = (
     "[profile.default]\n"
@@ -74,8 +79,10 @@ def test_a_filter_naming_a_timeout_key_is_not_a_budget() -> None:
     assert reading.global_timeout(config_text) == pytest.approx(4500.0), (
         "the filter naming global_timeout_probe was read as a whole-run budget"
     )
-    assert reading.termination_allowance(config_text) == pytest.approx(65.0), (
-        "the filter naming grace_period_probe was read as a grace period"
+    assert reading.termination_allowance(config_text) == pytest.approx(70.0), (
+        "the filter naming grace_period_probe was read as a grace period; the "
+        "ten seconds here is the override's own table naming none, which "
+        "nextest defaults rather than inheriting the profile's five"
     )
 
 
@@ -114,6 +121,157 @@ def test_a_slow_timeout_that_terminates_nothing_is_refused(config_text: str) -> 
     """
     with pytest.raises(reading.UnboundedTestError, match=r"terminate-after"):
         reading.largest_slow_timeout(config_text)
+
+
+def test_a_scalar_slow_timeout_is_read_as_the_unbounded_form() -> None:
+    """The scalar shorthand sets a period and nothing else.
+
+    ``slow-timeout = "60s"`` sets ``period`` and leaves
+    ``terminate-after`` unset, so the test is reported slow once per
+    period and runs on, exactly as the table form does without the key.
+    Skipping the scalar would leave the tier invisible, and the largest
+    budget reading as whatever the table forms beside it happened to
+    say.
+    """
+    config_text = '[profile.default]\nslow-timeout = "60s"\n'
+    with pytest.raises(reading.UnboundedTestError, match=r"terminate-after"):
+        reading.largest_slow_timeout(config_text)
+
+
+def test_a_scalar_slow_timeout_set_to_nothing_is_not_a_budget() -> None:
+    """An empty string leaves the key unset rather than zero-length.
+
+    nextest's deserializer returns nothing for an empty string, so the
+    profile is left with no per-test budget at all. Reading it as one
+    would fail a configuration nextest loads.
+    """
+    with pytest.raises(reading.MissingSlowTimeoutError):
+        reading.largest_slow_timeout('[profile.default]\nslow-timeout = ""\n')
+
+
+@pytest.mark.parametrize(
+    "reads",
+    [
+        pytest.param(reading.global_timeout, id="global-timeout"),
+        pytest.param(reading.largest_slow_timeout, id="largest-slow-timeout"),
+        pytest.param(reading.termination_allowance, id="termination-allowance"),
+        pytest.param(reading.bounds_a_single_test, id="bounds-a-single-test"),
+    ],
+)
+def test_every_reading_reports_malformed_toml_as_a_configuration_fault(
+    reads: cabc.Callable[[str], object],
+) -> None:
+    """`tomllib` raises `TOMLDecodeError`, a bare `ValueError`.
+
+    Every reading parses the file, so every reading has to report a file
+    nextest cannot parse as the configuration fault it is rather than as
+    an unhandled parser error several frames below the caller. One
+    reader plus the shared parser path would leave the next reader free
+    to bypass `_parsed` and grow the same leak again.
+    """
+    with pytest.raises(reading.UnparsableConfigurationError, match=r"not valid TOML"):
+        reads("[profile.default\n")
+
+
+@pytest.mark.parametrize(
+    "config_text",
+    [
+        pytest.param(
+            "[profile.default]\n"
+            'slow-timeout = { period = "60s", terminate-after = 0 }\n',
+            id="zero-periods",
+        ),
+        pytest.param(
+            "[profile.default]\n"
+            'slow-timeout = { period = "60s", terminate-after = -1 }\n',
+            id="a-negative-number",
+        ),
+        pytest.param(
+            "[profile.default]\n"
+            'slow-timeout = { period = "60s", terminate-after = 1.5 }\n',
+            id="a-fraction",
+        ),
+        pytest.param(
+            "[profile.default]\n"
+            'slow-timeout = { period = "60s", terminate-after = "2" }\n',
+            id="a-string",
+        ),
+        pytest.param(
+            "[profile.default]\n"
+            'slow-timeout = { period = "60s", terminate-after = true }\n',
+            id="a-boolean",
+        ),
+    ],
+)
+def test_a_terminate_after_nextest_would_refuse_is_a_shape_error(
+    config_text: str,
+) -> None:
+    """The key is typed as a whole number of periods above zero.
+
+    Reading any of these as a number would put a budget on the tier the
+    runner never applies, and the string form raised a bare `ValueError`
+    from the conversion rather than a shape error naming the file. Every
+    fault here is a `WorkflowShapeError`, so a malformed configuration
+    fails the same way whether or not assertions are enabled.
+    """
+    with pytest.raises(reading.MalformedTerminateAfterError, match=r"terminate-after"):
+        reading.largest_slow_timeout(config_text)
+
+
+@pytest.mark.parametrize(
+    "config_text",
+    [
+        pytest.param(
+            "[profile.default]\nslow-timeout = { terminate-after = 1 }\n",
+            id="no-period-at-all",
+        ),
+        pytest.param(
+            "[profile.default]\nslow-timeout = { period = 60, terminate-after = 1 }\n",
+            id="a-bare-number",
+        ),
+    ],
+)
+def test_a_period_nextest_could_not_read_is_a_shape_error(config_text: str) -> None:
+    """The table form requires a ``period`` nextest can read.
+
+    Skipping the entry instead would leave the file naming a tier the
+    runner will not load, and the reading would report it as absent
+    rather than as the configuration error it is.
+    """
+    with pytest.raises(reading.MalformedSlowTimeoutPeriodError, match=r"no period"):
+        reading.largest_slow_timeout(config_text)
+
+
+@pytest.mark.parametrize(
+    "config_text",
+    [
+        pytest.param(
+            "[profile.default]\n"
+            'slow-timeout = { period = "60s", terminate-after = 1, '
+            "grace-period = 5 }\n",
+            id="a-bare-number",
+        ),
+        pytest.param(
+            "[profile.default]\n"
+            'slow-timeout = { period = "60s", terminate-after = 1, '
+            "grace-period = true }\n",
+            id="a-boolean",
+        ),
+    ],
+)
+def test_a_grace_period_nextest_could_not_read_is_a_shape_error(
+    config_text: str,
+) -> None:
+    """The key is typed as a duration string.
+
+    nextest defaults it when it is absent, so absence is not a fault. A
+    value that is present and unreadable is: falling back to the default
+    would size the termination allowance against a number the file does
+    not set, and the watchdog above it against a run nextest will not
+    start.
+    """
+    with pytest.raises(reading.MalformedGracePeriodError, match=r"grace-period"):
+        reading.termination_allowance(config_text)
 
 
 def test_the_per_test_budget_is_a_product_not_a_period() -> None:

--- a/tests/workflow_contracts/nextest_config_test.py
+++ b/tests/workflow_contracts/nextest_config_test.py
@@ -1,0 +1,155 @@
+"""What the nextest reading counts as configuration, and what it does not.
+
+The contract compares budgets read out of `.config/nextest.toml`, and
+those readings can be wrong while the file is right. This repository's
+own file cannot expose most of the ways: nothing in it is commented out,
+no `filter` names a timeout key, and every `terminate-after` is one, so
+a reading that ignored the multiplier would agree with a correct one.
+
+The reading parses the file with `tomllib`. A text match finds a key
+inside a comment, inside a `filter` string, or in a table nextest never
+consults. The commented-out `global-timeout` is the case that matters
+most, because the contract requires that tier to be present.
+"""
+
+import nextest_config as reading
+import pytest
+
+_DEFAULT_PROFILE = (
+    "[profile.default]\n"
+    'slow-timeout = { period = "60s", terminate-after = 1, '
+    'grace-period = "5s" }\n'
+    'global-timeout = "75m"\n'
+)
+
+
+def test_a_commented_out_entry_is_not_configuration() -> None:
+    """A comment is not configuration, and TOML is what says so.
+
+    The reading parses the file, so a key inside a comment is not read
+    as a budget. The commented-out ``global-timeout`` is the case that
+    matters most: the contract requires that tier to be present, so a
+    text match would have gone on reporting a budget somebody had
+    switched off, and the four-tier contract would have passed with
+    three.
+    """
+    config_text = (
+        "[profile.default]\n"
+        '# global-timeout = "30m"\n'
+        '# slow-timeout = { period = "40m", terminate-after = 1, '
+        'grace-period = "30m" }\n'
+        'slow-timeout = { period = "60s", terminate-after = 1, '
+        'grace-period = "5s" }\n'
+        'global-timeout = "75m"\n'
+    )
+    assert reading.global_timeout(config_text) == pytest.approx(4500.0), (
+        "a commented-out global-timeout was read as the budget in force"
+    )
+    assert reading.largest_slow_timeout(config_text) == pytest.approx(60.0), (
+        "a commented-out slow-timeout was read as a live one"
+    )
+    assert reading.termination_allowance(config_text) == pytest.approx(65.0), (
+        "a commented-out grace period was read as the one in force"
+    )
+
+
+def test_a_filter_naming_a_timeout_key_is_not_a_budget() -> None:
+    """An override's ``filter`` is a string, not configuration.
+
+    A binary named after one of these keys would be matched by a text
+    search and read as a budget nextest never applies.
+    """
+    config_text = (
+        "[profile.default]\n"
+        'slow-timeout = { period = "60s", terminate-after = 1, '
+        'grace-period = "5s" }\n'
+        'global-timeout = "75m"\n'
+        "\n[[profile.default.overrides]]\n"
+        "filter = 'binary(global_timeout_probe) | binary(grace_period_probe)'\n"
+        'slow-timeout = { period = "180s", terminate-after = 1 }\n'
+    )
+    assert reading.largest_slow_timeout(config_text) == pytest.approx(180.0), (
+        "the override's own slow-timeout is the largest, not its filter's text"
+    )
+    assert reading.global_timeout(config_text) == pytest.approx(4500.0), (
+        "the filter naming global_timeout_probe was read as a whole-run budget"
+    )
+    assert reading.termination_allowance(config_text) == pytest.approx(65.0), (
+        "the filter naming grace_period_probe was read as a grace period"
+    )
+
+
+@pytest.mark.parametrize(
+    "config_text",
+    [
+        pytest.param(
+            '[profile.default]\nslow-timeout = { period = "60s" }\n',
+            id="a-profile-without-terminate-after",
+        ),
+        pytest.param(
+            "[profile.default]\n"
+            'slow-timeout = { period = "60s", grace-period = "5s" }\n',
+            id="a-table-with-only-a-grace-period",
+        ),
+        pytest.param(
+            "[profile.default]\n"
+            'slow-timeout = { period = "60s", terminate-after = 1 }\n'
+            "\n[[profile.default.overrides]]\n"
+            "filter = 'binary(slow)'\n"
+            'slow-timeout = { period = "20m" }\n',
+            id="an-override-without-terminate-after",
+        ),
+    ],
+)
+def test_a_slow_timeout_that_terminates_nothing_is_refused(config_text: str) -> None:
+    """`terminate-after` is optional, and without it nothing is bounded.
+
+    nextest treats its absence as no termination: the test is reported
+    slow, once per period, and runs on. Counting it as a single period
+    would put a number on the tier that is missing, so every comparison
+    above it would pass against a budget nextest never applies.
+
+    Every table in `.config/nextest.toml` sets it, so no value here
+    changes; this is what stops one appearing.
+    """
+    with pytest.raises(reading.UnboundedTestError, match=r"terminate-after"):
+        reading.largest_slow_timeout(config_text)
+
+
+def test_the_per_test_budget_is_a_product_not_a_period() -> None:
+    """`terminate-after` scales the period; the budget is their product.
+
+    Every multiplier in `.config/nextest.toml` is one, so a reading that
+    ignored the multiplier would agree with a correct one against the
+    real file and be wrong the moment somebody raised one. The reading
+    took the period alone before this change.
+    """
+    config_text = (
+        '[profile.default]\nslow-timeout = { period = "60s", terminate-after = 5 }\n'
+    )
+    assert reading.largest_slow_timeout(config_text) == pytest.approx(300.0), (
+        "five warning periods of sixty seconds is a 300s budget"
+    )
+
+
+def test_only_the_profile_s_own_table_bounds_an_unmatched_test() -> None:
+    """An override bounds what its filter matches, and nothing else.
+
+    A profile whose only `terminate-after` sits in an override leaves
+    every test the override does not match with no bound at all, while
+    the largest budget still reads comfortable. The two readings are
+    separate so the contract can say which is missing.
+    """
+    only_in_override = (
+        "[profile.default]\n"
+        'slow-timeout = { period = "60s" }\n'
+        "\n[[profile.default.overrides]]\n"
+        "filter = 'binary(slow)'\n"
+        'slow-timeout = { period = "20m", terminate-after = 1 }\n'
+    )
+    assert not reading.bounds_a_single_test(only_in_override), (
+        "a profile whose only terminate-after is an override's bounds no unmatched test"
+    )
+    assert reading.bounds_a_single_test(_DEFAULT_PROFILE), (
+        "this repository's own default profile bounds a test no override matches"
+    )

--- a/tests/workflow_contracts/nextest_config_test.py
+++ b/tests/workflow_contracts/nextest_config_test.py
@@ -245,6 +245,32 @@ def test_a_period_nextest_could_not_read_is_a_shape_error(config_text: str) -> N
 @pytest.mark.parametrize(
     "config_text",
     [
+        pytest.param("[profile.default]\nslow-timeout = 60\n", id="a-bare-number"),
+        pytest.param("[profile.default]\nslow-timeout = true\n", id="a-boolean"),
+        pytest.param("[profile.default]\nslow-timeout = 1.5\n", id="a-float"),
+        pytest.param('[profile.default]\nslow-timeout = ["60s"]\n', id="a-list"),
+    ],
+)
+def test_a_scalar_slow_timeout_nextest_would_refuse_is_a_shape_error(
+    config_text: str,
+) -> None:
+    """The key is a duration string or a table, and nextest reads nothing else.
+
+    Its own refusal is ``invalid type: integer `60`, expected a table
+    ({ period = "60s", terminate-after = 2 }) or a string ("60s")``. Both
+    readings that consume the key are checked, because skipping the value
+    would leave one reporting another entry's budget and the other
+    reporting a tier the file never set.
+    """
+    with pytest.raises(reading.MalformedSlowTimeoutPeriodError, match=r"no period"):
+        reading.largest_slow_timeout(config_text)
+    with pytest.raises(reading.MalformedSlowTimeoutPeriodError, match=r"no period"):
+        reading.termination_allowance(config_text)
+
+
+@pytest.mark.parametrize(
+    "config_text",
+    [
         pytest.param(
             "[profile.default]\n"
             'slow-timeout = { period = "60s", terminate-after = 1, '

--- a/tests/workflow_contracts/timeout_budgets.py
+++ b/tests/workflow_contracts/timeout_budgets.py
@@ -1,0 +1,285 @@
+"""Arithmetic behind the four-tier timeout contract.
+
+The contract in :mod:`timeout_ordering_test` compares budgets written down
+in three different files. Turning those files into comparable seconds is
+the part that can be wrong without any file being wrong, so it lives here
+where controlled configurations can drive it.
+
+This repository's own configuration reaches only one of the outcomes these
+helpers can produce: every ``grace-period`` in it is five seconds, so the
+termination allowance always lands on its floor. A contract that sees only
+the floor cannot tell the corrected rule from the one it replaced.
+
+Scope and re-use: these helpers own the reading of nextest duration strings
+and the watchdog rule they feed. They serve the workflow contracts under
+``tests/workflow_contracts`` and nothing else. They take text rather than
+paths, so the caller stays in charge of what it is asserting about;
+anything that needs a workflow document should use :mod:`workflow_support`
+instead. New timeout tiers belong here beside the three that exist rather
+than inline in a contract module.
+
+The helpers raise subclasses of :class:`WorkflowShapeError`, as
+:mod:`workflow_support` does, so a malformed configuration fails the same
+way whether or not assertions are enabled.
+"""
+
+import re
+import typing as typ
+
+from workflow_support import WorkflowShapeError
+
+#: Floor for the termination allowance, used when the configuration sets
+#: no grace period. Generous against nextest's ten-second default and far
+#: too small to hide a real overrun.
+MINIMUM_TERMINATION_ALLOWANCE_SECONDS: typ.Final[float] = 60.0
+
+#: ``30s``, ``5m``, ``20 m``: the durations nextest accepts here.
+_DURATION: typ.Final[re.Pattern[str]] = re.compile(
+    r"^\s*(?P<value>\d+(?:\.\d+)?)\s*(?P<unit>ms|s|m|h)\s*$"
+)
+
+_UNIT_SECONDS: typ.Final[dict[str, float]] = {
+    "ms": 0.001,
+    "s": 1.0,
+    "m": 60.0,
+    "h": 3600.0,
+}
+
+#: ``period`` as its own key. The lookbehind is what keeps
+#: ``grace-period`` out: the two keys sit in the same inline table and a
+#: substring match would read a termination allowance as a per-test budget.
+_PERIOD: typ.Final[re.Pattern[str]] = re.compile(r'(?<![\w-])period\s*=\s*"([^"]+)"')
+
+_GRACE_PERIOD: typ.Final[re.Pattern[str]] = re.compile(r'grace-period\s*=\s*"([^"]+)"')
+
+
+class UnrecognizedDurationError(WorkflowShapeError):
+    """A duration string was not one nextest would accept."""
+
+    def __init__(self, duration: str) -> None:
+        super().__init__(f"unrecognized nextest duration {duration!r}")
+
+
+class MissingDefaultProfileError(WorkflowShapeError):
+    """The nextest configuration declared no default profile."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "nextest.toml must declare a [profile.default] section; the "
+            "ordering contract has nothing to compare against without one"
+        )
+
+
+class MissingGlobalTimeoutError(WorkflowShapeError):
+    """The default profile set no whole-run budget."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "[profile.default] must set global-timeout; without it the "
+            "whole-run budget is unbounded and the watchdog becomes the "
+            "only limit"
+        )
+
+
+class MissingSlowTimeoutError(WorkflowShapeError):
+    """The configuration set no per-test budget."""
+
+    def __init__(self) -> None:
+        super().__init__("nextest.toml must set at least one slow-timeout period")
+
+
+def seconds(duration: str) -> float:
+    """Convert a nextest duration to seconds.
+
+    Parameters
+    ----------
+    duration : str
+        A duration as nextest spells it, such as ``"75m"``.
+
+    Returns
+    -------
+    float
+        The duration in seconds.
+
+    Raises
+    ------
+    UnrecognizedDurationError
+        If the string is not a duration nextest would accept.
+
+    Examples
+    --------
+    >>> seconds("75m")
+    4500.0
+    """
+    match = _DURATION.match(duration)
+    if match is None:
+        raise UnrecognizedDurationError(duration)
+    return float(match["value"]) * _UNIT_SECONDS[match["unit"]]
+
+
+def global_timeout(config_text: str) -> float:
+    r"""Return the default profile's ``global-timeout`` in seconds.
+
+    Read textually rather than through a TOML parser, because the value
+    must be matched to the profile it belongs to and the file declares
+    more than one profile.
+
+    Parameters
+    ----------
+    config_text : str
+        A nextest configuration file's text.
+
+    Returns
+    -------
+    float
+        The default profile's whole-run budget, in seconds.
+
+    Raises
+    ------
+    MissingDefaultProfileError
+        If no ``[profile.default]`` section is present.
+    MissingGlobalTimeoutError
+        If that section sets no ``global-timeout``.
+
+    Examples
+    --------
+    >>> global_timeout('[profile.default]\nglobal-timeout = "75m"\n')
+    4500.0
+    """
+    blocks = re.split(r"^\[profile\.", config_text, flags=re.MULTILINE)
+    default = next((block for block in blocks if block.startswith("default]")), None)
+    if default is None:
+        raise MissingDefaultProfileError
+    match = re.search(r'^global-timeout\s*=\s*"([^"]+)"', default, re.MULTILINE)
+    if match is None:
+        raise MissingGlobalTimeoutError
+    return seconds(match[1])
+
+
+def largest_slow_timeout(config_text: str) -> float:
+    """Return the longest single-test allowance in seconds.
+
+    Parameters
+    ----------
+    config_text : str
+        A nextest configuration file's text.
+
+    Returns
+    -------
+    float
+        The longest per-test budget.
+
+    Raises
+    ------
+    MissingSlowTimeoutError
+        If the configuration declares no per-test budget.
+
+    Examples
+    --------
+    >>> largest_slow_timeout('slow-timeout = { period = "20m" }')
+    1200.0
+    """
+    periods = _PERIOD.findall(config_text)
+    if not periods:
+        raise MissingSlowTimeoutError
+    return max(seconds(period) for period in periods)
+
+
+def termination_allowance(config_text: str) -> float:
+    """Return the time nextest may take to stop the run, in seconds.
+
+    Hitting the global timeout starts nextest's ordinary termination
+    procedure rather than stopping the run: on Unix it signals the process
+    group and waits ``slow-timeout.grace-period`` before killing it; on
+    Windows termination is immediate and the grace period is ignored for
+    timeouts.
+
+    Read from the configuration rather than fixed, because a profile that
+    raised its grace period past a hard-coded allowance would drift out of
+    the requirement this contract exists to hold. The floor covers the
+    case of a configuration that names no grace period at all, where
+    nextest's own ten-second default applies.
+
+    Parameters
+    ----------
+    config_text : str
+        A nextest configuration file's text.
+
+    Returns
+    -------
+    float
+        The largest configured grace period, or the floor when that is
+        smaller or absent.
+
+    Examples
+    --------
+    >>> termination_allowance('grace-period = "5s"')
+    60.0
+    >>> termination_allowance('grace-period = "3m"')
+    180.0
+    """
+    periods = _GRACE_PERIOD.findall(config_text)
+    largest = max((seconds(period) for period in periods), default=0.0)
+    return max(largest, MINIMUM_TERMINATION_ALLOWANCE_SECONDS)
+
+
+def watchdog_requirement(
+    global_timeout_seconds: float,
+    termination_allowance_seconds: float,
+    cold_build_seconds: float,
+) -> float:
+    """Return the smallest watchdog budget that does not pre-empt nextest.
+
+    The corrected rule, three terms rather than two: the whole-run budget,
+    the time nextest takes to terminate a run that spends it, and the
+    build that runs inside the watchdog's window but before nextest starts
+    its own clock.
+
+    Parameters
+    ----------
+    global_timeout_seconds : float
+        Nextest's whole-run budget.
+    termination_allowance_seconds : float
+        Time nextest may take to stop the run once that budget is spent.
+    cold_build_seconds : float
+        Build time inside the ``cargo`` invocation, before nextest starts.
+
+    Returns
+    -------
+    float
+        The smallest acceptable watchdog budget, in seconds.
+
+    Examples
+    --------
+    >>> watchdog_requirement(4500.0, 60.0, 900.0)
+    5460.0
+    """
+    return global_timeout_seconds + termination_allowance_seconds + cold_build_seconds
+
+
+def watchdog_shortfall(watchdog_seconds: float, required_seconds: float) -> float:
+    """Return how far a watchdog budget falls short of the requirement.
+
+    Zero when the budget is adequate, so a caller can report every
+    inadequate lane rather than stopping at the first.
+
+    Parameters
+    ----------
+    watchdog_seconds : float
+        The budget a coverage step declares.
+    required_seconds : float
+        The budget :func:`watchdog_requirement` calls for.
+
+    Returns
+    -------
+    float
+        The seconds by which the budget is short, or zero.
+
+    Examples
+    --------
+    >>> watchdog_shortfall(5400.0, 5460.0)
+    60.0
+    >>> watchdog_shortfall(6600.0, 5460.0)
+    0.0
+    """
+    return max(required_seconds - watchdog_seconds, 0.0)

--- a/tests/workflow_contracts/timeout_budgets.py
+++ b/tests/workflow_contracts/timeout_budgets.py
@@ -28,10 +28,16 @@ import typing as typ
 
 from workflow_support import WorkflowShapeError
 
-#: Floor for the termination allowance, used when the configuration sets
-#: no grace period. Generous against nextest's ten-second default and far
-#: too small to hide a real overrun.
-MINIMUM_TERMINATION_ALLOWANCE_SECONDS: typ.Final[float] = 60.0
+#: What nextest allows a test between ``SIGTERM`` and ``SIGKILL`` when
+#: the configuration names no grace period of its own.
+NEXTEST_DEFAULT_GRACE_PERIOD_SECONDS: typ.Final[float] = 10.0
+
+#: Added to that grace period to cover the teardown and report writing
+#: that follow it. A separate term rather than a floor over the two: a
+#: floor absorbs every grace period below it, so raising this file's
+#: five seconds to thirty would demand nothing more of the watchdog
+#: above it, and the saving would look free until the run it cancelled.
+TERMINATION_SAFETY_MARGIN_SECONDS: typ.Final[float] = 60.0
 
 #: ``30s``, ``5m``, ``20 m``: the durations nextest accepts here.
 _DURATION: typ.Final[re.Pattern[str]] = re.compile(
@@ -250,11 +256,20 @@ def termination_allowance(config_text: str) -> float:
     Windows termination is immediate and the grace period is ignored for
     timeouts.
 
-    Read from the configuration rather than fixed, because a profile that
-    raised its grace period past a hard-coded allowance would drift out of
-    the requirement this contract exists to hold. The floor covers the
-    case of a configuration that names no grace period at all, where
-    nextest's own ten-second default applies.
+    Two terms, added rather than maximized over, because they answer
+    different questions. The first is what nextest promises the test:
+    on Unix it signals the process group and waits
+    ``slow-timeout.grace-period`` before killing it, read from the
+    configuration so a profile that raised it raises the requirement
+    too, with nextest's own ten-second default when none is named. The
+    second is a fixed margin for the teardown and report writing that
+    follow.
+
+    A single floor over the two, which is what this read before, absorbs
+    every grace period below the margin. Raising this file's five
+    seconds to thirty would have demanded nothing more of the watchdog
+    above it, and the saving would have looked free until the run it
+    cancelled.
 
     Parameters
     ----------
@@ -264,19 +279,22 @@ def termination_allowance(config_text: str) -> float:
     Returns
     -------
     float
-        The largest configured grace period, or the floor when that is
-        smaller or absent.
+        The largest configured grace period, or nextest's default, plus
+        the safety margin.
 
     Examples
     --------
     >>> termination_allowance('grace-period = "5s"')
-    60.0
+    65.0
     >>> termination_allowance('grace-period = "3m"')
-    180.0
+    240.0
     """
     periods = _GRACE_PERIOD.findall(config_text)
-    largest = max((seconds(period) for period in periods), default=0.0)
-    return max(largest, MINIMUM_TERMINATION_ALLOWANCE_SECONDS)
+    largest = max(
+        (seconds(period) for period in periods),
+        default=NEXTEST_DEFAULT_GRACE_PERIOD_SECONDS,
+    )
+    return largest + TERMINATION_SAFETY_MARGIN_SECONDS
 
 
 def watchdog_requirement(

--- a/tests/workflow_contracts/timeout_budgets.py
+++ b/tests/workflow_contracts/timeout_budgets.py
@@ -54,9 +54,6 @@ _UNIT_SECONDS: typ.Final[dict[str, float]] = {
 #: ``period`` as its own key. The lookbehind is what keeps
 #: ``grace-period`` out: the two keys sit in the same inline table and a
 #: substring match would read a termination allowance as a per-test budget.
-_PERIOD: typ.Final[re.Pattern[str]] = re.compile(r'(?<![\w-])period\s*=\s*"([^"]+)"')
-
-_GRACE_PERIOD: typ.Final[re.Pattern[str]] = re.compile(r'grace-period\s*=\s*"([^"]+)"')
 
 
 class UnrecognizedDurationError(WorkflowShapeError):
@@ -150,6 +147,56 @@ class MissingSlowTimeoutError(WorkflowShapeError):
         super().__init__("nextest.toml must set at least one slow-timeout period")
 
 
+class UnparsableConfigurationError(WorkflowShapeError):
+    """The nextest configuration was not valid TOML.
+
+    Raised by the reading below rather than allowed to surface as a
+    parser error several frames away. A file nextest cannot parse has no
+    budgets to compare, which is a different fault from budgets in the
+    wrong order and needs a different remedy.
+
+    Parameters
+    ----------
+    detail : str
+        What the TOML parser objected to.
+
+    See Also
+    --------
+    largest_slow_timeout : One of the readings that raises this.
+    """
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(f"nextest.toml is not valid TOML: {detail}")
+
+
+class UnboundedTestError(WorkflowShapeError):
+    """A ``slow-timeout`` named no ``terminate-after``.
+
+    ``terminate-after`` is optional, and nextest treats its absence as no
+    termination at all: the test is reported slow, once per period, and
+    runs on. Reading that as a single period would put a number on the
+    tier that is missing, and every comparison above it would pass
+    against a budget nextest never applies.
+
+    Parameters
+    ----------
+    where : str
+        The dotted path of the table at fault, so the failure names the
+        profile or override rather than only the file.
+
+    See Also
+    --------
+    largest_slow_timeout : The reading that raises this.
+    """
+
+    def __init__(self, where: str) -> None:
+        super().__init__(
+            f"{where}.slow-timeout sets no terminate-after, so nextest reports "
+            f"the test as slow once per period and never stops it; there is no "
+            f"per-test tier to compare against"
+        )
+
+
 def seconds(duration: str) -> float:
     """Convert a nextest duration to seconds.
 
@@ -177,124 +224,6 @@ def seconds(duration: str) -> float:
     if match is None:
         raise UnrecognizedDurationError(duration)
     return float(match["value"]) * _UNIT_SECONDS[match["unit"]]
-
-
-def global_timeout(config_text: str) -> float:
-    r"""Return the default profile's ``global-timeout`` in seconds.
-
-    Read textually rather than through a TOML parser, because the value
-    must be matched to the profile it belongs to and the file declares
-    more than one profile.
-
-    Parameters
-    ----------
-    config_text : str
-        A nextest configuration file's text.
-
-    Returns
-    -------
-    float
-        The default profile's whole-run budget, in seconds.
-
-    Raises
-    ------
-    MissingDefaultProfileError
-        If no ``[profile.default]`` section is present.
-    MissingGlobalTimeoutError
-        If that section sets no ``global-timeout``.
-
-    Examples
-    --------
-    >>> global_timeout('[profile.default]\nglobal-timeout = "75m"\n')
-    4500.0
-    """
-    blocks = re.split(r"^\[profile\.", config_text, flags=re.MULTILINE)
-    default = next((block for block in blocks if block.startswith("default]")), None)
-    if default is None:
-        raise MissingDefaultProfileError
-    match = re.search(r'^global-timeout\s*=\s*"([^"]+)"', default, re.MULTILINE)
-    if match is None:
-        raise MissingGlobalTimeoutError
-    return seconds(match[1])
-
-
-def largest_slow_timeout(config_text: str) -> float:
-    """Return the longest single-test allowance in seconds.
-
-    Parameters
-    ----------
-    config_text : str
-        A nextest configuration file's text.
-
-    Returns
-    -------
-    float
-        The longest per-test budget.
-
-    Raises
-    ------
-    MissingSlowTimeoutError
-        If the configuration declares no per-test budget.
-
-    Examples
-    --------
-    >>> largest_slow_timeout('slow-timeout = { period = "20m" }')
-    1200.0
-    """
-    periods = _PERIOD.findall(config_text)
-    if not periods:
-        raise MissingSlowTimeoutError
-    return max(seconds(period) for period in periods)
-
-
-def termination_allowance(config_text: str) -> float:
-    """Return the time nextest may take to stop the run, in seconds.
-
-    Hitting the global timeout starts nextest's ordinary termination
-    procedure rather than stopping the run: on Unix it signals the process
-    group and waits ``slow-timeout.grace-period`` before killing it; on
-    Windows termination is immediate and the grace period is ignored for
-    timeouts.
-
-    Two terms, added rather than maximized over, because they answer
-    different questions. The first is what nextest promises the test:
-    on Unix it signals the process group and waits
-    ``slow-timeout.grace-period`` before killing it, read from the
-    configuration so a profile that raised it raises the requirement
-    too, with nextest's own ten-second default when none is named. The
-    second is a fixed margin for the teardown and report writing that
-    follow.
-
-    A single floor over the two, which is what this read before, absorbs
-    every grace period below the margin. Raising this file's five
-    seconds to thirty would have demanded nothing more of the watchdog
-    above it, and the saving would have looked free until the run it
-    cancelled.
-
-    Parameters
-    ----------
-    config_text : str
-        A nextest configuration file's text.
-
-    Returns
-    -------
-    float
-        The largest configured grace period, or nextest's default, plus
-        the safety margin.
-
-    Examples
-    --------
-    >>> termination_allowance('grace-period = "5s"')
-    65.0
-    >>> termination_allowance('grace-period = "3m"')
-    240.0
-    """
-    periods = _GRACE_PERIOD.findall(config_text)
-    largest = max(
-        (seconds(period) for period in periods),
-        default=NEXTEST_DEFAULT_GRACE_PERIOD_SECONDS,
-    )
-    return largest + TERMINATION_SAFETY_MARGIN_SECONDS
 
 
 def watchdog_requirement(

--- a/tests/workflow_contracts/timeout_budgets.py
+++ b/tests/workflow_contracts/timeout_budgets.py
@@ -54,14 +54,44 @@ _GRACE_PERIOD: typ.Final[re.Pattern[str]] = re.compile(r'grace-period\s*=\s*"([^
 
 
 class UnrecognizedDurationError(WorkflowShapeError):
-    """A duration string was not one nextest would accept."""
+    """A duration string was not one nextest would accept.
+
+    Raised by :func:`seconds` rather than guessing a magnitude. A
+    duration nobody can read is a configuration error, and putting an
+    arbitrary number into a budget comparison would hide it behind an
+    ordering assertion that then passes or fails for the wrong reason.
+
+    Parameters
+    ----------
+    duration : str
+        The string that could not be read, quoted into the message so
+        the failure names the value rather than only the file.
+
+    See Also
+    --------
+    seconds : The conversion that raises this.
+    """
 
     def __init__(self, duration: str) -> None:
         super().__init__(f"unrecognized nextest duration {duration!r}")
 
 
 class MissingDefaultProfileError(WorkflowShapeError):
-    """The nextest configuration declared no default profile."""
+    """The nextest configuration declared no ``[profile.default]``.
+
+    Raised by :func:`global_timeout`. The whole-run budget has to be
+    matched to the profile it belongs to, and the default profile is the
+    one the coverage lane runs under, so a file without it leaves the
+    ordering contract nothing to compare against rather than something
+    to compare loosely.
+
+    Takes no parameters: the file is fixed and naming it in the message
+    is enough to locate the fault.
+
+    See Also
+    --------
+    global_timeout : The reading that raises this.
+    """
 
     def __init__(self) -> None:
         super().__init__(
@@ -71,7 +101,20 @@ class MissingDefaultProfileError(WorkflowShapeError):
 
 
 class MissingGlobalTimeoutError(WorkflowShapeError):
-    """The default profile set no whole-run budget."""
+    """The default profile set no ``global-timeout``.
+
+    Raised by :func:`global_timeout` when the section exists but the key
+    does not. Without it the whole run is unbounded, so the cargo
+    watchdog becomes the only limit and a hung run is reported against
+    ``cargo`` rather than against the test that hung.
+
+    Takes no parameters, for the same reason as
+    :class:`MissingDefaultProfileError`.
+
+    See Also
+    --------
+    global_timeout : The reading that raises this.
+    """
 
     def __init__(self) -> None:
         super().__init__(
@@ -82,7 +125,20 @@ class MissingGlobalTimeoutError(WorkflowShapeError):
 
 
 class MissingSlowTimeoutError(WorkflowShapeError):
-    """The configuration set no per-test budget."""
+    """The configuration set no per-test budget anywhere.
+
+    Raised by :func:`largest_slow_timeout`. Nothing bounds a single test
+    without one, so this is a configuration error rather than a default
+    to fall back on: the tier-one comparison would otherwise be made
+    against a number nobody chose.
+
+    Takes no parameters, for the same reason as
+    :class:`MissingDefaultProfileError`.
+
+    See Also
+    --------
+    largest_slow_timeout : The reading that raises this.
+    """
 
     def __init__(self) -> None:
         super().__init__("nextest.toml must set at least one slow-timeout period")

--- a/tests/workflow_contracts/timeout_budgets.py
+++ b/tests/workflow_contracts/timeout_budgets.py
@@ -7,8 +7,10 @@ where controlled configurations can drive it.
 
 This repository's own configuration reaches only one of the outcomes these
 helpers can produce: every ``grace-period`` in it is five seconds, so the
-termination allowance always lands on its floor. A contract that sees only
-the floor cannot tell the corrected rule from the one it replaced.
+termination allowance always lands on the same sixty-five seconds. A
+contract that only ever sees one number cannot tell the corrected rule from
+the one it replaced, and dropping the term outright would leave the
+watchdog at 6,600 s with every assertion still passing.
 
 Scope and re-use: these helpers own the reading of nextest duration strings
 and the watchdog rule they feed. They serve the workflow contracts under
@@ -51,10 +53,6 @@ _UNIT_SECONDS: typ.Final[dict[str, float]] = {
     "h": 3600.0,
 }
 
-#: ``period`` as its own key. The lookbehind is what keeps
-#: ``grace-period`` out: the two keys sit in the same inline table and a
-#: substring match would read a termination allowance as a per-test budget.
-
 
 class UnrecognizedDurationError(WorkflowShapeError):
     """A duration string was not one nextest would accept.
@@ -93,7 +91,7 @@ class MissingDefaultProfileError(WorkflowShapeError):
 
     See Also
     --------
-    global_timeout : The reading that raises this.
+    nextest_config.global_timeout : The reading that raises this.
     """
 
     def __init__(self) -> None:
@@ -116,7 +114,7 @@ class MissingGlobalTimeoutError(WorkflowShapeError):
 
     See Also
     --------
-    global_timeout : The reading that raises this.
+    nextest_config.global_timeout : The reading that raises this.
     """
 
     def __init__(self) -> None:
@@ -140,7 +138,7 @@ class MissingSlowTimeoutError(WorkflowShapeError):
 
     See Also
     --------
-    largest_slow_timeout : The reading that raises this.
+    nextest_config.largest_slow_timeout : The reading that raises this.
     """
 
     def __init__(self) -> None:
@@ -162,7 +160,8 @@ class UnparsableConfigurationError(WorkflowShapeError):
 
     See Also
     --------
-    largest_slow_timeout : One of the readings that raises this.
+    nextest_config.largest_slow_timeout : One of the readings that
+        raises this.
     """
 
     def __init__(self, detail: str) -> None:
@@ -186,7 +185,7 @@ class UnboundedTestError(WorkflowShapeError):
 
     See Also
     --------
-    largest_slow_timeout : The reading that raises this.
+    nextest_config.largest_slow_timeout : The reading that raises this.
     """
 
     def __init__(self, where: str) -> None:
@@ -194,6 +193,98 @@ class UnboundedTestError(WorkflowShapeError):
             f"{where}.slow-timeout sets no terminate-after, so nextest reports "
             f"the test as slow once per period and never stops it; there is no "
             f"per-test tier to compare against"
+        )
+
+
+class MalformedSlowTimeoutPeriodError(WorkflowShapeError):
+    """A ``slow-timeout`` named no ``period`` nextest could read.
+
+    Raised by :func:`nextest_config.largest_slow_timeout` when the key is
+    absent, or is not a duration string. nextest requires it in the table
+    form and refuses a table without one, so reading the entry as absent
+    would report a missing tier where the file in fact names one nextest
+    will not load.
+
+    Parameters
+    ----------
+    where : str
+        The dotted path of the table at fault, so the failure names the
+        profile or override rather than only the file.
+    value : object
+        What the key held, quoted into the message so an unusable value
+        is named rather than only its absence reported.
+
+    See Also
+    --------
+    nextest_config.largest_slow_timeout : The reading that raises this.
+    """
+
+    def __init__(self, where: str, value: object) -> None:
+        super().__init__(
+            f"{where}.slow-timeout sets no period nextest can read "
+            f"({value!r}); nextest requires a duration string"
+        )
+
+
+class MalformedTerminateAfterError(WorkflowShapeError):
+    """A ``slow-timeout`` set a ``terminate-after`` nextest would refuse.
+
+    Raised by :func:`nextest_config.largest_slow_timeout`. nextest types
+    the key as a whole number of periods greater than zero, so zero, a
+    negative, a fraction and a boolean all fail to load the
+    configuration. Reading one anyway would put a budget on the tier the
+    runner never applies, and a string raised a bare ``ValueError`` from
+    the conversion rather than a shape error naming the file.
+
+    Parameters
+    ----------
+    where : str
+        The dotted path of the table at fault.
+    value : object
+        What the key held, quoted into the message so the failure names
+        the value rather than only the file.
+
+    See Also
+    --------
+    nextest_config.largest_slow_timeout : The reading that raises this.
+    UnboundedTestError : Raised instead when the key is absent, which
+        nextest reads as no termination at all rather than as a bad value.
+    """
+
+    def __init__(self, where: str, value: object) -> None:
+        super().__init__(
+            f"{where}.slow-timeout sets terminate-after = {value!r}; nextest "
+            f"requires a whole number of periods greater than zero"
+        )
+
+
+class MalformedGracePeriodError(WorkflowShapeError):
+    """A ``slow-timeout`` set a ``grace-period`` nextest would refuse.
+
+    Raised by :func:`nextest_config.termination_allowance`. nextest types
+    the key as a duration string and defaults it to ten seconds when it
+    is absent, so absence is not a fault. A value that is present and
+    unreadable is: falling back to the default there would size the
+    termination allowance against a number the file does not set, and
+    the watchdog above it against a run nextest will not start.
+
+    Parameters
+    ----------
+    where : str
+        The dotted path of the table at fault.
+    value : object
+        What the key held, quoted into the message so the failure names
+        the value rather than only the file.
+
+    See Also
+    --------
+    nextest_config.termination_allowance : The reading that raises this.
+    """
+
+    def __init__(self, where: str, value: object) -> None:
+        super().__init__(
+            f"{where}.slow-timeout sets grace-period = {value!r}; nextest "
+            f"requires a duration string"
         )
 
 

--- a/tests/workflow_contracts/timeout_budgets.py
+++ b/tests/workflow_contracts/timeout_budgets.py
@@ -41,9 +41,11 @@ NEXTEST_DEFAULT_GRACE_PERIOD_SECONDS: typ.Final[float] = 10.0
 #: above it, and the saving would look free until the run it cancelled.
 TERMINATION_SAFETY_MARGIN_SECONDS: typ.Final[float] = 60.0
 
-#: ``30s``, ``5m``, ``20 m``: the durations nextest accepts here.
+#: ``30s``, ``5m``, ``20 m``, ``1d``: the unit letters the readers model.
+#: nextest reads longer and compound spellings too (``1day``, ``1h 30m``);
+#: an unmodelled one raises rather than converting to a guess.
 _DURATION: typ.Final[re.Pattern[str]] = re.compile(
-    r"^\s*(?P<value>\d+(?:\.\d+)?)\s*(?P<unit>ms|s|m|h)\s*$"
+    r"^\s*(?P<value>\d+(?:\.\d+)?)\s*(?P<unit>ms|s|m|h|d)\s*$"
 )
 
 _UNIT_SECONDS: typ.Final[dict[str, float]] = {
@@ -51,11 +53,12 @@ _UNIT_SECONDS: typ.Final[dict[str, float]] = {
     "s": 1.0,
     "m": 60.0,
     "h": 3600.0,
+    "d": 86400.0,
 }
 
 
 class UnrecognizedDurationError(WorkflowShapeError):
-    """A duration string was not one nextest would accept.
+    """A duration string outside the units the readers convert.
 
     Raised by :func:`seconds` rather than guessing a magnitude. A
     duration nobody can read is a configuration error, and putting an
@@ -304,7 +307,7 @@ def seconds(duration: str) -> float:
     Raises
     ------
     UnrecognizedDurationError
-        If the string is not a duration nextest would accept.
+        If the string is not a duration the readers convert.
 
     Examples
     --------

--- a/tests/workflow_contracts/timeout_budgets_test.py
+++ b/tests/workflow_contracts/timeout_budgets_test.py
@@ -1,0 +1,243 @@
+"""Unit tests for the four-tier timeout arithmetic.
+
+The ordering contract in :mod:`timeout_ordering_test` reads this
+repository's own configuration, where every ``grace-period`` is five
+seconds. The termination allowance therefore always lands on its 60 s
+floor, and a contract that only ever sees the floor cannot tell the
+corrected rule from the one it replaced: deleting the term entirely would
+leave the watchdog at 6,600 s and every assertion passing.
+
+These tests drive the derivations with controlled configurations, so each
+branch is exercised where the repository's own numbers never reach: a
+grace period above the floor, one below it, none at all, and several
+profiles disagreeing. The watchdog rule is then checked term by term, and
+against a budget sized the old way.
+
+See "Test timeouts: four tiers, outermost last" in
+``docs/developers-guide.md``.
+"""
+
+import typing as typ
+
+import pytest
+import timeout_budgets as budgets
+
+#: A configuration reduced to the keys the derivations read. The real
+#: file's prose and overrides say nothing to this arithmetic.
+_DEFAULT_PROFILE: typ.Final[str] = """\
+[profile.default]
+slow-timeout = { period = "60s", terminate-after = 1, grace-period = "5s" }
+global-timeout = "75m"
+"""
+
+
+@pytest.mark.parametrize(
+    ("config_text", "expected"),
+    [
+        pytest.param("[profile.default]\n", 60.0, id="no-grace-period-at-all"),
+        pytest.param(
+            '[profile.default]\ngrace-period = "5s"\n',
+            60.0,
+            id="grace-period-below-the-floor",
+        ),
+        pytest.param(
+            '[profile.default]\ngrace-period = "60s"\n',
+            60.0,
+            id="grace-period-at-the-floor",
+        ),
+        pytest.param(
+            '[profile.default]\ngrace-period = "90s"\n',
+            90.0,
+            id="grace-period-above-the-floor",
+        ),
+        pytest.param(
+            '[profile.default]\ngrace-period = "3m"\n',
+            180.0,
+            id="grace-period-in-minutes",
+        ),
+        pytest.param(
+            '[profile.default]\ngrace-period = "5s"\n'
+            '[profile.long]\ngrace-period = "2m"\n',
+            120.0,
+            id="largest-of-several-profiles",
+        ),
+    ],
+)
+def test_the_termination_allowance_follows_the_configured_grace_period(
+    config_text: str, expected: float
+) -> None:
+    """A raised grace period raises the allowance; the floor catches the rest.
+
+    This is the whole point of reading the value rather than fixing it. A
+    profile that gives nextest three minutes to stop the run needs three
+    minutes of watchdog to cover it, and a hard-coded 60 s would silently
+    stop covering the case it exists for.
+    """
+    assert budgets.termination_allowance(config_text) == pytest.approx(expected), (
+        f"{config_text!r} must yield a {expected:.0f}s termination allowance; a "
+        f"watchdog sized from a smaller one would kill the run mid-termination"
+    )
+
+
+def test_the_termination_allowance_ignores_the_per_test_period() -> None:
+    """``period`` and ``grace-period`` share an inline table.
+
+    Reading the wrong one would put a twenty-minute per-test budget where
+    a five-second termination belongs, restoring by accident the very
+    over-sizing this correction removes.
+    """
+    config_text = '[profile.default]\nslow-timeout = { period = "20m" }\n'
+    assert budgets.termination_allowance(config_text) == pytest.approx(60.0), (
+        "the termination allowance read a 20m per-test period as a grace "
+        "period; only grace-period bounds how long nextest takes to stop"
+    )
+
+
+def test_the_largest_slow_timeout_ignores_the_grace_period() -> None:
+    """The per-test budget must not read a grace period either.
+
+    The two keys differ by a prefix, so a substring match returns whichever
+    is larger. Here the grace period is deliberately the larger.
+    """
+    config_text = (
+        '[profile.default]\nslow-timeout = { period = "60s", grace-period = "30m" }\n'
+    )
+    assert budgets.largest_slow_timeout(config_text) == pytest.approx(60.0), (
+        "the per-test ceiling read a 30m grace period as a slow-timeout; the "
+        "global timeout would then be held to a budget no test can spend"
+    )
+
+
+def test_the_largest_slow_timeout_takes_the_longest_of_several() -> None:
+    """Overrides raise the per-test ceiling the global timeout must clear."""
+    config_text = _DEFAULT_PROFILE + (
+        'slow-timeout = { period = "20m", grace-period = "5s" }\n'
+    )
+    assert budgets.largest_slow_timeout(config_text) == pytest.approx(20 * 60.0), (
+        "the longest override, not the default profile's period, is the "
+        "ceiling the global timeout has to clear"
+    )
+
+
+def test_a_configuration_with_no_per_test_budget_is_rejected() -> None:
+    """Nothing bounds a single test without one, so this is not a default."""
+    with pytest.raises(budgets.MissingSlowTimeoutError):
+        budgets.largest_slow_timeout("[profile.default]\n")
+
+
+def test_the_global_timeout_comes_from_the_default_profile() -> None:
+    """Another profile's budget is not the one the coverage lane runs under.
+
+    ``[profile.long]`` sets a shorter global timeout here. Reading the file
+    without regard to profile would compare the watchdog against a budget
+    no CI job uses.
+    """
+    config_text = _DEFAULT_PROFILE + '[profile.long]\nglobal-timeout = "30m"\n'
+    assert budgets.global_timeout(config_text) == pytest.approx(75 * 60.0), (
+        "the whole-run budget must come from [profile.default]; [profile.long] "
+        "sets 30m here and no coverage lane runs under it"
+    )
+
+
+def test_a_configuration_with_no_default_profile_is_rejected() -> None:
+    """The contract has nothing to compare against without one."""
+    with pytest.raises(budgets.MissingDefaultProfileError):
+        budgets.global_timeout('[profile.long]\nglobal-timeout = "30m"\n')
+
+
+def test_a_default_profile_with_no_global_timeout_is_rejected() -> None:
+    """An unbounded run leaves the watchdog as the only limit."""
+    with pytest.raises(budgets.MissingGlobalTimeoutError):
+        budgets.global_timeout("[profile.default]\nslow-timeout = { }\n")
+
+
+@pytest.mark.parametrize(
+    ("duration", "expected"),
+    [
+        pytest.param("500ms", 0.5, id="milliseconds"),
+        pytest.param("5s", 5.0, id="seconds"),
+        pytest.param("20 m", 1200.0, id="minutes-with-a-space"),
+        pytest.param("1h", 3600.0, id="hours"),
+        pytest.param("1.5m", 90.0, id="fractional"),
+    ],
+)
+def test_every_duration_unit_nextest_accepts_converts(
+    duration: str, expected: float
+) -> None:
+    """Each unit is a term in the comparison, so each must convert.
+
+    A unit read as seconds when it means minutes understates a budget by
+    sixty-fold, and the contract would pass on a lane that cannot work.
+    """
+    assert budgets.seconds(duration) == pytest.approx(expected), (
+        f"{duration!r} must convert to {expected}s; a misread unit puts an "
+        f"order-of-magnitude error straight into a budget comparison"
+    )
+
+
+def test_an_unrecognized_duration_is_rejected_rather_than_guessed() -> None:
+    """Guessing would put an arbitrary number into a budget comparison."""
+    with pytest.raises(budgets.UnrecognizedDurationError):
+        budgets.seconds("soon")
+
+
+def test_the_watchdog_requirement_is_the_sum_of_its_three_terms() -> None:
+    """The corrected rule, stated once, where a test can read it."""
+    required = budgets.watchdog_requirement(4500.0, 90.0, 900.0)
+    assert required == pytest.approx(5490.0), (
+        "the watchdog requirement must be the global timeout plus the "
+        "termination allowance plus the cold build"
+    )
+
+
+def test_the_termination_term_is_load_bearing_in_the_requirement() -> None:
+    """The correction only means something if the term moves the answer.
+
+    Raising the allowance must raise the requirement one second for one
+    second. A rule that ignored the term would return the same number for
+    both, which is exactly the state this branch corrects.
+    """
+    without = budgets.watchdog_requirement(4500.0, 0.0, 900.0)
+    with_allowance = budgets.watchdog_requirement(4500.0, 90.0, 900.0)
+    assert with_allowance - without == pytest.approx(90.0), (
+        f"a 90s allowance moved the requirement by "
+        f"{with_allowance - without:.0f}s; the term is not load-bearing"
+    )
+
+
+def test_a_watchdog_sized_without_the_termination_term_falls_short() -> None:
+    """The assertion must reject the budget the old rule would have allowed.
+
+    A watchdog covering the whole-run budget and the cold build exactly is
+    what a two-term rule calls sufficient. It is short by the termination
+    allowance, and the shortfall names that much.
+    """
+    required = budgets.watchdog_requirement(4500.0, 90.0, 900.0)
+    assert budgets.watchdog_shortfall(4500.0 + 900.0, required) == pytest.approx(
+        90.0
+    ), (
+        "a watchdog covering only the global timeout and the cold build must "
+        "be reported short by the whole termination allowance"
+    )
+
+
+def test_a_watchdog_at_the_requirement_is_not_short() -> None:
+    """The comparison is inclusive; an exactly-sized budget is adequate."""
+    required = budgets.watchdog_requirement(4500.0, 90.0, 900.0)
+    assert budgets.watchdog_shortfall(required, required) == pytest.approx(0.0), (
+        "a budget exactly at the requirement is adequate; reporting it short "
+        "would force every lane to carry arbitrary slack"
+    )
+
+
+def test_a_watchdog_above_the_requirement_reports_no_shortfall() -> None:
+    """Spare budget is reported as zero, not as a negative deficit.
+
+    The caller prints the shortfall in its failure message, so a negative
+    number would read as a lane needing less than it has.
+    """
+    required = budgets.watchdog_requirement(4500.0, 90.0, 900.0)
+    assert budgets.watchdog_shortfall(6600.0, required) == pytest.approx(0.0), (
+        "spare budget must report as zero; a negative shortfall would read in "
+        "the failure message as a lane needing less than it has"
+    )

--- a/tests/workflow_contracts/timeout_budgets_test.py
+++ b/tests/workflow_contracts/timeout_budgets_test.py
@@ -197,11 +197,10 @@ def test_a_default_profile_with_no_global_timeout_is_rejected() -> None:
         pytest.param("20 m", 1200.0, id="minutes-with-a-space"),
         pytest.param("1h", 3600.0, id="hours"),
         pytest.param("1.5m", 90.0, id="fractional"),
+        pytest.param("1d", 86400.0, id="days"),
     ],
 )
-def test_every_duration_unit_nextest_accepts_converts(
-    duration: str, expected: float
-) -> None:
+def test_every_modelled_duration_unit_converts(duration: str, expected: float) -> None:
     """Each unit is a term in the comparison, so each must convert.
 
     A unit read as seconds when it means minutes understates a budget by

--- a/tests/workflow_contracts/timeout_budgets_test.py
+++ b/tests/workflow_contracts/timeout_budgets_test.py
@@ -34,44 +34,52 @@ global-timeout = "75m"
 @pytest.mark.parametrize(
     ("config_text", "expected"),
     [
-        pytest.param("[profile.default]\n", 60.0, id="no-grace-period-at-all"),
+        pytest.param(
+            "[profile.default]\n",
+            10.0 + 60.0,
+            id="no-grace-period-falls-back-to-nextest-s-default",
+        ),
         pytest.param(
             '[profile.default]\ngrace-period = "5s"\n',
-            60.0,
-            id="grace-period-below-the-floor",
+            5.0 + 60.0,
+            id="a-grace-period-below-the-margin-still-counts",
         ),
         pytest.param(
             '[profile.default]\ngrace-period = "60s"\n',
-            60.0,
-            id="grace-period-at-the-floor",
+            60.0 + 60.0,
+            id="a-grace-period-equal-to-the-margin",
         ),
         pytest.param(
             '[profile.default]\ngrace-period = "90s"\n',
-            90.0,
-            id="grace-period-above-the-floor",
+            90.0 + 60.0,
+            id="a-grace-period-above-the-margin",
         ),
         pytest.param(
             '[profile.default]\ngrace-period = "3m"\n',
-            180.0,
-            id="grace-period-in-minutes",
+            180.0 + 60.0,
+            id="a-grace-period-in-minutes",
         ),
         pytest.param(
             '[profile.default]\ngrace-period = "5s"\n'
             '[profile.long]\ngrace-period = "2m"\n',
-            120.0,
-            id="largest-of-several-profiles",
+            120.0 + 60.0,
+            id="the-largest-of-several-profiles",
         ),
     ],
 )
 def test_the_termination_allowance_follows_the_configured_grace_period(
     config_text: str, expected: float
 ) -> None:
-    """A raised grace period raises the allowance; the floor catches the rest.
+    """The allowance is the grace period plus the margin, always both.
 
-    This is the whole point of reading the value rather than fixing it. A
-    profile that gives nextest three minutes to stop the run needs three
-    minutes of watchdog to cover it, and a hard-coded 60 s would silently
-    stop covering the case it exists for.
+    Two terms added, never a maximum over them. This is what makes a
+    raised grace period visible in the requirement: under the floor this
+    replaces, every value below sixty seconds produced the same answer,
+    so raising this file's five seconds to thirty would have demanded
+    nothing more of the watchdog above it.
+
+    A profile that gives nextest three minutes to stop the run needs
+    those three minutes of watchdog and the teardown margin besides.
     """
     assert budgets.termination_allowance(config_text) == pytest.approx(expected), (
         f"{config_text!r} must yield a {expected:.0f}s termination allowance; a "
@@ -87,7 +95,7 @@ def test_the_termination_allowance_ignores_the_per_test_period() -> None:
     over-sizing this correction removes.
     """
     config_text = '[profile.default]\nslow-timeout = { period = "20m" }\n'
-    assert budgets.termination_allowance(config_text) == pytest.approx(60.0), (
+    assert budgets.termination_allowance(config_text) == pytest.approx(70.0), (
         "the termination allowance read a 20m per-test period as a grace "
         "period; only grace-period bounds how long nextest takes to stop"
     )

--- a/tests/workflow_contracts/timeout_budgets_test.py
+++ b/tests/workflow_contracts/timeout_budgets_test.py
@@ -19,6 +19,7 @@ See "Test timeouts: four tiers, outermost last" in
 
 import typing as typ
 
+import nextest_config as reading
 import pytest
 import timeout_budgets as budgets
 
@@ -40,28 +41,40 @@ global-timeout = "75m"
             id="no-grace-period-falls-back-to-nextest-s-default",
         ),
         pytest.param(
-            '[profile.default]\ngrace-period = "5s"\n',
+            "[profile.default]\n"
+            'slow-timeout = { period = "60s", terminate-after = 1, '
+            'grace-period = "5s" }\n',
             5.0 + 60.0,
             id="a-grace-period-below-the-margin-still-counts",
         ),
         pytest.param(
-            '[profile.default]\ngrace-period = "60s"\n',
+            "[profile.default]\n"
+            'slow-timeout = { period = "60s", terminate-after = 1, '
+            'grace-period = "60s" }\n',
             60.0 + 60.0,
             id="a-grace-period-equal-to-the-margin",
         ),
         pytest.param(
-            '[profile.default]\ngrace-period = "90s"\n',
+            "[profile.default]\n"
+            'slow-timeout = { period = "60s", terminate-after = 1, '
+            'grace-period = "90s" }\n',
             90.0 + 60.0,
             id="a-grace-period-above-the-margin",
         ),
         pytest.param(
-            '[profile.default]\ngrace-period = "3m"\n',
+            "[profile.default]\n"
+            'slow-timeout = { period = "60s", terminate-after = 1, '
+            'grace-period = "3m" }\n',
             180.0 + 60.0,
             id="a-grace-period-in-minutes",
         ),
         pytest.param(
-            '[profile.default]\ngrace-period = "5s"\n'
-            '[profile.long]\ngrace-period = "2m"\n',
+            "[profile.default]\n"
+            'slow-timeout = { period = "60s", terminate-after = 1, '
+            'grace-period = "5s" }\n'
+            "\n[profile.long]\n"
+            'slow-timeout = { period = "60s", terminate-after = 1, '
+            'grace-period = "2m" }\n',
             120.0 + 60.0,
             id="the-largest-of-several-profiles",
         ),
@@ -81,7 +94,7 @@ def test_the_termination_allowance_follows_the_configured_grace_period(
     A profile that gives nextest three minutes to stop the run needs
     those three minutes of watchdog and the teardown margin besides.
     """
-    assert budgets.termination_allowance(config_text) == pytest.approx(expected), (
+    assert reading.termination_allowance(config_text) == pytest.approx(expected), (
         f"{config_text!r} must yield a {expected:.0f}s termination allowance; a "
         f"watchdog sized from a smaller one would kill the run mid-termination"
     )
@@ -94,8 +107,10 @@ def test_the_termination_allowance_ignores_the_per_test_period() -> None:
     a five-second termination belongs, restoring by accident the very
     over-sizing this correction removes.
     """
-    config_text = '[profile.default]\nslow-timeout = { period = "20m" }\n'
-    assert budgets.termination_allowance(config_text) == pytest.approx(70.0), (
+    config_text = (
+        '[profile.default]\nslow-timeout = { period = "20m", terminate-after = 1 }\n'
+    )
+    assert reading.termination_allowance(config_text) == pytest.approx(70.0), (
         "the termination allowance read a 20m per-test period as a grace "
         "period; only grace-period bounds how long nextest takes to stop"
     )
@@ -108,9 +123,11 @@ def test_the_largest_slow_timeout_ignores_the_grace_period() -> None:
     is larger. Here the grace period is deliberately the larger.
     """
     config_text = (
-        '[profile.default]\nslow-timeout = { period = "60s", grace-period = "30m" }\n'
+        "[profile.default]\n"
+        'slow-timeout = { period = "60s", terminate-after = 1, '
+        'grace-period = "30m" }\n'
     )
-    assert budgets.largest_slow_timeout(config_text) == pytest.approx(60.0), (
+    assert reading.largest_slow_timeout(config_text) == pytest.approx(60.0), (
         "the per-test ceiling read a 30m grace period as a slow-timeout; the "
         "global timeout would then be held to a budget no test can spend"
     )
@@ -119,9 +136,12 @@ def test_the_largest_slow_timeout_ignores_the_grace_period() -> None:
 def test_the_largest_slow_timeout_takes_the_longest_of_several() -> None:
     """Overrides raise the per-test ceiling the global timeout must clear."""
     config_text = _DEFAULT_PROFILE + (
-        'slow-timeout = { period = "20m", grace-period = "5s" }\n'
+        "\n[[profile.default.overrides]]\n"
+        "filter = 'binary(slow)'\n"
+        'slow-timeout = { period = "20m", terminate-after = 1, '
+        'grace-period = "5s" }\n'
     )
-    assert budgets.largest_slow_timeout(config_text) == pytest.approx(20 * 60.0), (
+    assert reading.largest_slow_timeout(config_text) == pytest.approx(20 * 60.0), (
         "the longest override, not the default profile's period, is the "
         "ceiling the global timeout has to clear"
     )
@@ -130,7 +150,7 @@ def test_the_largest_slow_timeout_takes_the_longest_of_several() -> None:
 def test_a_configuration_with_no_per_test_budget_is_rejected() -> None:
     """Nothing bounds a single test without one, so this is not a default."""
     with pytest.raises(budgets.MissingSlowTimeoutError):
-        budgets.largest_slow_timeout("[profile.default]\n")
+        reading.largest_slow_timeout("[profile.default]\n")
 
 
 def test_the_global_timeout_comes_from_the_default_profile() -> None:
@@ -141,7 +161,7 @@ def test_the_global_timeout_comes_from_the_default_profile() -> None:
     no CI job uses.
     """
     config_text = _DEFAULT_PROFILE + '[profile.long]\nglobal-timeout = "30m"\n'
-    assert budgets.global_timeout(config_text) == pytest.approx(75 * 60.0), (
+    assert reading.global_timeout(config_text) == pytest.approx(75 * 60.0), (
         "the whole-run budget must come from [profile.default]; [profile.long] "
         "sets 30m here and no coverage lane runs under it"
     )
@@ -150,13 +170,13 @@ def test_the_global_timeout_comes_from_the_default_profile() -> None:
 def test_a_configuration_with_no_default_profile_is_rejected() -> None:
     """The contract has nothing to compare against without one."""
     with pytest.raises(budgets.MissingDefaultProfileError):
-        budgets.global_timeout('[profile.long]\nglobal-timeout = "30m"\n')
+        reading.global_timeout('[profile.long]\nglobal-timeout = "30m"\n')
 
 
 def test_a_default_profile_with_no_global_timeout_is_rejected() -> None:
     """An unbounded run leaves the watchdog as the only limit."""
     with pytest.raises(budgets.MissingGlobalTimeoutError):
-        budgets.global_timeout("[profile.default]\nslow-timeout = { }\n")
+        reading.global_timeout("[profile.default]\nslow-timeout = { }\n")
 
 
 @pytest.mark.parametrize(

--- a/tests/workflow_contracts/timeout_budgets_test.py
+++ b/tests/workflow_contracts/timeout_budgets_test.py
@@ -2,16 +2,16 @@
 
 The ordering contract in :mod:`timeout_ordering_test` reads this
 repository's own configuration, where every ``grace-period`` is five
-seconds. The termination allowance therefore always lands on its 60 s
-floor, and a contract that only ever sees the floor cannot tell the
-corrected rule from the one it replaced: deleting the term entirely would
-leave the watchdog at 6,600 s and every assertion passing.
+seconds. The termination allowance therefore always lands on 65 s there,
+and a contract that only ever sees one number cannot tell the corrected
+rule from the one it replaced: deleting the term entirely would leave the
+watchdog at 6,600 s and every assertion passing.
 
 These tests drive the derivations with controlled configurations, so each
 branch is exercised where the repository's own numbers never reach: a
-grace period above the floor, one below it, none at all, and several
-profiles disagreeing. The watchdog rule is then checked term by term, and
-against a budget sized the old way.
+grace period above the sixty-second margin, one below it, one equal to it,
+none named at all, and several profiles disagreeing. The watchdog rule is
+then checked term by term, and against a budget sized the old way.
 
 See "Test timeouts: four tiers, outermost last" in
 ``docs/developers-guide.md``.
@@ -77,6 +77,16 @@ global-timeout = "75m"
             'grace-period = "2m" }\n',
             120.0 + 60.0,
             id="the-largest-of-several-profiles",
+        ),
+        pytest.param(
+            "[profile.default]\n"
+            'slow-timeout = { period = "60s", terminate-after = 1, '
+            'grace-period = "5s" }\n'
+            "\n[[profile.default.overrides]]\n"
+            "filter = 'binary(slow)'\n"
+            'slow-timeout = { period = "20m", terminate-after = 1 }\n',
+            10.0 + 60.0,
+            id="an-override-naming-none-takes-nextest-s-default",
         ),
     ],
 )

--- a/tests/workflow_contracts/timeout_ordering_test.py
+++ b/tests/workflow_contracts/timeout_ordering_test.py
@@ -24,9 +24,10 @@ allowances below are measured rather than assumed.
 
 Hitting the global timeout does not stop the run instantly either. On
 Unix nextest signals the process group and waits
-``slow-timeout.grace-period``, five seconds here, before killing it; on
-Windows termination is immediate and the grace period is ignored for
-timeouts. That allowance is seconds, not minutes.
+``slow-timeout.grace-period``, five seconds here, before killing it. On
+Windows, termination is immediate, and the grace period is ignored for
+timeouts. That allowance is seconds, not minutes, and it is read from the
+configuration so a profile that raises it raises the requirement too.
 
 See "Test timeouts: four tiers, outermost last" in
 ``docs/developers-guide.md``.
@@ -57,13 +58,10 @@ COVERAGE_ACTION: typ.Final[str] = "shared-actions/.github/actions/generate-cover
 #: cache; 15 minutes is that with room to spare.
 COLD_BUILD_ALLOWANCE_SECONDS: typ.Final[float] = 15 * 60.0
 
-#: Hitting the global timeout starts nextest's termination procedure
-#: rather than stopping the run. On Unix it signals the process group and
-#: waits ``slow-timeout.grace-period``, five seconds in this repository,
-#: before killing it; on Windows termination is immediate and the grace
-#: period is ignored for timeouts. Sixty seconds covers that with room,
-#: and is far too small to hide a real overrun.
-TERMINATION_ALLOWANCE_SECONDS: typ.Final[float] = 60.0
+#: Floor for the termination allowance, used when the configuration sets
+#: no grace period. Generous against nextest's ten-second default and far
+#: too small to hide a real overrun.
+MINIMUM_TERMINATION_ALLOWANCE_SECONDS: typ.Final[float] = 60.0
 
 #: Everything in the job that is not the coverage step. The job timer
 #: covers it; the watchdog does not. Taken from the worst of several
@@ -159,6 +157,36 @@ def global_timeout(nextest_config: str) -> float:
         "budget is unbounded and the watchdog becomes the only limit"
     )
     return _seconds(match[1])
+
+
+@pytest.fixture(scope="module")
+def termination_allowance(nextest_config: str) -> float:
+    """Return the time nextest may take to stop the run, in seconds.
+
+    Hitting the global timeout starts nextest's ordinary termination
+    procedure rather than stopping the run: on Unix it signals the
+    process group and waits ``slow-timeout.grace-period`` before killing
+    it; on Windows termination is immediate and the grace period is
+    ignored for timeouts.
+
+    Read from the configuration rather than fixed, because a profile that
+    raised its grace period past a hard-coded allowance would drift out
+    of the requirement this contract exists to hold.
+
+    Parameters
+    ----------
+    nextest_config : str
+        The nextest configuration file's text.
+
+    Returns
+    -------
+    float
+        The largest configured grace period, or the floor when that is
+        smaller or absent.
+    """
+    periods = re.findall(r'grace-period\s*=\s*"([^"]+)"', nextest_config)
+    largest = max((_seconds(period) for period in periods), default=0.0)
+    return max(largest, MINIMUM_TERMINATION_ALLOWANCE_SECONDS)
 
 
 @pytest.fixture(scope="module")
@@ -294,6 +322,7 @@ def test_every_coverage_step_declares_a_watchdog_budget(
 def test_the_watchdog_covers_the_nextest_budget_and_the_build(
     lanes: tuple[CoverageLane, ...],
     global_timeout: float,
+    termination_allowance: float,
 ) -> None:
     """Tier three must not pre-empt tier two.
 
@@ -308,18 +337,16 @@ def test_the_watchdog_covers_the_nextest_budget_and_the_build(
     stopping the run: on Unix it signals the process group and waits a
     grace period before killing it. Seconds, not minutes, but not zero.
     """
-    required = (
-        global_timeout + TERMINATION_ALLOWANCE_SECONDS + COLD_BUILD_ALLOWANCE_SECONDS
-    )
+    required = global_timeout + termination_allowance + COLD_BUILD_ALLOWANCE_SECONDS
     for lane in lanes:
         assert lane.watchdog is not None, str(lane)
         assert lane.watchdog >= required, (
             f"{lane} sets {WATCHDOG_VARIABLE}={lane.watchdog:.0f}s, below the "
             f"{required:.0f}s needed to cover the {global_timeout:.0f}s nextest "
-            f"budget, {TERMINATION_ALLOWANCE_SECONDS:.0f}s for nextest to "
-            f"terminate the run, and {COLD_BUILD_ALLOWANCE_SECONDS:.0f}s of cold "
-            f"build; a cold run would be killed before nextest's own budget "
-            f"expired"
+            f"budget, {termination_allowance:.0f}s for nextest to terminate the "
+            f"run, and {COLD_BUILD_ALLOWANCE_SECONDS:.0f}s of cold build; a cold "
+            f"run would be killed before nextest's budget and termination "
+            f"procedure had completed"
         )
 
 

--- a/tests/workflow_contracts/timeout_ordering_test.py
+++ b/tests/workflow_contracts/timeout_ordering_test.py
@@ -22,6 +22,12 @@ coverage and long before the work that follows it. Comparing the
 configured numbers alone would call an inverted lane correct, so the
 allowances below are measured rather than assumed.
 
+Hitting the global timeout does not stop the run instantly either. On
+Unix nextest signals the process group and waits
+``slow-timeout.grace-period``, five seconds here, before killing it; on
+Windows termination is immediate and the grace period is ignored for
+timeouts. That allowance is seconds, not minutes.
+
 See "Test timeouts: four tiers, outermost last" in
 ``docs/developers-guide.md``.
 """
@@ -50,6 +56,14 @@ COVERAGE_ACTION: typ.Final[str] = "shared-actions/.github/actions/generate-cover
 #: Measured at 3 m 31 s on run 33966769942 with a nearly cold compiler
 #: cache; 15 minutes is that with room to spare.
 COLD_BUILD_ALLOWANCE_SECONDS: typ.Final[float] = 15 * 60.0
+
+#: Hitting the global timeout starts nextest's termination procedure
+#: rather than stopping the run. On Unix it signals the process group and
+#: waits ``slow-timeout.grace-period``, five seconds in this repository,
+#: before killing it; on Windows termination is immediate and the grace
+#: period is ignored for timeouts. Sixty seconds covers that with room,
+#: and is far too small to hide a real overrun.
+TERMINATION_ALLOWANCE_SECONDS: typ.Final[float] = 60.0
 
 #: Everything in the job that is not the coverage step. The job timer
 #: covers it; the watchdog does not. Taken from the worst of several
@@ -280,7 +294,6 @@ def test_every_coverage_step_declares_a_watchdog_budget(
 def test_the_watchdog_covers_the_nextest_budget_and_the_build(
     lanes: tuple[CoverageLane, ...],
     global_timeout: float,
-    largest_slow_timeout: float,
 ) -> None:
     """Tier three must not pre-empt tier two.
 
@@ -290,21 +303,23 @@ def test_the_watchdog_covers_the_nextest_budget_and_the_build(
     still pre-empting it whenever the build takes longer than the
     difference, so the build allowance is part of the comparison.
 
-    The far end matters too. A test already running when the global
-    timeout expires is allowed to finish, so the run can outlast that
-    budget by the longest per-test allowance. Whether that tail is ever
-    reached or not, allowing for it costs nothing: the watchdog only
-    fires on an overrun.
+    The far end matters too, though less than it first appears. Hitting
+    the global timeout starts nextest's termination procedure rather than
+    stopping the run: on Unix it signals the process group and waits a
+    grace period before killing it. Seconds, not minutes, but not zero.
     """
-    required = global_timeout + largest_slow_timeout + COLD_BUILD_ALLOWANCE_SECONDS
+    required = (
+        global_timeout + TERMINATION_ALLOWANCE_SECONDS + COLD_BUILD_ALLOWANCE_SECONDS
+    )
     for lane in lanes:
         assert lane.watchdog is not None, str(lane)
         assert lane.watchdog >= required, (
             f"{lane} sets {WATCHDOG_VARIABLE}={lane.watchdog:.0f}s, below the "
             f"{required:.0f}s needed to cover the {global_timeout:.0f}s nextest "
-            f"budget, the {largest_slow_timeout:.0f}s a test already running may "
-            f"still take, and {COLD_BUILD_ALLOWANCE_SECONDS:.0f}s of cold build; "
-            f"a cold run would be killed before nextest's own budget expired"
+            f"budget, {TERMINATION_ALLOWANCE_SECONDS:.0f}s for nextest to "
+            f"terminate the run, and {COLD_BUILD_ALLOWANCE_SECONDS:.0f}s of cold "
+            f"build; a cold run would be killed before nextest's own budget "
+            f"expired"
         )
 
 

--- a/tests/workflow_contracts/timeout_ordering_test.py
+++ b/tests/workflow_contracts/timeout_ordering_test.py
@@ -92,63 +92,54 @@ def ci_workflow() -> dict[str, typ.Any]:
     return yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
 
 
-@pytest.fixture(scope="module")
-def global_timeout(nextest_config: str) -> float:
-    """Return the default profile's ``global-timeout`` in seconds.
+class NextestBudgets(typ.NamedTuple):
+    """The three budgets read out of ``.config/nextest.toml``.
 
-    Parameters
+    They arrive as one value rather than three fixtures because three
+    fixtures that each read the same file and delegate one call differ
+    only in which call they make.
+
+    Attributes
     ----------
-    nextest_config : str
-        The nextest configuration file's text.
-
-    Returns
-    -------
-    float
+    global_timeout : float
         The default profile's whole-run budget, in seconds.
-    """
-    return budgets.global_timeout(nextest_config)
-
-
-@pytest.fixture(scope="module")
-def termination_allowance(nextest_config: str) -> float:
-    """Return the time nextest may take to stop the run, in seconds.
-
-    Read from the configuration rather than fixed, because a profile that
-    raised its grace period past a hard-coded allowance would drift out of
-    the requirement this contract exists to hold. See
-    :func:`timeout_budgets.termination_allowance`, whose behaviour away
-    from this repository's own five-second grace periods is covered by
-    :mod:`timeout_budgets_test`.
-
-    Parameters
-    ----------
-    nextest_config : str
-        The nextest configuration file's text.
-
-    Returns
-    -------
-    float
-        The largest configured grace period, or the floor when that is
-        smaller or absent.
-    """
-    return budgets.termination_allowance(nextest_config)
-
-
-@pytest.fixture(scope="module")
-def largest_slow_timeout(nextest_config: str) -> float:
-    """Return the longest single-test allowance in seconds.
-
-    Parameters
-    ----------
-    nextest_config : str
-        The nextest configuration file's text.
-
-    Returns
-    -------
-    float
+    termination_allowance : float
+        The time nextest may take to stop a run that spends it. Read from
+        the configuration rather than fixed, because a profile that
+        raised its grace period past a hard-coded allowance would drift
+        out of the requirement this contract exists to hold.
+    largest_slow_timeout : float
         The longest per-test budget.
     """
-    return budgets.largest_slow_timeout(nextest_config)
+
+    global_timeout: float
+    termination_allowance: float
+    largest_slow_timeout: float
+
+
+@pytest.fixture(scope="module")
+def nextest_budgets(nextest_config: str) -> NextestBudgets:
+    """Return the budgets the configuration sets.
+
+    The derivations themselves live in :mod:`timeout_budgets`, and their
+    behaviour away from this repository's own five-second grace periods
+    is covered by :mod:`timeout_budgets_test`.
+
+    Parameters
+    ----------
+    nextest_config : str
+        The nextest configuration file's text.
+
+    Returns
+    -------
+    NextestBudgets
+        The three budgets, in seconds.
+    """
+    return NextestBudgets(
+        global_timeout=budgets.global_timeout(nextest_config),
+        termination_allowance=budgets.termination_allowance(nextest_config),
+        largest_slow_timeout=budgets.largest_slow_timeout(nextest_config),
+    )
 
 
 class CoverageLane(typ.NamedTuple):
@@ -264,8 +255,7 @@ def test_every_coverage_step_declares_a_watchdog_budget(
 
 def test_the_watchdog_covers_the_nextest_budget_and_the_build(
     lanes: tuple[CoverageLane, ...],
-    global_timeout: float,
-    termination_allowance: float,
+    nextest_budgets: NextestBudgets,
 ) -> None:
     """Tier three must not pre-empt tier two.
 
@@ -280,6 +270,8 @@ def test_the_watchdog_covers_the_nextest_budget_and_the_build(
     stopping the run: on Unix it signals the process group and waits a
     grace period before killing it. Seconds, not minutes, but not zero.
     """
+    global_timeout = nextest_budgets.global_timeout
+    termination_allowance = nextest_budgets.termination_allowance
     required = budgets.watchdog_requirement(
         global_timeout, termination_allowance, COLD_BUILD_ALLOWANCE_SECONDS
     )
@@ -297,14 +289,15 @@ def test_the_watchdog_covers_the_nextest_budget_and_the_build(
 
 
 def test_the_nextest_global_timeout_sits_above_the_largest_slow_timeout(
-    global_timeout: float,
-    largest_slow_timeout: float,
+    nextest_budgets: NextestBudgets,
 ) -> None:
     """Tier two must not pre-empt tier one.
 
     A global timeout below the longest per-test allowance kills the run
     before the test that allowance exists for can finish.
     """
+    global_timeout = nextest_budgets.global_timeout
+    largest_slow_timeout = nextest_budgets.largest_slow_timeout
     assert global_timeout > largest_slow_timeout, (
         f"the {global_timeout:.0f}s global-timeout is not above the "
         f"{largest_slow_timeout:.0f}s largest per-test slow-timeout; the run "

--- a/tests/workflow_contracts/timeout_ordering_test.py
+++ b/tests/workflow_contracts/timeout_ordering_test.py
@@ -33,10 +33,10 @@ See "Test timeouts: four tiers, outermost last" in
 ``docs/developers-guide.md``.
 """
 
-import re
 import typing as typ
 
 import pytest
+import timeout_budgets as budgets
 import yaml
 from workflow_support import ROOT
 
@@ -58,11 +58,6 @@ COVERAGE_ACTION: typ.Final[str] = "shared-actions/.github/actions/generate-cover
 #: cache; 15 minutes is that with room to spare.
 COLD_BUILD_ALLOWANCE_SECONDS: typ.Final[float] = 15 * 60.0
 
-#: Floor for the termination allowance, used when the configuration sets
-#: no grace period. Generous against nextest's ten-second default and far
-#: too small to hide a real overrun.
-MINIMUM_TERMINATION_ALLOWANCE_SECONDS: typ.Final[float] = 60.0
-
 #: Everything in the job that is not the coverage step. The job timer
 #: covers it; the watchdog does not. Taken from the worst of several
 #: runs rather than one: 14 m 03 s before and 36 m 41 s after on run
@@ -71,36 +66,6 @@ MINIMUM_TERMINATION_ALLOWANCE_SECONDS: typ.Final[float] = 60.0
 #: end-to-end scenario ran at 8 m 19 s and 13 m 07 s rather than about
 #: three minutes each. 75 minutes covers the worse pair with room.
 NON_COVERAGE_ALLOWANCE_SECONDS: typ.Final[float] = 75 * 60.0
-
-#: ``30s``, ``5m``, ``20 m``: the durations nextest accepts here.
-_DURATION: typ.Final[re.Pattern[str]] = re.compile(
-    r"^\s*(?P<value>\d+(?:\.\d+)?)\s*(?P<unit>ms|s|m|h)\s*$"
-)
-
-_UNIT_SECONDS: typ.Final[dict[str, float]] = {
-    "ms": 0.001,
-    "s": 1.0,
-    "m": 60.0,
-    "h": 3600.0,
-}
-
-
-def _seconds(duration: str) -> float:
-    """Convert a nextest duration to seconds.
-
-    Parameters
-    ----------
-    duration : str
-        A duration as nextest spells it, such as ``"75m"``.
-
-    Returns
-    -------
-    float
-        The duration in seconds.
-    """
-    match = _DURATION.match(duration)
-    assert match is not None, f"unrecognized nextest duration {duration!r}"
-    return float(match["value"]) * _UNIT_SECONDS[match["unit"]]
 
 
 @pytest.fixture(scope="module")
@@ -131,10 +96,6 @@ def ci_workflow() -> dict[str, typ.Any]:
 def global_timeout(nextest_config: str) -> float:
     """Return the default profile's ``global-timeout`` in seconds.
 
-    Read textually rather than through a TOML parser, because the value
-    must be matched to the profile it belongs to and the file declares
-    more than one profile.
-
     Parameters
     ----------
     nextest_config : str
@@ -145,33 +106,19 @@ def global_timeout(nextest_config: str) -> float:
     float
         The default profile's whole-run budget, in seconds.
     """
-    blocks = re.split(r"^\[profile\.", nextest_config, flags=re.MULTILINE)
-    default = next((block for block in blocks if block.startswith("default]")), None)
-    assert default is not None, (
-        "nextest.toml must declare a [profile.default] section; the ordering "
-        "contract has nothing to compare against without one"
-    )
-    match = re.search(r'^global-timeout\s*=\s*"([^"]+)"', default, re.MULTILINE)
-    assert match is not None, (
-        "[profile.default] must set global-timeout; without it the whole-run "
-        "budget is unbounded and the watchdog becomes the only limit"
-    )
-    return _seconds(match[1])
+    return budgets.global_timeout(nextest_config)
 
 
 @pytest.fixture(scope="module")
 def termination_allowance(nextest_config: str) -> float:
     """Return the time nextest may take to stop the run, in seconds.
 
-    Hitting the global timeout starts nextest's ordinary termination
-    procedure rather than stopping the run: on Unix it signals the
-    process group and waits ``slow-timeout.grace-period`` before killing
-    it; on Windows termination is immediate and the grace period is
-    ignored for timeouts.
-
     Read from the configuration rather than fixed, because a profile that
-    raised its grace period past a hard-coded allowance would drift out
-    of the requirement this contract exists to hold.
+    raised its grace period past a hard-coded allowance would drift out of
+    the requirement this contract exists to hold. See
+    :func:`timeout_budgets.termination_allowance`, whose behaviour away
+    from this repository's own five-second grace periods is covered by
+    :mod:`timeout_budgets_test`.
 
     Parameters
     ----------
@@ -184,9 +131,7 @@ def termination_allowance(nextest_config: str) -> float:
         The largest configured grace period, or the floor when that is
         smaller or absent.
     """
-    periods = re.findall(r'grace-period\s*=\s*"([^"]+)"', nextest_config)
-    largest = max((_seconds(period) for period in periods), default=0.0)
-    return max(largest, MINIMUM_TERMINATION_ALLOWANCE_SECONDS)
+    return budgets.termination_allowance(nextest_config)
 
 
 @pytest.fixture(scope="module")
@@ -203,9 +148,7 @@ def largest_slow_timeout(nextest_config: str) -> float:
     float
         The longest per-test budget.
     """
-    periods = re.findall(r'period\s*=\s*"([^"]+)"', nextest_config)
-    assert periods, "nextest.toml must set at least one slow-timeout period"
-    return max(_seconds(period) for period in periods)
+    return budgets.largest_slow_timeout(nextest_config)
 
 
 class CoverageLane(typ.NamedTuple):
@@ -337,14 +280,17 @@ def test_the_watchdog_covers_the_nextest_budget_and_the_build(
     stopping the run: on Unix it signals the process group and waits a
     grace period before killing it. Seconds, not minutes, but not zero.
     """
-    required = global_timeout + termination_allowance + COLD_BUILD_ALLOWANCE_SECONDS
+    required = budgets.watchdog_requirement(
+        global_timeout, termination_allowance, COLD_BUILD_ALLOWANCE_SECONDS
+    )
     for lane in lanes:
         assert lane.watchdog is not None, str(lane)
-        assert lane.watchdog >= required, (
-            f"{lane} sets {WATCHDOG_VARIABLE}={lane.watchdog:.0f}s, below the "
-            f"{required:.0f}s needed to cover the {global_timeout:.0f}s nextest "
-            f"budget, {termination_allowance:.0f}s for nextest to terminate the "
-            f"run, and {COLD_BUILD_ALLOWANCE_SECONDS:.0f}s of cold build; a cold "
+        shortfall = budgets.watchdog_shortfall(lane.watchdog, required)
+        assert not shortfall, (
+            f"{lane} sets {WATCHDOG_VARIABLE}={lane.watchdog:.0f}s, {shortfall:.0f}s "
+            f"below the {required:.0f}s needed to cover the {global_timeout:.0f}s "
+            f"nextest budget, {termination_allowance:.0f}s for nextest to terminate "
+            f"the run, and {COLD_BUILD_ALLOWANCE_SECONDS:.0f}s of cold build; a cold "
             f"run would be killed before nextest's budget and termination "
             f"procedure had completed"
         )

--- a/tests/workflow_contracts/timeout_ordering_test.py
+++ b/tests/workflow_contracts/timeout_ordering_test.py
@@ -122,9 +122,10 @@ class NextestBudgets(typ.NamedTuple):
 def nextest_budgets(nextest_config: str) -> NextestBudgets:
     """Return the budgets the configuration sets.
 
-    The derivations themselves live in :mod:`timeout_budgets`, and their
-    behaviour away from this repository's own five-second grace periods
-    is covered by :mod:`timeout_budgets_test`.
+    The three readings are :mod:`nextest_config`'s, and what each of them
+    counts as configuration is covered by :mod:`nextest_config_test`. What
+    this contract does with the numbers afterwards, the watchdog
+    arithmetic, is :mod:`timeout_budgets`'.
 
     Parameters
     ----------

--- a/tests/workflow_contracts/timeout_ordering_test.py
+++ b/tests/workflow_contracts/timeout_ordering_test.py
@@ -35,6 +35,7 @@ See "Test timeouts: four tiers, outermost last" in
 
 import typing as typ
 
+import nextest_config as reading
 import pytest
 import timeout_budgets as budgets
 import yaml
@@ -136,9 +137,9 @@ def nextest_budgets(nextest_config: str) -> NextestBudgets:
         The three budgets, in seconds.
     """
     return NextestBudgets(
-        global_timeout=budgets.global_timeout(nextest_config),
-        termination_allowance=budgets.termination_allowance(nextest_config),
-        largest_slow_timeout=budgets.largest_slow_timeout(nextest_config),
+        global_timeout=reading.global_timeout(nextest_config),
+        termination_allowance=reading.termination_allowance(nextest_config),
+        largest_slow_timeout=reading.largest_slow_timeout(nextest_config),
     )
 
 


### PR DESCRIPTION
## What was wrong

The timeout section that landed in `#722` says a test already running when nextest's global timeout expires is allowed to finish, and sizes the middle term of the watchdog rule at the 20 minute trybuild allowance.

I wrote that. I said at the time that I had not verified nextest's behaviour at that boundary, and argued the sizing was safe under either reading because the watchdog only fires on an overrun. The safety argument held. The claim did not.

From nextest's own documentation:

> When a global timeout occurs, nextest follows the procedure in How nextest terminates tests above.

That procedure sends `SIGTERM` to the process group on Unix, waits `slow-timeout.grace-period` (ten seconds by default, five in this repository), then sends `SIGKILL`. On Windows termination is immediate and the grace period is ignored for timeouts.

So the term is a termination allowance measured in seconds, not an allowance of tens of minutes.

## What changes

The rule, in the guide and in the contract:

```text
watchdog >= nextest global-timeout + termination allowance + cold build
```

**No value moves.** The watchdog stays at 6,600 s and the job ceiling at 190 minutes. Both were chosen from the wrong premise and both exceed what the corrected rule requires, so nothing here is a fix to behaviour.

The guide says outright what the paragraph used to claim, rather than quietly replacing it. Nine other repositories are due to copy this section, and one of them will eventually wonder why their arithmetic does not match an older commit.

## Why it matters here rather than only upstream

`leynos/shared-actions#468` carries the canonical wording, and every repository adopting this contract will point at it. This repository is the reference implementation they copy from, so it has to teach the corrected rule rather than the one that happened to give a safe answer.

## Verification

`make test-workflow-contracts` passes at 131. Two mutations against the contract itself, both caught:

| Mutation | Result |
| --- | --- |
| watchdog at 5,400 s, covering the global timeout and the build but not the termination | fails |
| watchdog equal to the global timeout | fails |

## Testing the rule where this repository's numbers never reach

The contract alone could not tell the corrected rule from the one it replaced. Every `grace-period` in `.config/nextest.toml` is five seconds, so the termination allowance always lands on the same sixty-five seconds, and deleting the term outright would have left the watchdog at 6,600 s with every assertion passing.

The arithmetic therefore moves into `tests/workflow_contracts/timeout_budgets.py`, beside the contract, taking text rather than paths so a test stays in charge of what it asserts about. `timeout_budgets_test.py` drives it with controlled configurations: a grace period above the sixty-second margin, equal to it, below it, absent, in minutes, and several profiles disagreeing; every duration unit the readings model; and a watchdog sized the way the superseded two-term rule would have sized it.

Three mutations against the derivations, all caught:

| Mutation | Failing test |
| --- | --- |
| termination margin set to zero | the margin cases |
| termination term dropped from the watchdog rule | the two-term sizing |
| shortfall no longer clamped at zero | the spare-budget case |

One more defect surfaced while the arithmetic was being pinned down. The per-test ceiling matched `period` as a substring, so `grace-period` satisfied it too. This repository's values made it harmless, five seconds against a twenty-minute override, but a configuration whose grace period exceeded every test budget would have held the global timeout to a ceiling no test can spend. The reading now parses the configuration as TOML and takes each key by name, so the two cannot be confused at all.

A review of this branch found the same shape of defect one level up. A `slow-timeout` that was neither a duration string nor a table — a bare number, a boolean, a list — was skipped in silence, and nextest refuses such a file outright (`invalid type: integer 60, expected a table ... or a string`). The skip read a file the runner will not load as one declaring no per-test budget, and where another entry declared one it reported that entry's budget in place of the fault. Both readings route through the one reader, so the refusal is raised there, and the empty string stays absent because that is what nextest reads it as. The derivation also reads `1d`, which humantime accepts and the readers did not; the longer spellings (`1day`) and compound forms (`1h 30m`) that nextest also accepts remain outside what the readings model, and fail loudly rather than converting a guess. Two mutations, both caught: removing the refusal fails the four malformed cases with the absent-budget error, and removing `d` fails the day case as an unreadable duration.

Formatting, markdownlint and the repository's Python lints are clean.

## Summary by Sourcery

Correct the workflow timeout contract to reserve a configurable termination allowance after nextest's global timeout and validate the complete three-term watchdog budget.

Bug Fixes:
- Correct the timeout contract to account for nextest's termination grace period rather than the longest per-test timeout after the global timeout.
- Fix nextest configuration parsing so timeout values are read from active TOML settings, honor termination multipliers and defaults, and avoid confusing `period` with `grace-period`.

Enhancements:
- Extract timeout-budget calculations and nextest configuration reading into dedicated workflow-contract helpers.
- Strengthen watchdog validation to report shortfalls against the global timeout, termination allowance, and cold-build requirements.

Documentation:
- Update the developer guide and CI workflow comments to document nextest's termination behavior and the corrected watchdog sizing rule.

Tests:
- Add unit and mutation-focused coverage for duration parsing, profile and override handling, grace-period calculations, unbounded tests, and watchdog arithmetic.

## References

- Lody session: https://lody.ai/leynos/sessions/26054d2b-5a4d-4c36-aeb7-131912701ddc
