### PR TITLE
Bind the lockfile refresh head ref in the environment (#702)

### DIFF
--- a/.github/workflows/refresh-derived-fixture-lockfiles.yml
+++ b/.github/workflows/refresh-derived-fixture-lockfiles.yml
@@ -53,7 +53,12 @@ jobs:
 
       - name: Push refreshed lockfiles
         if: ${{ steps.commit.outputs.changed == 'true' }}
-        run: git push origin HEAD:${{ github.event.pull_request.head.ref }}
+        # The head ref reaches the shell as quoted data, never as script text.
+        # Git ref names may contain shell metacharacters, and the Dependabot
+        # guard narrows who can trigger this job, not what the ref may hold.
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: git push origin "HEAD:$HEAD_REF"
 
       - name: Validate refreshed fixture lockfiles
         if: ${{ steps.commit.outputs.changed != 'true' }}

--- a/tests/workflow_contracts/derived_fixture_lockfiles_test.py
+++ b/tests/workflow_contracts/derived_fixture_lockfiles_test.py
@@ -9,20 +9,25 @@ workflow limited to its lock-refresh targets; the ordinary CI workflow
 continues to build and exercise the fixtures, and the shared
 ``make check-fixture-lockfiles`` gate validates the refreshed set.  The push
 target is a caller-controlled ref name, so it reaches the shell through the
-environment as quoted data rather than as interpolated script text.
+environment as quoted data rather than as interpolated script text.  Running
+that fragment, rather than reading it, is
+:mod:`lockfile_refresh_support`; this module owns the assertions.
 
 Run via ``make test-workflow-contracts``.
 """
 
-import os
 import re
-import shutil
-import stat
-import subprocess  # ruff: ignore[suspicious-subprocess-import] - runs a script this repository declares.
 from pathlib import Path
 
 import pytest
 import yaml
+from lockfile_refresh_support import (
+    HOSTILE_HEAD_REF,
+    INJECTION_ARTEFACT,
+    INVOCATION_LOG_NAME,
+    resolve_fragment,
+    run_fragment,
+)
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = ROOT / ".github" / "workflows" / "refresh-derived-fixture-lockfiles.yml"
@@ -227,72 +232,15 @@ def test_push_step_never_interpolates_untrusted_refs_inline(
     )
 
 
-#: The shell the runner starts for a `run:` fragment, resolved to an absolute
-#: path so the harness uses the same interpreter the runner does rather than
-#: whichever `bash` a contributor's PATH offers first.
-BASH = shutil.which("bash") or "/bin/bash"
-#: A ref name that runs a command when a shell parses it rather than quotes
-#: it.  Git permits `$`, `(`, `)`, `;` and `/` in a ref name, so a push target
-#: built by interpolation is reachable from the pull request supplying the ref.
-HOSTILE_HEAD_REF = "issue/$(touch pwned);ref"
-#: The file the hostile ref creates only when the shell parses it as syntax.
-INJECTION_ARTEFACT = "pwned"
-#: The expression the runner substitutes with the pull request's head ref.
-HEAD_REF_EXPRESSION = re.compile(
-    r"\$\{\{\s*github\.event\.pull_request\.head\.ref\s*\}\}"
-)
-
-
-def _write_recording_git(directory: Path, log_name: str) -> Path:
-    """Put a git stand-in on PATH that records each argument vector it gets.
-
-    Parameters
-    ----------
-    directory : pathlib.Path
-        The directory to write the stand-in into, which the caller also
-        prepends to PATH.
-    log_name : str
-        The environment variable holding the log to append to.
-
-    Returns
-    -------
-    pathlib.Path
-        The log file the stand-in appends one NUL-separated argv per line to.
-    """
-    invocation_log = directory / "git-invocations.log"
-    recording_git = directory / "git"
-    recording_git.write_text(
-        "\n".join([
-            "#!/usr/bin/env sh",
-            "",
-            'for argument in "$@"; do',
-            f'    printf "\\0%s" "$argument" >> "${log_name}"',
-            "done",
-            f'printf "\\n" >> "${log_name}"',
-            "",
-        ]),
-        encoding="utf-8",
-    )
-    recording_git.chmod(recording_git.stat().st_mode | stat.S_IXUSR)
-    return invocation_log
-
-
 def _push_fragment(
     push: dict[str, object], head_ref: str
 ) -> tuple[str, dict[str, str]]:
     """Return the push step's script and environment as the runner resolves them.
 
-    GitHub substitutes every ``${{ ... }}`` in the script text and in the
-    environment before the shell starts, so the harness does the same rather
-    than inventing a configuration.  That is what lets it tell the two forms
-    apart: a step that names the ref inline receives the hostile value as
-    *script text*, while one that reads it from the environment receives it as
-    data.
-
     A step that declares no environment is run as it stands, so the injection
-    this test exists to catch still happens and is reported as an executed
-    command rather than as a shape complaint.  The env binding itself is
-    pinned exactly by the sibling contract tests.
+    the hostile-ref contract exists to catch still happens and is reported as
+    an executed command rather than as a shape complaint.  The env binding
+    itself is pinned exactly by the sibling shape contracts.
 
     Parameters
     ----------
@@ -313,36 +261,7 @@ def _push_fragment(
             assert isinstance(script, str), "the push step must declare a shell script"
     declared = push.get("env", {})
     assert isinstance(declared, dict), "the push step's environment must be a mapping"
-    return (
-        _substituted(HEAD_REF_EXPRESSION, head_ref, script),
-        {
-            str(name): _substituted(HEAD_REF_EXPRESSION, head_ref, str(value))
-            for name, value in declared.items()
-        },
-    )
-
-
-def _substituted(expression: re.Pattern[str], value: str, text: str) -> str:
-    """Return *text* with every *expression* replaced by *value*.
-
-    The value is inserted literally, so one carrying backslashes or group
-    references reaches the script as the runner would write it.
-
-    Parameters
-    ----------
-    expression : re.Pattern[str]
-        The expression to replace.
-    value : str
-        What the runner substitutes for it.
-    text : str
-        The script text or environment value to rewrite.
-
-    Returns
-    -------
-    str
-        The rewritten text.
-    """
-    return expression.sub(lambda _match: value, text)
+    return resolve_fragment(script, declared, head_ref)
 
 
 def test_push_step_delivers_a_hostile_head_ref_as_one_inert_argument(
@@ -354,29 +273,9 @@ def test_push_step_delivers_a_hostile_head_ref_as_one_inert_argument(
 
     working_dir = tmp_path / "workdir"
     working_dir.mkdir()
-    # The fragment goes to a file and runs as `bash <file>`, which is the form
-    # the runner uses; a `bash -c` harness would execute something the runner
-    # never does.
-    script_path = working_dir / "push.sh"
-    script_path.write_text(script, encoding="utf-8")
-    log_name = "GIT_INVOCATIONS"
-    invocation_log = _write_recording_git(working_dir, log_name)
+    result = run_fragment(script, environment, working_dir)
 
-    result = subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true] - the script is this repository's own.
-        [BASH, str(script_path)],
-        check=False,
-        capture_output=True,
-        text=True,
-        env={
-            **os.environ,
-            **environment,
-            "PATH": f"{working_dir}{os.pathsep}{os.environ['PATH']}",
-            log_name: str(invocation_log),
-        },
-        cwd=working_dir,
-        timeout=30,
-    )
-
+    invocation_log = working_dir / INVOCATION_LOG_NAME
     recorded = [
         line.split("\0")[1:]
         for line in invocation_log.read_text(encoding="utf-8").splitlines()

--- a/tests/workflow_contracts/derived_fixture_lockfiles_test.py
+++ b/tests/workflow_contracts/derived_fixture_lockfiles_test.py
@@ -7,11 +7,14 @@ checked-out pull request head, and the lockfiles regenerated through the
 authoritative ``make update-fixture-lockfiles`` target.  They also keep the
 workflow limited to its lock-refresh targets; the ordinary CI workflow
 continues to build and exercise the fixtures, and the shared
-``make check-fixture-lockfiles`` gate validates the refreshed set.
+``make check-fixture-lockfiles`` gate validates the refreshed set.  The push
+target is a caller-controlled ref name, so it reaches the shell through the
+environment as quoted data rather than as interpolated script text.
 
 Run via ``make test-workflow-contracts``.
 """
 
+import re
 from pathlib import Path
 
 import pytest
@@ -183,10 +186,38 @@ def test_refresh_commit_and_push_touch_only_generated_lockfiles(
     assert push.get("if") == "${{ steps.commit.outputs.changed == 'true' }}", (
         "the push step must run only when lockfiles changed"
     )
-    assert (
-        push.get("run")
-        == "git push origin HEAD:${{ github.event.pull_request.head.ref }}"
-    ), "the push step must push the refreshed lockfiles to the pull-request head"
+    assert push.get("env") == {
+        "HEAD_REF": "${{ github.event.pull_request.head.ref }}",
+    }, (
+        "the push step must bind the pull-request head ref in the environment "
+        "so the shell receives it as data"
+    )
+    assert push.get("run") == 'git push origin "HEAD:$HEAD_REF"', (
+        "the push step must push the refreshed lockfiles to the pull-request "
+        "head branch named by HEAD_REF"
+    )
+
+
+# Context values the shell must never parse as script.  The trailing ``\b``
+# keeps ``github.event_name``, a fixed event label, out of the match.
+_UNTRUSTED_INLINE_EXPRESSION = re.compile(
+    r"\$\{\{[^}]*github\.(?:event\b|head_ref\b)[^}]*\}\}"
+)
+
+
+def test_push_step_never_interpolates_untrusted_refs_inline(
+    refresh_job: dict[str, object],
+) -> None:
+    """A caller-controlled ref name must not reach the shell as script text."""
+    push = _named_step(refresh_job, "Push refreshed lockfiles")
+    script = push.get("run")
+    assert isinstance(script, str), "the push step must declare a shell script"
+    offending = _UNTRUSTED_INLINE_EXPRESSION.findall(script)
+    assert not offending, (
+        f"the push step script must not interpolate {offending} inline: bind "
+        'each untrusted value in env: and reference it as "$VAR" so the shell '
+        "parses it as quoted data instead of as script"
+    )
 
 
 def test_validation_runs_when_refresh_changes_nothing(

--- a/tests/workflow_contracts/derived_fixture_lockfiles_test.py
+++ b/tests/workflow_contracts/derived_fixture_lockfiles_test.py
@@ -14,7 +14,11 @@ environment as quoted data rather than as interpolated script text.
 Run via ``make test-workflow-contracts``.
 """
 
+import os
 import re
+import shutil
+import stat
+import subprocess  # ruff: ignore[suspicious-subprocess-import] - runs a script this repository declares.
 from pathlib import Path
 
 import pytest
@@ -210,13 +214,185 @@ def test_push_step_never_interpolates_untrusted_refs_inline(
 ) -> None:
     """A caller-controlled ref name must not reach the shell as script text."""
     push = _named_step(refresh_job, "Push refreshed lockfiles")
-    script = push.get("run")
-    assert isinstance(script, str), "the push step must declare a shell script"
+    match push.get("run"):
+        case str() as script:
+            pass
+        case script:
+            assert isinstance(script, str), "the push step must declare a shell script"
     offending = _UNTRUSTED_INLINE_EXPRESSION.findall(script)
     assert not offending, (
         f"the push step script must not interpolate {offending} inline: bind "
         'each untrusted value in env: and reference it as "$VAR" so the shell '
         "parses it as quoted data instead of as script"
+    )
+
+
+#: The shell the runner starts for a `run:` fragment, resolved to an absolute
+#: path so the harness uses the same interpreter the runner does rather than
+#: whichever `bash` a contributor's PATH offers first.
+BASH = shutil.which("bash") or "/bin/bash"
+#: A ref name that runs a command when a shell parses it rather than quotes
+#: it.  Git permits `$`, `(`, `)`, `;` and `/` in a ref name, so a push target
+#: built by interpolation is reachable from the pull request supplying the ref.
+HOSTILE_HEAD_REF = "issue/$(touch pwned);ref"
+#: The file the hostile ref creates only when the shell parses it as syntax.
+INJECTION_ARTEFACT = "pwned"
+#: The expression the runner substitutes with the pull request's head ref.
+HEAD_REF_EXPRESSION = re.compile(
+    r"\$\{\{\s*github\.event\.pull_request\.head\.ref\s*\}\}"
+)
+
+
+def _write_recording_git(directory: Path, log_name: str) -> Path:
+    """Put a git stand-in on PATH that records each argument vector it gets.
+
+    Parameters
+    ----------
+    directory : pathlib.Path
+        The directory to write the stand-in into, which the caller also
+        prepends to PATH.
+    log_name : str
+        The environment variable holding the log to append to.
+
+    Returns
+    -------
+    pathlib.Path
+        The log file the stand-in appends one NUL-separated argv per line to.
+    """
+    invocation_log = directory / "git-invocations.log"
+    recording_git = directory / "git"
+    recording_git.write_text(
+        "\n".join([
+            "#!/usr/bin/env sh",
+            "",
+            'for argument in "$@"; do',
+            f'    printf "\\0%s" "$argument" >> "${log_name}"',
+            "done",
+            f'printf "\\n" >> "${log_name}"',
+            "",
+        ]),
+        encoding="utf-8",
+    )
+    recording_git.chmod(recording_git.stat().st_mode | stat.S_IXUSR)
+    return invocation_log
+
+
+def _push_fragment(
+    push: dict[str, object], head_ref: str
+) -> tuple[str, dict[str, str]]:
+    """Return the push step's script and environment as the runner resolves them.
+
+    GitHub substitutes every ``${{ ... }}`` in the script text and in the
+    environment before the shell starts, so the harness does the same rather
+    than inventing a configuration.  That is what lets it tell the two forms
+    apart: a step that names the ref inline receives the hostile value as
+    *script text*, while one that reads it from the environment receives it as
+    data.
+
+    A step that declares no environment is run as it stands, so the injection
+    this test exists to catch still happens and is reported as an executed
+    command rather than as a shape complaint.  The env binding itself is
+    pinned exactly by the sibling contract tests.
+
+    Parameters
+    ----------
+    push : dict[str, object]
+        The parsed push step.
+    head_ref : str
+        The ref name to stand in for the one a pull request supplies.
+
+    Returns
+    -------
+    tuple[str, dict[str, str]]
+        The resolved script, and the environment to run it with.
+    """
+    match push.get("run"):
+        case str() as script:
+            pass
+        case script:
+            assert isinstance(script, str), "the push step must declare a shell script"
+    declared = push.get("env", {})
+    assert isinstance(declared, dict), "the push step's environment must be a mapping"
+    return (
+        _substituted(HEAD_REF_EXPRESSION, head_ref, script),
+        {
+            str(name): _substituted(HEAD_REF_EXPRESSION, head_ref, str(value))
+            for name, value in declared.items()
+        },
+    )
+
+
+def _substituted(expression: re.Pattern[str], value: str, text: str) -> str:
+    """Return *text* with every *expression* replaced by *value*.
+
+    The value is inserted literally, so one carrying backslashes or group
+    references reaches the script as the runner would write it.
+
+    Parameters
+    ----------
+    expression : re.Pattern[str]
+        The expression to replace.
+    value : str
+        What the runner substitutes for it.
+    text : str
+        The script text or environment value to rewrite.
+
+    Returns
+    -------
+    str
+        The rewritten text.
+    """
+    return expression.sub(lambda _match: value, text)
+
+
+def test_push_step_delivers_a_hostile_head_ref_as_one_inert_argument(
+    refresh_job: dict[str, object], tmp_path: Path
+) -> None:
+    """A ref the runner supplies reaches git whole and never reaches a shell."""
+    push = _named_step(refresh_job, "Push refreshed lockfiles")
+    script, environment = _push_fragment(push, HOSTILE_HEAD_REF)
+
+    working_dir = tmp_path / "workdir"
+    working_dir.mkdir()
+    # The fragment goes to a file and runs as `bash <file>`, which is the form
+    # the runner uses; a `bash -c` harness would execute something the runner
+    # never does.
+    script_path = working_dir / "push.sh"
+    script_path.write_text(script, encoding="utf-8")
+    log_name = "GIT_INVOCATIONS"
+    invocation_log = _write_recording_git(working_dir, log_name)
+
+    result = subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true] - the script is this repository's own.
+        [BASH, str(script_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            **environment,
+            "PATH": f"{working_dir}{os.pathsep}{os.environ['PATH']}",
+            log_name: str(invocation_log),
+        },
+        cwd=working_dir,
+        timeout=30,
+    )
+
+    recorded = [
+        line.split("\0")[1:]
+        for line in invocation_log.read_text(encoding="utf-8").splitlines()
+    ]
+    assert recorded == [["push", "origin", f"HEAD:{HOSTILE_HEAD_REF}"]], (
+        "the push step must hand git the whole ref as one argument, got "
+        f"{recorded}: a ref the shell parsed would arrive split, substituted, "
+        "or run"
+    )
+    assert not (working_dir / INJECTION_ARTEFACT).exists(), (
+        "the head ref must reach the shell as data: the hostile ref created "
+        f"{INJECTION_ARTEFACT!r}, so the shell parsed it as syntax"
+    )
+    assert result.returncode == 0, (
+        "the push step must survive a ref name carrying shell metacharacters, "
+        f"exit {result.returncode}, stderr {result.stderr!r}"
     )
 
 

--- a/tests/workflow_contracts/lockfile_refresh_support.py
+++ b/tests/workflow_contracts/lockfile_refresh_support.py
@@ -1,0 +1,164 @@
+"""Execution harness for the lockfile-refresh push step.
+
+The contracts in :mod:`derived_fixture_lockfiles_test` pin the push step's
+text.  Whether a caller-controlled ref name reaches the shell as script text
+or as data is a runtime fact, so these helpers resolve a step the way the
+runner does and execute it against a recording ``git``.
+
+The helpers raise rather than assert, so the module carries no blanket lint
+suppression and a malformed workflow fails the same way whether or not
+assertions are enabled.
+"""
+
+import os
+import re
+import shutil
+import stat
+import subprocess  # ruff: ignore[suspicious-subprocess-import] - runs a script this repository declares.
+import typing as typ
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+    from pathlib import Path
+
+#: The shell the runner starts for a `run:` fragment, resolved to an absolute
+#: path so the harness uses the same interpreter the runner does rather than
+#: whichever `bash` a contributor's PATH offers first.
+BASH: typ.Final[str] = shutil.which("bash") or "/bin/bash"
+#: A ref name that runs a command when a shell parses it rather than quotes
+#: it.  Git permits `$`, `(`, `)`, `;` and `/` in a ref name, so a push target
+#: built by interpolation is reachable from the pull request supplying the ref.
+HOSTILE_HEAD_REF: typ.Final[str] = "issue/$(touch pwned);ref"
+#: The file the hostile ref creates only when the shell parses it as syntax.
+INJECTION_ARTEFACT: typ.Final[str] = "pwned"
+#: The expression the runner substitutes with the pull request's head ref.
+HEAD_REF_EXPRESSION: typ.Final[re.Pattern[str]] = re.compile(
+    r"\$\{\{\s*github\.event\.pull_request\.head\.ref\s*\}\}"
+)
+#: The variable the recording ``git`` appends its argument vectors to.
+INVOCATION_LOG_VARIABLE: typ.Final[str] = "GIT_INVOCATIONS"
+#: The file the recording ``git`` appends its argument vectors to.
+INVOCATION_LOG_NAME: typ.Final[str] = "git-invocations.log"
+
+
+def substituted(expression: re.Pattern[str], value: str, text: str) -> str:
+    """Return *text* with every *expression* replaced by *value*.
+
+    The value is inserted literally, so one carrying backslashes or group
+    references reaches the script as the runner would write it.
+
+    Returns
+    -------
+    str
+        The rewritten text.
+    """
+    return expression.sub(lambda _match: value, text)
+
+
+def resolve_fragment(
+    script: str, declared: cabc.Mapping[str, object], head_ref: str
+) -> tuple[str, dict[str, str]]:
+    """Return the script and environment the runner hands the shell.
+
+    GitHub substitutes every ``${{ ... }}`` in the script text and in the
+    environment before the shell starts, so the harness does the same rather
+    than inventing a configuration.  That is what lets a contract tell the two
+    forms apart: a step that names the ref inline receives the value as *script
+    text*, while one that reads it from the environment receives it as data.
+
+    Parameters
+    ----------
+    script : str
+        The step's ``run`` fragment.
+    declared : collections.abc.Mapping[str, object]
+        The step's ``env`` mapping, or an empty mapping when it declares none.
+    head_ref : str
+        The ref name to stand in for the one a pull request supplies.
+
+    Returns
+    -------
+    tuple[str, dict[str, str]]
+        The resolved script, and the environment to run it with.
+    """
+    return (
+        substituted(HEAD_REF_EXPRESSION, head_ref, script),
+        {
+            str(name): substituted(HEAD_REF_EXPRESSION, head_ref, str(value))
+            for name, value in declared.items()
+        },
+    )
+
+
+def write_recording_git(directory: Path) -> Path:
+    """Put a git stand-in on PATH that records each argument vector it gets.
+
+    Parameters
+    ----------
+    directory : pathlib.Path
+        The directory to write the stand-in into, which the caller also
+        prepends to PATH.
+
+    Returns
+    -------
+    pathlib.Path
+        The log file the stand-in appends one NUL-separated argv per line to.
+    """
+    invocation_log = directory / INVOCATION_LOG_NAME
+    recording_git = directory / "git"
+    recording_git.write_text(
+        "\n".join([
+            "#!/usr/bin/env sh",
+            "",
+            'for argument in "$@"; do',
+            f'    printf "\\0%s" "$argument" >> "${INVOCATION_LOG_VARIABLE}"',
+            "done",
+            f'printf "\\n" >> "${INVOCATION_LOG_VARIABLE}"',
+            "",
+        ]),
+        encoding="utf-8",
+    )
+    recording_git.chmod(recording_git.stat().st_mode | stat.S_IXUSR)
+    return invocation_log
+
+
+def run_fragment(
+    script: str, environment: cabc.Mapping[str, str], working_dir: Path
+) -> subprocess.CompletedProcess[str]:
+    """Run *script* as ``bash <file>`` with the recording git first on PATH.
+
+    The fragment goes to a file and runs as ``bash <file>``, which is the form
+    the runner uses; a ``bash -c`` harness would execute something the runner
+    never does.  The log the recording git writes is
+    ``working_dir``/:data:`INVOCATION_LOG_NAME`.
+
+    Parameters
+    ----------
+    script : str
+        The resolved script text.
+    environment : collections.abc.Mapping[str, str]
+        The resolved environment the runner would set for the step.
+    working_dir : pathlib.Path
+        The directory to run in, which also holds the recording git.
+
+    Returns
+    -------
+    subprocess.CompletedProcess[str]
+        The finished fragment, with its output captured.
+    """
+    script_path = working_dir / "push.sh"
+    script_path.write_text(script, encoding="utf-8")
+    invocation_log = write_recording_git(working_dir)
+    return subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true] - the script is this repository's own.
+        [BASH, str(script_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            **environment,
+            "PATH": f"{working_dir}{os.pathsep}{os.environ['PATH']}",
+            INVOCATION_LOG_VARIABLE: str(invocation_log),
+        },
+        cwd=working_dir,
+        timeout=30,
+    )


### PR DESCRIPTION
## Summary

Resolves the actionlint untrusted-expression finding in the Dependabot lockfile refresh workflow, and pins the safe shape with a contract test. Closes #702.

## The finding

`actionlint` reported, at `.github/workflows/refresh-derived-fixture-lockfiles.yml:56`:

```
"github.event.pull_request.head.ref" is potentially untrusted. avoid using it directly in inline scripts. instead, pass it through an environment variable.
```

The step ran `git push origin HEAD:${{ github.event.pull_request.head.ref }}`. The workflow has `contents: write` and runs on `pull_request_target`, and the `dependabot[bot]` actor guard narrows who can trigger the job rather than what a ref name may hold. Git ref names may contain shell metacharacters, and the expression was substituted into the script text before the shell parsed it, so the value was reachable as syntax rather than as data.

## The fix

The ref is now bound in the step environment and read as a quoted expansion:

```yaml
      - name: Push refreshed lockfiles
        if: ${{ steps.commit.outputs.changed == 'true' }}
        env:
          HEAD_REF: ${{ github.event.pull_request.head.ref }}
        run: git push origin "HEAD:$HEAD_REF"
```

The Dependabot guard, the checkout of `github.event.pull_request.head.sha`, and the push target are all unchanged; only the route the value takes into the shell changes. `.github/actionlint.yaml` was not touched, so its default injection checks stay active and no rule was suppressed.

## Verification

The acceptance command from the ticket now completes with exit 0 and no output:

```
~/go/bin/actionlint -ignore shellcheck -config-file .github/actionlint.yaml .github/workflows/*.yml
```

`tests/workflow_contracts/derived_fixture_lockfiles_test.py` asserts the new `env:` and `run:` shape, and a new sibling test fails if a `github.event` or `github.head_ref` expression returns to the push script. Both tests were confirmed to fail against the previous line, so the guard is falsifiable rather than vacuous.

| Gate | Result |
| --- | --- |
| `make check-fmt` | pass |
| `make lint` | pass |
| `make typecheck` | pass |
| `make test` | pass: 1910 nextest tests, doctests, 118 script tests |
| `make test-workflow-contracts` | pass: 113 tests |
| `make -B spelling` | pass |
| `make markdownlint` | pass |
| `make nixie` | pass |
| ticket actionlint command | pass: exit 0, 0 bytes of output |
| `coderabbit review --agent` | 0 findings |

## References

- Issue: https://github.com/leynos/rstest-bdd/issues/702
- Lody session: https://lody.ai/leynos/sessions/2ef3d48a-ae2b-4eed-a976-f945e69590fb

## Summary by Sourcery

Harden the Dependabot lockfile refresh push step against untrusted pull request ref names.

Bug Fixes:
- Prevent shell injection in the lockfile refresh workflow by passing the pull request head ref through the environment as quoted data.

Enhancements:
- Add workflow contracts that verify the push step shape and execute it with hostile ref names to ensure they remain a single inert Git argument.

Tests:
- Add runtime contract coverage for untrusted ref handling, including detection of inline GitHub expressions and shell-injection artifacts.