### PR TITLE
Adopt lading v0.3.0 and attribute the publish step's compiler cache (#720)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -661,13 +661,46 @@ jobs:
           LADING_SCCACHE_STATS_JSON: ${{ runner.temp }}/sccache-publish.json
         run: make publish-check
 
+      # Runs whatever the publish step did, so an absent or malformed
+      # report is reported rather than inferred from an empty artefact.
+      # It never fails the job: the report is evidence about a build, not
+      # the build, and a publish that failed before lading wrote anything
+      # has already failed the job on its own account.
+      - name: Verify publish-step compiler-cache statistics
+        if: ${{ always() && runner.os == 'Linux' }}
+        shell: bash
+        env:
+          STATS_PATH: ${{ runner.temp }}/sccache-publish.json
+        run: |
+          set -uo pipefail
+          warn() {
+            echo "::warning title=publish-statistics::$1"
+          }
+          if [[ ! -f "${STATS_PATH}" ]]; then
+            warn "lading wrote no compiler-cache report to ${STATS_PATH}; either the publish step failed before lading ran, or the resolved lading predates LADING_SCCACHE_STATS_JSON. This run's publish cost is unattributable."
+            exit 0
+          fi
+          if [[ ! -s "${STATS_PATH}" ]]; then
+            warn "${STATS_PATH} is empty; lading created it but wrote no report."
+            exit 0
+          fi
+          if ! python3 -c 'import json, os; json.load(open(os.environ["STATS_PATH"]))'; then
+            warn "${STATS_PATH} is not valid JSON, so the publish step's compiler-cache report cannot be read."
+            exit 0
+          fi
+          echo 'Publish-step compiler-cache report:'
+          cat "${STATS_PATH}"
+
       - name: Upload publish-step compiler-cache statistics
         if: ${{ always() && runner.os == 'Linux' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: sccache-publish-${{ matrix.os }}-${{ strategy.job-index }}
           path: ${{ runner.temp }}/sccache-publish.json
-          if-no-files-found: ignore
+          # `warn`, not `ignore`: the verification step above says why the
+          # file is missing, and a silent upload of nothing looks the same
+          # as an upload of a report nobody read.
+          if-no-files-found: warn
           retention-days: 7
 
       # Exactly one writer per key: the default-features lane on trunk, per

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
       RUSTFLAGS: -D warnings
       RUSTDOCFLAGS: -D warnings
-      LADING_REF: e0a8d43fa3d6d7598cad0d4c25883e7ea625feb9
+      LADING_REF: c3740ef48da4c89752fcb98fff4f1c27284e5f12
       BUN_VERSION: '1.2.21'
       MERMAID_CLI_VERSION: '11.9.0'
       MERMAN_CLI_VERSION: '0.7.0'
@@ -650,7 +650,25 @@ jobs:
       # the Windows lanes. Keep it to the one portable command; the disk the
       # publish build starts with is the reading the discard step prints last.
       - name: Publish dry run
+        env:
+          # lading v0.3.0 can report the compiler cache around each
+          # packaged build. Set here rather than in the Makefile so a
+          # local `make publish-check` stays quiet and the file lands
+          # where the upload step below can find it. The statistics are
+          # differenced around each invocation rather than zeroed, so the
+          # end-of-job sccache report keeps its meaning (rstest-bdd#720,
+          # leynos/shared-actions#459).
+          LADING_SCCACHE_STATS_JSON: ${{ runner.temp }}/sccache-publish.json
         run: make publish-check
+
+      - name: Upload publish-step compiler-cache statistics
+        if: ${{ always() && runner.os == 'Linux' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: sccache-publish-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ${{ runner.temp }}/sccache-publish.json
+          if-no-files-found: ignore
+          retention-days: 7
 
       # Exactly one writer per key: the default-features lane on trunk, per
       # runner operating system, because every key carries `runner.os`.

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ SPELLING_HELPER_PYTEST = PYTHONPATH=scripts $(UV_ENV) $(UV) run --no-project \
 	--with pytest-cov==7.0.0 python -m pytest
 # Shared Markdown file list used by markdownlint and the spelling gate.
 MD_FILES_FIND = find . -type f -name '*.md' -not -path '*/target/*' -not -path '*/node_modules/*' -not -path './.vtcode/*' -print0
-LADING_REF ?= e0a8d43fa3d6d7598cad0d4c25883e7ea625feb9
+LADING_REF ?= c3740ef48da4c89752fcb98fff4f1c27284e5f12
 LADING_SPEC ?= lading @ git+https://github.com/leynos/lading@$(LADING_REF)
 PYTHON_TARGETS ?= $(filter-out $(SPELLING_PY_SRCS),$(shell find scripts tests/workflow_contracts -type f -name "*.py" -print | sort))
 PYLINT_PYTHON ?= pypy

--- a/docs/adr-020-consolidate-on-the-tracing-logging-facade.md
+++ b/docs/adr-020-consolidate-on-the-tracing-logging-facade.md
@@ -48,10 +48,9 @@ neither facade disappears from a build whichever way the decision goes.
 
 ## Decision outcome
 
-`rstest-bdd` emits warnings through `tracing::warn!`. The two former `log`
-call sites — the ambiguous step-return override in `StepContext::insert_value`
-and the specificity-calculation failure in the step registry — now use
-`tracing`.
+`rstest-bdd` emits warnings through `tracing::warn!`. The two former `log` call
+sites — the ambiguous step-return override in `StepContext::insert_value` and
+the specificity-calculation failure in the step registry — now use `tracing`.
 
 `rstest-bdd` enables tracing's `log` feature. When no `tracing` subscriber has
 ever been installed, tracing's macros emit a `log` record instead, so a
@@ -65,18 +64,18 @@ stderr, selecting the delivery route the way tracing's own `log` bridge does:
 
 Table: Warning delivery routes and the stderr fallback
 
-| `tracing` subscriber | `log` logger | Warning delivered by     | Stderr mirror |
-| -------------------- | ------------ | ------------------------ | ------------- |
-| Records `WARN`       | Any          | The subscriber           | No            |
-| None ever installed  | Installed    | Tracing's `log` bridge   | No            |
-| Filters `WARN` out   | None         | Nothing                  | Yes           |
-| None ever installed  | None         | Nothing                  | Yes           |
+| `tracing` subscriber | `log` logger | Warning delivered by   | Stderr mirror |
+| -------------------- | ------------ | ---------------------- | ------------- |
+| Records `WARN`       | Any          | The subscriber         | No            |
+| None ever installed  | Installed    | Tracing's `log` bridge | No            |
+| Filters `WARN` out   | None         | Nothing                | Yes           |
+| None ever installed  | None         | Nothing                | Yes           |
 
 The probe and the emitting macro are colocated and share an explicit target
-constant, so both are subject to identical filtering. The target is spelled
-out rather than taken from `module_path!()` because the helper module's own
-path (`rstest_bdd::context::warnings`) is not the target consumers already
-capture or filter.
+constant, so both are subject to identical filtering. The target is spelled out
+rather than taken from `module_path!()` because the helper module's own path
+(`rstest_bdd::context::warnings`) is not the target consumers already capture
+or filter.
 
 ## Rationale
 
@@ -97,10 +96,10 @@ It is not used to emit anything; it answers one question — whether a `log`
 listener exists — which the stderr fallback must know to avoid either printing
 a duplicate or swallowing the warning. Tracing's bridge fires only while no
 dispatcher has ever been set. That condition is observable through
-`tracing::dispatcher::has_been_set`, so the fallback selects its route the
-same way the bridge does: an enabled `log` logger counts as a listener only
-while no dispatcher exists, and never on the dispatcher route, where tracing
-would drop the event before the bridge could forward it.
+`tracing::dispatcher::has_been_set`, so the fallback selects its route the same
+way the bridge does: an enabled `log` logger counts as a listener only while no
+dispatcher exists, and never on the dispatcher route, where tracing would drop
+the event before the bridge could forward it.
 
 The stderr mirror fires when a subscriber filters `WARN` out and no `log`
 logger is present. Preferring a redundant line to a silently dropped

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -243,6 +243,20 @@ expects it. `lading_pin_test.py` asserts that the step still asks for the
 statistics and that the file is uploaded, because a file written into the
 runner's temporary directory and never collected is discarded with the runner.
 
+A verification step sits between the two. It reads the report the publish step
+wrote, parses it, and prints it to the log, and where the file is absent, empty
+or unparsable it says which and why. That distinction is the point: an absent
+report and a report nobody opened look identical in the artefact list, so a
+lading that stopped writing the file would read as an uneventful run. The step
+never fails the job, because the report is evidence about a build rather than
+the build itself, and a publish that failed before lading ran has already
+failed on its own account. Both it and the upload carry
+`${{ always() && runner.os == 'Linux' }}`: without `always()` the run whose
+cost is most worth reading, the failed one, would upload nothing, and without
+the Linux guard the Windows lanes, which never write the file, would report a
+missing one every time. The upload's `if-no-files-found` is `warn` rather than
+`ignore` for the same reason.
+
 `make publish-check` depends on `stage-published-gpui-e2e`, which extracts
 packaged crates from `target/package/`. That path, and five others in the
 Makefile including the `target/%/$(APP)` build rules, name the target directory

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -252,10 +252,16 @@ directory from `cargo metadata` would be a Makefile-wide change rather than a
 fix to one recipe, and is worth doing only if the shared-cache layout is wanted
 here.
 
-lading is pinned twice, in `ci.yml` and in the Makefile, so that CI and a local
-run resolve the same tool. The same contract asserts the two agree and that the
-pin is a commit rather than a tag. Drift there would be quiet: both sides keep
-working while validating publish readiness against different versions.
+lading is pinned three times: in `ci.yml`, in the Makefile, and in
+`pyproject.toml`'s `python-tools` group for a bare `uv run lading`. The same
+contract asserts all three agree and that the pin is a commit rather than a tag.
+Drift there would be quiet: every side keeps working while validating publish
+readiness against different versions.
+
+The project group is the easiest of the three to forget, because the Makefile's
+`--with` overlay masks it. `make publish-check` resolves the Makefile's pin
+whatever the group holds, so the group can sit generations behind without any
+command failing, which is exactly where it was found.
 
 Check each `main` run with `ubi gh leynos/rstest-bdd list-cache-entries`. It
 must show the archive keys and the `sccache` objects on Ubicloud's side before

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -223,6 +223,31 @@ after installing `sccache`, and the final step publishes `sccache --show-stats`
 in text and JSON to the job summary alongside every cache key, hit result, and
 the backend in use.
 
+
+#### Attributing the publish step's share
+
+The end-of-job report is job-wide, so it cannot say what any one step spent.
+That matters most for the publish dry run, which is the longest step in the
+lane and, until lading v0.3.0, said nothing at all about its compiler cache.
+
+Setting `LADING_SCCACHE_STATS_JSON` on that step makes lading read `sccache`
+around each packaged build and write the results to a file, uploaded as the
+`sccache-publish-*` artefact. The figures are differenced around each
+invocation rather than obtained by zeroing the counters, so the end-of-job
+report keeps its meaning; a tool that zeroed them would silently make every
+later reading a partial one.
+
+The variable is set on the workflow step rather than in the Makefile, so a
+local `make publish-check` stays quiet and the file lands where the upload step
+expects it. `lading_pin_test.py` asserts that the step still asks for the
+statistics and that the file is uploaded, because a file written into the
+runner's temporary directory and never collected is discarded with the runner.
+
+lading is pinned twice, in `ci.yml` and in the Makefile, so that CI and a local
+run resolve the same tool. The same contract asserts the two agree and that the
+pin is a commit rather than a tag. Drift there would be quiet: both sides keep
+working while validating publish readiness against different versions.
+
 Check each `main` run with `ubi gh leynos/rstest-bdd list-cache-entries`. It
 must show the archive keys and the `sccache` objects on Ubicloud's side before
 any warm-cache measurement is trustworthy. That was verified on 2026-09-03 at

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -227,8 +227,7 @@ the backend in use.
 
 The end-of-job report is job-wide, so it cannot say what any one step spent.
 That matters most for the publish dry run, which is the longest step in the
-lane and, until lading v0.3.0, attributed nothing at all to its compiler
-cache.
+lane and, until lading v0.3.0, attributed nothing at all to its compiler cache.
 
 Setting `LADING_SCCACHE_STATS_JSON` on that step makes lading read `sccache`
 around each packaged build and write the results to a file, uploaded as the
@@ -237,42 +236,40 @@ invocation rather than obtained by zeroing the counters, so the end-of-job
 report keeps its meaning; a tool that zeroed them would silently make every
 later reading a partial one.
 
-The variable is set on the workflow step rather than in the Makefile, so a
-local `make publish-check` stays quiet and the file lands where the upload
-step expects it. That the publish step asks for the statistics, that the
-upload collects the same path the publish step writes, that reading and
-collecting follow the writing, and that the report steps still run on a
-failed Linux run, is asserted by `publish_report_shape_test.py`, because a
-file written into the runner's temporary directory and never collected is
-discarded with the runner.
+The variable is set on the workflow step rather than in the Makefile, so a local
+`make publish-check` stays quiet and the file lands where the upload step
+expects it. That the publish step asks for the statistics, that the upload
+collects the same path the publish step writes, that reading and collecting
+follow the writing, and that the report steps still run on a failed Linux run,
+is asserted by `publish_report_shape_test.py`, because a file written into the
+runner's temporary directory and never collected is discarded with the runner.
 
-A verification step sits between the two. It reads the report the publish
-step wrote, parses it, and prints it to the log, and where the file is
-absent, empty or unparsable it says which and why. That distinction is the
-point: an absent report and a report nobody opened look identical in the
-artefact list, so a lading that stopped writing the file would read as an
-uneventful run. The step never fails the job, because the report is evidence
-about a build rather than the build itself, and a publish that failed before
-lading ran has already failed on its own account. Both it and the upload
-carry
+A verification step sits between the two. It reads the report the publish step
+wrote, parses it, and prints it to the log, and where the file is absent, empty
+or unparsable it says which and why. That distinction is the point: an absent
+report and a report nobody opened look identical in the artefact list, so a
+lading that stopped writing the file would read as an uneventful run. The step
+never fails the job, because the report is evidence about a build rather than
+the build itself, and a publish that failed before lading ran has already
+failed on its own account. Both it and the upload carry
 `${{ always() && runner.os == 'Linux' }}`: without `always()` the run whose
 cost is most worth reading, the failed one, would upload nothing, and without
 the Linux guard the Windows lanes, which never write the file, would report a
-missing one every time. `publish_report_shape_test.py` asserts both
-conditions, and that the upload's `if-no-files-found` is `warn` rather than
-`ignore`, so an absent report is surfaced rather than swallowed.
+missing one every time. `publish_report_shape_test.py` asserts both conditions,
+and that the upload's `if-no-files-found` is `warn` rather than `ignore`, so an
+absent report is surfaced rather than swallowed.
 
-`publish_verification_script_test.py` runs that script rather than reading
-it for substrings. It extracts the Bash fragment the workflow's `Verify
-publish-step compiler-cache statistics` step declares, writes it to a file,
-and runs it as `bash <file>`, the way a runner executes a step. Four cases
-run against it in turn — a missing report, an empty one, malformed JSON,
-and a valid one — and each must exit successfully, the valid report
-printing without `::warning`. The cases are driven by
-`publish_report_support.run_verification`, which puts the report outside
-the script's working directory and sets `STATS_PATH` to that report, so a
-script that resolved the report relative to the working directory instead
-of through `STATS_PATH` fails the contract here rather than on the runner.
+`publish_verification_script_test.py` runs that script rather than reading it
+for substrings. It extracts the Bash fragment the workflow's
+`Verify publish-step compiler-cache statistics` step declares, writes it to a
+file, and runs it as `bash <file>`, the way a runner executes a step. Four
+cases run against it in turn — a missing report, an empty one, malformed JSON,
+and a valid one — and each must exit successfully, the valid report printing
+without `::warning`. The cases are driven by
+`publish_report_support.run_verification`, which puts the report outside the
+script's working directory and sets `STATS_PATH` to that report, so a script
+that resolved the report relative to the working directory instead of through
+`STATS_PATH` fails the contract here rather than on the runner.
 
 `make publish-check` depends on `stage-published-gpui-e2e`, which extracts
 packaged crates from `target/package/`. That path, and five others in the
@@ -283,21 +280,20 @@ directory from `cargo metadata` would be a Makefile-wide change rather than a
 fix to one recipe, and is worth doing only if the shared-cache layout is wanted
 here.
 
-lading is pinned four times: in `ci.yml`, in the Makefile's `LADING_REF`,
-in `pyproject.toml`'s `python-tools` dependency group for a bare
-`uv run lading`, and in `uv.lock`. `lading_pin_test.py` asserts that all
-four agree and that the pin is a commit rather than a tag. Drift would be
-quiet: every side keeps working while validating publish readiness against
-different versions.
+lading is pinned four times: in `ci.yml`, in the Makefile's `LADING_REF`, in
+`pyproject.toml`'s `python-tools` dependency group for a bare `uv run lading`,
+and in `uv.lock`. `lading_pin_test.py` asserts that all four agree and that the
+pin is a commit rather than a tag. Drift would be quiet: every side keeps
+working while validating publish readiness against different versions.
 
 The project group is the easiest of the four to forget. `make publish-check`
 runs lading through a `--with "$(LADING_SPEC)"` overlay built from the
 Makefile's own `LADING_REF`, so it resolves the Makefile's pin whatever the
 group holds, and the group can sit generations behind without any command
-failing, which is exactly where it was found. `uv.lock` determines what a
-bare `uv run` installs: the group states a commit and the lock records the
-one resolution chose, so the two can disagree only through an incomplete
-bump, and the failure is silent because the lock file wins.
+failing, which is exactly where it was found. `uv.lock` determines what a bare
+`uv run` installs: the group states a commit and the lock records the one
+resolution chose, so the two can disagree only through an incomplete bump, and
+the failure is silent because the lock file wins.
 
 Check each `main` run with `ubi gh leynos/rstest-bdd list-cache-entries`. It
 must show the archive keys and the `sccache` objects on Ubicloud's side before
@@ -1304,21 +1300,21 @@ oracle.
 ### Property tests in the gpui-counter example
 
 The gpui-counter example checks its delta arithmetic with property tests in
-`examples/gpui-counter/src/prop_tests.rs`, a `#[cfg(test)]` module declared
-from `examples/gpui-counter/src/lib.rs`. The crate requires the workspace
+`examples/gpui-counter/src/prop_tests.rs`, a `#[cfg(test)]` module declared from
+`examples/gpui-counter/src/lib.rs`. The crate requires the workspace
 `proptest` development dependency (`proptest.workspace = true` under
-`[dev-dependencies]` in `examples/gpui-counter/Cargo.toml`). The tests run
-with `cargo test -p gpui-counter` and execute as part of the normal workspace
-test suite; `.config/nextest.toml` has no gpui-counter override, so they run
-under the default 60 s slow-timeout with no configuration needed.
+`[dev-dependencies]` in `examples/gpui-counter/Cargo.toml`). The tests run with
+`cargo test -p gpui-counter` and execute as part of the normal workspace test
+suite; `.config/nextest.toml` has no gpui-counter override, so they run under
+the default 60 s slow-timeout with no configuration needed.
 
 The property tests verify the `i64` -> `i32` saturation invariant of
-`saturate_to_i32`: values above `i32::MAX` saturate to `i32::MAX`, values
-below `i32::MIN` saturate to `i32::MIN`, in-range values convert unchanged,
-and every result stays inside the `i32` range. The boundary strategies start
-above `i32::MAX` and end below `i32::MIN`, so the saturation regions are
-exercised densely without relying on random draws landing there; the exact
-boundary values are pinned by deterministic cases added in the same change.
+`saturate_to_i32`: values above `i32::MAX` saturate to `i32::MAX`, values below
+`i32::MIN` saturate to `i32::MIN`, in-range values convert unchanged, and every
+result stays inside the `i32` range. The boundary strategies start above
+`i32::MAX` and end below `i32::MIN`, so the saturation regions are exercised
+densely without relying on random draws landing there; the exact boundary
+values are pinned by deterministic cases added in the same change.
 
 ### Bulk-migration cookbook reference suite
 
@@ -2028,10 +2024,10 @@ subscriber is set.
 
 Warnings raised from `StepContext` go through the private `context::warnings`
 module, which emits under the established `rstest_bdd::context` target and
-mirrors the message to stderr when the selected delivery route has no
-listener. That mirror is what keeps a diagnostic visible in the common case of
-a test binary with no logging configured at all, so new step-context warnings
-should use it rather than calling `tracing::warn!` directly.
+mirrors the message to stderr when the selected delivery route has no listener.
+That mirror is what keeps a diagnostic visible in the common case of a test
+binary with no logging configured at all, so new step-context warnings should
+use it rather than calling `tracing::warn!` directly.
 
 Harness implementations should emit a `tracing::error!` event before returning
 `Err` from `HarnessAdapter::run`. Use structured fields so downstream test

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -223,7 +223,6 @@ after installing `sccache`, and the final step publishes `sccache --show-stats`
 in text and JSON to the job summary alongside every cache key, hit result, and
 the backend in use.
 
-
 #### Attributing the publish step's share
 
 The end-of-job report is job-wide, so it cannot say what any one step spent.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -228,7 +228,8 @@ the backend in use.
 
 The end-of-job report is job-wide, so it cannot say what any one step spent.
 That matters most for the publish dry run, which is the longest step in the
-lane and, until lading v0.3.0, said nothing at all about its compiler cache.
+lane and, until lading v0.3.0, attributed nothing at all to its compiler
+cache.
 
 Setting `LADING_SCCACHE_STATS_JSON` on that step makes lading read `sccache`
 around each packaged build and write the results to a file, uploaded as the
@@ -238,19 +239,21 @@ report keeps its meaning; a tool that zeroed them would silently make every
 later reading a partial one.
 
 The variable is set on the workflow step rather than in the Makefile, so a
-local `make publish-check` stays quiet and the file lands where the upload step
-expects it. `lading_pin_test.py` asserts that the step still asks for the
-statistics and that the file is uploaded, because a file written into the
-runner's temporary directory and never collected is discarded with the runner.
+local `make publish-check` stays quiet and the file lands where the upload
+step expects it. `lading_pin_test.py` asserts that the step still asks for
+the statistics and that the file is uploaded, because a file written into the
+runner's temporary directory and never collected is discarded with the
+runner.
 
-A verification step sits between the two. It reads the report the publish step
-wrote, parses it, and prints it to the log, and where the file is absent, empty
-or unparsable it says which and why. That distinction is the point: an absent
-report and a report nobody opened look identical in the artefact list, so a
-lading that stopped writing the file would read as an uneventful run. The step
-never fails the job, because the report is evidence about a build rather than
-the build itself, and a publish that failed before lading ran has already
-failed on its own account. Both it and the upload carry
+A verification step sits between the two. It reads the report the publish
+step wrote, parses it, and prints it to the log, and where the file is
+absent, empty or unparsable it says which and why. That distinction is the
+point: an absent report and a report nobody opened look identical in the
+artefact list, so a lading that stopped writing the file would read as an
+uneventful run. The step never fails the job, because the report is evidence
+about a build rather than the build itself, and a publish that failed before
+lading ran has already failed on its own account. Both it and the upload
+carry
 `${{ always() && runner.os == 'Linux' }}`: without `always()` the run whose
 cost is most worth reading, the failed one, would upload nothing, and without
 the Linux guard the Windows lanes, which never write the file, would report a

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -240,10 +240,12 @@ later reading a partial one.
 
 The variable is set on the workflow step rather than in the Makefile, so a
 local `make publish-check` stays quiet and the file lands where the upload
-step expects it. `lading_pin_test.py` asserts that the step still asks for
-the statistics and that the file is uploaded, because a file written into the
-runner's temporary directory and never collected is discarded with the
-runner.
+step expects it. That the publish step asks for the statistics, that the
+upload collects the same path the publish step writes, that reading and
+collecting follow the writing, and that the report steps still run on a
+failed Linux run, is asserted by `publish_report_shape_test.py`, because a
+file written into the runner's temporary directory and never collected is
+discarded with the runner.
 
 A verification step sits between the two. It reads the report the publish
 step wrote, parses it, and prints it to the log, and where the file is
@@ -257,8 +259,21 @@ carry
 `${{ always() && runner.os == 'Linux' }}`: without `always()` the run whose
 cost is most worth reading, the failed one, would upload nothing, and without
 the Linux guard the Windows lanes, which never write the file, would report a
-missing one every time. The upload's `if-no-files-found` is `warn` rather than
-`ignore` for the same reason.
+missing one every time. `publish_report_shape_test.py` asserts both
+conditions, and that the upload's `if-no-files-found` is `warn` rather than
+`ignore`, so an absent report is surfaced rather than swallowed.
+
+`publish_verification_script_test.py` runs that script rather than reading
+it for substrings. It extracts the Bash fragment the workflow's `Verify
+publish-step compiler-cache statistics` step declares, writes it to a file,
+and runs it as `bash <file>`, the way a runner executes a step. Four cases
+run against it in turn — a missing report, an empty one, malformed JSON,
+and a valid one — and each must exit successfully, the valid report
+printing without `::warning`. The cases are driven by
+`publish_report_support.run_verification`, which puts the report outside
+the script's working directory and sets `STATS_PATH` to that report, so a
+script that resolved the report relative to the working directory instead
+of through `STATS_PATH` fails the contract here rather than on the runner.
 
 `make publish-check` depends on `stage-published-gpui-e2e`, which extracts
 packaged crates from `target/package/`. That path, and five others in the
@@ -269,16 +284,21 @@ directory from `cargo metadata` would be a Makefile-wide change rather than a
 fix to one recipe, and is worth doing only if the shared-cache layout is wanted
 here.
 
-lading is pinned three times: in `ci.yml`, in the Makefile, and in
-`pyproject.toml`'s `python-tools` group for a bare `uv run lading`. The same
-contract asserts all three agree and that the pin is a commit rather than a tag.
-Drift there would be quiet: every side keeps working while validating publish
-readiness against different versions.
+lading is pinned four times: in `ci.yml`, in the Makefile's `LADING_REF`,
+in `pyproject.toml`'s `python-tools` dependency group for a bare
+`uv run lading`, and in `uv.lock`. `lading_pin_test.py` asserts that all
+four agree and that the pin is a commit rather than a tag. Drift would be
+quiet: every side keeps working while validating publish readiness against
+different versions.
 
-The project group is the easiest of the three to forget, because the Makefile's
-`--with` overlay masks it. `make publish-check` resolves the Makefile's pin
-whatever the group holds, so the group can sit generations behind without any
-command failing, which is exactly where it was found.
+The project group is the easiest of the four to forget. `make publish-check`
+runs lading through a `--with "$(LADING_SPEC)"` overlay built from the
+Makefile's own `LADING_REF`, so it resolves the Makefile's pin whatever the
+group holds, and the group can sit generations behind without any command
+failing, which is exactly where it was found. `uv.lock` determines what a
+bare `uv run` installs: the group states a commit and the lock records the
+one resolution chose, so the two can disagree only through an incomplete
+bump, and the failure is silent because the lock file wins.
 
 Check each `main` run with `ubi gh leynos/rstest-bdd list-cache-entries`. It
 must show the archive keys and the `sccache` objects on Ubicloud's side before

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -243,6 +243,15 @@ expects it. `lading_pin_test.py` asserts that the step still asks for the
 statistics and that the file is uploaded, because a file written into the
 runner's temporary directory and never collected is discarded with the runner.
 
+`make publish-check` depends on `stage-published-gpui-e2e`, which extracts
+packaged crates from `target/package/`. That path, and five others in the
+Makefile including the `target/%/$(APP)` build rules, name the target directory
+literally, so none of them work under a `CARGO_TARGET_DIR` that points outside
+the tree. Run these targets without such an override. Making them read the
+directory from `cargo metadata` would be a Makefile-wide change rather than a
+fix to one recipe, and is worth doing only if the shared-cache layout is wanted
+here.
+
 lading is pinned twice, in `ci.yml` and in the Makefile, so that CI and a local
 run resolve the same tool. The same contract asserts the two agree and that the
 pin is a commit rather than a tag. Drift there would be quiet: both sides keep

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ default-groups = ["python-tools"]
 python-tools = [
     "df12-python-lints @ git+https://github.com/leynos/df12-python-lints.git@v0.3.0",
     "hypothesis",
-    "lading @ git+https://github.com/leynos/lading@d3217a599ea34adad6a6e3845845fff2fe923758",
+    "lading @ git+https://github.com/leynos/lading@c3740ef48da4c89752fcb98fff4f1c27284e5f12",
     "pathspec==1.1.1",
     "pylint",
     "pytest",

--- a/tests/workflow_contracts/conftest.py
+++ b/tests/workflow_contracts/conftest.py
@@ -1,0 +1,23 @@
+"""Fixtures shared by the publish-report workflow contracts.
+
+The `build-test` job is parsed once per module rather than per call, so
+every assertion in a module reads the same parse: a loader that reread
+the file could not tell a contract failure from a file edited mid-run.
+"""
+
+import typing as typ
+
+import pytest
+from publish_report_support import build_test_job_document
+
+
+@pytest.fixture(scope="module")
+def build_test_job() -> dict[str, typ.Any]:
+    """Return the packaging job, parsed once for the whole module.
+
+    Returns
+    -------
+    dict[str, typ.Any]
+        The job that runs the publish dry run.
+    """
+    return build_test_job_document()

--- a/tests/workflow_contracts/conftest.py
+++ b/tests/workflow_contracts/conftest.py
@@ -1,23 +1,30 @@
 """Fixtures shared by the publish-report workflow contracts.
 
-The `build-test` job is parsed once per module rather than per call, so
-every assertion in a module reads the same parse: a loader that reread
-the file could not tell a contract failure from a file edited mid-run.
+The `build-test` job is read and parsed once per module rather than per
+call, so every assertion in a module reads the same parse: a loader that
+reread the file could not tell a contract failure from a file edited
+mid-run. Repository access happens through
+:func:`workflow_support.repository_file` and YAML parsing through
+:func:`workflow_support.parse_workflow`, behind the
+:func:`publish_report_support.read_build_test_job_document` boundary.
 """
 
 import typing as typ
 
 import pytest
-from publish_report_support import build_test_job_document
+from publish_report_support import read_build_test_job_document
 
 
 @pytest.fixture(scope="module")
 def build_test_job() -> dict[str, typ.Any]:
-    """Return the packaging job, parsed once for the whole module.
+    """Return the packaging job, read and parsed once for the module.
 
     Returns
     -------
     dict[str, typ.Any]
         The job that runs the publish dry run.
+
+    Delegates to :func:`publish_report_support.read_build_test_job_document`,
+    which documents the raised contract errors.
     """
-    return build_test_job_document()
+    return read_build_test_job_document()

--- a/tests/workflow_contracts/lading_pin_parsing_test.py
+++ b/tests/workflow_contracts/lading_pin_parsing_test.py
@@ -1,0 +1,135 @@
+"""Behaviour of the lading pin parsers against synthetic documents.
+
+`lading_pin_test` asserts that the repository's own four pins agree. It
+cannot say what happens when one of them is malformed, because a
+repository holding a malformed pin is exactly what the contract exists
+to prevent. These tests supply the malformed documents directly, so the
+refusals the readers promise are exercised rather than assumed.
+
+Run via ``make test-workflow-contracts``.
+"""
+
+import pytest
+from lading_pins import (
+    lading_ref_in_lockfile,
+    lading_ref_in_makefile,
+    lading_ref_in_pyproject,
+)
+from publish_report_support import PublishReportShapeError
+from workflow_support import MissingRepositoryFileError, repository_file
+
+COMMIT = "0123456789abcdef0123456789abcdef01234567"
+OTHER_COMMIT = "89abcdef0123456789abcdef0123456789abcdef"
+
+
+def makefile_text(ref: str) -> str:
+    """Return a Makefile pinning lading to one reference.
+
+    Parameters
+    ----------
+    ref : str
+        The reference to write into ``LADING_REF``.
+
+    Returns
+    -------
+    str
+        A Makefile carrying that pin among other variables.
+    """
+    return f"APP ?= rstest-bdd\nLADING_REF ?= {ref}\n\nall:\n\t@true\n"
+
+
+def lockfile_text(*revisions: str) -> str:
+    """Return a lock file resolving lading to the given revisions.
+
+    Parameters
+    ----------
+    *revisions : str
+        The commits to record. None yields a lock file naming no lading
+        revision at all.
+
+    Returns
+    -------
+    str
+        A lock file fragment carrying those resolutions.
+    """
+    entries = "\n".join(
+        f'source = {{ git = "https://github.com/leynos/lading?rev={revision}" }}'
+        for revision in revisions
+    )
+    return f'[[package]]\nname = "lading"\n{entries}\n'
+
+
+def pyproject_text(ref: str) -> str:
+    """Return a project manifest pinning lading to one reference.
+
+    Parameters
+    ----------
+    ref : str
+        The reference to write into the project group's requirement.
+
+    Returns
+    -------
+    str
+        A manifest carrying that requirement.
+    """
+    return (
+        "[dependency-groups]\npython-tools = [\n"
+        f'  "lading @ git+https://github.com/leynos/lading@{ref}",\n]\n'
+    )
+
+
+def test_the_makefile_parser_reads_the_pin_it_declares() -> None:
+    """A Makefile's ``LADING_REF`` is the commit the parser returns."""
+    parsed = lading_ref_in_makefile(makefile_text(COMMIT))
+
+    assert parsed == COMMIT, (
+        f"the Makefile's LADING_REF must be read verbatim, got {parsed!r}"
+    )
+
+
+def test_the_lockfile_parser_reads_the_revision_it_records() -> None:
+    """A lock file's single lading revision is what the parser returns."""
+    parsed = lading_ref_in_lockfile(lockfile_text(COMMIT))
+
+    assert parsed == COMMIT, (
+        f"the lock file's lading revision must be read verbatim, got {parsed!r}"
+    )
+
+
+def test_the_pyproject_parser_reads_the_pin_it_declares() -> None:
+    """The project group's commit is what the parser returns."""
+    parsed = lading_ref_in_pyproject(pyproject_text(COMMIT))
+
+    assert parsed == COMMIT, (
+        f"the project group's lading pin must be read verbatim, got {parsed!r}"
+    )
+
+
+def test_a_makefile_without_the_pin_is_refused() -> None:
+    """A Makefile that sets no ``LADING_REF`` resolves no tool at all."""
+    with pytest.raises(PublishReportShapeError, match="LADING_REF"):
+        lading_ref_in_makefile("APP ?= rstest-bdd\n")
+
+
+def test_a_lockfile_naming_no_revision_is_refused() -> None:
+    """Without a revision the lock file cannot say what `uv run` installs."""
+    with pytest.raises(PublishReportShapeError, match="git revision"):
+        lading_ref_in_lockfile('[[package]]\nname = "lading"\n')
+
+
+def test_a_lockfile_naming_two_revisions_is_refused() -> None:
+    """Two resolutions leave which one a bare `uv run` installs undecided."""
+    with pytest.raises(PublishReportShapeError, match="one commit"):
+        lading_ref_in_lockfile(lockfile_text(COMMIT, OTHER_COMMIT))
+
+
+def test_a_pyproject_pinning_a_moving_reference_is_refused() -> None:
+    """A tag lets the tool change under a pin that still reads green."""
+    with pytest.raises(PublishReportShapeError, match="pin lading by commit"):
+        lading_ref_in_pyproject(pyproject_text("v0.3.0"))
+
+
+def test_the_repository_boundary_refuses_an_absent_file() -> None:
+    """The readers' one filesystem call names the file it could not find."""
+    with pytest.raises(MissingRepositoryFileError, match="no-such-pin-file"):
+        repository_file("no-such-pin-file.toml")

--- a/tests/workflow_contracts/lading_pin_test.py
+++ b/tests/workflow_contracts/lading_pin_test.py
@@ -23,14 +23,17 @@ Run via ``make test-workflow-contracts``.
 
 import re
 import typing as typ
-from pathlib import Path
 
-import yaml
+import pytest
+from workflow_support import job, repository_file, steps
 
-REPOSITORY_ROOT: typ.Final[Path] = Path(__file__).resolve().parents[2]
-MAKEFILE_PATH: typ.Final[Path] = REPOSITORY_ROOT / "Makefile"
-PYPROJECT_PATH: typ.Final[Path] = REPOSITORY_ROOT / "pyproject.toml"
-WORKFLOW_PATH: typ.Final[Path] = REPOSITORY_ROOT / ".github" / "workflows" / "ci.yml"
+#: The workflow these assertions read, loaded through
+#: :func:`workflow_support.job` so file access and YAML parsing happen at
+#: one boundary rather than in each contract.
+CI_WORKFLOW: typ.Final[str] = "ci.yml"
+
+#: The job that packages the crates.
+BUILD_TEST_JOB: typ.Final[str] = "build-test"
 
 #: The step that runs the publish dry run.
 DRY_RUN_STEP: typ.Final[str] = "Publish dry run"
@@ -40,6 +43,22 @@ STATS_VARIABLE: typ.Final[str] = "LADING_SCCACHE_STATS_JSON"
 
 #: The action that collects the statistics file.
 UPLOAD_ACTION: typ.Final[str] = "actions/upload-artifact@"
+
+#: The step that reads the report before it is uploaded.
+VERIFY_STEP: typ.Final[str] = "Verify publish-step compiler-cache statistics"
+
+#: The step that collects the report.
+UPLOAD_STEP: typ.Final[str] = "Upload publish-step compiler-cache statistics"
+
+#: The condition both steps carry. Written out rather than matched
+#: loosely: `always()` alone would upload from the Windows lanes, which
+#: never write the file, and `runner.os == 'Linux'` alone would skip the
+#: run that failed, which is the run whose cost is worth reading.
+LINUX_ALWAYS: typ.Final[str] = "${{ always() && runner.os == 'Linux' }}"
+
+#: How long the artefact is kept. Asserted because an artefact that
+#: expires before anyone compares two runs is not evidence.
+RETENTION_DAYS: typ.Final[int] = 7
 
 _FULL_SHA: typ.Final[re.Pattern[str]] = re.compile(r"^[0-9a-f]{40}$")
 
@@ -52,7 +71,7 @@ def _makefile_lading_ref() -> str:
     str
         The commit the Makefile resolves lading from.
     """
-    makefile = MAKEFILE_PATH.read_text(encoding="utf-8")
+    makefile = repository_file("Makefile")
     match = re.search(r"^LADING_REF \?= (?P<ref>\S+)$", makefile, re.MULTILINE)
     assert match is not None, "the Makefile must define LADING_REF"
     return match["ref"]
@@ -66,7 +85,7 @@ def _pyproject_lading_ref() -> str:
     str
         The commit `uv` resolves lading from for a bare `uv run`.
     """
-    pyproject = PYPROJECT_PATH.read_text(encoding="utf-8")
+    pyproject = repository_file("pyproject.toml")
     match = re.search(
         r"lading @ git\+https://github\.com/leynos/lading@(?P<ref>[0-9a-f]{40})",
         pyproject,
@@ -75,15 +94,15 @@ def _pyproject_lading_ref() -> str:
     return match["ref"]
 
 
-def _workflow() -> dict[str, typ.Any]:
-    """Return the parsed CI workflow.
+def _build_test_steps() -> list[dict[str, typ.Any]]:
+    """Return the packaging job's steps, in document order.
 
     Returns
     -------
-    dict[str, typ.Any]
-        The workflow document.
+    list[dict[str, typ.Any]]
+        The steps of the job that runs the publish dry run.
     """
-    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    return typ.cast("list[dict[str, typ.Any]]", steps(job(CI_WORKFLOW, BUILD_TEST_JOB)))
 
 
 def _build_test_env() -> dict[str, typ.Any]:
@@ -94,25 +113,64 @@ def _build_test_env() -> dict[str, typ.Any]:
     dict[str, typ.Any]
         The job-level environment.
     """
-    environment = _workflow()["jobs"]["build-test"].get("env")
+    environment = job(CI_WORKFLOW, BUILD_TEST_JOB).get("env")
     assert isinstance(environment, dict), "build-test must define env"
     return environment
 
 
+def _step_index(name: str) -> int:
+    """Return the position of the one step with ``name``.
+
+    Uniqueness is part of the assertion. Two steps of the same name would
+    make every ordering claim below ambiguous, and the one that mattered
+    could be the one that moved.
+
+    Parameters
+    ----------
+    name : str
+        The step's declared name.
+
+    Returns
+    -------
+    int
+        Its index among the job's steps.
+    """
+    matches = [
+        index
+        for index, step in enumerate(_build_test_steps())
+        if step.get("name") == name
+    ]
+    assert len(matches) == 1, (
+        f"{BUILD_TEST_JOB} must declare exactly one {name!r} step, found {len(matches)}"
+    )
+    return matches[0]
+
+
+def _step(name: str) -> dict[str, typ.Any]:
+    """Return the one step with ``name``.
+
+    Parameters
+    ----------
+    name : str
+        The step's declared name.
+
+    Returns
+    -------
+    dict[str, typ.Any]
+        The step.
+    """
+    return _build_test_steps()[_step_index(name)]
+
+
 def _dry_run_steps() -> list[dict[str, typ.Any]]:
-    """Return every publish dry-run step in the workflow.
+    """Return every publish dry-run step in the packaging job.
 
     Returns
     -------
     list[dict[str, typ.Any]]
         The steps named for the dry run.
     """
-    return [
-        step
-        for job in _workflow()["jobs"].values()
-        for step in job.get("steps", [])
-        if step.get("name") == DRY_RUN_STEP
-    ]
+    return [step for step in _build_test_steps() if step.get("name") == DRY_RUN_STEP]
 
 
 def test_every_lading_pin_agrees() -> None:
@@ -167,61 +225,136 @@ def test_the_dry_run_asks_for_compiler_cache_statistics() -> None:
         )
 
 
-def _workflow_steps() -> list[dict[str, typ.Any]]:
-    """Return every step of every job in the workflow.
+def _statistics_path() -> str:
+    """Return the one path the workflow tells lading to write to.
 
     Returns
     -------
-    list[dict[str, typ.Any]]
-        The steps, in document order.
+    str
+        The configured file path.
     """
-    return [
-        step for job in _workflow()["jobs"].values() for step in job.get("steps", [])
-    ]
-
-
-def _statistics_paths() -> set[str]:
-    """Return every path the workflow tells lading to write statistics to.
-
-    Returns
-    -------
-    set[str]
-        The configured file paths.
-    """
-    return {
-        str(value)
-        for step in _workflow_steps()
-        if (value := (step.get("env") or {}).get(STATS_VARIABLE))
-    }
-
-
-def _uploads_of(paths: set[str]) -> list[dict[str, typ.Any]]:
-    """Return the upload steps that collect one of ``paths``.
-
-    Parameters
-    ----------
-    paths : set[str]
-        Paths the workflow writes statistics to.
-
-    Returns
-    -------
-    list[dict[str, typ.Any]]
-        The matching upload steps.
-    """
-    return [
-        step
-        for step in _workflow_steps()
-        if UPLOAD_ACTION in str(step.get("uses", ""))
-        and str((step.get("with") or {}).get("path", "")) in paths
-    ]
+    environment = _step(DRY_RUN_STEP).get("env") or {}
+    path = environment.get(STATS_VARIABLE)
+    assert isinstance(path, str), (
+        f"the {DRY_RUN_STEP!r} step must set {STATS_VARIABLE} to a path, got {path!r}"
+    )
+    assert path, f"the {DRY_RUN_STEP!r} step must set {STATS_VARIABLE}"
+    return path
 
 
 def test_the_statistics_file_is_uploaded() -> None:
-    """A file written into RUNNER_TEMP and never uploaded is not evidence."""
-    paths = _statistics_paths()
+    """A file written into RUNNER_TEMP and never uploaded is not evidence.
 
-    assert _uploads_of(paths), (
-        f"the file named by {STATS_VARIABLE} must be uploaded as an artefact; "
-        f"written into the runner's temporary directory and left there, it is "
-        f"discarded with the runner. Configured paths: {sorted(paths)}"
+    The upload has to collect the path the publish step wrote, so the two
+    are compared rather than each checked against a constant. A step that
+    uploaded a stale path would satisfy either check alone.
+    """
+    upload = _step(UPLOAD_STEP)
+    assert UPLOAD_ACTION in str(upload.get("uses", "")), (
+        f"{UPLOAD_STEP!r} must use {UPLOAD_ACTION}, not {upload.get('uses')!r}"
+    )
+    with_block = upload.get("with") or {}
+    assert with_block.get("path") == _statistics_path(), (
+        f"{UPLOAD_STEP!r} uploads {with_block.get('path')!r}, which is not "
+        f"the {_statistics_path()!r} the publish step writes; the report "
+        f"would be discarded with the runner"
+    )
+
+
+def test_the_upload_follows_the_publish_step() -> None:
+    """Ordering is the whole of it: nothing exists to upload before.
+
+    A step order that put the upload first would pass every assertion
+    about its inputs and collect nothing on every run.
+    """
+    publish = _step_index(DRY_RUN_STEP)
+    verify = _step_index(VERIFY_STEP)
+    upload = _step_index(UPLOAD_STEP)
+    assert publish < verify < upload, (
+        f"the publish step (index {publish}) must precede the verification "
+        f"(index {verify}) and the upload (index {upload}); a report is "
+        f"read and collected after it is written, not before"
+    )
+
+
+@pytest.mark.parametrize("step_name", [VERIFY_STEP, UPLOAD_STEP], ids=str)
+def test_the_report_steps_run_on_a_failed_linux_run(step_name: str) -> None:
+    """The run worth reading is often the one that failed.
+
+    Both halves of the condition are load-bearing and each fails a
+    different way. Without ``always()`` a failed publish uploads nothing,
+    which is the run whose cost is worth knowing. Without the Linux
+    guard, the Windows lanes, which never write the file, would report a
+    missing one on every run.
+    """
+    condition = str(_step(step_name).get("if", ""))
+    assert condition == LINUX_ALWAYS, (
+        f"{step_name!r} has if: {condition!r}, not {LINUX_ALWAYS!r}"
+    )
+
+
+def test_the_artefact_is_named_per_lane_and_kept() -> None:
+    """One name per lane, kept long enough to compare two runs.
+
+    A name shared across the matrix collides, and the second lane's
+    upload fails or overwrites the first. A retention shorter than the
+    comparison window makes the artefact evidence that expires before it
+    is read.
+    """
+    with_block = _step(UPLOAD_STEP).get("with") or {}
+    name = str(with_block.get("name", ""))
+    assert "${{ matrix.os }}" in name, (
+        f"the artefact name {name!r} must vary by operating system, or two "
+        f"lanes collide on one name"
+    )
+    assert "${{ strategy.job-index }}" in name, (
+        f"the artefact name {name!r} must vary by matrix leg, or two legs on "
+        f"one operating system collide"
+    )
+    assert with_block.get("retention-days") == RETENTION_DAYS, (
+        f"the artefact must be kept for {RETENTION_DAYS} days, not "
+        f"{with_block.get('retention-days')!r}"
+    )
+
+
+def test_a_missing_report_is_surfaced_rather_than_swallowed() -> None:
+    """Silence and success look identical on an absent report.
+
+    ``if-no-files-found: ignore`` uploads nothing and says nothing, so a
+    lading that stopped writing the file would read as a run whose report
+    nobody happened to open. The verification step names the cause; the
+    upload's own setting must not contradict it.
+    """
+    with_block = _step(UPLOAD_STEP).get("with") or {}
+    assert with_block.get("if-no-files-found") == "warn", (
+        f"the upload must warn on a missing report, not "
+        f"{with_block.get('if-no-files-found')!r}"
+    )
+
+
+def test_the_verification_step_reads_the_report_it_was_given() -> None:
+    """A verification that checked a different path proves nothing.
+
+    It also must not fail the job. The report is evidence about a build,
+    not the build, and a publish that failed before lading ran has
+    already failed on its own account.
+    """
+    verify = _step(VERIFY_STEP)
+    environment = verify.get("env") or {}
+    assert environment.get("STATS_PATH") == _statistics_path(), (
+        f"{VERIFY_STEP!r} reads {environment.get('STATS_PATH')!r}, not the "
+        f"{_statistics_path()!r} the publish step writes"
+    )
+    script = str(verify.get("run", ""))
+    assert "::warning" in script, (
+        f"{VERIFY_STEP!r} must report a missing or unreadable report as a "
+        f"warning; a silent check is the state this replaces"
+    )
+    assert "json.load" in script, (
+        f"{VERIFY_STEP!r} must parse the report rather than only test that "
+        f"the file exists; an empty or truncated file would pass otherwise"
+    )
+    assert "exit 1" not in script, (
+        f"{VERIFY_STEP!r} must not fail the job: the report is evidence "
+        f"about the build, not the build"
     )

--- a/tests/workflow_contracts/lading_pin_test.py
+++ b/tests/workflow_contracts/lading_pin_test.py
@@ -1,11 +1,17 @@
 """Contract tests for the lading pin and its compiler-cache reporting.
 
-lading runs the publish dry run, and it is pinned twice: `ci.yml` sets
-`LADING_REF` for the job, and the Makefile sets it again so a local
-`make publish-check` resolves the same tool. Two pins for one tool drift,
-and the failure is quiet: CI validates publish readiness with one version
-while a developer validates it with another, and each believes the other
-agrees.
+lading runs the publish dry run, and it is pinned three times: `ci.yml`
+sets `LADING_REF` for the job, the Makefile sets it again so a local
+`make publish-check` resolves the same tool, and `pyproject.toml` pins it
+in the `python-tools` group for a bare `uv run lading`. Three pins for one
+tool drift, and the failure is quiet: CI validates publish readiness with
+one version while a developer validates it with another, and each
+believes the other agrees.
+
+The third is the easiest to miss, because the Makefile's `--with` overlay
+masks it: `make publish-check` resolves the Makefile's pin regardless of
+what the project group holds, so the group can sit generations behind
+without any command failing.
 
 The version itself is not asserted. A bump should need one paired change,
 not three. What is asserted is that the two agree, and that the workflow
@@ -23,6 +29,7 @@ import yaml
 
 REPOSITORY_ROOT: typ.Final[Path] = Path(__file__).resolve().parents[2]
 MAKEFILE_PATH: typ.Final[Path] = REPOSITORY_ROOT / "Makefile"
+PYPROJECT_PATH: typ.Final[Path] = REPOSITORY_ROOT / "pyproject.toml"
 WORKFLOW_PATH: typ.Final[Path] = REPOSITORY_ROOT / ".github" / "workflows" / "ci.yml"
 
 #: The step that runs the publish dry run.
@@ -30,6 +37,9 @@ DRY_RUN_STEP: typ.Final[str] = "Publish dry run"
 
 #: The environment variable lading reads for its statistics file.
 STATS_VARIABLE: typ.Final[str] = "LADING_SCCACHE_STATS_JSON"
+
+#: The action that collects the statistics file.
+UPLOAD_ACTION: typ.Final[str] = "actions/upload-artifact@"
 
 _FULL_SHA: typ.Final[re.Pattern[str]] = re.compile(r"^[0-9a-f]{40}$")
 
@@ -45,6 +55,23 @@ def _makefile_lading_ref() -> str:
     makefile = MAKEFILE_PATH.read_text(encoding="utf-8")
     match = re.search(r"^LADING_REF \?= (?P<ref>\S+)$", makefile, re.MULTILINE)
     assert match is not None, "the Makefile must define LADING_REF"
+    return match["ref"]
+
+
+def _pyproject_lading_ref() -> str:
+    """Return the project group's lading pin.
+
+    Returns
+    -------
+    str
+        The commit `uv` resolves lading from for a bare `uv run`.
+    """
+    pyproject = PYPROJECT_PATH.read_text(encoding="utf-8")
+    match = re.search(
+        r"lading @ git\+https://github\.com/leynos/lading@(?P<ref>[0-9a-f]{40})",
+        pyproject,
+    )
+    assert match is not None, "pyproject.toml must pin lading by commit"
     return match["ref"]
 
 
@@ -88,19 +115,23 @@ def _dry_run_steps() -> list[dict[str, typ.Any]]:
     ]
 
 
-def test_the_two_lading_pins_agree() -> None:
-    """CI and the Makefile must resolve the same lading.
+def test_every_lading_pin_agrees() -> None:
+    """All three places must resolve the same lading.
 
-    Drift here is quiet rather than loud: both sides keep working, and
+    Drift here is quiet rather than loud: every side keeps working, and
     each validates publish readiness against a different tool while
-    believing the other agrees.
+    believing the others agree. The project group is the easiest to
+    forget, because the Makefile's `--with` overlay hides it.
     """
-    workflow_ref = _build_test_env().get("LADING_REF")
-    makefile_ref = _makefile_lading_ref()
+    pins = {
+        "ci.yml": _build_test_env().get("LADING_REF"),
+        "Makefile": _makefile_lading_ref(),
+        "pyproject.toml": _pyproject_lading_ref(),
+    }
 
-    assert workflow_ref == makefile_ref, (
-        f"ci.yml pins lading at {workflow_ref!r} and the Makefile at "
-        f"{makefile_ref!r}; a bump must move both"
+    assert len(set(pins.values())) == 1, (
+        f"every lading pin must name the same commit; a bump must move all "
+        f"of them: {pins}"
     )
 
 
@@ -136,25 +167,61 @@ def test_the_dry_run_asks_for_compiler_cache_statistics() -> None:
         )
 
 
-def test_the_statistics_file_is_uploaded() -> None:
-    """A file written into RUNNER_TEMP and never uploaded is not evidence."""
-    workflow = _workflow()
-    stats_paths = {
-        str((step.get("env") or {}).get(STATS_VARIABLE))
-        for job in workflow["jobs"].values()
-        for step in job.get("steps", [])
-        if (step.get("env") or {}).get(STATS_VARIABLE)
-    }
-    uploads = [
-        step
-        for job in workflow["jobs"].values()
-        for step in job.get("steps", [])
-        if "actions/upload-artifact@" in str(step.get("uses", ""))
-        and str((step.get("with") or {}).get("path", "")) in stats_paths
+def _workflow_steps() -> list[dict[str, typ.Any]]:
+    """Return every step of every job in the workflow.
+
+    Returns
+    -------
+    list[dict[str, typ.Any]]
+        The steps, in document order.
+    """
+    return [
+        step for job in _workflow()["jobs"].values() for step in job.get("steps", [])
     ]
 
-    assert uploads, (
+
+def _statistics_paths() -> set[str]:
+    """Return every path the workflow tells lading to write statistics to.
+
+    Returns
+    -------
+    set[str]
+        The configured file paths.
+    """
+    return {
+        str(value)
+        for step in _workflow_steps()
+        if (value := (step.get("env") or {}).get(STATS_VARIABLE))
+    }
+
+
+def _uploads_of(paths: set[str]) -> list[dict[str, typ.Any]]:
+    """Return the upload steps that collect one of ``paths``.
+
+    Parameters
+    ----------
+    paths : set[str]
+        Paths the workflow writes statistics to.
+
+    Returns
+    -------
+    list[dict[str, typ.Any]]
+        The matching upload steps.
+    """
+    return [
+        step
+        for step in _workflow_steps()
+        if UPLOAD_ACTION in str(step.get("uses", ""))
+        and str((step.get("with") or {}).get("path", "")) in paths
+    ]
+
+
+def test_the_statistics_file_is_uploaded() -> None:
+    """A file written into RUNNER_TEMP and never uploaded is not evidence."""
+    paths = _statistics_paths()
+
+    assert _uploads_of(paths), (
         f"the file named by {STATS_VARIABLE} must be uploaded as an artefact; "
         f"written into the runner's temporary directory and left there, it is "
-        f"discarded with the runner"
+        f"discarded with the runner. Configured paths: {sorted(paths)}"
     )

--- a/tests/workflow_contracts/lading_pin_test.py
+++ b/tests/workflow_contracts/lading_pin_test.py
@@ -1,0 +1,160 @@
+"""Contract tests for the lading pin and its compiler-cache reporting.
+
+lading runs the publish dry run, and it is pinned twice: `ci.yml` sets
+`LADING_REF` for the job, and the Makefile sets it again so a local
+`make publish-check` resolves the same tool. Two pins for one tool drift,
+and the failure is quiet: CI validates publish readiness with one version
+while a developer validates it with another, and each believes the other
+agrees.
+
+The version itself is not asserted. A bump should need one paired change,
+not three. What is asserted is that the two agree, and that the workflow
+still asks lading for the compiler-cache statistics whose absence made
+the publish step's cost unattributable (rstest-bdd#720).
+
+Run via ``make test-workflow-contracts``.
+"""
+
+import re
+import typing as typ
+from pathlib import Path
+
+import yaml
+
+REPOSITORY_ROOT: typ.Final[Path] = Path(__file__).resolve().parents[2]
+MAKEFILE_PATH: typ.Final[Path] = REPOSITORY_ROOT / "Makefile"
+WORKFLOW_PATH: typ.Final[Path] = REPOSITORY_ROOT / ".github" / "workflows" / "ci.yml"
+
+#: The step that runs the publish dry run.
+DRY_RUN_STEP: typ.Final[str] = "Publish dry run"
+
+#: The environment variable lading reads for its statistics file.
+STATS_VARIABLE: typ.Final[str] = "LADING_SCCACHE_STATS_JSON"
+
+_FULL_SHA: typ.Final[re.Pattern[str]] = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _makefile_lading_ref() -> str:
+    """Return the Makefile's lading pin.
+
+    Returns
+    -------
+    str
+        The commit the Makefile resolves lading from.
+    """
+    makefile = MAKEFILE_PATH.read_text(encoding="utf-8")
+    match = re.search(r"^LADING_REF \?= (?P<ref>\S+)$", makefile, re.MULTILINE)
+    assert match is not None, "the Makefile must define LADING_REF"
+    return match["ref"]
+
+
+def _workflow() -> dict[str, typ.Any]:
+    """Return the parsed CI workflow.
+
+    Returns
+    -------
+    dict[str, typ.Any]
+        The workflow document.
+    """
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _build_test_env() -> dict[str, typ.Any]:
+    """Return the build-test job's environment mapping.
+
+    Returns
+    -------
+    dict[str, typ.Any]
+        The job-level environment.
+    """
+    environment = _workflow()["jobs"]["build-test"].get("env")
+    assert isinstance(environment, dict), "build-test must define env"
+    return environment
+
+
+def _dry_run_steps() -> list[dict[str, typ.Any]]:
+    """Return every publish dry-run step in the workflow.
+
+    Returns
+    -------
+    list[dict[str, typ.Any]]
+        The steps named for the dry run.
+    """
+    return [
+        step
+        for job in _workflow()["jobs"].values()
+        for step in job.get("steps", [])
+        if step.get("name") == DRY_RUN_STEP
+    ]
+
+
+def test_the_two_lading_pins_agree() -> None:
+    """CI and the Makefile must resolve the same lading.
+
+    Drift here is quiet rather than loud: both sides keep working, and
+    each validates publish readiness against a different tool while
+    believing the other agrees.
+    """
+    workflow_ref = _build_test_env().get("LADING_REF")
+    makefile_ref = _makefile_lading_ref()
+
+    assert workflow_ref == makefile_ref, (
+        f"ci.yml pins lading at {workflow_ref!r} and the Makefile at "
+        f"{makefile_ref!r}; a bump must move both"
+    )
+
+
+def test_the_lading_pin_is_a_commit() -> None:
+    """A tag or branch would let the tool change under a green pin."""
+    makefile_ref = _makefile_lading_ref()
+
+    assert _FULL_SHA.match(makefile_ref), (
+        f"LADING_REF must be a full 40-character commit SHA, not a tag or "
+        f"branch: {makefile_ref!r}"
+    )
+
+
+def test_the_dry_run_asks_for_compiler_cache_statistics() -> None:
+    """The publish step's cost must stay attributable.
+
+    Without this the step is the longest in the job and says nothing
+    about what it spent, which is what made the earlier 36-minute runs
+    impossible to reason about.
+    """
+    steps = _dry_run_steps()
+    assert steps, f"ci.yml must have a {DRY_RUN_STEP!r} step"
+
+    for step in steps:
+        environment = step.get("env") or {}
+        assert STATS_VARIABLE in environment, (
+            f"the {DRY_RUN_STEP!r} step must set {STATS_VARIABLE} so lading "
+            f"reports the compiler cache around each packaged build"
+        )
+        assert str(environment[STATS_VARIABLE]).endswith(".json"), (
+            f"{STATS_VARIABLE} must name a JSON file, got "
+            f"{environment[STATS_VARIABLE]!r}"
+        )
+
+
+def test_the_statistics_file_is_uploaded() -> None:
+    """A file written into RUNNER_TEMP and never uploaded is not evidence."""
+    workflow = _workflow()
+    stats_paths = {
+        str((step.get("env") or {}).get(STATS_VARIABLE))
+        for job in workflow["jobs"].values()
+        for step in job.get("steps", [])
+        if (step.get("env") or {}).get(STATS_VARIABLE)
+    }
+    uploads = [
+        step
+        for job in workflow["jobs"].values()
+        for step in job.get("steps", [])
+        if "actions/upload-artifact@" in str(step.get("uses", ""))
+        and str((step.get("with") or {}).get("path", "")) in stats_paths
+    ]
+
+    assert uploads, (
+        f"the file named by {STATS_VARIABLE} must be uploaded as an artefact; "
+        f"written into the runner's temporary directory and left there, it is "
+        f"discarded with the runner"
+    )

--- a/tests/workflow_contracts/lading_pin_test.py
+++ b/tests/workflow_contracts/lading_pin_test.py
@@ -21,13 +21,13 @@ Run via ``make test-workflow-contracts``.
 
 import typing as typ
 
-from publish_report_support import FULL_SHA as _FULL_SHA
-from publish_report_support import (
-    build_test_env,
+from lading_pins import (
     lockfile_lading_ref,
     makefile_lading_ref,
     pyproject_lading_ref,
 )
+from publish_report_support import FULL_SHA as _FULL_SHA
+from publish_report_support import build_test_env
 
 
 def test_every_lading_pin_agrees(build_test_job: dict[str, typ.Any]) -> None:

--- a/tests/workflow_contracts/lading_pin_test.py
+++ b/tests/workflow_contracts/lading_pin_test.py
@@ -1,190 +1,51 @@
-"""Contract tests for the lading pin and its compiler-cache reporting.
+"""Contract for the lading pin, in every place it lives.
 
-lading runs the publish dry run, and it is pinned three times: `ci.yml`
+lading runs the publish dry run, and it is pinned four times: `ci.yml`
 sets `LADING_REF` for the job, the Makefile sets it again so a local
-`make publish-check` resolves the same tool, and `pyproject.toml` pins it
-in the `python-tools` group for a bare `uv run lading`. Three pins for one
-tool drift, and the failure is quiet: CI validates publish readiness with
-one version while a developer validates it with another, and each
-believes the other agrees.
+`make publish-check` resolves the same tool, `pyproject.toml` pins it in
+the `python-tools` group for a bare `uv run lading`, and `uv.lock`
+records the commit resolution actually chose.
 
-The third is the easiest to miss, because the Makefile's `--with` overlay
-masks it: `make publish-check` resolves the Makefile's pin regardless of
-what the project group holds, so the group can sit generations behind
-without any command failing.
+Four pins for one tool drift, and the failure is quiet: CI validates
+publish readiness with one version while a developer validates it with
+another, and each believes the other agrees. The project group is the
+easiest to forget, because the Makefile's `--with` overlay masks it; the
+lock file is the one that decides what a bare `uv run` installs.
 
-The version itself is not asserted. A bump should need one paired change,
-not three. What is asserted is that the two agree, and that the workflow
-still asks lading for the compiler-cache statistics whose absence made
-the publish step's cost unattributable (rstest-bdd#720).
+The version itself is not asserted. A bump should need one paired
+change, not four. What is asserted is that they agree, and that the pin
+is a commit rather than a moving reference.
 
 Run via ``make test-workflow-contracts``.
 """
 
-import re
 import typing as typ
 
-import pytest
-from workflow_support import job, repository_file, steps
-
-#: The workflow these assertions read, loaded through
-#: :func:`workflow_support.job` so file access and YAML parsing happen at
-#: one boundary rather than in each contract.
-CI_WORKFLOW: typ.Final[str] = "ci.yml"
-
-#: The job that packages the crates.
-BUILD_TEST_JOB: typ.Final[str] = "build-test"
-
-#: The step that runs the publish dry run.
-DRY_RUN_STEP: typ.Final[str] = "Publish dry run"
-
-#: The environment variable lading reads for its statistics file.
-STATS_VARIABLE: typ.Final[str] = "LADING_SCCACHE_STATS_JSON"
-
-#: The action that collects the statistics file.
-UPLOAD_ACTION: typ.Final[str] = "actions/upload-artifact@"
-
-#: The step that reads the report before it is uploaded.
-VERIFY_STEP: typ.Final[str] = "Verify publish-step compiler-cache statistics"
-
-#: The step that collects the report.
-UPLOAD_STEP: typ.Final[str] = "Upload publish-step compiler-cache statistics"
-
-#: The condition both steps carry. Written out rather than matched
-#: loosely: `always()` alone would upload from the Windows lanes, which
-#: never write the file, and `runner.os == 'Linux'` alone would skip the
-#: run that failed, which is the run whose cost is worth reading.
-LINUX_ALWAYS: typ.Final[str] = "${{ always() && runner.os == 'Linux' }}"
-
-#: How long the artefact is kept. Asserted because an artefact that
-#: expires before anyone compares two runs is not evidence.
-RETENTION_DAYS: typ.Final[int] = 7
-
-_FULL_SHA: typ.Final[re.Pattern[str]] = re.compile(r"^[0-9a-f]{40}$")
+from publish_report_support import FULL_SHA as _FULL_SHA
+from publish_report_support import (
+    build_test_env,
+    lockfile_lading_ref,
+    makefile_lading_ref,
+    pyproject_lading_ref,
+)
 
 
-def _makefile_lading_ref() -> str:
-    """Return the Makefile's lading pin.
-
-    Returns
-    -------
-    str
-        The commit the Makefile resolves lading from.
-    """
-    makefile = repository_file("Makefile")
-    match = re.search(r"^LADING_REF \?= (?P<ref>\S+)$", makefile, re.MULTILINE)
-    assert match is not None, "the Makefile must define LADING_REF"
-    return match["ref"]
-
-
-def _pyproject_lading_ref() -> str:
-    """Return the project group's lading pin.
-
-    Returns
-    -------
-    str
-        The commit `uv` resolves lading from for a bare `uv run`.
-    """
-    pyproject = repository_file("pyproject.toml")
-    match = re.search(
-        r"lading @ git\+https://github\.com/leynos/lading@(?P<ref>[0-9a-f]{40})",
-        pyproject,
-    )
-    assert match is not None, "pyproject.toml must pin lading by commit"
-    return match["ref"]
-
-
-def _build_test_steps() -> list[dict[str, typ.Any]]:
-    """Return the packaging job's steps, in document order.
-
-    Returns
-    -------
-    list[dict[str, typ.Any]]
-        The steps of the job that runs the publish dry run.
-    """
-    return typ.cast("list[dict[str, typ.Any]]", steps(job(CI_WORKFLOW, BUILD_TEST_JOB)))
-
-
-def _build_test_env() -> dict[str, typ.Any]:
-    """Return the build-test job's environment mapping.
-
-    Returns
-    -------
-    dict[str, typ.Any]
-        The job-level environment.
-    """
-    environment = job(CI_WORKFLOW, BUILD_TEST_JOB).get("env")
-    assert isinstance(environment, dict), "build-test must define env"
-    return environment
-
-
-def _step_index(name: str) -> int:
-    """Return the position of the one step with ``name``.
-
-    Uniqueness is part of the assertion. Two steps of the same name would
-    make every ordering claim below ambiguous, and the one that mattered
-    could be the one that moved.
-
-    Parameters
-    ----------
-    name : str
-        The step's declared name.
-
-    Returns
-    -------
-    int
-        Its index among the job's steps.
-    """
-    matches = [
-        index
-        for index, step in enumerate(_build_test_steps())
-        if step.get("name") == name
-    ]
-    assert len(matches) == 1, (
-        f"{BUILD_TEST_JOB} must declare exactly one {name!r} step, found {len(matches)}"
-    )
-    return matches[0]
-
-
-def _step(name: str) -> dict[str, typ.Any]:
-    """Return the one step with ``name``.
-
-    Parameters
-    ----------
-    name : str
-        The step's declared name.
-
-    Returns
-    -------
-    dict[str, typ.Any]
-        The step.
-    """
-    return _build_test_steps()[_step_index(name)]
-
-
-def _dry_run_steps() -> list[dict[str, typ.Any]]:
-    """Return every publish dry-run step in the packaging job.
-
-    Returns
-    -------
-    list[dict[str, typ.Any]]
-        The steps named for the dry run.
-    """
-    return [step for step in _build_test_steps() if step.get("name") == DRY_RUN_STEP]
-
-
-def test_every_lading_pin_agrees() -> None:
-    """All three places must resolve the same lading.
+def test_every_lading_pin_agrees(build_test_job: dict[str, typ.Any]) -> None:
+    """All four places must resolve the same lading.
 
     Drift here is quiet rather than loud: every side keeps working, and
     each validates publish readiness against a different tool while
     believing the others agree. The project group is the easiest to
-    forget, because the Makefile's `--with` overlay hides it.
+    forget, because the Makefile's `--with` overlay hides it, and the
+    lock file is the one that decides what a bare `uv run` installs, so
+    a bump that moved the group and not the lock would leave the group's
+    commit stated and another one used.
     """
     pins = {
-        "ci.yml": _build_test_env().get("LADING_REF"),
-        "Makefile": _makefile_lading_ref(),
-        "pyproject.toml": _pyproject_lading_ref(),
+        "ci.yml": build_test_env(build_test_job).get("LADING_REF"),
+        "Makefile": makefile_lading_ref(),
+        "pyproject.toml": pyproject_lading_ref(),
+        "uv.lock": lockfile_lading_ref(),
     }
 
     assert len(set(pins.values())) == 1, (
@@ -195,166 +56,9 @@ def test_every_lading_pin_agrees() -> None:
 
 def test_the_lading_pin_is_a_commit() -> None:
     """A tag or branch would let the tool change under a green pin."""
-    makefile_ref = _makefile_lading_ref()
+    makefile_ref = makefile_lading_ref()
 
     assert _FULL_SHA.match(makefile_ref), (
         f"LADING_REF must be a full 40-character commit SHA, not a tag or "
         f"branch: {makefile_ref!r}"
-    )
-
-
-def test_the_dry_run_asks_for_compiler_cache_statistics() -> None:
-    """The publish step's cost must stay attributable.
-
-    Without this the step is the longest in the job and says nothing
-    about what it spent, which is what made the earlier 36-minute runs
-    impossible to reason about.
-    """
-    steps = _dry_run_steps()
-    assert steps, f"ci.yml must have a {DRY_RUN_STEP!r} step"
-
-    for step in steps:
-        environment = step.get("env") or {}
-        assert STATS_VARIABLE in environment, (
-            f"the {DRY_RUN_STEP!r} step must set {STATS_VARIABLE} so lading "
-            f"reports the compiler cache around each packaged build"
-        )
-        assert str(environment[STATS_VARIABLE]).endswith(".json"), (
-            f"{STATS_VARIABLE} must name a JSON file, got "
-            f"{environment[STATS_VARIABLE]!r}"
-        )
-
-
-def _statistics_path() -> str:
-    """Return the one path the workflow tells lading to write to.
-
-    Returns
-    -------
-    str
-        The configured file path.
-    """
-    environment = _step(DRY_RUN_STEP).get("env") or {}
-    path = environment.get(STATS_VARIABLE)
-    assert isinstance(path, str), (
-        f"the {DRY_RUN_STEP!r} step must set {STATS_VARIABLE} to a path, got {path!r}"
-    )
-    assert path, f"the {DRY_RUN_STEP!r} step must set {STATS_VARIABLE}"
-    return path
-
-
-def test_the_statistics_file_is_uploaded() -> None:
-    """A file written into RUNNER_TEMP and never uploaded is not evidence.
-
-    The upload has to collect the path the publish step wrote, so the two
-    are compared rather than each checked against a constant. A step that
-    uploaded a stale path would satisfy either check alone.
-    """
-    upload = _step(UPLOAD_STEP)
-    assert UPLOAD_ACTION in str(upload.get("uses", "")), (
-        f"{UPLOAD_STEP!r} must use {UPLOAD_ACTION}, not {upload.get('uses')!r}"
-    )
-    with_block = upload.get("with") or {}
-    assert with_block.get("path") == _statistics_path(), (
-        f"{UPLOAD_STEP!r} uploads {with_block.get('path')!r}, which is not "
-        f"the {_statistics_path()!r} the publish step writes; the report "
-        f"would be discarded with the runner"
-    )
-
-
-def test_the_upload_follows_the_publish_step() -> None:
-    """Ordering is the whole of it: nothing exists to upload before.
-
-    A step order that put the upload first would pass every assertion
-    about its inputs and collect nothing on every run.
-    """
-    publish = _step_index(DRY_RUN_STEP)
-    verify = _step_index(VERIFY_STEP)
-    upload = _step_index(UPLOAD_STEP)
-    assert publish < verify < upload, (
-        f"the publish step (index {publish}) must precede the verification "
-        f"(index {verify}) and the upload (index {upload}); a report is "
-        f"read and collected after it is written, not before"
-    )
-
-
-@pytest.mark.parametrize("step_name", [VERIFY_STEP, UPLOAD_STEP], ids=str)
-def test_the_report_steps_run_on_a_failed_linux_run(step_name: str) -> None:
-    """The run worth reading is often the one that failed.
-
-    Both halves of the condition are load-bearing and each fails a
-    different way. Without ``always()`` a failed publish uploads nothing,
-    which is the run whose cost is worth knowing. Without the Linux
-    guard, the Windows lanes, which never write the file, would report a
-    missing one on every run.
-    """
-    condition = str(_step(step_name).get("if", ""))
-    assert condition == LINUX_ALWAYS, (
-        f"{step_name!r} has if: {condition!r}, not {LINUX_ALWAYS!r}"
-    )
-
-
-def test_the_artefact_is_named_per_lane_and_kept() -> None:
-    """One name per lane, kept long enough to compare two runs.
-
-    A name shared across the matrix collides, and the second lane's
-    upload fails or overwrites the first. A retention shorter than the
-    comparison window makes the artefact evidence that expires before it
-    is read.
-    """
-    with_block = _step(UPLOAD_STEP).get("with") or {}
-    name = str(with_block.get("name", ""))
-    assert "${{ matrix.os }}" in name, (
-        f"the artefact name {name!r} must vary by operating system, or two "
-        f"lanes collide on one name"
-    )
-    assert "${{ strategy.job-index }}" in name, (
-        f"the artefact name {name!r} must vary by matrix leg, or two legs on "
-        f"one operating system collide"
-    )
-    assert with_block.get("retention-days") == RETENTION_DAYS, (
-        f"the artefact must be kept for {RETENTION_DAYS} days, not "
-        f"{with_block.get('retention-days')!r}"
-    )
-
-
-def test_a_missing_report_is_surfaced_rather_than_swallowed() -> None:
-    """Silence and success look identical on an absent report.
-
-    ``if-no-files-found: ignore`` uploads nothing and says nothing, so a
-    lading that stopped writing the file would read as a run whose report
-    nobody happened to open. The verification step names the cause; the
-    upload's own setting must not contradict it.
-    """
-    with_block = _step(UPLOAD_STEP).get("with") or {}
-    assert with_block.get("if-no-files-found") == "warn", (
-        f"the upload must warn on a missing report, not "
-        f"{with_block.get('if-no-files-found')!r}"
-    )
-
-
-def test_the_verification_step_reads_the_report_it_was_given() -> None:
-    """A verification that checked a different path proves nothing.
-
-    It also must not fail the job. The report is evidence about a build,
-    not the build, and a publish that failed before lading ran has
-    already failed on its own account.
-    """
-    verify = _step(VERIFY_STEP)
-    environment = verify.get("env") or {}
-    assert environment.get("STATS_PATH") == _statistics_path(), (
-        f"{VERIFY_STEP!r} reads {environment.get('STATS_PATH')!r}, not the "
-        f"{_statistics_path()!r} the publish step writes"
-    )
-    script = str(verify.get("run", ""))
-    assert "::warning" in script, (
-        f"{VERIFY_STEP!r} must report a missing or unreadable report as a "
-        f"warning; a silent check is the state this replaces"
-    )
-    assert "json.load" in script, (
-        f"{VERIFY_STEP!r} must parse the report rather than only test that "
-        f"the file exists; an empty or truncated file would pass otherwise"
-    )
-    assert "exit 1" not in script, (
-        f"{VERIFY_STEP!r} must not fail the job: the report is evidence "
-        f"about the build, not the build"
     )

--- a/tests/workflow_contracts/lading_pins.py
+++ b/tests/workflow_contracts/lading_pins.py
@@ -4,6 +4,15 @@ Separated from `publish_report_support` so the pin readers and the
 publish-report vocabulary stay legible apart, and so neither module
 outgrows the 400-line limit the Python lint gate enforces.
 
+Each pin is read in two halves: a pure function that parses supplied
+text, and a one-line reader that fetches that text through
+:func:`workflow_support.repository_file` and delegates. The parsers are
+therefore testable against synthetic documents, including the malformed
+ones no repository file will ever hold, and the only filesystem access
+in this module is the single call each reader makes. A reader
+propagates :class:`workflow_support.MissingRepositoryFileError` when the
+file it names is absent.
+
 Run via ``make test-workflow-contracts``.
 """
 
@@ -12,9 +21,20 @@ import re
 from publish_report_support import PublishReportShapeError, _require
 from workflow_support import repository_file
 
+LOCKFILE_REVISION = re.compile(r"github\.com/leynos/lading\?rev=([0-9a-f]{40})")
+MAKEFILE_PIN = re.compile(r"^LADING_REF \?= (?P<ref>\S+)$", re.MULTILINE)
+PYPROJECT_PIN = re.compile(
+    r"lading @ git\+https://github\.com/leynos/lading@(?P<ref>[0-9a-f]{40})"
+)
 
-def makefile_lading_ref() -> str:
-    """Return the Makefile's lading pin.
+
+def lading_ref_in_makefile(makefile: str) -> str:
+    """Return the lading pin a Makefile's text declares.
+
+    Parameters
+    ----------
+    makefile : str
+        The text of a Makefile.
 
     Returns
     -------
@@ -24,18 +44,17 @@ def makefile_lading_ref() -> str:
     Raises
     ------
     PublishReportShapeError
-        If the Makefile defines no ``LADING_REF``.
+        If the text defines no ``LADING_REF``.
     """
-    makefile = repository_file("Makefile")
-    match = re.search(r"^LADING_REF \?= (?P<ref>\S+)$", makefile, re.MULTILINE)
+    match = MAKEFILE_PIN.search(makefile)
     if match is None:
         message = "the Makefile must define LADING_REF"
         raise PublishReportShapeError(message)
     return match["ref"]
 
 
-def lockfile_lading_ref() -> str:
-    """Return the commit `uv.lock` resolves Lading to.
+def lading_ref_in_lockfile(lockfile: str) -> str:
+    """Return the commit a lock file's text resolves lading to.
 
     The fourth place the pin lives, and the one that decides what a bare
     ``uv run`` actually installs: the project group states a commit and
@@ -43,24 +62,23 @@ def lockfile_lading_ref() -> str:
     only through an incomplete bump, and the failure is silent, because
     the lock file wins.
 
-    A lock file recording no Lading revision, or resolving Lading to
-    more than one, raises :class:`PublishReportShapeError` through
-    :func:`_require`: either way the lock file cannot say what a bare
-    ``uv run`` installs. The lint refuses a ``Raises`` section for an
-    exception a function does not raise directly, so it is stated here.
+    Text recording no lading revision, or resolving lading to more than
+    one, raises :class:`PublishReportShapeError` through :func:`_require`:
+    either way the lock file cannot say what a bare ``uv run`` installs.
+    The lint refuses a ``Raises`` section for an exception a function
+    does not raise directly, so it is stated here.
+
+    Parameters
+    ----------
+    lockfile : str
+        The text of a ``uv`` lock file.
 
     Returns
     -------
     str
         The commit recorded in the lock file.
     """
-    lockfile = repository_file("uv.lock")
-    matches = set(
-        re.findall(
-            r"github\.com/leynos/lading\?rev=([0-9a-f]{40})",
-            lockfile,
-        )
-    )
+    matches = set(LOCKFILE_REVISION.findall(lockfile))
     _require(matches, "uv.lock must record a lading git revision")
     _require(
         len(matches) == 1,
@@ -69,8 +87,13 @@ def lockfile_lading_ref() -> str:
     return matches.pop()
 
 
-def pyproject_lading_ref() -> str:
-    """Return the project group's lading pin.
+def lading_ref_in_pyproject(pyproject: str) -> str:
+    """Return the lading pin a project manifest's text declares.
+
+    Parameters
+    ----------
+    pyproject : str
+        The text of a ``pyproject.toml``.
 
     Returns
     -------
@@ -80,14 +103,59 @@ def pyproject_lading_ref() -> str:
     Raises
     ------
     PublishReportShapeError
-        If `pyproject.toml` does not pin lading by commit.
+        If the text does not pin lading by commit.
     """
-    pyproject = repository_file("pyproject.toml")
-    match = re.search(
-        r"lading @ git\+https://github\.com/leynos/lading@(?P<ref>[0-9a-f]{40})",
-        pyproject,
-    )
+    match = PYPROJECT_PIN.search(pyproject)
     if match is None:
         message = "pyproject.toml must pin lading by commit"
         raise PublishReportShapeError(message)
     return match["ref"]
+
+
+def makefile_lading_ref() -> str:
+    """Return the repository Makefile's lading pin.
+
+    Reads ``Makefile`` through the repository boundary and parses it with
+    :func:`lading_ref_in_makefile`, so a missing file raises
+    :class:`workflow_support.MissingRepositoryFileError` and a file
+    without the pin raises :class:`PublishReportShapeError`.
+
+    Returns
+    -------
+    str
+        The commit the Makefile resolves lading from.
+    """
+    return lading_ref_in_makefile(repository_file("Makefile"))
+
+
+def lockfile_lading_ref() -> str:
+    """Return the commit the repository's `uv.lock` resolves lading to.
+
+    Reads ``uv.lock`` through the repository boundary and parses it with
+    :func:`lading_ref_in_lockfile`, so a missing file raises
+    :class:`workflow_support.MissingRepositoryFileError` and a lock file
+    naming no revision, or more than one, raises
+    :class:`PublishReportShapeError`.
+
+    Returns
+    -------
+    str
+        The commit recorded in the lock file.
+    """
+    return lading_ref_in_lockfile(repository_file("uv.lock"))
+
+
+def pyproject_lading_ref() -> str:
+    """Return the repository project group's lading pin.
+
+    Reads ``pyproject.toml`` through the repository boundary and parses
+    it with :func:`lading_ref_in_pyproject`, so a missing file raises
+    :class:`workflow_support.MissingRepositoryFileError` and a manifest
+    without a commit pin raises :class:`PublishReportShapeError`.
+
+    Returns
+    -------
+    str
+        The commit `uv` resolves lading from for a bare `uv run`.
+    """
+    return lading_ref_in_pyproject(repository_file("pyproject.toml"))

--- a/tests/workflow_contracts/lading_pins.py
+++ b/tests/workflow_contracts/lading_pins.py
@@ -1,0 +1,87 @@
+"""Reads the four places lading's pin is written.
+
+Separated from `publish_report_support` so the pin readers and the
+publish-report vocabulary stay legible apart, and so neither module
+outgrows the 400-line limit the Python lint gate enforces.
+
+Run via ``make test-workflow-contracts``.
+"""
+
+import re
+
+from publish_report_support import PublishReportShapeError, _require
+from workflow_support import repository_file
+
+
+def makefile_lading_ref() -> str:
+    """Return the Makefile's lading pin.
+
+    Returns
+    -------
+    str
+        The commit the Makefile resolves lading from.
+
+    Raises
+    ------
+    PublishReportShapeError
+        If the Makefile defines no ``LADING_REF``.
+    """
+    makefile = repository_file("Makefile")
+    match = re.search(r"^LADING_REF \?= (?P<ref>\S+)$", makefile, re.MULTILINE)
+    if match is None:
+        message = "the Makefile must define LADING_REF"
+        raise PublishReportShapeError(message)
+    return match["ref"]
+
+
+def lockfile_lading_ref() -> str:
+    """Return the commit `uv.lock` resolves Lading to.
+
+    The fourth place the pin lives, and the one that decides what a bare
+    ``uv run`` actually installs: the project group states a commit and
+    the lock file records the one resolution chose. They can disagree
+    only through an incomplete bump, and the failure is silent, because
+    the lock file wins.
+
+    Returns
+    -------
+    str
+        The commit recorded in the lock file.
+    """
+    lockfile = repository_file("uv.lock")
+    matches = set(
+        re.findall(
+            r"github\.com/leynos/lading\?rev=([0-9a-f]{40})",
+            lockfile,
+        )
+    )
+    _require(matches, "uv.lock must record a lading git revision")
+    _require(
+        len(matches) == 1,
+        f"uv.lock must resolve lading to one commit, found {sorted(matches)}",
+    )
+    return matches.pop()
+
+
+def pyproject_lading_ref() -> str:
+    """Return the project group's lading pin.
+
+    Returns
+    -------
+    str
+        The commit `uv` resolves lading from for a bare `uv run`.
+
+    Raises
+    ------
+    PublishReportShapeError
+        If `pyproject.toml` does not pin lading by commit.
+    """
+    pyproject = repository_file("pyproject.toml")
+    match = re.search(
+        r"lading @ git\+https://github\.com/leynos/lading@(?P<ref>[0-9a-f]{40})",
+        pyproject,
+    )
+    if match is None:
+        message = "pyproject.toml must pin lading by commit"
+        raise PublishReportShapeError(message)
+    return match["ref"]

--- a/tests/workflow_contracts/lading_pins.py
+++ b/tests/workflow_contracts/lading_pins.py
@@ -43,6 +43,12 @@ def lockfile_lading_ref() -> str:
     only through an incomplete bump, and the failure is silent, because
     the lock file wins.
 
+    A lock file recording no Lading revision, or resolving Lading to
+    more than one, raises :class:`PublishReportShapeError` through
+    :func:`_require`: either way the lock file cannot say what a bare
+    ``uv run`` installs. The lint refuses a ``Raises`` section for an
+    exception a function does not raise directly, so it is stated here.
+
     Returns
     -------
     str

--- a/tests/workflow_contracts/publish_report_shape_test.py
+++ b/tests/workflow_contracts/publish_report_shape_test.py
@@ -1,0 +1,188 @@
+"""Contract for how the publish step's compiler-cache report is handled.
+
+The publish dry run asks lading for a report; a verification step reads
+it and says when there is none; an upload collects it. This module
+asserts the shape of those three steps and the budgets around them: that
+the paths agree, that the order is write, read, collect, that both
+report steps run on a failed Linux run, and that the artefact is named
+per lane and kept.
+
+Running the verification script for real is
+:mod:`publish_verification_script_test`; this module reads the workflow.
+
+Run via ``make test-workflow-contracts``.
+"""
+
+import typing as typ
+
+import pytest
+from publish_report_support import (
+    DRY_RUN_STEP,
+    LINUX_ALWAYS,
+    RETENTION_DAYS,
+    STATS_VARIABLE,
+    UPLOAD_ACTION,
+    UPLOAD_STEP,
+    VERIFY_STEP,
+    dry_run_steps,
+    mapping_at,
+    statistics_path,
+    step_index,
+    step_named,
+)
+
+
+def test_the_dry_run_asks_for_compiler_cache_statistics(
+    build_test_job: dict[str, typ.Any],
+) -> None:
+    """The publish step's cost must stay attributable.
+
+    Without this the step is the longest in the job and says nothing
+    about what it spent, which is what made the earlier 36-minute runs
+    impossible to reason about.
+    """
+    steps = dry_run_steps(build_test_job)
+    assert steps, f"ci.yml must have a {DRY_RUN_STEP!r} step"
+
+    for step in steps:
+        environment = mapping_at(step, "env", f"the {DRY_RUN_STEP!r} step")
+        assert STATS_VARIABLE in environment, (
+            f"the {DRY_RUN_STEP!r} step must set {STATS_VARIABLE} so lading "
+            f"reports the compiler cache around each packaged build"
+        )
+        assert str(environment[STATS_VARIABLE]).endswith(".json"), (
+            f"{STATS_VARIABLE} must name a JSON file, got "
+            f"{environment[STATS_VARIABLE]!r}"
+        )
+
+
+def test_the_statistics_file_is_uploaded(build_test_job: dict[str, typ.Any]) -> None:
+    """A file written into RUNNER_TEMP and never uploaded is not evidence.
+
+    The upload has to collect the path the publish step wrote, so the two
+    are compared rather than each checked against a constant. A step that
+    uploaded a stale path would satisfy either check alone.
+    """
+    upload = step_named(build_test_job, UPLOAD_STEP)
+    assert UPLOAD_ACTION in str(upload.get("uses", "")), (
+        f"{UPLOAD_STEP!r} must use {UPLOAD_ACTION}, not {upload.get('uses')!r}"
+    )
+    with_block = mapping_at(upload, "with", f"the {UPLOAD_STEP!r} step")
+    assert with_block.get("path") == statistics_path(build_test_job), (
+        f"{UPLOAD_STEP!r} uploads {with_block.get('path')!r}, which is not "
+        f"the {statistics_path(build_test_job)!r} the publish step writes; the report "
+        f"would be discarded with the runner"
+    )
+
+
+def test_the_upload_follows_the_publishstep_named(
+    build_test_job: dict[str, typ.Any],
+) -> None:
+    """Ordering is the whole of it: nothing exists to upload before.
+
+    A step order that put the upload first would pass every assertion
+    about its inputs and collect nothing on every run.
+    """
+    publish = step_index(build_test_job, DRY_RUN_STEP)
+    verify = step_index(build_test_job, VERIFY_STEP)
+    upload = step_index(build_test_job, UPLOAD_STEP)
+    assert publish < verify < upload, (
+        f"the publish step (index {publish}) must precede the verification "
+        f"(index {verify}) and the upload (index {upload}); a report is "
+        f"read and collected after it is written, not before"
+    )
+
+
+@pytest.mark.parametrize("step_name", [VERIFY_STEP, UPLOAD_STEP], ids=str)
+def test_the_report_steps_run_on_a_failed_linux_run(
+    build_test_job: dict[str, typ.Any], step_name: str
+) -> None:
+    """The run worth reading is often the one that failed.
+
+    Both halves of the condition are load-bearing and each fails a
+    different way. Without ``always()`` a failed publish uploads nothing,
+    which is the run whose cost is worth knowing. Without the Linux
+    guard, the Windows lanes, which never write the file, would report a
+    missing one on every run.
+    """
+    condition = str(step_named(build_test_job, step_name).get("if", ""))
+    assert condition == LINUX_ALWAYS, (
+        f"{step_name!r} has if: {condition!r}, not {LINUX_ALWAYS!r}"
+    )
+
+
+def test_the_artefact_is_named_per_lane_and_kept(
+    build_test_job: dict[str, typ.Any],
+) -> None:
+    """One name per lane, kept long enough to compare two runs.
+
+    A name shared across the matrix collides, and the second lane's
+    upload fails or overwrites the first. A retention shorter than the
+    comparison window makes the artefact evidence that expires before it
+    is read.
+    """
+    with_block = mapping_at(
+        step_named(build_test_job, UPLOAD_STEP), "with", f"the {UPLOAD_STEP!r} step"
+    )
+    name = str(with_block.get("name", ""))
+    assert "${{ matrix.os }}" in name, (
+        f"the artefact name {name!r} must vary by operating system, or two "
+        f"lanes collide on one name"
+    )
+    assert "${{ strategy.job-index }}" in name, (
+        f"the artefact name {name!r} must vary by matrix leg, or two legs on "
+        f"one operating system collide"
+    )
+    assert with_block.get("retention-days") == RETENTION_DAYS, (
+        f"the artefact must be kept for {RETENTION_DAYS} days, not "
+        f"{with_block.get('retention-days')!r}"
+    )
+
+
+def test_a_missing_report_is_surfaced_rather_than_swallowed(
+    build_test_job: dict[str, typ.Any],
+) -> None:
+    """Silence and success look identical on an absent report.
+
+    ``if-no-files-found: ignore`` uploads nothing and says nothing, so a
+    lading that stopped writing the file would read as a run whose report
+    nobody happened to open. The verification step names the cause; the
+    upload's own setting must not contradict it.
+    """
+    with_block = mapping_at(
+        step_named(build_test_job, UPLOAD_STEP), "with", f"the {UPLOAD_STEP!r} step"
+    )
+    assert with_block.get("if-no-files-found") == "warn", (
+        f"the upload must warn on a missing report, not "
+        f"{with_block.get('if-no-files-found')!r}"
+    )
+
+
+def test_the_verification_step_reads_the_report_it_was_given(
+    build_test_job: dict[str, typ.Any],
+) -> None:
+    """A verification that checked a different path proves nothing.
+
+    It also must not fail the job. The report is evidence about a build,
+    not the build, and a publish that failed before lading ran has
+    already failed on its own account.
+    """
+    verify = step_named(build_test_job, VERIFY_STEP)
+    environment = mapping_at(verify, "env", f"the {VERIFY_STEP!r} step")
+    assert environment.get("STATS_PATH") == statistics_path(build_test_job), (
+        f"{VERIFY_STEP!r} reads {environment.get('STATS_PATH')!r}, not the "
+        f"{statistics_path(build_test_job)!r} the publish step writes"
+    )
+    script = str(verify.get("run", ""))
+    assert "::warning" in script, (
+        f"{VERIFY_STEP!r} must report a missing or unreadable report as a "
+        f"warning; a silent check is the state this replaces"
+    )
+    assert "json.load" in script, (
+        f"{VERIFY_STEP!r} must parse the report rather than only test that "
+        f"the file exists; an empty or truncated file would pass otherwise"
+    )
+    assert "exit 1" not in script, (
+        f"{VERIFY_STEP!r} must not fail the job: the report is evidence "
+        f"about the build, not the build"
+    )

--- a/tests/workflow_contracts/publish_report_support.py
+++ b/tests/workflow_contracts/publish_report_support.py
@@ -242,6 +242,11 @@ def step_named(build_test_job: dict[str, typ.Any], name: str) -> dict[str, typ.A
 def dry_run_steps(build_test_job: dict[str, typ.Any]) -> list[dict[str, typ.Any]]:
     """Return every publish dry-run step in the packaging job.
 
+    Parameters
+    ----------
+    build_test_job : dict[str, typ.Any]
+        The parsed job.
+
     Returns
     -------
     list[dict[str, typ.Any]]
@@ -256,6 +261,11 @@ def dry_run_steps(build_test_job: dict[str, typ.Any]) -> list[dict[str, typ.Any]
 
 def statistics_path(build_test_job: dict[str, typ.Any]) -> str:
     """Return the one path the workflow tells lading to write to.
+
+    Parameters
+    ----------
+    build_test_job : dict[str, typ.Any]
+        The parsed job.
 
     Returns
     -------

--- a/tests/workflow_contracts/publish_report_support.py
+++ b/tests/workflow_contracts/publish_report_support.py
@@ -154,16 +154,20 @@ def mapping_at(owner: object, key: str, subject: str) -> dict[str, typ.Any]:
         If the owner is not a mapping, or the key holds something that
         is neither a mapping nor absent.
     """
-    if not isinstance(owner, dict):
-        message = f"{subject} must be a mapping, got {owner!r}"
-        raise PublishReportShapeError(message)
-    value = owner.get(key)
-    if value is None:
-        return {}
-    if not isinstance(value, dict):
-        message = f"{subject}'s {key!r} must be a mapping, got {value!r}"
-        raise PublishReportShapeError(message)
-    return value
+    match owner:
+        case dict():
+            pass
+        case _:
+            message = f"{subject} must be a mapping, got {owner!r}"
+            raise PublishReportShapeError(message)
+    match owner.get(key):
+        case None:
+            return {}
+        case dict() as value:
+            return value
+        case value:
+            message = f"{subject}'s {key!r} must be a mapping, got {value!r}"
+            raise PublishReportShapeError(message)
 
 
 def build_test_env(build_test_job: dict[str, typ.Any]) -> dict[str, typ.Any]:
@@ -266,13 +270,15 @@ def statistics_path(build_test_job: dict[str, typ.Any]) -> str:
     """
     step = step_named(build_test_job, DRY_RUN_STEP)
     environment = mapping_at(step, "env", f"the {DRY_RUN_STEP!r} step")
-    path = environment.get(STATS_VARIABLE)
-    if not isinstance(path, str):
-        message = (
-            f"the {DRY_RUN_STEP!r} step must set {STATS_VARIABLE} to a path, "
-            f"got {path!r}"
-        )
-        raise PublishReportShapeError(message)
+    match environment.get(STATS_VARIABLE):
+        case str() as path:
+            pass
+        case path:
+            message = (
+                f"the {DRY_RUN_STEP!r} step must set {STATS_VARIABLE} to a "
+                f"path, got {path!r}"
+            )
+            raise PublishReportShapeError(message)
     _require(path, f"the {DRY_RUN_STEP!r} step must set {STATS_VARIABLE}")
     return path
 
@@ -296,10 +302,12 @@ def verification_script(build_test_job: dict[str, typ.Any]) -> str:
         If the verification step declares no run script, or an empty
         one.
     """
-    script = step_named(build_test_job, VERIFY_STEP).get("run")
-    if not isinstance(script, str):
-        message = f"{VERIFY_STEP!r} must declare a run script, got {script!r}"
-        raise PublishReportShapeError(message)
+    match step_named(build_test_job, VERIFY_STEP).get("run"):
+        case str() as script:
+            pass
+        case script:
+            message = f"{VERIFY_STEP!r} must declare a run script, got {script!r}"
+            raise PublishReportShapeError(message)
     _require(script.strip(), f"{VERIFY_STEP!r}'s run script is empty")
     return script
 

--- a/tests/workflow_contracts/publish_report_support.py
+++ b/tests/workflow_contracts/publish_report_support.py
@@ -1,0 +1,388 @@
+"""Shared vocabulary for the publish-report workflow contracts.
+
+Three contract modules read the same `build-test` job: the lading pins,
+the shape of the report's verification and upload, and the verification
+script run for real. The job, the step lookup and the mapping guard live
+here so the three ask the same questions of the same parse rather than
+each growing its own.
+
+Run via ``make test-workflow-contracts``.
+"""
+
+import os
+import re
+import shutil
+import subprocess  # ruff: ignore[suspicious-subprocess-import] - runs a script this repository declares.
+import typing as typ
+
+if typ.TYPE_CHECKING:
+    from pathlib import Path
+
+from workflow_support import WorkflowShapeError, job, repository_file, steps
+
+#: The workflow these assertions read, loaded through
+#: :func:`workflow_support.job` so file access and YAML parsing happen at
+#: one boundary rather than in each contract.
+CI_WORKFLOW: typ.Final[str] = "ci.yml"
+
+#: The job that packages the crates.
+BUILD_TEST_JOB: typ.Final[str] = "build-test"
+
+#: The step that runs the publish dry run.
+DRY_RUN_STEP: typ.Final[str] = "Publish dry run"
+
+#: The environment variable lading reads for its statistics file.
+STATS_VARIABLE: typ.Final[str] = "LADING_SCCACHE_STATS_JSON"
+
+#: The action that collects the statistics file.
+UPLOAD_ACTION: typ.Final[str] = "actions/upload-artifact@"
+
+#: The shell the verification step declares, resolved to an absolute
+#: path so the harness starts the same interpreter the runner does
+#: rather than whichever `bash` a contributor's PATH offers first.
+BASH: typ.Final[str] = shutil.which("bash") or "/bin/bash"
+
+#: The step that reads the report before it is uploaded.
+VERIFY_STEP: typ.Final[str] = "Verify publish-step compiler-cache statistics"
+
+#: The step that collects the report.
+UPLOAD_STEP: typ.Final[str] = "Upload publish-step compiler-cache statistics"
+
+#: The condition both steps carry. Written out rather than matched
+#: loosely: `always()` alone would upload from the Windows lanes, which
+#: never write the file, and `runner.os == 'Linux'` alone would skip the
+#: run that failed, which is the run whose cost is worth reading.
+LINUX_ALWAYS: typ.Final[str] = "${{ always() && runner.os == 'Linux' }}"
+
+#: How long the artefact is kept. Asserted because an artefact that
+#: expires before anyone compares two runs is not evidence.
+RETENTION_DAYS: typ.Final[int] = 7
+
+FULL_SHA: typ.Final[re.Pattern[str]] = re.compile(r"^[0-9a-f]{40}$")
+
+
+class PublishReportShapeError(WorkflowShapeError):
+    """The workflow or a pin file did not have the shape these read.
+
+    Raised rather than asserted, because this module is not a test
+    module and its assertions would be stripped under ``-O``. It derives
+    from :class:`workflow_support.WorkflowShapeError`, so a shape
+    violation reads as a failed expectation in test output rather than
+    as an unexpected crash, exactly as the workflow loaders' do.
+
+    Parameters
+    ----------
+    message : str
+        What was expected, and what was found instead.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
+def _require(condition: object, message: str) -> None:
+    """Raise :class:`PublishReportShapeError` when a condition fails.
+
+    Parameters
+    ----------
+    condition : object
+        The condition to check for truthiness.
+    message : str
+        What to report when it does not hold.
+
+    Raises
+    ------
+    PublishReportShapeError
+        If the condition is falsy.
+    """
+    if not condition:
+        raise PublishReportShapeError(message)
+
+
+def makefile_lading_ref() -> str:
+    """Return the Makefile's lading pin.
+
+    Returns
+    -------
+    str
+        The commit the Makefile resolves lading from.
+    """
+    makefile = repository_file("Makefile")
+    match = re.search(r"^LADING_REF \?= (?P<ref>\S+)$", makefile, re.MULTILINE)
+    if match is None:
+        raise PublishReportShapeError("the Makefile must define LADING_REF")
+    return match["ref"]
+
+
+def lockfile_lading_ref() -> str:
+    """Return the commit `uv.lock` resolves Lading to.
+
+    The fourth place the pin lives, and the one that decides what a bare
+    ``uv run`` actually installs: the project group states a commit and
+    the lock file records the one resolution chose. They can disagree
+    only through an incomplete bump, and the failure is silent, because
+    the lock file wins.
+
+    Returns
+    -------
+    str
+        The commit recorded in the lock file.
+    """
+    lockfile = repository_file("uv.lock")
+    matches = set(
+        re.findall(
+            r"github\.com/leynos/lading\?rev=([0-9a-f]{40})",
+            lockfile,
+        )
+    )
+    _require(matches, "uv.lock must record a lading git revision")
+    _require(
+        len(matches) == 1,
+        f"uv.lock must resolve lading to one commit, found {sorted(matches)}",
+    )
+    return matches.pop()
+
+
+def pyproject_lading_ref() -> str:
+    """Return the project group's lading pin.
+
+    Returns
+    -------
+    str
+        The commit `uv` resolves lading from for a bare `uv run`.
+    """
+    pyproject = repository_file("pyproject.toml")
+    match = re.search(
+        r"lading @ git\+https://github\.com/leynos/lading@(?P<ref>[0-9a-f]{40})",
+        pyproject,
+    )
+    if match is None:
+        raise PublishReportShapeError("pyproject.toml must pin lading by commit")
+    return match["ref"]
+
+
+def build_test_job_document() -> dict[str, typ.Any]:
+    """Return the packaging job, parsed from the workflow.
+
+    Returns
+    -------
+    dict[str, typ.Any]
+        The job that runs the publish dry run.
+    """
+    return typ.cast("dict[str, typ.Any]", job(CI_WORKFLOW, BUILD_TEST_JOB))
+
+
+def build_test_steps(build_test_job: dict[str, typ.Any]) -> list[dict[str, typ.Any]]:
+    """Return the packaging job's steps, in document order.
+
+    Parameters
+    ----------
+    build_test_job : dict[str, typ.Any]
+        The parsed job.
+
+    Returns
+    -------
+    list[dict[str, typ.Any]]
+        The steps of the job that runs the publish dry run.
+    """
+    return typ.cast("list[dict[str, typ.Any]]", steps(build_test_job))
+
+
+def mapping_at(owner: object, key: str, subject: str) -> dict[str, typ.Any]:
+    """Return a nested mapping, failing with the location when it is not.
+
+    ``(step.get("env") or {})`` accepts a non-empty scalar or list and
+    then raises ``AttributeError`` on the next ``.get``, which reports a
+    Python fault rather than the workflow shape that caused it. This
+    reports the shape.
+
+    Parameters
+    ----------
+    owner : object
+        The step or job the mapping belongs to.
+    key : str
+        The key holding the mapping, such as ``"env"`` or ``"with"``.
+    subject : str
+        What to name in the failure message.
+
+    Returns
+    -------
+    dict[str, typ.Any]
+        The mapping, or an empty one when the key is absent.
+    """
+    if not isinstance(owner, dict):
+        raise PublishReportShapeError(f"{subject} must be a mapping, got {owner!r}")
+    value = owner.get(key)
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise PublishReportShapeError(
+            f"{subject}'s {key!r} must be a mapping, got {value!r}"
+        )
+    return value
+
+
+def build_test_env(build_test_job: dict[str, typ.Any]) -> dict[str, typ.Any]:
+    """Return the build-test job's environment mapping.
+
+    Parameters
+    ----------
+    build_test_job : dict[str, typ.Any]
+        The parsed job.
+
+    Returns
+    -------
+    dict[str, typ.Any]
+        The job-level environment.
+    """
+    environment = mapping_at(build_test_job, "env", f"the {BUILD_TEST_JOB} job")
+    _require(environment, f"{BUILD_TEST_JOB} must define env")
+    return environment
+
+
+def step_index(build_test_job: dict[str, typ.Any], name: str) -> int:
+    """Return the position of the one step with ``name``.
+
+    Uniqueness is part of the assertion. Two steps of the same name would
+    make every ordering claim below ambiguous, and the one that mattered
+    could be the one that moved.
+
+    Parameters
+    ----------
+    build_test_job : dict[str, typ.Any]
+        The parsed job.
+    name : str
+        The step's declared name.
+
+    Returns
+    -------
+    int
+        Its index among the job's steps.
+    """
+    matches = [
+        index
+        for index, step in enumerate(build_test_steps(build_test_job))
+        if step.get("name") == name
+    ]
+    _require(
+        len(matches) == 1,
+        f"{BUILD_TEST_JOB} must declare exactly one {name!r} step, found "
+        f"{len(matches)}",
+    )
+    return matches[0]
+
+
+def step_named(build_test_job: dict[str, typ.Any], name: str) -> dict[str, typ.Any]:
+    """Return the one step with ``name``.
+
+    Parameters
+    ----------
+    build_test_job : dict[str, typ.Any]
+        The parsed job.
+    name : str
+        The step's declared name.
+
+    Returns
+    -------
+    dict[str, typ.Any]
+        The step.
+    """
+    steps_ = build_test_steps(build_test_job)
+    return steps_[step_index(build_test_job, name)]
+
+
+def dry_run_steps(build_test_job: dict[str, typ.Any]) -> list[dict[str, typ.Any]]:
+    """Return every publish dry-run step in the packaging job.
+
+    Returns
+    -------
+    list[dict[str, typ.Any]]
+        The steps named for the dry run.
+    """
+    return [
+        step
+        for step in build_test_steps(build_test_job)
+        if step.get("name") == DRY_RUN_STEP
+    ]
+
+
+def statistics_path(build_test_job: dict[str, typ.Any]) -> str:
+    """Return the one path the workflow tells lading to write to.
+
+    Returns
+    -------
+    str
+        The configured file path.
+    """
+    step = step_named(build_test_job, DRY_RUN_STEP)
+    environment = mapping_at(step, "env", f"the {DRY_RUN_STEP!r} step")
+    path = environment.get(STATS_VARIABLE)
+    if not isinstance(path, str):
+        raise PublishReportShapeError(
+            f"the {DRY_RUN_STEP!r} step must set {STATS_VARIABLE} to a path, "
+            f"got {path!r}"
+        )
+    _require(path, f"the {DRY_RUN_STEP!r} step must set {STATS_VARIABLE}")
+    return path
+
+
+def verification_script(build_test_job: dict[str, typ.Any]) -> str:
+    """Return the verification step's shell script.
+
+    Parameters
+    ----------
+    build_test_job : dict[str, typ.Any]
+        The parsed job.
+
+    Returns
+    -------
+    str
+        The script the runner executes.
+    """
+    script = step_named(build_test_job, VERIFY_STEP).get("run")
+    if not isinstance(script, str):
+        raise PublishReportShapeError(
+            f"{VERIFY_STEP!r} must declare a run script, got {script!r}"
+        )
+    _require(script.strip(), f"{VERIFY_STEP!r}'s run script is empty")
+    return script
+
+
+def run_verification(
+    build_test_job: dict[str, typ.Any], tmp_path: Path, contents: bytes | None
+) -> subprocess.CompletedProcess[str]:
+    """Run the workflow's verification script against one report.
+
+    The script is written to a file and run as ``bash <file>`` rather
+    than passed to ``bash -c``. Bash 3.2 exec-replaces itself with the
+    last external command of a ``-c`` string, so a harness using that
+    form measures something the runner never does; runners execute
+    fragments from a file.
+
+    Parameters
+    ----------
+    build_test_job : dict[str, typ.Any]
+        The parsed job.
+    tmp_path : Path
+        A directory to hold the script and the report.
+    contents : bytes or None
+        What to write to the report path, or None to leave it absent.
+
+    Returns
+    -------
+    subprocess.CompletedProcess[str]
+        The finished process, with output captured.
+    """
+    script_path = tmp_path / "verify.sh"
+    script_path.write_text(verification_script(build_test_job), encoding="utf-8")
+    stats_path = tmp_path / "sccache-publish.json"
+    if contents is not None:
+        stats_path.write_bytes(contents)
+    return subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true] - the script is this repository's own.
+        [BASH, str(script_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "STATS_PATH": str(stats_path)},
+        cwd=tmp_path,
+    )

--- a/tests/workflow_contracts/publish_report_support.py
+++ b/tests/workflow_contracts/publish_report_support.py
@@ -9,20 +9,21 @@ each growing its own.
 Run via ``make test-workflow-contracts``.
 """
 
-import os
 import re
-import shutil
-import subprocess  # ruff: ignore[suspicious-subprocess-import] - runs a script this repository declares.
 import typing as typ
 
-if typ.TYPE_CHECKING:
-    from pathlib import Path
+from workflow_support import (
+    WorkflowShapeError,
+    job_from_document,
+    parse_workflow,
+    repository_file,
+    steps,
+)
 
-from workflow_support import WorkflowShapeError, job, steps
-
-#: The workflow these assertions read, loaded through
-#: :func:`workflow_support.job` so file access and YAML parsing happen at
-#: one boundary rather than in each contract.
+#: The workflow these assertions read. Its text is fetched through
+#: :func:`workflow_support.repository_file` and parsed by
+#: :func:`workflow_support.parse_workflow`, so repository access and
+#: YAML parsing each happen at one boundary rather than in each contract.
 CI_WORKFLOW: typ.Final[str] = "ci.yml"
 
 #: The job that packages the crates.
@@ -36,11 +37,6 @@ STATS_VARIABLE: typ.Final[str] = "LADING_SCCACHE_STATS_JSON"
 
 #: The action that collects the statistics file.
 UPLOAD_ACTION: typ.Final[str] = "actions/upload-artifact@"
-
-#: The shell the verification step declares, resolved to an absolute
-#: path so the harness starts the same interpreter the runner does
-#: rather than whichever `bash` a contributor's PATH offers first.
-BASH: typ.Final[str] = shutil.which("bash") or "/bin/bash"
 
 #: The step that reads the report before it is uploaded.
 VERIFY_STEP: typ.Final[str] = "Verify publish-step compiler-cache statistics"
@@ -99,15 +95,49 @@ def _require(condition: object, message: str) -> None:
         raise PublishReportShapeError(message)
 
 
-def build_test_job_document() -> dict[str, typ.Any]:
-    """Return the packaging job, parsed from the workflow.
+def build_test_job_from_document(
+    workflow_document: dict[str, typ.Any],
+) -> dict[str, typ.Any]:
+    """Extract the packaging job from an already-parsed workflow.
+
+    A pure function: no repository access. The repository-backed form
+    is :func:`read_build_test_job_document`.
+
+    Parameters
+    ----------
+    workflow_document : dict[str, typ.Any]
+        The parsed workflow mapping, as returned by
+        :func:`workflow_support.parse_workflow`.
+
+    Returns
+    -------
+    dict[str, typ.Any]
+        The job that runs the publish dry run.
+
+    """
+    return typ.cast(
+        "dict[str, typ.Any]",
+        job_from_document(workflow_document, BUILD_TEST_JOB),
+    )
+
+
+def read_build_test_job_document() -> dict[str, typ.Any]:
+    """Read the repository workflow and return its packaging job.
+
+    A thin wrapper over the repository boundary: it reads
+    :data:`CI_WORKFLOW` through :func:`workflow_support.repository_file`
+    and delegates to the pure :func:`build_test_job_from_document`.
+    Exists only for contract fixtures that must start from the
+    repository's own content.
 
     Returns
     -------
     dict[str, typ.Any]
         The job that runs the publish dry run.
     """
-    return typ.cast("dict[str, typ.Any]", job(CI_WORKFLOW, BUILD_TEST_JOB))
+    workflow_text = repository_file(".github", "workflows", CI_WORKFLOW)
+    workflow_document = parse_workflow(workflow_text)
+    return build_test_job_from_document(workflow_document)
 
 
 def build_test_steps(build_test_job: dict[str, typ.Any]) -> list[dict[str, typ.Any]]:
@@ -320,59 +350,3 @@ def verification_script(build_test_job: dict[str, typ.Any]) -> str:
             raise PublishReportShapeError(message)
     _require(script.strip(), f"{VERIFY_STEP!r}'s run script is empty")
     return script
-
-
-def run_verification(
-    build_test_job: dict[str, typ.Any], tmp_path: Path, contents: bytes | None
-) -> subprocess.CompletedProcess[str]:
-    """Run the workflow's verification script against one report.
-
-    The script is written to a file and run as ``bash <file>`` rather
-    than passed to ``bash -c``. Bash 3.2 exec-replaces itself with the
-    last external command of a ``-c`` string, so a harness using that
-    form measures something the runner never does; runners execute
-    fragments from a file.
-
-    The report is deliberately placed outside the working directory
-    the script runs in. The runner resolves the report through
-    ``$STATS_PATH`` from the step's environment, not through the
-    working directory, so a script that read the bare file name would
-    pass a harness that put both in one directory and fail on the
-    runner, where no such file exists next to the fragment. The
-    harness mirrors that geometry so the contract catches the mistake
-    before CI does.
-
-    Parameters
-    ----------
-    build_test_job : dict[str, typ.Any]
-        The parsed job.
-    tmp_path : Path
-        A directory to hold the script's working directory and the
-        report's, kept separate so the report is not reachable from the
-        script's working directory.
-    contents : bytes or None
-        What to write to the report path, or None to leave it absent.
-
-    Returns
-    -------
-    subprocess.CompletedProcess[str]
-        The finished process, with output captured.
-    """
-    working_dir = tmp_path / "workdir"
-    report_dir = tmp_path / "report"
-    working_dir.mkdir()
-    report_dir.mkdir()
-
-    script_path = working_dir / "verify.sh"
-    script_path.write_text(verification_script(build_test_job), encoding="utf-8")
-    stats_path = report_dir / "sccache-publish.json"
-    if contents is not None:
-        stats_path.write_bytes(contents)
-    return subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true] - the script is this repository's own.
-        [BASH, str(script_path)],
-        check=False,
-        capture_output=True,
-        text=True,
-        env={**os.environ, "STATS_PATH": str(stats_path)},
-        cwd=working_dir,
-    )

--- a/tests/workflow_contracts/publish_report_support.py
+++ b/tests/workflow_contracts/publish_report_support.py
@@ -18,7 +18,7 @@ import typing as typ
 if typ.TYPE_CHECKING:
     from pathlib import Path
 
-from workflow_support import WorkflowShapeError, job, repository_file, steps
+from workflow_support import WorkflowShapeError, job, steps
 
 #: The workflow these assertions read, loaded through
 #: :func:`workflow_support.job` so file access and YAML parsing happen at
@@ -99,68 +99,6 @@ def _require(condition: object, message: str) -> None:
         raise PublishReportShapeError(message)
 
 
-def makefile_lading_ref() -> str:
-    """Return the Makefile's lading pin.
-
-    Returns
-    -------
-    str
-        The commit the Makefile resolves lading from.
-    """
-    makefile = repository_file("Makefile")
-    match = re.search(r"^LADING_REF \?= (?P<ref>\S+)$", makefile, re.MULTILINE)
-    if match is None:
-        raise PublishReportShapeError("the Makefile must define LADING_REF")
-    return match["ref"]
-
-
-def lockfile_lading_ref() -> str:
-    """Return the commit `uv.lock` resolves Lading to.
-
-    The fourth place the pin lives, and the one that decides what a bare
-    ``uv run`` actually installs: the project group states a commit and
-    the lock file records the one resolution chose. They can disagree
-    only through an incomplete bump, and the failure is silent, because
-    the lock file wins.
-
-    Returns
-    -------
-    str
-        The commit recorded in the lock file.
-    """
-    lockfile = repository_file("uv.lock")
-    matches = set(
-        re.findall(
-            r"github\.com/leynos/lading\?rev=([0-9a-f]{40})",
-            lockfile,
-        )
-    )
-    _require(matches, "uv.lock must record a lading git revision")
-    _require(
-        len(matches) == 1,
-        f"uv.lock must resolve lading to one commit, found {sorted(matches)}",
-    )
-    return matches.pop()
-
-
-def pyproject_lading_ref() -> str:
-    """Return the project group's lading pin.
-
-    Returns
-    -------
-    str
-        The commit `uv` resolves lading from for a bare `uv run`.
-    """
-    pyproject = repository_file("pyproject.toml")
-    match = re.search(
-        r"lading @ git\+https://github\.com/leynos/lading@(?P<ref>[0-9a-f]{40})",
-        pyproject,
-    )
-    if match is None:
-        raise PublishReportShapeError("pyproject.toml must pin lading by commit")
-    return match["ref"]
-
-
 def build_test_job_document() -> dict[str, typ.Any]:
     """Return the packaging job, parsed from the workflow.
 
@@ -209,16 +147,22 @@ def mapping_at(owner: object, key: str, subject: str) -> dict[str, typ.Any]:
     -------
     dict[str, typ.Any]
         The mapping, or an empty one when the key is absent.
+
+    Raises
+    ------
+    PublishReportShapeError
+        If the owner is not a mapping, or the key holds something that
+        is neither a mapping nor absent.
     """
     if not isinstance(owner, dict):
-        raise PublishReportShapeError(f"{subject} must be a mapping, got {owner!r}")
+        message = f"{subject} must be a mapping, got {owner!r}"
+        raise PublishReportShapeError(message)
     value = owner.get(key)
     if value is None:
         return {}
     if not isinstance(value, dict):
-        raise PublishReportShapeError(
-            f"{subject}'s {key!r} must be a mapping, got {value!r}"
-        )
+        message = f"{subject}'s {key!r} must be a mapping, got {value!r}"
+        raise PublishReportShapeError(message)
     return value
 
 
@@ -313,15 +257,22 @@ def statistics_path(build_test_job: dict[str, typ.Any]) -> str:
     -------
     str
         The configured file path.
+
+    Raises
+    ------
+    PublishReportShapeError
+        If the step sets no report path, or sets one that is not a
+        string.
     """
     step = step_named(build_test_job, DRY_RUN_STEP)
     environment = mapping_at(step, "env", f"the {DRY_RUN_STEP!r} step")
     path = environment.get(STATS_VARIABLE)
     if not isinstance(path, str):
-        raise PublishReportShapeError(
+        message = (
             f"the {DRY_RUN_STEP!r} step must set {STATS_VARIABLE} to a path, "
             f"got {path!r}"
         )
+        raise PublishReportShapeError(message)
     _require(path, f"the {DRY_RUN_STEP!r} step must set {STATS_VARIABLE}")
     return path
 
@@ -338,12 +289,17 @@ def verification_script(build_test_job: dict[str, typ.Any]) -> str:
     -------
     str
         The script the runner executes.
+
+    Raises
+    ------
+    PublishReportShapeError
+        If the verification step declares no run script, or an empty
+        one.
     """
     script = step_named(build_test_job, VERIFY_STEP).get("run")
     if not isinstance(script, str):
-        raise PublishReportShapeError(
-            f"{VERIFY_STEP!r} must declare a run script, got {script!r}"
-        )
+        message = f"{VERIFY_STEP!r} must declare a run script, got {script!r}"
+        raise PublishReportShapeError(message)
     _require(script.strip(), f"{VERIFY_STEP!r}'s run script is empty")
     return script
 

--- a/tests/workflow_contracts/publish_report_support.py
+++ b/tests/workflow_contracts/publish_report_support.py
@@ -323,12 +323,23 @@ def run_verification(
     form measures something the runner never does; runners execute
     fragments from a file.
 
+    The report is deliberately placed outside the working directory
+    the script runs in. The runner resolves the report through
+    ``$STATS_PATH`` from the step's environment, not through the
+    working directory, so a script that read the bare file name would
+    pass a harness that put both in one directory and fail on the
+    runner, where no such file exists next to the fragment. The
+    harness mirrors that geometry so the contract catches the mistake
+    before CI does.
+
     Parameters
     ----------
     build_test_job : dict[str, typ.Any]
         The parsed job.
     tmp_path : Path
-        A directory to hold the script and the report.
+        A directory to hold the script's working directory and the
+        report's, kept separate so the report is not reachable from the
+        script's working directory.
     contents : bytes or None
         What to write to the report path, or None to leave it absent.
 
@@ -337,9 +348,14 @@ def run_verification(
     subprocess.CompletedProcess[str]
         The finished process, with output captured.
     """
-    script_path = tmp_path / "verify.sh"
+    working_dir = tmp_path / "workdir"
+    report_dir = tmp_path / "report"
+    working_dir.mkdir()
+    report_dir.mkdir()
+
+    script_path = working_dir / "verify.sh"
     script_path.write_text(verification_script(build_test_job), encoding="utf-8")
-    stats_path = tmp_path / "sccache-publish.json"
+    stats_path = report_dir / "sccache-publish.json"
     if contents is not None:
         stats_path.write_bytes(contents)
     return subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true] - the script is this repository's own.
@@ -348,5 +364,5 @@ def run_verification(
         capture_output=True,
         text=True,
         env={**os.environ, "STATS_PATH": str(stats_path)},
-        cwd=tmp_path,
+        cwd=working_dir,
     )

--- a/tests/workflow_contracts/publish_verification_script_test.py
+++ b/tests/workflow_contracts/publish_verification_script_test.py
@@ -1,0 +1,103 @@
+"""The publish report's verification script, executed.
+
+Asserting that the script's text contains `::warning` says nothing about
+which branch reaches it, nor whether the job survives. These run the
+script the workflow declares, against a report that is missing, empty,
+malformed and valid in turn, and read what it prints.
+
+The script is written to a file and run as `bash <file>` rather than
+passed to `bash -c`. Bash 3.2 exec-replaces itself with the last
+external command of a `-c` string, so a harness using that form measures
+something the runner never does; runners execute fragments from a file.
+
+Run via ``make test-workflow-contracts``.
+"""
+
+import typing as typ
+
+from publish_report_support import run_verification
+
+if typ.TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestTheVerificationScriptRuns:
+    """The script itself, executed, rather than read for substrings.
+
+    Asserting that the text contains ``::warning`` says nothing about
+    which branch reaches it or whether the job survives. These run the
+    script the workflow declares, against a report that is missing,
+    empty, malformed and valid in turn.
+    """
+
+    def test_a_missing_report_warns_and_leaves_the_job_alive(
+        self, build_test_job: dict[str, typ.Any], tmp_path: Path
+    ) -> None:
+        """The common case: the publish step failed before lading ran.
+
+        The warning has to name the path and offer a cause, because the
+        artefact list looks identical whether the report was never
+        written or was written and never read.
+        """
+        result = run_verification(build_test_job, tmp_path, None)
+
+        assert result.returncode == 0, result.stderr
+        # Three parts of one sentence, checked separately so a failure
+        # names which part is missing: the annotation GitHub renders, the
+        # cause a maintainer acts on, and the path they look for. A
+        # snapshot would fix the whole wording, which changes for reasons
+        # this contract has no opinion about.
+        expected = (
+            "::warning title=publish-statistics::",
+            "wrote no compiler-cache report",
+            "sccache-publish.json",
+        )
+        missing = [fragment for fragment in expected if fragment not in result.stdout]
+        assert not missing, (
+            f"the warning must carry the annotation, the cause and the path; "
+            f"missing {missing} from {result.stdout!r}"
+        )
+
+    def test_an_empty_report_is_distinguished_from_a_missing_one(
+        self, build_test_job: dict[str, typ.Any], tmp_path: Path
+    ) -> None:
+        """Lading created the file and wrote nothing to it.
+
+        A different fault from never running, and the message says so:
+        collapsing the two would send the reader looking for a publish
+        failure that did not happen.
+        """
+        result = run_verification(build_test_job, tmp_path, b"")
+
+        assert result.returncode == 0, result.stderr
+        assert "is empty" in result.stdout, result.stdout
+        assert "wrote no compiler-cache report" not in result.stdout, result.stdout
+
+    def test_a_malformed_report_is_reported_as_unreadable(
+        self, build_test_job: dict[str, typ.Any], tmp_path: Path
+    ) -> None:
+        """A truncated write leaves a non-empty file that is not JSON.
+
+        Testing only for existence would pass this, which is why the
+        script parses rather than stats.
+        """
+        result = run_verification(build_test_job, tmp_path, b'{"requests": ')
+
+        assert result.returncode == 0, result.stderr
+        assert "not valid JSON" in result.stdout, result.stdout
+
+    def test_a_valid_report_is_printed_rather_than_warned_about(
+        self, build_test_job: dict[str, typ.Any], tmp_path: Path
+    ) -> None:
+        """The successful case, which must produce no warning at all.
+
+        A script that warned unconditionally would pass all three cases
+        above and tell a maintainer nothing.
+        """
+        report = b'{"stats": {"compile_requests": 42, "cache_hits": 7}}'
+        result = run_verification(build_test_job, tmp_path, report)
+
+        assert result.returncode == 0, result.stderr
+        assert "::warning" not in result.stdout, result.stdout
+        assert "Publish-step compiler-cache report:" in result.stdout, result.stdout
+        assert "compile_requests" in result.stdout, result.stdout

--- a/tests/workflow_contracts/publish_verification_script_test.py
+++ b/tests/workflow_contracts/publish_verification_script_test.py
@@ -15,7 +15,7 @@ Run via ``make test-workflow-contracts``.
 
 import typing as typ
 
-from publish_report_support import run_verification
+from workflow_queries import run_verification
 
 if typ.TYPE_CHECKING:
     from pathlib import Path

--- a/tests/workflow_contracts/workflow_boundary_test.py
+++ b/tests/workflow_contracts/workflow_boundary_test.py
@@ -30,34 +30,40 @@ def test_missing_file_raises_missing_repository_file_error() -> None:
     assert "definitely-absent.yml" in message, message
 
 
-def test_permission_error_is_wrapped() -> None:
-    """Permission failures surface as RepositoryReadError, not OSError."""
-    with (
-        mock.patch(
-            "pathlib.Path.read_text",
-            side_effect=PermissionError(13, "Permission denied"),
+@pytest.mark.parametrize(
+    ("read_failure", "parts", "category_fragment", "path_fragment"),
+    [
+        pytest.param(
+            PermissionError(13, "Permission denied"),
+            (".github", "workflows", "ci.yml"),
+            "permission",
+            "ci.yml",
+            id="permission-error",
         ),
+        pytest.param(
+            OSError(5, "Input/output error"),
+            ("Makefile",),
+            "unreadable",
+            "Makefile",
+            id="other-os-error",
+        ),
+    ],
+)
+def test_read_failure_is_wrapped(
+    read_failure: Exception,
+    parts: tuple[str, ...],
+    category_fragment: str,
+    path_fragment: str,
+) -> None:
+    """Filesystem read failures surface as RepositoryReadError, not OSError."""
+    with (
+        mock.patch("pathlib.Path.read_text", side_effect=read_failure),
         pytest.raises(RepositoryReadError) as excinfo,
     ):
-        repository_file(".github", "workflows", "ci.yml")
+        repository_file(*parts)
     message = str(excinfo.value)
-    assert "permission" in message, message
-    assert "ci.yml" in message, message
-
-
-def test_other_os_error_is_wrapped() -> None:
-    """Non-permission read failures surface as RepositoryReadError."""
-    with (
-        mock.patch(
-            "pathlib.Path.read_text",
-            side_effect=OSError(5, "Input/output error"),
-        ),
-        pytest.raises(RepositoryReadError) as excinfo,
-    ):
-        repository_file("Makefile")
-    message = str(excinfo.value)
-    assert "unreadable" in message, message
-    assert "Makefile" in message, message
+    assert category_fragment in message, message
+    assert path_fragment in message, message
 
 
 def test_unicode_decode_error_is_wrapped() -> None:

--- a/tests/workflow_contracts/workflow_boundary_test.py
+++ b/tests/workflow_contracts/workflow_boundary_test.py
@@ -1,0 +1,95 @@
+"""Focused contracts for the workflow-support parse and repository boundary."""
+
+from unittest import mock
+
+import pytest
+from workflow_support import (
+    MissingRepositoryFileError,
+    NotAMappingError,
+    RepositoryReadError,
+    job_from_document,
+    parse_workflow,
+    repository_file,
+)
+
+MINIMAL_WORKFLOW = """\
+name: CI
+jobs:
+  build:
+    steps:
+      - run: make test
+"""
+
+
+def test_missing_file_raises_missing_repository_file_error() -> None:
+    """Absent repository paths surface as MissingRepositoryFileError."""
+    with pytest.raises(MissingRepositoryFileError) as excinfo:
+        repository_file(".github", "workflows", "definitely-absent.yml")
+    message = str(excinfo.value)
+    assert "must exist" in message, message
+    assert "definitely-absent.yml" in message, message
+
+
+def test_permission_error_is_wrapped() -> None:
+    """Permission failures surface as RepositoryReadError, not OSError."""
+    with (
+        mock.patch(
+            "pathlib.Path.read_text",
+            side_effect=PermissionError(13, "Permission denied"),
+        ),
+        pytest.raises(RepositoryReadError) as excinfo,
+    ):
+        repository_file(".github", "workflows", "ci.yml")
+    message = str(excinfo.value)
+    assert "permission" in message, message
+    assert "ci.yml" in message, message
+
+
+def test_other_os_error_is_wrapped() -> None:
+    """Non-permission read failures surface as RepositoryReadError."""
+    with (
+        mock.patch(
+            "pathlib.Path.read_text",
+            side_effect=OSError(5, "Input/output error"),
+        ),
+        pytest.raises(RepositoryReadError) as excinfo,
+    ):
+        repository_file("Makefile")
+    message = str(excinfo.value)
+    assert "unreadable" in message, message
+    assert "Makefile" in message, message
+
+
+def test_unicode_decode_error_is_wrapped() -> None:
+    """Non-UTF-8 bytes surface as RepositoryReadError, not UnicodeDecodeError."""
+    decode_error = UnicodeDecodeError("utf-8", b"\x00\xff", 0, 1, "invalid start byte")
+    with (
+        mock.patch(
+            "pathlib.Path.read_text",
+            side_effect=decode_error,
+        ),
+        pytest.raises(RepositoryReadError) as excinfo,
+    ):
+        repository_file(".github", "workflows", "ci.yml")
+    message = str(excinfo.value)
+    assert "utf-8" in message.lower(), message
+    assert "ci.yml" in message, message
+
+
+def test_parse_workflow_rejects_non_mapping() -> None:
+    """A YAML scalar or sequence document violates the mapping contract."""
+    with pytest.raises(NotAMappingError):
+        parse_workflow("- just\n- a\n- list\n")
+
+
+def test_parse_workflow_accepts_mapping() -> None:
+    """A mapping document parses to a dict."""
+    document = parse_workflow(MINIMAL_WORKFLOW)
+    assert document["name"] == "CI", document
+
+
+def test_job_from_document_extracts_named_job() -> None:
+    """job_from_document extracts the job under the given name."""
+    document = parse_workflow(MINIMAL_WORKFLOW)
+    job = job_from_document(document, "build")
+    assert job["steps"] == [{"run": "make test"}], job["steps"]

--- a/tests/workflow_contracts/workflow_mapping_guard_test.py
+++ b/tests/workflow_contracts/workflow_mapping_guard_test.py
@@ -1,0 +1,48 @@
+"""The guard that reads a nested workflow mapping.
+
+`(step.get("env") or {})` accepts a non-empty scalar or list and then
+raises `AttributeError` on the next read, which reports a fault in the
+contract rather than the shape in the workflow that caused it. These
+cover the guard that reports the shape instead.
+
+Run via ``make test-workflow-contracts``.
+"""
+
+import pytest
+from publish_report_support import mapping_at
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("LADING_REF=abc", id="a-scalar"),
+        pytest.param(["LADING_REF=abc"], id="a-list"),
+        pytest.param(42, id="a-number"),
+    ],
+)
+def test_a_malformed_nested_mapping_fails_as_a_shape_violation(
+    value: object,
+) -> None:
+    """A scalar where a mapping belongs must name the workflow, not Python.
+
+    ``(step.get("env") or {})`` accepts every value here and then raises
+    ``AttributeError`` on the next read, which reports a fault in the
+    contract rather than the shape in the workflow that caused it. A
+    ``list`` is the realistic one: `env:` written as a sequence of
+    `KEY=value` strings parses cleanly and means nothing to GitHub.
+    """
+    with pytest.raises(AssertionError, match="must be a mapping"):
+        mapping_at({"env": value}, "env", "the step under test")
+
+
+def test_an_absent_nested_mapping_reads_as_empty() -> None:
+    """A step with no `env:` is ordinary, not malformed.
+
+    The guard has to separate absent from wrong, or every step without
+    the key would fail the contract instead of the assertions that read
+    it reporting what is missing.
+    """
+    assert mapping_at({}, "env", "the step under test") == {}, (
+        "a step with no env: must read as an empty mapping, or every such "
+        "step fails the contract instead of the assertion that reads it"
+    )

--- a/tests/workflow_contracts/workflow_queries.py
+++ b/tests/workflow_contracts/workflow_queries.py
@@ -7,8 +7,12 @@ reads as a list comprehension and one assertion.
 """
 
 import dataclasses
+import os
+import shutil
+import subprocess  # ruff: ignore[suspicious-subprocess-import] - runs a script this repository declares.
 import typing as typ
 
+from publish_report_support import verification_script
 from workflow_support import (
     ROOT,
     cache_owner,
@@ -22,10 +26,17 @@ from workflow_support import (
 
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
+    from pathlib import Path
 
 SHARED_CACHE_OWNING_ACTIONS = ("setup-rust", "generate-coverage")
 # GitHub accepts either extension, so a contract that scans one is a gap.
 WORKFLOW_SUFFIXES = (".yml", ".yaml")
+
+
+#: The shell the verification step declares, resolved to an absolute
+#: path so the harness starts the same interpreter the runner does
+#: rather than whichever `bash` a contributor's PATH offers first.
+BASH: typ.Final[str] = shutil.which("bash") or "/bin/bash"
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -252,3 +263,59 @@ def direct_workspace_test_steps() -> list[str]:
         A location string per offending step.
     """
     return [str(ref) for ref in iter_steps() if runs_workspace_tests(ref.step)]
+
+
+def run_verification(
+    build_test_job: dict[str, typ.Any], tmp_path: Path, contents: bytes | None
+) -> subprocess.CompletedProcess[str]:
+    """Run the workflow's verification script against one report.
+
+    The script is written to a file and run as ``bash <file>`` rather
+    than passed to ``bash -c``. Bash 3.2 exec-replaces itself with the
+    last external command of a ``-c`` string, so a harness using that
+    form measures something the runner never does; runners execute
+    fragments from a file.
+
+    The report is deliberately placed outside the working directory
+    the script runs in. The runner resolves the report through
+    ``$STATS_PATH`` from the step's environment, not through the
+    working directory, so a script that read the bare file name would
+    pass a harness that put both in one directory and fail on the
+    runner, where no such file exists next to the fragment. The
+    harness mirrors that geometry so the contract catches the mistake
+    before CI does.
+
+    Parameters
+    ----------
+    build_test_job : dict[str, typ.Any]
+        The parsed job.
+    tmp_path : Path
+        A directory to hold the script's working directory and the
+        report's, kept separate so the report is not reachable from the
+        script's working directory.
+    contents : bytes or None
+        What to write to the report path, or None to leave it absent.
+
+    Returns
+    -------
+    subprocess.CompletedProcess[str]
+        The finished process, with output captured.
+    """
+    working_dir = tmp_path / "workdir"
+    report_dir = tmp_path / "report"
+    working_dir.mkdir()
+    report_dir.mkdir()
+
+    script_path = working_dir / "verify.sh"
+    script_path.write_text(verification_script(build_test_job), encoding="utf-8")
+    stats_path = report_dir / "sccache-publish.json"
+    if contents is not None:
+        stats_path.write_bytes(contents)
+    return subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true] - the script is this repository's own.
+        [BASH, str(script_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "STATS_PATH": str(stats_path)},
+        cwd=working_dir,
+    )

--- a/tests/workflow_contracts/workflow_support.py
+++ b/tests/workflow_contracts/workflow_support.py
@@ -76,6 +76,13 @@ class CacheStepPathsError(WorkflowShapeError):
         super().__init__("a cache step must declare its paths")
 
 
+class MissingRepositoryFileError(WorkflowShapeError):
+    """A file the contracts read is not in the repository."""
+
+    def __init__(self, subject: str) -> None:
+        super().__init__(f"{subject} must exist in the repository")
+
+
 class AmbiguousStepError(WorkflowShapeError):
     """A step name did not match exactly one step in a job."""
 
@@ -106,6 +113,35 @@ def workflow(workflow_name: str) -> dict[str, object]:
     if not isinstance(document, dict):
         raise NotAMappingError(workflow_name)
     return document
+
+
+def repository_file(*parts: str) -> str:
+    """Return the text of one file in the repository.
+
+    The single reading boundary for contracts that assert on files other
+    than workflows. Contracts that opened paths themselves each grew
+    their own root, encoding and error handling, and a contract with its
+    own file access has no boundary to test at.
+
+    Parameters
+    ----------
+    *parts : str
+        Path components below the repository root.
+
+    Returns
+    -------
+    str
+        The file's contents.
+
+    Raises
+    ------
+    MissingRepositoryFileError
+        If no such file exists.
+    """
+    path = ROOT.joinpath(*parts)
+    if not path.is_file():
+        raise MissingRepositoryFileError("/".join(parts))
+    return path.read_text(encoding="utf-8")
 
 
 def jobs(workflow_name: str) -> dict[str, dict[str, object]]:

--- a/tests/workflow_contracts/workflow_support.py
+++ b/tests/workflow_contracts/workflow_support.py
@@ -48,6 +48,28 @@ class NotAMappingError(WorkflowShapeError):
         super().__init__(f"{subject} must parse to a mapping")
 
 
+class UnparsableWorkflowError(WorkflowShapeError):
+    """A workflow document is not parsable YAML.
+
+    Raised by :func:`parse_workflow` when ``yaml.safe_load`` raises, so
+    a malformed workflow fails as a shape violation with the same
+    treatment as any other contract failure rather than as a raw parser
+    fault.
+
+    Parameters
+    ----------
+    subject : str
+        What was being parsed, named in the error message.
+
+    See Also
+    --------
+    parse_workflow : The parsing boundary that raises this.
+    """
+
+    def __init__(self, subject: str) -> None:
+        super().__init__(f"{subject} is not parsable YAML")
+
+
 class MissingKeyError(WorkflowShapeError):
     """A document did not declare a structure the contracts require."""
 
@@ -99,6 +121,32 @@ class MissingRepositoryFileError(WorkflowShapeError):
         super().__init__(f"{subject} must exist in the repository")
 
 
+class RepositoryReadError(WorkflowShapeError):
+    """A repository file exists but could not be read as UTF-8 text.
+
+    The single reading boundary (:func:`repository_file`) turns every
+    other failure of the filesystem or the decoder into this one shape
+    violation, so a contract that names an unreadable file fails with
+    the path and the failure category instead of a raw ``OSError``.
+
+    Parameters
+    ----------
+    subject : str
+        The path, relative to the repository root, that was unreadable.
+        Rendered natively, so a Windows reader sees a Windows path.
+    category : str
+        Human-readable failure category, e.g. ``permission denied``.
+
+    See Also
+    --------
+    repository_file : The reading boundary that raises this.
+    """
+
+    def __init__(self, subject: str, category: str) -> None:
+        self.category = category
+        super().__init__(f"{subject} could not be read: {category}")
+
+
 class AmbiguousStepError(WorkflowShapeError):
     """A step name did not match exactly one step in a job."""
 
@@ -119,16 +167,76 @@ def workflow(workflow_name: str) -> dict[str, object]:
     dict[str, object]
         The parsed workflow mapping.
 
+    Any failure is a :class:`workflow_support.WorkflowShapeError` raised
+    by :func:`repository_file` (absent or unreadable file) or by
+    :func:`parse_workflow` (non-mapping document).
+    """
+    return parse_workflow(repository_file(".github", "workflows", workflow_name))
+
+
+def parse_workflow(workflow_text: str) -> dict[str, object]:
+    """Parse one workflow document from its YAML text.
+
+    A pure function: no repository access. The reader half of the split
+    is :func:`workflow`, which reads the file through
+    :func:`repository_file` and hands the text here.
+
+    Parameters
+    ----------
+    workflow_text : str
+        The raw YAML text of one workflow.
+
+    Returns
+    -------
+    dict[str, object]
+        The parsed workflow mapping.
+
     Raises
     ------
+    UnparsableWorkflowError
+        If the document is not parsable YAML.
     NotAMappingError
         If the document does not parse to a mapping.
     """
-    workflow_path = ROOT / ".github" / "workflows" / workflow_name
-    document = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    try:
+        document = yaml.safe_load(workflow_text)
+    except yaml.YAMLError:
+        raise UnparsableWorkflowError("workflow") from None
     if not isinstance(document, dict):
-        raise NotAMappingError(workflow_name)
+        raise NotAMappingError("workflow")
     return document
+
+
+def job_from_document(document: dict[str, object], job_name: str) -> dict[str, object]:
+    """Extract one named job from a parsed workflow mapping.
+
+    A pure function: no repository access. The repository-backed form
+    is :func:`job`.
+
+    Parameters
+    ----------
+    document : dict[str, object]
+        The parsed workflow mapping, as returned by :func:`parse_workflow`.
+    job_name : str
+        Key of the job within the workflow's ``jobs`` mapping.
+
+    Returns
+    -------
+    dict[str, object]
+        The parsed job mapping.
+
+    Raises
+    ------
+    MissingKeyError
+        If the workflow does not declare the named job.
+    """
+    declared = document.get("jobs")
+    if not isinstance(declared, dict):
+        raise MissingKeyError("workflow", "jobs")
+    selected = declared.get(job_name)
+    if not isinstance(selected, dict):
+        raise MissingKeyError("workflow", job_name)
+    return selected
 
 
 def repository_file(*parts: str) -> str:
@@ -138,6 +246,12 @@ def repository_file(*parts: str) -> str:
     than workflows. Contracts that opened paths themselves each grew
     their own root, encoding and error handling, and a contract with its
     own file access has no boundary to test at.
+
+    Every failure is reported as a :class:`WorkflowShapeError`: an
+    absent file raises :class:`MissingRepositoryFileError`, and every
+    other filesystem or decoding failure raises
+    :class:`RepositoryReadError` carrying the failure category, so no
+    raw ``OSError`` or ``UnicodeDecodeError`` escapes this helper API.
 
     Parameters
     ----------
@@ -153,11 +267,21 @@ def repository_file(*parts: str) -> str:
     ------
     MissingRepositoryFileError
         If no such file exists.
+    RepositoryReadError
+        If the file exists but cannot be read as UTF-8 text.
     """
     path = ROOT.joinpath(*parts)
-    if not path.is_file():
-        raise MissingRepositoryFileError(str(Path(*parts)))
-    return path.read_text(encoding="utf-8")
+    subject = str(Path(*parts))
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError, IsADirectoryError, NotADirectoryError:
+        raise MissingRepositoryFileError(subject) from None
+    except PermissionError:
+        raise RepositoryReadError(subject, "permission denied") from None
+    except UnicodeDecodeError:
+        raise RepositoryReadError(subject, "not valid UTF-8 text") from None
+    except OSError as read_error:
+        raise RepositoryReadError(subject, f"unreadable ({read_error})") from None
 
 
 def jobs(workflow_name: str) -> dict[str, dict[str, object]]:
@@ -200,15 +324,10 @@ def job(workflow_name: str, job_name: str) -> dict[str, object]:
     dict[str, object]
         The parsed job mapping.
 
-    Raises
-    ------
-    MissingKeyError
-        If the workflow does not declare the named job.
+    Fails with :class:`workflow_support.MissingKeyError` if the workflow
+    does not declare the named job.
     """
-    selected = jobs(workflow_name).get(job_name)
-    if not isinstance(selected, dict):
-        raise MissingKeyError(workflow_name, job_name)
-    return selected
+    return job_from_document(workflow(workflow_name), job_name)
 
 
 def steps(job_document: dict[str, object]) -> list[dict[str, object]]:

--- a/tests/workflow_contracts/workflow_support.py
+++ b/tests/workflow_contracts/workflow_support.py
@@ -77,7 +77,23 @@ class CacheStepPathsError(WorkflowShapeError):
 
 
 class MissingRepositoryFileError(WorkflowShapeError):
-    """A file the contracts read is not in the repository."""
+    """A file a contract reads is not in the repository.
+
+    Raised by :func:`repository_file` rather than letting an
+    ``OSError`` escape, so a contract that names a file which has moved
+    fails as a shape violation with the path in the message, the same
+    way a malformed workflow does.
+
+    Parameters
+    ----------
+    subject : str
+        The path, relative to the repository root, that was not found.
+        Rendered natively, so a Windows reader sees a Windows path.
+
+    See Also
+    --------
+    repository_file : The reading boundary that raises this.
+    """
 
     def __init__(self, subject: str) -> None:
         super().__init__(f"{subject} must exist in the repository")
@@ -140,7 +156,7 @@ def repository_file(*parts: str) -> str:
     """
     path = ROOT.joinpath(*parts)
     if not path.is_file():
-        raise MissingRepositoryFileError("/".join(parts))
+        raise MissingRepositoryFileError(str(Path(*parts)))
     return path.read_text(encoding="utf-8")
 
 

--- a/typos.local.toml
+++ b/typos.local.toml
@@ -28,6 +28,8 @@ ignore = [
   '(?m)^\s*types: \[opened, reopened, synchronize, labeled, ready_for_review\]$',
   '\bCompilerArtifact\b',
   '"reason": "compiler-artifact"',
+  # The action's own name, quoted when a contract matches a `uses:` value.
+  'actions/upload-artifact',
   # Tokio names and attributes are external Rust APIs.
   '\bRuntimeFlavor\b',
   '\bruntime_flavor\b',

--- a/typos.toml
+++ b/typos.toml
@@ -63,6 +63,7 @@ extend-ignore-re = [
     "\\{color\\}",
     "`[^`\\n]+`",
     "`mold`",
+    "actions/upload-artifact",
     "expected current_thread flavor in output",
     "flavor = \"current_thread\"",
     "flavor = \\\\\"current_thread\\\\\"",

--- a/uv.lock
+++ b/uv.lock
@@ -157,8 +157,8 @@ wheels = [
 
 [[package]]
 name = "lading"
-version = "0.1.0"
-source = { git = "https://github.com/leynos/lading?rev=d3217a599ea34adad6a6e3845845fff2fe923758#d3217a599ea34adad6a6e3845845fff2fe923758" }
+version = "0.3.0"
+source = { git = "https://github.com/leynos/lading?rev=c3740ef48da4c89752fcb98fff4f1c27284e5f12#c3740ef48da4c89752fcb98fff4f1c27284e5f12" }
 dependencies = [
     { name = "cuprum" },
     { name = "cyclopts" },
@@ -377,7 +377,7 @@ python-tools = [
 python-tools = [
     { name = "df12-python-lints", git = "https://github.com/leynos/df12-python-lints.git?rev=v0.3.0" },
     { name = "hypothesis" },
-    { name = "lading", git = "https://github.com/leynos/lading?rev=d3217a599ea34adad6a6e3845845fff2fe923758" },
+    { name = "lading", git = "https://github.com/leynos/lading?rev=c3740ef48da4c89752fcb98fff4f1c27284e5f12" },
     { name = "pathspec", specifier = "==1.1.1" },
     { name = "pylint" },
     { name = "pytest" },


### PR DESCRIPTION
## The pin

`LADING_REF` sat at `e0a8d43f` from 30 August, seven commits behind the v0.3.0 tag. It moves to `c3740ef4` in both places that set it, `ci.yml` and the Makefile.

v0.3.0 carries three things this repository wants:

- the Windows CP1252 relay fix (`leynos/lading#250`), which this repository reported
- per-crate timing for the publish order (`#254`)
- opt-in sccache statistics (`#255`), asked for in `rstest-bdd#720`

## The reporting

The publish dry run is the longest step in the Linux lane and said nothing about what it spent. The end-of-job sccache report is job-wide, so it cannot attribute any of that time to the step. On a recent cold run the step took 36 minutes and the report could not say whether that was compilation or cache misses.

Setting `LADING_SCCACHE_STATS_JSON` on the step makes lading read `sccache` around each packaged build and write the results to a file, which a new step uploads as `sccache-publish-*`.

The variable is set on the workflow step rather than in the Makefile, so a local `make publish-check` stays quiet and the file lands where the upload expects it. The statistics are differenced around each invocation rather than obtained by zeroing the counters, so the end-of-job report keeps its meaning; a tool that zeroed them would silently make every later reading partial.

## Verified against the new ref

Ran the dry run locally before pushing, per the packet. It completed successfully:

| Observation | Value |
| --- | --- |
| crate invocations packaged | 16 |
| sccache queries, all successful | 18 |
| slowest package step | `rstest-bdd-patterns`, 9.9 s |

The file it wrote carries the wrapper path, a baseline reading, per-crate hits, misses, requests and seconds, and a final reading. One entry as an example:

```json
{"crate": "rstest-bdd-patterns", "errors": 0, "hits": 0, "misses": 53,
 "requests": 90, "seconds": 9.904, "subcommand": "package"}
```

That is the attribution `#720` asked for: per crate, per subcommand, inside the step rather than across the job.

## Verification

`tests/workflow_contracts/lading_pin_test.py` asserts that the two pins agree, that the pin is a commit rather than a tag, that the step still asks for the statistics, and that the file is uploaded. The last one matters because a file written into the runner's temporary directory and never collected is discarded with the runner.

Four mutations, each caught:

| Mutation | Result |
| --- | --- |
| the two pins disagree | fails |
| the pin becomes the `v0.3.0` tag | fails |
| the statistics variable dropped | fails |
| the upload step dropped | fails |

The script that does the reading is itself exercised by `publish_verification_script_test.py`, whose harness runs it from a working directory that does not contain the report, mirroring the runner's geometry; a script that read the report by bare file name rather than through `$STATS_PATH` would fail there.

`make test-workflow-contracts` passes at 92. Formatting, markdownlint, the spelling gate and the repository's Python lints are clean.

## Note

The upload uses `actions/upload-artifact` pinned to `043fb46d` (v7.0.1), which is the version already used eight times across the estate rather than a new one.

## Summary by Sourcery

Adopt lading v0.3.0 and make compiler-cache usage attributable to the publish dry run in Linux CI.

New Features:
- Add per-publish-step compiler-cache statistics verification and artifact collection for Linux CI runs.

Bug Fixes:
- Adopt the lading revision containing the Windows CP1252 relay fix and publish timing improvements.

Enhancements:
- Keep lading references synchronized across CI, Makefile, Python tooling, and the lockfile while enforcing commit-based pins.
- Improve workflow contract coverage for report generation, validation, upload behavior, and repository parsing boundaries.

CI:
- Configure the publish dry run to emit compiler-cache statistics and preserve them for seven days with lane-specific artifacts.
- Run report verification and collection after failed Linux publish steps without failing the job when the report is missing or malformed.

Documentation:
- Document publish-step compiler-cache attribution, report handling, and lading pin maintenance for developers.

Tests:
- Add workflow contract tests covering lading pin consistency, report paths and ordering, failure conditions, artifact settings, and executable verification-script behavior.

Chores:
- Apply formatting and wording updates to existing developer documentation and typo configuration.

## References

- [lody session](https://lody.ai/leynos/sessions/ba56abab-a0c7-483f-af81-34d255c8d859)