### PR TITLE
Fix actionlint expression finding in lockfile refresh workflow (#709)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ proptest-regressions/
 .uv-cache/
 .uv-tools/
 .vtcode/
+memories/
 .claude/
 *.swp
 *.swo

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2626,12 +2626,26 @@ pattern in `crates/rstest-bdd/tests/feature_rebuild_invalidation/`:
   so the check and the refresh path always agree on which fixtures are
   authoritative. A stale lockfile therefore fails before the behavioural
   nested-Cargo tests can mask the drift.
-- The test copies the fixture into `target/tests/<name>/` under the shared
-  workspace `target/`, rewrites the copied manifest's relative `path = "…"`
-  values to absolute paths (resolving against the *source* directory, whose
-  depth the `..` counts match), and mutates only the copy.
-- A versioned stamp file (a hash of the source tree, written last) makes the
-  copy idempotent; stale scratch trees are always re-copied.
+- The Dependabot lockfile refresh runs in
+  `.github/workflows/refresh-derived-fixture-lockfiles.yml`, which triggers
+  only on `pull_request_target` events from Dependabot (`dependabot[bot]`) that
+  touch the configured Cargo manifest paths (the workspace root, `crates/**`,
+  and the two published-GPUI fixtures). The job checks out the pull request
+  head SHA, refreshes every standalone fixture lockfile with
+  `make update-fixture-lockfiles`, commits only `**/Cargo.lock` paths, and —
+  when nothing changed — validates the no-op refresh with
+  `make check-fixture-lockfiles`.
+  The workflow's push step is a shell-safety invariant:
+  `github.event.pull_request.head.ref` is untrusted input, so the step assigns
+  it only through the step-level `HEAD_REF` environment variable, and the push
+  command must remain `git push origin "HEAD:$HEAD_REF"`. Do not interpolate
+  `github.event.pull_request.head.ref` directly into a `run:` block: a ref
+  name may carry shell metacharacters, and inline substitution would hand the
+  shell executable script instead of quoted data. The property and shape
+  contracts in `tests/workflow_contracts/derived_fixture_lockfiles_test.py` —
+  run through `make test-workflow-contracts` — enforce this contract, including
+  a Hypothesis test that executes the push step against generated hostile ref
+  names.
 - Every nested `cargo` invocation uses a controlled child environment:
   `.env_clear()` plus a captured snapshot of the parent, with `CARGO_MAKEFLAGS`,
   `CARGO_PKG_*`, and `CARGO_LLVM_COV*` stripped, and `CARGO_TARGET_DIR`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1310,3 +1310,21 @@ boundary without importing Trymark's syntax or reporting model into
     supplied locations, and proves no Rust test crate is generated or compiled.
   - See `docs/adr-018-parser-neutral-scenario-execution.md` (Extension
     boundary and Compatibility and migration).
+
+## 14. Engineering hygiene
+
+This phase tracks repository-level hardening and tooling work that does not
+belong to a feature phase.
+
+- [x] 14.1.1. Clear the actionlint script-injection finding on the
+  Dependabot lockfile refresh workflow. Finish line:
+  `.github/workflows/refresh-derived-fixture-lockfiles.yml` no longer
+  interpolates `github.event.pull_request.head.ref` in an inline shell
+  script; the push step binds the expression to a `PR_HEAD_REF` environment
+  variable and expands it quoted, preserving the existing dispatch
+  semantics. Delivered 2026-09-07: the push step now reads
+  `git push origin "HEAD:$PR_HEAD_REF"` and the workflow contract test locks
+  in both the env mapping and the command. Validation:
+  `actionlint -config-file .github/actionlint.yaml
+  .github/workflows/refresh-derived-fixture-lockfiles.yml` and `make
+  test-workflow-contracts` passed.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1320,11 +1320,11 @@ belong to a feature phase.
   Dependabot lockfile refresh workflow. Finish line:
   `.github/workflows/refresh-derived-fixture-lockfiles.yml` no longer
   interpolates `github.event.pull_request.head.ref` in an inline shell
-  script; the push step binds the expression to a `PR_HEAD_REF` environment
+  script; the push step binds the expression to a `HEAD_REF` environment
   variable and expands it quoted, preserving the existing dispatch
   semantics. Delivered 2026-09-07: the push step now reads
-  `git push origin "HEAD:$PR_HEAD_REF"` and the workflow contract test locks
-  in both the env mapping and the command. Validation:
+  `git push origin "HEAD:$HEAD_REF"` and the workflow contract test locks in
+  both the env mapping and the command. Validation:
   `actionlint -config-file .github/actionlint.yaml
   .github/workflows/refresh-derived-fixture-lockfiles.yml` and `make
   test-workflow-contracts` passed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,15 @@ extend-ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "scripts/tests/test_*.py" = ["S101", "PLR0913", "PLR0917", "PLR2004", "PLR6301"]
-"tests/workflow_contracts/*_test.py" = ["S101", "PLR0913", "PLR0917", "PLR2004", "PLR6301"]
+"tests/workflow_contracts/*_test.py" = [
+    "S101",
+    "S404",
+    "S603",
+    "PLR0913",
+    "PLR0917",
+    "PLR2004",
+    "PLR6301",
+]
 
 [tool.ruff.lint.flake8-import-conventions]
 banned-from = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,8 +93,6 @@ extend-ignore = [
 "scripts/tests/test_*.py" = ["S101", "PLR0913", "PLR0917", "PLR2004", "PLR6301"]
 "tests/workflow_contracts/*_test.py" = [
     "S101",
-    "S404",
-    "S603",
     "PLR0913",
     "PLR0917",
     "PLR2004",

--- a/tests/workflow_contracts/derived_fixture_lockfiles_test.py
+++ b/tests/workflow_contracts/derived_fixture_lockfiles_test.py
@@ -23,9 +23,9 @@ from pathlib import Path
 import hypothesis
 import pytest
 import yaml
-from hypothesis import strategies as st
 from lockfile_refresh_support import (
     HOSTILE_HEAD_REF,
+    HOSTILE_HEAD_REF_STRATEGY,
     INJECTION_ARTEFACT,
     INVOCATION_LOG_NAME,
     read_invocation_log,
@@ -289,33 +289,12 @@ def _example_working_dir(tmp_path: Path, example_index: int) -> Path:
     return working_dir
 
 
-# Ref fragments a hostile caller could reach a git ref name through, alongside
-# ordinary ref-like text.  Metacharacters probe quoting, expansion, command
-# substitution, globs, escapes, and field splitting, so the property fails for
-# any parsing the shell does rather than only for the one scripted value.
-_REF_METACHARACTERS = "'\";|&$()`*?[]\\ \t\n"
-_hostile_head_ref = st.one_of(
-    st.text(
-        alphabet=st.characters(min_codepoint=33, max_codepoint=0x10FFFF),
-        min_size=1,
-        max_size=48,
-    ),
-    st.lists(st.sampled_from(_REF_METACHARACTERS), min_size=1, max_size=16).map(
-        "".join
-    ),
-).filter(
-    # An embedded newline ends the runner's script file, so the shell could
-    # only ever see a prefix of the value; git cannot express such a ref
-    # either, so the property skips the unrepresentable case.
-    lambda ref: "\n" not in ref
-)
-
 # Counts the property test's invocations so each generated example gets a
 # fresh scratch directory inside the one function-scoped ``tmp_path``.
 _EXAMPLE_SEQUENCE = 0
 
 
-@hypothesis.given(head_ref=_hostile_head_ref)
+@hypothesis.given(head_ref=HOSTILE_HEAD_REF_STRATEGY)
 @hypothesis.settings(
     max_examples=25,
     deadline=dt.timedelta(seconds=5),

--- a/tests/workflow_contracts/derived_fixture_lockfiles_test.py
+++ b/tests/workflow_contracts/derived_fixture_lockfiles_test.py
@@ -16,17 +16,22 @@ that fragment, rather than reading it, is
 Run via ``make test-workflow-contracts``.
 """
 
+import datetime as dt
 import re
 from pathlib import Path
 
+import hypothesis
 import pytest
 import yaml
+from hypothesis import strategies as st
 from lockfile_refresh_support import (
     HOSTILE_HEAD_REF,
     INJECTION_ARTEFACT,
     INVOCATION_LOG_NAME,
+    read_invocation_log,
     resolve_fragment,
     run_fragment,
+    run_fragment_through_posix_shell,
 )
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -265,6 +270,87 @@ def _push_fragment(
     return resolve_fragment(script, declared, head_ref)
 
 
+def _example_working_dir(tmp_path: Path, example_index: int) -> Path:
+    """Return a fresh per-example scratch directory inside *tmp_path*.
+
+    Hypothesis reruns a ``@given`` test body once per generated example while
+    pytest's function-scoped ``tmp_path`` stays put, so the examples would
+    otherwise share one directory.  A fresh subdirectory per example keeps one
+    example's recording-git log and injection sentinel from leaking into the
+    next, and the index is unique across the examples of one run.
+
+    Returns
+    -------
+    pathlib.Path
+        The created scratch directory for one generated example.
+    """
+    working_dir = tmp_path / f"example-{example_index}"
+    working_dir.mkdir()
+    return working_dir
+
+
+# Ref fragments a hostile caller could reach a git ref name through, alongside
+# ordinary ref-like text.  Metacharacters probe quoting, expansion, command
+# substitution, globs, escapes, and field splitting, so the property fails for
+# any parsing the shell does rather than only for the one scripted value.
+_REF_METACHARACTERS = "'\";|&$()`*?[]\\ \t\n"
+_hostile_head_ref = st.one_of(
+    st.text(
+        alphabet=st.characters(min_codepoint=33, max_codepoint=0x10FFFF),
+        min_size=1,
+        max_size=48,
+    ),
+    st.lists(st.sampled_from(_REF_METACHARACTERS), min_size=1, max_size=16).map(
+        "".join
+    ),
+).filter(
+    # An embedded newline ends the runner's script file, so the shell could
+    # only ever see a prefix of the value; git cannot express such a ref
+    # either, so the property skips the unrepresentable case.
+    lambda ref: "\n" not in ref
+)
+
+# Counts the property test's invocations so each generated example gets a
+# fresh scratch directory inside the one function-scoped ``tmp_path``.
+_EXAMPLE_SEQUENCE = 0
+
+
+@hypothesis.given(head_ref=_hostile_head_ref)
+@hypothesis.settings(
+    max_examples=25,
+    deadline=dt.timedelta(seconds=5),
+    suppress_health_check=[hypothesis.HealthCheck.function_scoped_fixture],
+)
+def test_push_step_treats_any_generated_head_ref_as_inert_data(
+    refresh_job: dict[str, object], tmp_path: Path, head_ref: str
+) -> None:
+    """Any ref value reaches git as one argument, whatever it carries."""
+    global _EXAMPLE_SEQUENCE
+    _EXAMPLE_SEQUENCE += 1
+    push = _named_step(refresh_job, "Push refreshed lockfiles")
+    script, environment = _push_fragment(push, head_ref)
+
+    working_dir = _example_working_dir(tmp_path, _EXAMPLE_SEQUENCE)
+    result = run_fragment_through_posix_shell(script, environment, working_dir)
+
+    invocation_log = working_dir / INVOCATION_LOG_NAME
+    recorded = read_invocation_log(invocation_log)
+    assert recorded == [["push", "origin", f"HEAD:{head_ref}"]], (
+        f"the push step must hand git the whole generated ref {head_ref!r} as "
+        f"one argument, got {recorded}: a ref the shell parsed would arrive "
+        "split, substituted, or run"
+    )
+    assert not (working_dir / INJECTION_ARTEFACT).exists(), (
+        f"the generated ref {head_ref!r} must reach the shell as data: the "
+        f"sentinel {INJECTION_ARTEFACT!r} appeared, so the shell parsed the "
+        "ref as syntax"
+    )
+    assert result.returncode == 0, (
+        f"the push step must survive the generated ref {head_ref!r}, exit "
+        f"{result.returncode}, stderr {result.stderr!r}"
+    )
+
+
 def test_push_step_delivers_a_hostile_head_ref_as_one_inert_argument(
     refresh_job: dict[str, object], tmp_path: Path
 ) -> None:
@@ -277,10 +363,7 @@ def test_push_step_delivers_a_hostile_head_ref_as_one_inert_argument(
     result = run_fragment(script, environment, working_dir)
 
     invocation_log = working_dir / INVOCATION_LOG_NAME
-    recorded = [
-        line.split("\0")[1:]
-        for line in invocation_log.read_text(encoding="utf-8").splitlines()
-    ]
+    recorded = read_invocation_log(invocation_log)
     assert recorded == [["push", "origin", f"HEAD:{HOSTILE_HEAD_REF}"]], (
         "the push step must hand git the whole ref as one argument, got "
         f"{recorded}: a ref the shell parsed would arrive split, substituted, "

--- a/tests/workflow_contracts/lockfile_refresh_support.py
+++ b/tests/workflow_contracts/lockfile_refresh_support.py
@@ -21,6 +21,8 @@ if typ.TYPE_CHECKING:
     import collections.abc as cabc
     from pathlib import Path
 
+from hypothesis import strategies as st
+
 #: The shell the runner starts for a `run:` fragment, resolved to an absolute
 #: path so the harness uses the same interpreter the runner does rather than
 #: whichever `bash` a contributor's PATH offers first.
@@ -43,6 +45,26 @@ HEAD_REF_EXPRESSION: typ.Final[re.Pattern[str]] = re.compile(
 INVOCATION_LOG_VARIABLE: typ.Final[str] = "GIT_INVOCATIONS"
 #: The file the recording ``git`` appends its argument vectors to.
 INVOCATION_LOG_NAME: typ.Final[str] = "git-invocations.log"
+# Ref fragments a hostile caller could reach a git ref name through, alongside
+# ordinary ref-like text.  Metacharacters probe quoting, expansion, command
+# substitution, globs, escapes, and field splitting, so the property fails for
+# any parsing the shell does rather than only for the one scripted value.
+_REF_METACHARACTERS = "'\";|&$()`*?[]\\ \t\n"
+HOSTILE_HEAD_REF_STRATEGY: typ.Final = st.one_of(
+    st.text(
+        alphabet=st.characters(min_codepoint=33, max_codepoint=0x10FFFF),
+        min_size=1,
+        max_size=48,
+    ),
+    st.lists(st.sampled_from(_REF_METACHARACTERS), min_size=1, max_size=16).map(
+        "".join
+    ),
+).filter(
+    # An embedded newline ends the runner's script file, so the shell could
+    # only ever see a prefix of the value; git cannot express such a ref
+    # either, so the property skips the unrepresentable case.
+    lambda ref: "\n" not in ref
+)
 
 
 def read_invocation_log(invocation_log: Path) -> list[list[str]]:

--- a/tests/workflow_contracts/lockfile_refresh_support.py
+++ b/tests/workflow_contracts/lockfile_refresh_support.py
@@ -25,6 +25,10 @@ if typ.TYPE_CHECKING:
 #: path so the harness uses the same interpreter the runner does rather than
 #: whichever `bash` a contributor's PATH offers first.
 BASH: typ.Final[str] = shutil.which("bash") or "/bin/bash"
+#: The plain POSIX shell a ``sh -c`` fragment runs under, pinned as a literal
+#: so a contract exercises the runner's interpreter rather than whichever
+#: ``sh`` a contributor's PATH resolves first.
+POSIX_SHELL: typ.Final[str] = "/bin/sh"
 #: A ref name that runs a command when a shell parses it rather than quotes
 #: it.  Git permits `$`, `(`, `)`, `;` and `/` in a ref name, so a push target
 #: built by interpolation is reachable from the pull request supplying the ref.
@@ -39,6 +43,37 @@ HEAD_REF_EXPRESSION: typ.Final[re.Pattern[str]] = re.compile(
 INVOCATION_LOG_VARIABLE: typ.Final[str] = "GIT_INVOCATIONS"
 #: The file the recording ``git`` appends its argument vectors to.
 INVOCATION_LOG_NAME: typ.Final[str] = "git-invocations.log"
+
+
+def read_invocation_log(invocation_log: Path) -> list[list[str]]:
+    """Return the argument vectors the recording ``git`` appended.
+
+    The log splits on the newline the recorder writes after each vector and
+    nowhere else: a hostile ref name may itself carry a NEL (U+0085) or any
+    other character Python's :meth:`str.splitlines` treats as a boundary, and
+    parsing those as record separators would report a ref the shell delivered
+    whole as if the shell had split it.
+
+    Parameters
+    ----------
+    invocation_log : pathlib.Path
+        The log file :func:`write_recording_git` returned.
+
+    Returns
+    -------
+    list[list[str]]
+        One argv per line, with the recorder's process name stripped.
+    """
+    # The recorder ends every vector with a newline, so the split leaves one
+    # empty trailing element; everything before it is a complete record.
+    lines = invocation_log.read_bytes().split(b"\n")[:-1]
+    return [
+        [
+            argument.decode("utf-8", "surrogateescape")
+            for argument in line.split(b"\0")[1:]
+        ]
+        for line in lines
+    ]
 
 
 def substituted(expression: re.Pattern[str], value: str, text: str) -> str:
@@ -121,6 +156,45 @@ def write_recording_git(directory: Path) -> Path:
     return invocation_log
 
 
+def run_with_recording_git(
+    argv: cabc.Sequence[str],
+    environment: cabc.Mapping[str, str],
+    working_dir: Path,
+) -> subprocess.CompletedProcess[str]:
+    """Run *argv* with the recording git first on PATH.
+
+    Parameters
+    ----------
+    argv : collections.abc.Sequence[str]
+        The command vector to execute, whose head resolves the shell the
+        fragment runs under.
+    environment : collections.abc.Mapping[str, str]
+        The resolved environment the runner would set for the step.
+    working_dir : pathlib.Path
+        The directory to run in, which also holds the recording git.
+
+    Returns
+    -------
+    subprocess.CompletedProcess[str]
+        The finished fragment, with its output captured.
+    """
+    invocation_log = write_recording_git(working_dir)
+    return subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true] - the script is this repository's own.
+        argv,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            **environment,
+            "PATH": f"{working_dir}{os.pathsep}{os.environ['PATH']}",
+            INVOCATION_LOG_VARIABLE: str(invocation_log),
+        },
+        cwd=working_dir,
+        timeout=30,
+    )
+
+
 def run_fragment(
     script: str, environment: cabc.Mapping[str, str], working_dir: Path
 ) -> subprocess.CompletedProcess[str]:
@@ -147,18 +221,32 @@ def run_fragment(
     """
     script_path = working_dir / "push.sh"
     script_path.write_text(script, encoding="utf-8")
-    invocation_log = write_recording_git(working_dir)
-    return subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true] - the script is this repository's own.
-        [BASH, str(script_path)],
-        check=False,
-        capture_output=True,
-        text=True,
-        env={
-            **os.environ,
-            **environment,
-            "PATH": f"{working_dir}{os.pathsep}{os.environ['PATH']}",
-            INVOCATION_LOG_VARIABLE: str(invocation_log),
-        },
-        cwd=working_dir,
-        timeout=30,
-    )
+    return run_with_recording_git([BASH, str(script_path)], environment, working_dir)
+
+
+def run_fragment_through_posix_shell(
+    script: str, environment: cabc.Mapping[str, str], working_dir: Path
+) -> subprocess.CompletedProcess[str]:
+    """Run *script* through ``sh -c`` with the recording git first on PATH.
+
+    :func:`run_fragment` runs a fragment the way the runner does, as
+    ``bash <file>``.  This helper instead hands the fragment to
+    ``/bin/sh -c``, so a property test can attack the push step's parsing
+    with generated hostile refs under the plain POSIX shell rather than
+    trusting only the runner's bash form.
+
+    Parameters
+    ----------
+    script : str
+        The resolved script text.
+    environment : collections.abc.Mapping[str, str]
+        The resolved environment the runner would set for the step.
+    working_dir : pathlib.Path
+        The directory to run in, which also holds the recording git.
+
+    Returns
+    -------
+    subprocess.CompletedProcess[str]
+        The finished fragment, with its output captured.
+    """
+    return run_with_recording_git([POSIX_SHELL, "-c", script], environment, working_dir)


### PR DESCRIPTION
## Summary by Sourcery

Harden the Dependabot lockfile refresh workflow against actionlint-reported shell injection while expanding contract tests to enforce safe push behavior.

Bug Fixes:
- Prevent shell injection in the Dependabot lockfile refresh workflow by passing the pull request head ref through a quoted environment variable when pushing refreshed lockfiles.

Enhancements:
- Strengthen workflow contract coverage with property-based tests that verify hostile ref names remain inert data across POSIX shell execution.
- Improve invocation-log parsing and test harness support for validating shell command arguments.

Documentation:
- Document the workflow’s shell-safety invariant and record the completed engineering-hygiene work in the roadmap.

Tests:
- Add generated hostile-ref tests covering quoting, expansion, command substitution, field splitting, and other shell metacharacters.

Chores:
- Apply formatting cleanup to workflow-contract lint configuration.