### PR TITLE
Prefetch fixture dependencies before the mutation lane runs (#721)

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -45,3 +45,8 @@ jobs:
       # dependent crates' trybuild/integration tests, which
       # cargo-mutants' per-package default would miss).
       extra-args: "--all-features --test-workspace=true"
+      # The nested cargo-spawning harnesses build their fixture crates with
+      # `--locked --offline`, and this lane runs no outer workspace build
+      # that would already have resolved those lockfiles, so warm the
+      # registry from each fixture's committed lockfile first.
+      setup-commands: "make prefetch-fixture-deps"

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ VALE ?= vale
 .PHONY: check-published-gpui-e2e-lock
 .PHONY: forbid-async-trait vale update-ui-lints-lock update-published-gpui-0-2-2-lock update-published-gpui-e2e-lock
 .PHONY: update-feature-rebuild-fixtures-lock
-.PHONY: check-fixture-lockfiles update-fixture-lockfiles
+.PHONY: check-fixture-lockfiles update-fixture-lockfiles prefetch-fixture-deps
 .PHONY: test-workflow-contracts
 
 SHELL := bash
@@ -271,6 +271,14 @@ check-fixture-lockfiles: check-published-gpui-e2e-lock ## Validate every fixture
 # cannot stale it out from under `cargo test --locked`.
 update-fixture-lockfiles: update-published-gpui-e2e-lock ## Regenerate every fixture lockfile via cargo generate-lockfile
 	$(PROJECT_PYTHON) scripts/check_fixture_lockfiles.py --refresh
+
+# Warm ~/.cargo/registry from every committed fixture lockfile. The nested
+# cargo-spawning harnesses build their fixtures with `--locked --offline`, and
+# the mutation lane, unlike the ordinary CI lane, runs no outer online
+# workspace build that would have resolved those lockfiles already, so this
+# prefetch has to finish before cargo-mutants starts.
+prefetch-fixture-deps: ## Warm the Cargo cache for the mutation lane's offline fixture builds
+	$(PROJECT_PYTHON) scripts/check_fixture_lockfiles.py --fetch
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2653,6 +2653,23 @@ pattern in `crates/rstest-bdd/tests/feature_rebuild_invalidation/`:
   filling `~/.cargo/registry` from the committed lockfile without building
   anything. Discovery is shared with the gate, so the prefetch covers exactly
   the fixtures the gate validates.
+- Every `--fetch` run closes with exactly one machine-readable metrics record,
+  whether every fixture downloaded or some failed: a single line prefixed
+  `fixture-prefetch-metrics:` whose JSON payload carries `schema_version`
+  (currently `1`), `total`, `succeeded`, `failed`, `elapsed_ms`, `outcome`
+  (`success` or `failure`) and `cache_outcome`. The record holds counts, a
+  duration and the outcome only — never a manifest path, crate name, command
+  line, environment value, URL or Cargo output — so a job log can be
+  aggregated without exposing anything about the machine that produced it.
+  The line rides the stream matching the outcome: standard output beside the
+  success summary, standard error beside the failure reports, so a reader
+  capturing one stream never mistakes a failed prefetch for a clean one. The
+  elapsed time covers the whole operation, every fixture included, not the
+  first fetch. `cache_outcome` is `unknown`, and must stay that way until
+  Cargo offers machine-readable evidence: `cargo fetch` reports a download
+  only as a human-readable progress line and prints nothing when the crate is
+  already cached, so the absence of a download line proves nothing and the
+  record never infers a cache hit from silence.
 - It is needed because the nested-cargo harnesses
   (`crates/rstest-bdd/tests/feature_rebuild_invalidation.rs` and its
   `harness/addition.rs` module) build their fixtures with `--locked --offline`,

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2646,6 +2646,29 @@ pattern in `crates/rstest-bdd/tests/feature_rebuild_invalidation/`:
   run through `make test-workflow-contracts` — enforce this contract, including
   a Hypothesis test that executes the push step against generated hostile ref
   names.
+- The mutation lane pre-fetches standalone fixture dependencies with
+  `make prefetch-fixture-deps`, which runs
+  `scripts/check_fixture_lockfiles.py --fetch`: that mode runs `cargo fetch
+  --locked --manifest-path <fixture>/Cargo.toml` for every discovered fixture,
+  filling `~/.cargo/registry` from the committed lockfile without building
+  anything. Discovery is shared with the gate, so the prefetch covers exactly
+  the fixtures the gate validates.
+- It is needed because the nested-cargo harnesses
+  (`crates/rstest-bdd/tests/feature_rebuild_invalidation.rs` and its
+  `harness/addition.rs` module) build their fixtures with `--locked --offline`,
+  and the mutation lane runs no outer online workspace build to warm that
+  cache: `.github/workflows/mutation-testing.yml` passes the target as the
+  reusable workflow's `setup-commands`, which runs in each mutants job before
+  cargo-mutants starts. Without it the baseline fails, because nothing has
+  downloaded the crates the fixture lockfiles pin (`proc-macro-error-attr3` was
+  the crate that surfaced it).
+- Keep the two mechanisms apart: `make check-fixture-lockfiles` proves a
+  lockfile still resolves against a full, online registry view and never passes
+  `--offline` (a lockfile that only resolves from a partial cache would hide
+  the drift it exists to catch), while the rebuild-invalidation experiment
+  keeps its own `--offline` runs because it verifies reproducible nested-Cargo
+  behaviour. The prefetch only makes those offline runs resolvable; it never
+  stands in for the gate.
 - Every nested `cargo` invocation uses a controlled child environment:
   `.env_clear()` plus a captured snapshot of the parent, with `CARGO_MAKEFLAGS`,
   `CARGO_PKG_*`, and `CARGO_LLVM_COV*` stripped, and `CARGO_TARGET_DIR`

--- a/scripts/check_fixture_lockfiles.py
+++ b/scripts/check_fixture_lockfiles.py
@@ -23,7 +23,9 @@ import sys
 import typing as typ
 from pathlib import Path
 
+from fixture_lockfile_discovery import discover_fixture_manifests
 from fixture_lockfile_reporting import (
+    FixtureLockfileError,
     GateMode,
     print_check_summary,
     print_failures,
@@ -35,34 +37,8 @@ from fixture_lockfile_reporting import (
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
 
-#: Directory names the scan never descends into: build output, tool caches and
-#: editor state can all hold generated manifests that are not fixtures.
-EXCLUDED_DIRECTORIES = frozenset({".git", ".vtcode", "target", "node_modules", ".venv"})
-
-#: Manifests that opt out of the workspace but resolve against artefacts staged
-#: under ``target/`` by ``make stage-published-gpui-e2e``. They have no lockfile
-#: to validate until that staging runs, so they stay on their own targets.
-STAGED_FIXTURES = frozenset({"tests/fixtures/published-gpui-e2e"})
-
 CARGO = "cargo"
 METADATA_FORMAT_VERSION = "1"
-
-
-class FixtureLockfileError(RuntimeError):
-    """A fixture lockfile is stale, or no fixture manifest was discovered."""
-
-    @staticmethod
-    def no_manifests_message() -> str:
-        """Return the message for an empty discovery result."""
-        return (
-            "no standalone fixture manifests found; the discovery contract "
-            "expects at least one committed fixture lockfile"
-        )
-
-    @staticmethod
-    def cargo_unavailable_message(cargo: str, manifest: Path, error: OSError) -> str:
-        """Return the message for a Cargo executable that could not run."""
-        return f"cannot run {cargo} for {manifest}: {error}"
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -75,158 +51,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--list", action="store_true", help="list the manifests")
     return parser.parse_args(argv)
-
-
-def iter_cargo_manifests(root: Path) -> cabc.Iterator[Path]:
-    """Yield every ``Cargo.toml`` beneath *root*, pruning excluded directories.
-
-    Walking manually (rather than ``Path.rglob``) keeps build output such as
-    ``target/`` and nested scratch copies out of the discovery set.
-
-    Yields
-    ------
-    Path
-        The next manifest beneath *root*, outside the excluded directories.
-    """
-    stack = [root]
-    while stack:
-        directory = stack.pop()
-        try:
-            entries = sorted(directory.iterdir())
-        except OSError:
-            continue
-        for entry in entries:
-            if entry.is_dir() and entry.name not in EXCLUDED_DIRECTORIES:
-                stack.append(entry)
-            elif entry.name == "Cargo.toml" and entry.is_file():
-                yield entry
-
-
-def is_standalone_workspace(manifest: Path) -> bool:
-    """Return whether *manifest* opts out of the root workspace.
-
-    A fixture excludes itself from the enclosing workspace by declaring its own
-    ``[workspace]`` section. The stanza usually carries no members, so the check
-    looks for the section rather than for a member list.
-
-    Parameters
-    ----------
-    manifest : Path
-        The manifest under test.
-
-    Returns
-    -------
-    bool
-        True when the manifest declares its own ``[workspace]`` section.
-    """
-    try:
-        text = manifest.read_text(encoding="utf-8")
-    except OSError:
-        return False
-    return "[workspace]" in text
-
-
-def has_path_dependency(manifest: Path) -> bool:
-    """Return whether *manifest* declares at least one local ``path =`` source.
-
-    Parameters
-    ----------
-    manifest : Path
-        The manifest under test.
-
-    Returns
-    -------
-    bool
-        True when at least one dependency resolves from the local filesystem.
-    """
-    try:
-        text = manifest.read_text(encoding="utf-8")
-    except OSError:
-        return False
-    return "path = " in text
-
-
-def is_staged_fixture(manifest: Path, root: Path) -> bool:
-    """Return whether *manifest* resolves against ``target/`` staged artefacts.
-
-    The published-GPUI end-to-end fixture patches crates.io dependencies onto
-    ``target/published-gpui-e2e/`` package extractions that only exist after
-    ``make stage-published-gpui-e2e``. It therefore has no resolvable graph
-    until staging runs and is validated by the dedicated targets instead.
-
-    Parameters
-    ----------
-    manifest : Path
-        The manifest under test.
-    root : Path
-        The repository root the manifest lives beneath.
-
-    Returns
-    -------
-    bool
-        True when the manifest belongs to a staged fixture directory.
-    """
-    try:
-        return manifest.parent.relative_to(root).as_posix() in STAGED_FIXTURES
-    except ValueError:
-        return False
-
-
-def is_workspace_root(manifest: Path, root: Path) -> bool:
-    """Return whether *manifest* is the root workspace manifest itself.
-
-    The root manifest resolves through the workspace resolver against the root
-    lockfile, which the ordinary workspace build already validates. The fixture
-    gate covers only the crates that opted out of that resolver.
-
-    Parameters
-    ----------
-    manifest : Path
-        The manifest under test.
-    root : Path
-        The repository root the manifest lives beneath.
-
-    Returns
-    -------
-    bool
-        True when *manifest* is the workspace root manifest.
-    """
-    return manifest == root / "Cargo.toml"
-
-
-def discover_fixture_manifests(root: Path) -> list[Path]:
-    """Return every standalone fixture manifest beneath *root*, sorted.
-
-    A manifest qualifies when it opts out of the workspace with ``[workspace]``,
-    uses a local ``path =`` dependency, and commits a sibling ``Cargo.lock``.
-
-    Parameters
-    ----------
-    root : Path
-        The repository root to scan.
-
-    Returns
-    -------
-    list[Path]
-        The sorted authoritative fixture manifests.
-
-    Raises
-    ------
-    FixtureLockfileError
-        No fixture manifest was found, so the gate's contract is broken.
-    """
-    manifests = [
-        path
-        for path in iter_cargo_manifests(root)
-        if is_standalone_workspace(path)
-        and has_path_dependency(path)
-        and (path.parent / "Cargo.lock").is_file()
-        and not is_staged_fixture(path, root)
-        and not is_workspace_root(path, root)
-    ]
-    if not manifests:
-        raise FixtureLockfileError(FixtureLockfileError.no_manifests_message())
-    return sorted(manifests)
 
 
 def cargo_metadata_command(manifest: Path) -> list[str]:
@@ -306,26 +130,27 @@ def refresh_lockfile(manifest: Path) -> subprocess.CompletedProcess[str]:
 
 
 def collect_fixture_results(
-    root: Path,
     manifests: list[Path],
+    operation: cabc.Callable[[Path], subprocess.CompletedProcess[str]],
     prepare: cabc.Callable[[Path], object] | None = None,
 ) -> list[tuple[Path, subprocess.CompletedProcess[str]]]:
-    """Return the failing locked-metadata results for *manifests*.
+    """Return the failing results of *operation* over *manifests*.
 
     Each manifest is optionally prepared (refresh mode regenerates its lockfile
-    first), then validated with locked ``cargo metadata``; the loop never
-    stops at the first failure so one gate run reports every stale fixture.
+    first), then run through *operation*, the locked ``cargo metadata``
+    validation both modes share. The loop never stops at the first failure so
+    one gate run reports every fixture.
 
     Returns
     -------
     list[tuple[Path, subprocess.CompletedProcess[str]]]
-        Every ``(manifest, result)`` pair whose lockfile failed to resolve.
+        Every ``(manifest, result)`` pair whose operation failed.
     """
     failures: list[tuple[Path, subprocess.CompletedProcess[str]]] = []
     for manifest in manifests:
         if prepare is not None:
             prepare(manifest)
-        result = run_cargo_metadata(manifest)
+        result = operation(manifest)
         if result.returncode != 0:
             failures.append((manifest, result))
     return failures
@@ -337,11 +162,11 @@ def _report_fixture_operation(
     mode: GateMode,
 ) -> int:
     """Collect, report, and summarize one gate operation over *manifests*."""
-    results = collect_fixture_results(root, manifests, prepare=mode.prepare)
+    results = collect_fixture_results(manifests, mode.operation, prepare=mode.prepare)
     failures = [
         mode.failure_message(
             manifest.relative_to(root),
-            cargo_metadata_command(manifest),
+            mode.command(manifest),
             result.stdout,
             result.stderr,
         )
@@ -358,7 +183,12 @@ def check_fixtures(root: Path, manifests: list[Path]) -> int:
     return _report_fixture_operation(
         root,
         manifests,
-        GateMode(stale_failure_message, print_check_summary),
+        GateMode(
+            stale_failure_message,
+            print_check_summary,
+            cargo_metadata_command,
+            run_cargo_metadata,
+        ),
     )
 
 
@@ -367,7 +197,13 @@ def refresh_fixtures(root: Path, manifests: list[Path]) -> int:
     return _report_fixture_operation(
         root,
         manifests,
-        GateMode(refresh_failure_message, print_refresh_summary, refresh_lockfile),
+        GateMode(
+            refresh_failure_message,
+            print_refresh_summary,
+            cargo_metadata_command,
+            run_cargo_metadata,
+            refresh_lockfile,
+        ),
     )
 
 

--- a/scripts/check_fixture_lockfiles.py
+++ b/scripts/check_fixture_lockfiles.py
@@ -1,20 +1,23 @@
 #!/usr/bin/env python3
-"""Validate and refresh the standalone fixture lockfiles.
+"""Validate, refresh, and prefetch the standalone fixture lockfiles.
 
 Standalone fixture crates opt out of the workspace with a ``[workspace]``
 stanza, use local ``path =`` dependencies, and commit their own ``Cargo.lock``
 so nested ``--locked`` invocations stay hermetic; a dependency bump therefore
 stales them. This script discovers every tracked manifest matching that shape,
-so the check and refresh targets stay in step as fixtures are added, then runs
-``cargo metadata --locked`` per manifest and fails with the manifest path and
-Cargo output when the lockfile is stale.
+so the check, refresh, and prefetch targets stay in step as fixtures are added,
+then runs ``cargo metadata --locked`` per manifest and fails with the manifest
+path and Cargo output when the lockfile is stale. The prefetch mode instead runs
+``cargo fetch --locked`` per manifest, warming ``~/.cargo/registry`` so a later
+``--offline`` build of the same lockfile resolves without a network.
 
-Usage: ``python3 scripts/check_fixture_lockfiles.py [--refresh] [--list]``.
+Usage: ``python3 scripts/check_fixture_lockfiles.py [--refresh|--fetch] [--list]``.
 
-Exit codes: 0 when every committed fixture lockfile resolves; 1 when a lockfile
-is stale or no fixture was discovered. The published-GPUI fixtures resolve
-against staged or crates.io artefacts, so they are validated by their own
-``make check-published-gpui`` and ``make e2e-published-gpui`` targets.
+Exit codes: 0 when every committed fixture lockfile resolves and every prefetch
+succeeds; 1 when a lockfile is stale, a prefetch fails, or no fixture was
+discovered. The published-GPUI fixtures resolve against staged or crates.io
+artefacts, so they are validated by their own ``make check-published-gpui`` and
+``make e2e-published-gpui`` targets.
 """
 
 import argparse
@@ -27,8 +30,10 @@ from fixture_lockfile_discovery import discover_fixture_manifests
 from fixture_lockfile_reporting import (
     FixtureLockfileError,
     GateMode,
+    fetch_failure_message,
     print_check_summary,
     print_failures,
+    print_fetch_summary,
     print_refresh_summary,
     refresh_failure_message,
     stale_failure_message,
@@ -44,10 +49,19 @@ METADATA_FORMAT_VERSION = "1"
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
         "--refresh",
         action="store_true",
         help="regenerate each discovered lockfile instead of only validating it",
+    )
+    mode.add_argument(
+        "--fetch",
+        action="store_true",
+        help=(
+            "download each discovered lockfile's dependencies into the local "
+            "Cargo registry cache instead of validating the lockfile"
+        ),
     )
     parser.add_argument("--list", action="store_true", help="list the manifests")
     return parser.parse_args(argv)
@@ -69,6 +83,11 @@ def cargo_metadata_command(manifest: Path) -> list[str]:
 def cargo_refresh_command(manifest: Path) -> list[str]:
     """Build the ``cargo generate-lockfile`` command for *manifest*."""
     return [CARGO, "generate-lockfile", "--manifest-path", str(manifest)]
+
+
+def cargo_fetch_command(manifest: Path) -> list[str]:
+    """Build the locked ``cargo fetch`` command for *manifest*."""
+    return [CARGO, "fetch", "--locked", "--manifest-path", str(manifest)]
 
 
 def run_cargo_command(
@@ -129,6 +148,23 @@ def refresh_lockfile(manifest: Path) -> subprocess.CompletedProcess[str]:
     return run_cargo_command(cargo_refresh_command(manifest), manifest)
 
 
+def fetch_fixture_dependencies(manifest: Path) -> subprocess.CompletedProcess[str]:
+    """Download the locked dependencies of *manifest* into the Cargo cache.
+
+    ``cargo fetch --locked`` fills ``~/.cargo/registry`` from the committed
+    lockfile without building anything, so a later ``--offline`` invocation of
+    the same lockfile resolves from the cache. The mutation lane runs this mode
+    because it has no outer online workspace build to warm that cache before its
+    nested fixture tests run.
+
+    Returns
+    -------
+    subprocess.CompletedProcess[str]
+        The completed invocation; errors per :func:`run_cargo_command`.
+    """
+    return run_cargo_command(cargo_fetch_command(manifest), manifest)
+
+
 def collect_fixture_results(
     manifests: list[Path],
     operation: cabc.Callable[[Path], subprocess.CompletedProcess[str]],
@@ -137,9 +173,9 @@ def collect_fixture_results(
     """Return the failing results of *operation* over *manifests*.
 
     Each manifest is optionally prepared (refresh mode regenerates its lockfile
-    first), then run through *operation*, the locked ``cargo metadata``
-    validation both modes share. The loop never stops at the first failure so
-    one gate run reports every fixture.
+    first), then run through *operation*: locked ``cargo metadata`` for the
+    check and refresh modes, locked ``cargo fetch`` for the prefetch mode. The
+    loop never stops at the first failure so one gate run reports every fixture.
 
     Returns
     -------
@@ -207,6 +243,20 @@ def refresh_fixtures(root: Path, manifests: list[Path]) -> int:
     )
 
 
+def fetch_fixtures(root: Path, manifests: list[Path]) -> int:
+    """Prefetch every fixture's locked dependencies, returning the exit code."""
+    return _report_fixture_operation(
+        root,
+        manifests,
+        GateMode(
+            fetch_failure_message,
+            print_fetch_summary,
+            cargo_fetch_command,
+            fetch_fixture_dependencies,
+        ),
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     """Run the fixture-lockfile gate."""
     args = parse_args(argv)
@@ -220,6 +270,8 @@ def main(argv: list[str] | None = None) -> int:
         for manifest in manifests:
             print(manifest.relative_to(root))
         return 0
+    if args.fetch:
+        return fetch_fixtures(root, manifests)
     if args.refresh:
         return refresh_fixtures(root, manifests)
     return check_fixtures(root, manifests)

--- a/scripts/check_fixture_lockfiles.py
+++ b/scripts/check_fixture_lockfiles.py
@@ -86,7 +86,18 @@ def cargo_refresh_command(manifest: Path) -> list[str]:
 
 
 def cargo_fetch_command(manifest: Path) -> list[str]:
-    """Build the locked ``cargo fetch`` command for *manifest*."""
+    """Build the locked ``cargo fetch`` command for *manifest*.
+
+    Returns
+    -------
+    list[str]
+        The locked ``cargo fetch`` argv for *manifest*.
+
+    Examples
+    --------
+    >>> cargo_fetch_command(Path("fixtures/minimal/Cargo.toml"))
+    ['cargo', 'fetch', '--locked', '--manifest-path', 'fixtures/minimal/Cargo.toml']
+    """
     return [CARGO, "fetch", "--locked", "--manifest-path", str(manifest)]
 
 
@@ -161,6 +172,17 @@ def fetch_fixture_dependencies(manifest: Path) -> subprocess.CompletedProcess[st
     -------
     subprocess.CompletedProcess[str]
         The completed invocation; errors per :func:`run_cargo_command`.
+
+    Examples
+    --------
+    Prefetch the dependencies of a single fixture manifest::
+
+        fetch_fixture_dependencies(
+            Path("crates/cargo-bdd/tests/fixtures/minimal/Cargo.toml")
+        )
+
+    The completed invocation carries ``returncode == 0`` once every locked
+    crate is cached; a non-zero code marks that fixture as a failed prefetch.
     """
     return run_cargo_command(cargo_fetch_command(manifest), manifest)
 
@@ -244,7 +266,20 @@ def refresh_fixtures(root: Path, manifests: list[Path]) -> int:
 
 
 def fetch_fixtures(root: Path, manifests: list[Path]) -> int:
-    """Prefetch every fixture's locked dependencies, returning the exit code."""
+    """Prefetch every fixture's locked dependencies, returning the exit code.
+
+    Returns
+    -------
+    int
+        The exit code: ``0`` when every prefetch succeeded, otherwise ``1``.
+
+    Examples
+    --------
+    Prefetch every discovered fixture, as ``--fetch`` does; a clean run
+    returns ``0`` and any failed ``cargo fetch`` returns ``1``::
+
+        fetch_fixtures(root, discover_fixture_manifests(root))
+    """
     return _report_fixture_operation(
         root,
         manifests,

--- a/scripts/check_fixture_lockfiles.py
+++ b/scripts/check_fixture_lockfiles.py
@@ -9,7 +9,9 @@ so the check, refresh, and prefetch targets stay in step as fixtures are added,
 then runs ``cargo metadata --locked`` per manifest and fails with the manifest
 path and Cargo output when the lockfile is stale. The prefetch mode instead runs
 ``cargo fetch --locked`` per manifest, warming ``~/.cargo/registry`` so a later
-``--offline`` build of the same lockfile resolves without a network.
+``--offline`` build of the same lockfile resolves without a network, and closes
+the run with one bounded machine-readable metrics record on the stream that
+matches the outcome (see :func:`fixture_lockfile_reporting.print_prefetch_metrics`).
 
 Usage: ``python3 scripts/check_fixture_lockfiles.py [--refresh|--fetch] [--list]``.
 
@@ -23,6 +25,7 @@ artefacts, so they are validated by their own ``make check-published-gpui`` and
 import argparse
 import subprocess  # ruff: ignore[suspicious-subprocess-import] - the gate invokes the trusted local cargo executable.
 import sys
+import time
 import typing as typ
 from pathlib import Path
 
@@ -34,6 +37,7 @@ from fixture_lockfile_reporting import (
     print_check_summary,
     print_failures,
     print_fetch_summary,
+    print_prefetch_metrics,
     print_refresh_summary,
     refresh_failure_message,
     stale_failure_message,
@@ -219,8 +223,21 @@ def _report_fixture_operation(
     manifests: list[Path],
     mode: GateMode,
 ) -> int:
-    """Collect, report, and summarize one gate operation over *manifests*."""
+    """Collect, report, and summarize one gate operation over *manifests*.
+
+    The clock runs around the whole operation — every fixture, not the first —
+    so the metrics record a mode asks for describes the complete run. A failing
+    fixture never ends the loop, so the counts it reports are always the full
+    set the run visited.
+
+    Returns
+    -------
+    int
+        The exit code: ``0`` when every fixture passed, otherwise ``1``.
+    """
+    started = time.monotonic()
     results = collect_fixture_results(manifests, mode.operation, prepare=mode.prepare)
+    elapsed_ms = round((time.monotonic() - started) * 1000)
     failures = [
         mode.failure_message(
             manifest.relative_to(root),
@@ -233,6 +250,8 @@ def _report_fixture_operation(
     if failures:
         print_failures(failures)
     mode.print_summary(len(manifests), len(failures))
+    if mode.report_metrics is not None:
+        mode.report_metrics(len(manifests), len(failures), elapsed_ms)
     return 1 if failures else 0
 
 
@@ -268,6 +287,10 @@ def refresh_fixtures(root: Path, manifests: list[Path]) -> int:
 def fetch_fixtures(root: Path, manifests: list[Path]) -> int:
     """Prefetch every fixture's locked dependencies, returning the exit code.
 
+    The run always closes with exactly one machine-readable metrics record,
+    whether every fixture downloaded or some failed, on the stream matching the
+    outcome; the human-readable reports and summaries are unchanged.
+
     Returns
     -------
     int
@@ -288,6 +311,7 @@ def fetch_fixtures(root: Path, manifests: list[Path]) -> int:
             print_fetch_summary,
             cargo_fetch_command,
             fetch_fixture_dependencies,
+            report_metrics=print_prefetch_metrics,
         ),
     )
 

--- a/scripts/fixture_lockfile_discovery.py
+++ b/scripts/fixture_lockfile_discovery.py
@@ -85,11 +85,15 @@ def _read_manifest(manifest: Path) -> dict[str, object] | None:
 
 def _holds_path_key(value: object) -> bool:
     """Return whether *value* holds a ``path`` key anywhere beneath it."""
-    if isinstance(value, dict):
-        return "path" in value or any(_holds_path_key(item) for item in value.values())
-    if isinstance(value, list):
-        return any(_holds_path_key(item) for item in value)
-    return False
+    match value:
+        case dict():
+            return "path" in value or any(
+                _holds_path_key(item) for item in value.values()
+            )
+        case list():
+            return any(_holds_path_key(item) for item in value)
+        case _:
+            return False
 
 
 def _declares_local_source(table: cabc.Mapping[str, object]) -> bool:

--- a/scripts/fixture_lockfile_discovery.py
+++ b/scripts/fixture_lockfile_discovery.py
@@ -96,6 +96,13 @@ def _holds_path_key(value: object) -> bool:
             return False
 
 
+def _value_declares_local_source(key: str, value: dict[str, object]) -> bool:
+    """Return whether *value* declares a local source for TOML table *key*."""
+    if key.endswith("dependencies") or key == "patch":
+        return _holds_path_key(value)
+    return _declares_local_source(value)
+
+
 def _declares_local_source(table: cabc.Mapping[str, object]) -> bool:
     """Return whether *table* resolves a dependency from the local filesystem.
 
@@ -111,12 +118,7 @@ def _declares_local_source(table: cabc.Mapping[str, object]) -> bool:
         True when one of those specifications names a local path source.
     """
     for key, value in table.items():
-        if not isinstance(value, dict):
-            continue
-        if key.endswith("dependencies") or key == "patch":
-            if _holds_path_key(value):
-                return True
-        elif _declares_local_source(value):
+        if isinstance(value, dict) and _value_declares_local_source(key, value):
             return True
     return False
 

--- a/scripts/fixture_lockfile_discovery.py
+++ b/scripts/fixture_lockfile_discovery.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Discover the standalone fixture manifests the lockfile gate covers.
+
+Standalone fixture crates opt out of the workspace with a ``[workspace]``
+stanza, use local ``path =`` dependencies, and commit their own ``Cargo.lock``
+so nested ``--locked`` invocations stay hermetic; a dependency bump therefore
+stales them. Discovery lives apart from the gate's Cargo plumbing so the
+validation gate, the refresh path, and the mutation lane's dependency prefetch
+all resolve one fixture set, and so the gate script stays inside the 400-line
+module budget.
+"""
+
+import typing as typ
+
+from fixture_lockfile_reporting import FixtureLockfileError
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+    from pathlib import Path
+
+#: Directory names the scan never descends into: build output, tool caches and
+#: editor state can all hold generated manifests that are not fixtures.
+EXCLUDED_DIRECTORIES = frozenset({".git", ".vtcode", "target", "node_modules", ".venv"})
+
+#: Manifests that opt out of the workspace but resolve against artefacts staged
+#: under ``target/`` by ``make stage-published-gpui-e2e``. They have no lockfile
+#: to validate until that staging runs, so they stay on their own targets.
+STAGED_FIXTURES = frozenset({"tests/fixtures/published-gpui-e2e"})
+
+
+def iter_cargo_manifests(root: Path) -> cabc.Iterator[Path]:
+    """Yield every ``Cargo.toml`` beneath *root*, pruning excluded directories.
+
+    Walking manually (rather than ``Path.rglob``) keeps build output such as
+    ``target/`` and nested scratch copies out of the discovery set.
+
+    Yields
+    ------
+    Path
+        The next manifest beneath *root*, outside the excluded directories.
+    """
+    stack = [root]
+    while stack:
+        directory = stack.pop()
+        try:
+            entries = sorted(directory.iterdir())
+        except OSError:
+            continue
+        for entry in entries:
+            if entry.is_dir() and entry.name not in EXCLUDED_DIRECTORIES:
+                stack.append(entry)
+            elif entry.name == "Cargo.toml" and entry.is_file():
+                yield entry
+
+
+def is_standalone_workspace(manifest: Path) -> bool:
+    """Return whether *manifest* opts out of the root workspace.
+
+    A fixture excludes itself from the enclosing workspace by declaring its own
+    ``[workspace]`` section. The stanza usually carries no members, so the check
+    looks for the section rather than for a member list.
+
+    Parameters
+    ----------
+    manifest : Path
+        The manifest under test.
+
+    Returns
+    -------
+    bool
+        True when the manifest declares its own ``[workspace]`` section.
+    """
+    try:
+        text = manifest.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return "[workspace]" in text
+
+
+def has_path_dependency(manifest: Path) -> bool:
+    """Return whether *manifest* declares at least one local ``path =`` source.
+
+    Parameters
+    ----------
+    manifest : Path
+        The manifest under test.
+
+    Returns
+    -------
+    bool
+        True when at least one dependency resolves from the local filesystem.
+    """
+    try:
+        text = manifest.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return "path = " in text
+
+
+def is_staged_fixture(manifest: Path, root: Path) -> bool:
+    """Return whether *manifest* resolves against ``target/`` staged artefacts.
+
+    The published-GPUI end-to-end fixture patches crates.io dependencies onto
+    ``target/published-gpui-e2e/`` package extractions that only exist after
+    ``make stage-published-gpui-e2e``. It therefore has no resolvable graph
+    until staging runs and is validated by the dedicated targets instead.
+
+    Parameters
+    ----------
+    manifest : Path
+        The manifest under test.
+    root : Path
+        The repository root the manifest lives beneath.
+
+    Returns
+    -------
+    bool
+        True when the manifest belongs to a staged fixture directory.
+    """
+    try:
+        return manifest.parent.relative_to(root).as_posix() in STAGED_FIXTURES
+    except ValueError:
+        return False
+
+
+def is_workspace_root(manifest: Path, root: Path) -> bool:
+    """Return whether *manifest* is the root workspace manifest itself.
+
+    The root manifest resolves through the workspace resolver against the root
+    lockfile, which the ordinary workspace build already validates. The fixture
+    gate covers only the crates that opted out of that resolver.
+
+    Parameters
+    ----------
+    manifest : Path
+        The manifest under test.
+    root : Path
+        The repository root the manifest lives beneath.
+
+    Returns
+    -------
+    bool
+        True when *manifest* is the workspace root manifest.
+    """
+    return manifest == root / "Cargo.toml"
+
+
+def discover_fixture_manifests(root: Path) -> list[Path]:
+    """Return every standalone fixture manifest beneath *root*, sorted.
+
+    A manifest qualifies when it opts out of the workspace with ``[workspace]``,
+    uses a local ``path =`` dependency, and commits a sibling ``Cargo.lock``.
+
+    Parameters
+    ----------
+    root : Path
+        The repository root to scan.
+
+    Returns
+    -------
+    list[Path]
+        The sorted authoritative fixture manifests.
+
+    Raises
+    ------
+    FixtureLockfileError
+        No fixture manifest was found, so the gate's contract is broken.
+    """
+    manifests = [
+        path
+        for path in iter_cargo_manifests(root)
+        if is_standalone_workspace(path)
+        and has_path_dependency(path)
+        and (path.parent / "Cargo.lock").is_file()
+        and not is_staged_fixture(path, root)
+        and not is_workspace_root(path, root)
+    ]
+    if not manifests:
+        raise FixtureLockfileError(FixtureLockfileError.no_manifests_message())
+    return sorted(manifests)

--- a/scripts/fixture_lockfile_discovery.py
+++ b/scripts/fixture_lockfile_discovery.py
@@ -10,6 +10,7 @@ all resolve one fixture set, and so the gate script stays inside the 400-line
 module budget.
 """
 
+import tomllib
 import typing as typ
 
 from fixture_lockfile_reporting import FixtureLockfileError
@@ -32,7 +33,10 @@ def iter_cargo_manifests(root: Path) -> cabc.Iterator[Path]:
     """Yield every ``Cargo.toml`` beneath *root*, pruning excluded directories.
 
     Walking manually (rather than ``Path.rglob``) keeps build output such as
-    ``target/`` and nested scratch copies out of the discovery set.
+    ``target/`` and nested scratch copies out of the discovery set. The walk
+    descends only into real directories, so a symlink cannot send it back up
+    its own tree and have the same subtree re-walked until the platform's
+    symlink limit is reached.
 
     Yields
     ------
@@ -47,10 +51,70 @@ def iter_cargo_manifests(root: Path) -> cabc.Iterator[Path]:
         except OSError:
             continue
         for entry in entries:
-            if entry.is_dir() and entry.name not in EXCLUDED_DIRECTORIES:
+            if entry.name in EXCLUDED_DIRECTORIES:
+                continue
+            if entry.is_dir(follow_symlinks=False):
                 stack.append(entry)
             elif entry.name == "Cargo.toml" and entry.is_file():
                 yield entry
+
+
+def _read_manifest(manifest: Path) -> dict[str, object] | None:
+    """Parse *manifest* as TOML, or return None when it cannot be read.
+
+    Classification reads the parsed document rather than the raw text so a
+    comment or an unrelated string value can never pass for a declaration.
+
+    Parameters
+    ----------
+    manifest : Path
+        The manifest to parse.
+
+    Returns
+    -------
+    dict[str, object] | None
+        The manifest's tables, or None when the file is unreadable or is not
+        valid TOML.
+    """
+    try:
+        with manifest.open("rb") as handle:
+            return tomllib.load(handle)
+    except OSError, tomllib.TOMLDecodeError:
+        return None
+
+
+def _holds_path_key(value: object) -> bool:
+    """Return whether *value* holds a ``path`` key anywhere beneath it."""
+    if isinstance(value, dict):
+        return "path" in value or any(_holds_path_key(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_holds_path_key(item) for item in value)
+    return False
+
+
+def _declares_local_source(table: cabc.Mapping[str, object]) -> bool:
+    """Return whether *table* resolves a dependency from the local filesystem.
+
+    Cargo reads dependency specifications from the ``dependencies``,
+    ``dev-dependencies``, ``build-dependencies``, and ``workspace`` tables —
+    including their ``target``-qualified and table-per-dependency spellings —
+    and takes path overrides from the ``patch`` tables. Following every nested
+    table reaches all of those spellings.
+
+    Returns
+    -------
+    bool
+        True when one of those specifications names a local path source.
+    """
+    for key, value in table.items():
+        if not isinstance(value, dict):
+            continue
+        if key.endswith("dependencies") or key == "patch":
+            if _holds_path_key(value):
+                return True
+        elif _declares_local_source(value):
+            return True
+    return False
 
 
 def is_standalone_workspace(manifest: Path) -> bool:
@@ -70,15 +134,12 @@ def is_standalone_workspace(manifest: Path) -> bool:
     bool
         True when the manifest declares its own ``[workspace]`` section.
     """
-    try:
-        text = manifest.read_text(encoding="utf-8")
-    except OSError:
-        return False
-    return "[workspace]" in text
+    data = _read_manifest(manifest)
+    return data is not None and "workspace" in data
 
 
 def has_path_dependency(manifest: Path) -> bool:
-    """Return whether *manifest* declares at least one local ``path =`` source.
+    """Return whether *manifest* declares at least one local ``path`` source.
 
     Parameters
     ----------
@@ -90,11 +151,8 @@ def has_path_dependency(manifest: Path) -> bool:
     bool
         True when at least one dependency resolves from the local filesystem.
     """
-    try:
-        text = manifest.read_text(encoding="utf-8")
-    except OSError:
-        return False
-    return "path = " in text
+    data = _read_manifest(manifest)
+    return data is not None and _declares_local_source(data)
 
 
 def is_staged_fixture(manifest: Path, root: Path) -> bool:

--- a/scripts/fixture_lockfile_reporting.py
+++ b/scripts/fixture_lockfile_reporting.py
@@ -3,10 +3,13 @@
 
 Keeping the message formatting and the shared error type apart from the Cargo
 plumbing lets the gate script stay under the 400-line budget while the wording
-of a stale-lockfile or failed-prefetch failure stays testable in one place.
+of a stale-lockfile or failed-prefetch failure stays testable in one place. The
+prefetch mode's machine-readable metrics record lives here too, beside the
+human-readable summary it accompanies.
 """
 
 import dataclasses
+import json
 import sys
 import typing as typ
 
@@ -17,6 +20,22 @@ if typ.TYPE_CHECKING:
 
 #: Suggested remediation printed when a lockfile no longer resolves.
 REFRESH_HINT = "run 'make update-fixture-lockfiles' to refresh them"
+
+#: Prefix marking the prefetch metrics record, so one grep or line filter finds
+#: the record in a job log without parsing the human-readable lines.
+PREFETCH_METRICS_PREFIX = "fixture-prefetch-metrics: "
+
+#: Schema version of the prefetch metrics record; bump it when the field set or
+#: a field's meaning changes, never when a value changes.
+PREFETCH_METRICS_SCHEMA_VERSION = 1
+
+#: Cache outcome recorded when Cargo offers no reliable cache/download
+#: evidence. ``cargo fetch`` reports downloads as human-readable progress lines
+#: and prints nothing when the cache already has a crate, so the absence of a
+#: download line proves nothing and the record never guesses. ``unknown`` is
+#: the only bounded value available today; a machine-readable Cargo signal
+#: would be needed before a record may say more.
+CACHE_OUTCOME_UNKNOWN = "unknown"
 
 
 class FixtureLockfileError(RuntimeError):
@@ -158,6 +177,82 @@ def print_fetch_summary(total: int, failed: int) -> None:
         print(f"prefetched dependencies for {total} fixture(s)")
 
 
+def prefetch_metrics_record(
+    total: int,
+    succeeded: int,
+    failed: int,
+    elapsed_ms: int,
+) -> str:
+    """Render the bounded prefetch metrics record for one ``--fetch`` run.
+
+    The record carries counts, a duration, the outcome, and the cache outcome —
+    never a manifest path, crate name, command line, environment value, URL, or
+    Cargo output — so an aggregating reader can parse it without learning
+    anything about the machine that produced it. Field order is fixed and the
+    JSON is emitted compactly, so the same numbers always render the same line.
+
+    Parameters
+    ----------
+    total : int
+        The number of fixtures the prefetch visited.
+    succeeded : int
+        The number of fixtures whose dependencies are now cached.
+    failed : int
+        The number of fixtures whose ``cargo fetch`` failed.
+    elapsed_ms : int
+        Wall-clock milliseconds the whole prefetch took.
+
+    Returns
+    -------
+    str
+        The prefixed JSON line standing for one prefetch run.
+
+    Examples
+    --------
+    >>> expected = (
+    ...     'fixture-prefetch-metrics: {"schema_version":1,"total":2,'
+    ...     '"succeeded":2,"failed":0,"elapsed_ms":7,"outcome":"success",'
+    ...     '"cache_outcome":"unknown"}'
+    ... )
+    >>> prefetch_metrics_record(2, 2, 0, 7) == expected
+    True
+    """
+    return PREFETCH_METRICS_PREFIX + json.dumps(
+        {
+            "schema_version": PREFETCH_METRICS_SCHEMA_VERSION,
+            "total": total,
+            "succeeded": succeeded,
+            "failed": failed,
+            "elapsed_ms": elapsed_ms,
+            "outcome": "failure" if failed else "success",
+            "cache_outcome": CACHE_OUTCOME_UNKNOWN,
+        },
+        separators=(",", ":"),
+    )
+
+
+def print_prefetch_metrics(total: int, failed: int, elapsed_ms: int) -> None:
+    """
+    Print the prefetch metrics record beside the summary for the same outcome.
+
+    A clean run carries its record on standard output with the success summary;
+    a failed run carries it on standard error with the failure reports, so a
+    reader capturing only one stream never reads a failed prefetch as a clean
+    one.
+
+    Parameters
+    ----------
+    total : int
+        The number of fixtures the prefetch visited.
+    failed : int
+        The number of fixtures whose dependencies could not be fetched.
+    elapsed_ms : int
+        Wall-clock milliseconds the whole prefetch took.
+    """
+    record = prefetch_metrics_record(total, total - failed, failed, elapsed_ms)
+    print(record, file=sys.stderr if failed else sys.stdout)
+
+
 @dataclasses.dataclass(frozen=True, slots=True)
 class GateMode:
     """Bundle the callables that distinguish one fixture-gate operation.
@@ -178,6 +273,10 @@ class GateMode:
         Run that argv for one manifest; a non-zero exit is a failure.
     prepare : cabc.Callable[[Path], object] | None
         Optional per-manifest step before the operation, or None.
+    report_metrics : cabc.Callable[[int, int, int], None] | None
+        Optional machine-readable record of the whole run, taking the fixture
+        total, the failed count, and the elapsed milliseconds; None for a mode
+        that emits no record.
     """
 
     failure_message: cabc.Callable[[Path, list[str], str, str], str]
@@ -185,3 +284,4 @@ class GateMode:
     command: cabc.Callable[[Path], list[str]]
     operation: cabc.Callable[[Path], subprocess.CompletedProcess[str]]
     prepare: cabc.Callable[[Path], object] | None = None
+    report_metrics: cabc.Callable[[int, int, int], None] | None = None

--- a/scripts/fixture_lockfile_reporting.py
+++ b/scripts/fixture_lockfile_reporting.py
@@ -41,6 +41,44 @@ class FixtureLockfileError(RuntimeError):
         return f"cannot run {cargo} for {manifest}: {error}"
 
 
+# ruff: ignore[too-many-arguments, too-many-positional-arguments] - five report parts.
+# pylint: disable-next=too-many-arguments,too-many-positional-arguments
+def _failure_message(
+    heading: str,
+    manifest: Path,
+    command: list[str],
+    result_stdout: str,
+    result_stderr: str,
+) -> str:
+    """
+    Render the shared Cargo failure report under an operation-specific heading.
+
+    Parameters
+    ----------
+    heading : str
+        The opening clause naming the failed operation, carrying whatever
+        punctuation that operation's established wording uses.
+    manifest : Path
+        The fixture the failed Cargo run belongs to.
+    command : list[str]
+        The Cargo command that failed, for reproduction.
+    result_stdout : str
+        Captured standard output from the failed Cargo run.
+    result_stderr : str
+        Captured standard error from the failed Cargo run.
+
+    Returns
+    -------
+    str
+        The multi-line failure report.
+    """
+    return (
+        f"{heading} {manifest}\n"
+        f"command: {' '.join(command)}\n"
+        f"cargo output:\n{result_stdout}{result_stderr}"
+    )
+
+
 def stale_failure_message(
     manifest: Path, command: list[str], result_stdout: str, result_stderr: str
 ) -> str:
@@ -63,10 +101,12 @@ def stale_failure_message(
     str
         The multi-line failure report.
     """
-    return (
-        f"stale or unusable fixture lockfile: {manifest}\n"
-        f"command: {' '.join(command)}\n"
-        f"cargo output:\n{result_stdout}{result_stderr}"
+    return _failure_message(
+        "stale or unusable fixture lockfile:",
+        manifest,
+        command,
+        result_stdout,
+        result_stderr,
     )
 
 
@@ -92,10 +132,12 @@ def refresh_failure_message(
     str
         The multi-line failure report.
     """
-    return (
-        f"refresh failed for {manifest}\n"
-        f"command: {' '.join(command)}\n"
-        f"cargo output:\n{result_stdout}{result_stderr}"
+    return _failure_message(
+        "refresh failed for",
+        manifest,
+        command,
+        result_stdout,
+        result_stderr,
     )
 
 
@@ -121,10 +163,12 @@ def fetch_failure_message(
     str
         The multi-line failure report.
     """
-    return (
-        f"failed to prefetch fixture dependencies: {manifest}\n"
-        f"command: {' '.join(command)}\n"
-        f"cargo output:\n{result_stdout}{result_stderr}"
+    return _failure_message(
+        "failed to prefetch fixture dependencies:",
+        manifest,
+        command,
+        result_stdout,
+        result_stderr,
     )
 
 

--- a/scripts/fixture_lockfile_reporting.py
+++ b/scripts/fixture_lockfile_reporting.py
@@ -3,7 +3,7 @@
 
 Keeping the message formatting and the shared error type apart from the Cargo
 plumbing lets the gate script stay under the 400-line budget while the wording
-of a stale-lockfile failure stays testable in one place.
+of a stale-lockfile or failed-prefetch failure stays testable in one place.
 """
 
 import dataclasses
@@ -99,6 +99,35 @@ def refresh_failure_message(
     )
 
 
+def fetch_failure_message(
+    manifest: Path, command: list[str], result_stdout: str, result_stderr: str
+) -> str:
+    """
+    Return the failure text for a fixture whose dependencies did not download.
+
+    Parameters
+    ----------
+    manifest : Path
+        The fixture whose locked dependencies could not be fetched.
+    command : list[str]
+        The Cargo command that failed, for reproduction.
+    result_stdout : str
+        Captured standard output from the failed Cargo run.
+    result_stderr : str
+        Captured standard error from the failed Cargo run.
+
+    Returns
+    -------
+    str
+        The multi-line failure report.
+    """
+    return (
+        f"failed to prefetch fixture dependencies: {manifest}\n"
+        f"command: {' '.join(command)}\n"
+        f"cargo output:\n{result_stdout}{result_stderr}"
+    )
+
+
 def print_failures(failures: list[str]) -> None:
     """
     Print every failure report to standard error.
@@ -149,12 +178,33 @@ def print_refresh_summary(total: int, failed: int) -> None:
         print(f"refreshed {total} fixture lockfile(s)")
 
 
+def print_fetch_summary(total: int, failed: int) -> None:
+    """
+    Print the dependency-prefetch outcome to standard output.
+
+    Parameters
+    ----------
+    total : int
+        The number of fixtures the prefetch visited.
+    failed : int
+        The number of fixtures whose dependencies could not be fetched.
+    """
+    if failed:
+        print(
+            f"{failed} of {total} fixture dependency prefetch(es) failed",
+            file=sys.stderr,
+        )
+    else:
+        print(f"prefetched dependencies for {total} fixture(s)")
+
+
 @dataclasses.dataclass(frozen=True, slots=True)
 class GateMode:
     """Bundle the callables that distinguish one fixture-gate operation.
 
-    Bundling keeps the gate script's entry points to three call arguments,
-    inside the ``max-args`` lint budget.
+    Bundling keeps :func:`check_fixtures`, :func:`refresh_fixtures`, and
+    :func:`fetch_fixtures` in the gate script to three call arguments, inside
+    the ``max-args`` lint budget.
 
     Parameters
     ----------

--- a/scripts/fixture_lockfile_reporting.py
+++ b/scripts/fixture_lockfile_reporting.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Failure and success reporting for the fixture-lockfile gate.
 
-Keeping the message formatting apart from the Cargo plumbing lets the gate
-script stay under the 400-line budget while the wording of a stale-lockfile
-failure stays testable in one place.
+Keeping the message formatting and the shared error type apart from the Cargo
+plumbing lets the gate script stay under the 400-line budget while the wording
+of a stale-lockfile failure stays testable in one place.
 """
 
 import dataclasses
@@ -12,10 +12,33 @@ import typing as typ
 
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
+    import subprocess
     from pathlib import Path
 
 #: Suggested remediation printed when a lockfile no longer resolves.
 REFRESH_HINT = "run 'make update-fixture-lockfiles' to refresh them"
+
+
+class FixtureLockfileError(RuntimeError):
+    """A fixture lockfile is stale, or no fixture manifest was discovered.
+
+    Lives with the reporting helpers rather than the gate script so the
+    discovery module and the gate can both raise it without importing each
+    other.
+    """
+
+    @staticmethod
+    def no_manifests_message() -> str:
+        """Return the message for an empty discovery result."""
+        return (
+            "no standalone fixture manifests found; the discovery contract "
+            "expects at least one committed fixture lockfile"
+        )
+
+    @staticmethod
+    def cargo_unavailable_message(cargo: str, manifest: Path, error: OSError) -> str:
+        """Return the message for a Cargo executable that could not run."""
+        return f"cannot run {cargo} for {manifest}: {error}"
 
 
 def stale_failure_message(
@@ -130,8 +153,8 @@ def print_refresh_summary(total: int, failed: int) -> None:
 class GateMode:
     """Bundle the callables that distinguish one fixture-gate operation.
 
-    Bundling keeps :func:`check_fixtures` and :func:`refresh_fixtures` in the
-    gate script to three call arguments, inside the ``max-args`` lint budget.
+    Bundling keeps the gate script's entry points to three call arguments,
+    inside the ``max-args`` lint budget.
 
     Parameters
     ----------
@@ -139,10 +162,16 @@ class GateMode:
         Render one failing manifest and Cargo output as report text.
     print_summary : cabc.Callable[[int, int], None]
         Close the run with the total and failed counts.
+    command : cabc.Callable[[Path], list[str]]
+        Build the Cargo argv the failure report quotes for reproduction.
+    operation : cabc.Callable[[Path], subprocess.CompletedProcess[str]]
+        Run that argv for one manifest; a non-zero exit is a failure.
     prepare : cabc.Callable[[Path], object] | None
-        Optional per-manifest operation before validation, or None.
+        Optional per-manifest step before the operation, or None.
     """
 
     failure_message: cabc.Callable[[Path, list[str], str, str], str]
     print_summary: cabc.Callable[[int, int], None]
+    command: cabc.Callable[[Path], list[str]]
+    operation: cabc.Callable[[Path], subprocess.CompletedProcess[str]]
     prepare: cabc.Callable[[Path], object] | None = None

--- a/scripts/fixture_lockfile_reporting.py
+++ b/scripts/fixture_lockfile_reporting.py
@@ -9,7 +9,6 @@ of a stale-lockfile or failed-prefetch failure stays testable in one place.
 import dataclasses
 import sys
 import typing as typ
-from functools import partial
 
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
@@ -42,57 +41,49 @@ class FixtureLockfileError(RuntimeError):
         return f"cannot run {cargo} for {manifest}: {error}"
 
 
-# ruff: ignore[too-many-arguments, too-many-positional-arguments] - five report parts.
-# pylint: disable-next=too-many-arguments,too-many-positional-arguments
-def _failure_message(
-    heading: str,
-    manifest: Path,
-    command: list[str],
-    result_stdout: str,
-    result_stderr: str,
-) -> str:
+def _failure_message(heading: str) -> cabc.Callable[[Path, list[str], str, str], str]:
     """
-    Render the shared Cargo failure report under an operation-specific heading.
+    Build the shared Cargo failure-report formatter for *heading*.
+
+    Every gate operation reports a failure the same way and differs only in the
+    clause that opens the report, so one factory serves all three messages. The
+    returned formatter takes the four parts the gate has in hand: the failing
+    manifest, the Cargo command that failed, and the two captured streams.
 
     Parameters
     ----------
     heading : str
         The opening clause naming the failed operation, carrying whatever
         punctuation that operation's established wording uses.
-    manifest : Path
-        The fixture the failed Cargo run belongs to.
-    command : list[str]
-        The Cargo command that failed, for reproduction.
-    result_stdout : str
-        Captured standard output from the failed Cargo run.
-    result_stderr : str
-        Captured standard error from the failed Cargo run.
 
     Returns
     -------
-    str
-        The multi-line failure report.
+    cabc.Callable[[Path, list[str], str, str], str]
+        A formatter rendering one multi-line failure report.
     """
-    return (
-        f"{heading} {manifest}\n"
-        f"command: {' '.join(command)}\n"
-        f"cargo output:\n{result_stdout}{result_stderr}"
-    )
+
+    def report(
+        manifest: Path,
+        command: list[str],
+        result_stdout: str,
+        result_stderr: str,
+    ) -> str:
+        """Render one failure report under the factory's heading."""
+        return (
+            f"{heading} {manifest}\n"
+            f"command: {' '.join(command)}\n"
+            f"cargo output:\n{result_stdout}{result_stderr}"
+        )
+
+    return report
 
 
 # The three gate messages share one report body and differ only by the heading
 # that opens it. Each heading keeps the punctuation of the wording it has always
 # produced — including the colon-free refresh heading — so no report changes.
-stale_failure_message = partial(
-    _failure_message,
-    "stale or unusable fixture lockfile:",
-)
-refresh_failure_message = partial(
-    _failure_message,
-    "refresh failed for",
-)
-fetch_failure_message = partial(
-    _failure_message,
+stale_failure_message = _failure_message("stale or unusable fixture lockfile:")
+refresh_failure_message = _failure_message("refresh failed for")
+fetch_failure_message = _failure_message(
     "failed to prefetch fixture dependencies:",
 )
 

--- a/scripts/fixture_lockfile_reporting.py
+++ b/scripts/fixture_lockfile_reporting.py
@@ -9,6 +9,7 @@ of a stale-lockfile or failed-prefetch failure stays testable in one place.
 import dataclasses
 import sys
 import typing as typ
+from functools import partial
 
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
@@ -79,97 +80,21 @@ def _failure_message(
     )
 
 
-def stale_failure_message(
-    manifest: Path, command: list[str], result_stdout: str, result_stderr: str
-) -> str:
-    """
-    Return the failure text naming the stale manifest with Cargo's output.
-
-    Parameters
-    ----------
-    manifest : Path
-        The fixture whose lockfile failed to resolve.
-    command : list[str]
-        The Cargo command that failed, for reproduction.
-    result_stdout : str
-        Captured standard output from the failed Cargo run.
-    result_stderr : str
-        Captured standard error from the failed Cargo run.
-
-    Returns
-    -------
-    str
-        The multi-line failure report.
-    """
-    return _failure_message(
-        "stale or unusable fixture lockfile:",
-        manifest,
-        command,
-        result_stdout,
-        result_stderr,
-    )
-
-
-def refresh_failure_message(
-    manifest: Path, command: list[str], result_stdout: str, result_stderr: str
-) -> str:
-    """
-    Return the failure text for a lockfile that is stale after a refresh.
-
-    Parameters
-    ----------
-    manifest : Path
-        The fixture whose lockfile still fails to resolve after refreshing.
-    command : list[str]
-        The verification command that failed, for reproduction.
-    result_stdout : str
-        Captured standard output from the failed verification run.
-    result_stderr : str
-        Captured standard error from the failed verification run.
-
-    Returns
-    -------
-    str
-        The multi-line failure report.
-    """
-    return _failure_message(
-        "refresh failed for",
-        manifest,
-        command,
-        result_stdout,
-        result_stderr,
-    )
-
-
-def fetch_failure_message(
-    manifest: Path, command: list[str], result_stdout: str, result_stderr: str
-) -> str:
-    """
-    Return the failure text for a fixture whose dependencies did not download.
-
-    Parameters
-    ----------
-    manifest : Path
-        The fixture whose locked dependencies could not be fetched.
-    command : list[str]
-        The Cargo command that failed, for reproduction.
-    result_stdout : str
-        Captured standard output from the failed Cargo run.
-    result_stderr : str
-        Captured standard error from the failed Cargo run.
-
-    Returns
-    -------
-    str
-        The multi-line failure report.
-    """
-    return _failure_message(
-        "failed to prefetch fixture dependencies:",
-        manifest,
-        command,
-        result_stdout,
-        result_stderr,
-    )
+# The three gate messages share one report body and differ only by the heading
+# that opens it. Each heading keeps the punctuation of the wording it has always
+# produced — including the colon-free refresh heading — so no report changes.
+stale_failure_message = partial(
+    _failure_message,
+    "stale or unusable fixture lockfile:",
+)
+refresh_failure_message = partial(
+    _failure_message,
+    "refresh failed for",
+)
+fetch_failure_message = partial(
+    _failure_message,
+    "failed to prefetch fixture dependencies:",
+)
 
 
 def print_failures(failures: list[str]) -> None:

--- a/scripts/tests/test_check_fixture_lockfiles.py
+++ b/scripts/tests/test_check_fixture_lockfiles.py
@@ -29,6 +29,7 @@ from fixture_lockfile_reporting import (
     fetch_failure_message,
     print_check_summary,
     print_fetch_summary,
+    print_prefetch_metrics,
     print_refresh_summary,
     refresh_failure_message,
     stale_failure_message,
@@ -270,6 +271,7 @@ def test_gate_wrappers_delegate_to_the_shared_reporter() -> None:
                 print_fetch_summary,
                 cargo_fetch_command,
                 fetch_fixture_dependencies,
+                report_metrics=print_prefetch_metrics,
             ),
         ),
     ]

--- a/scripts/tests/test_check_fixture_lockfiles.py
+++ b/scripts/tests/test_check_fixture_lockfiles.py
@@ -1,7 +1,8 @@
 """Unit tests for the standalone fixture-lockfile gate.
 
-These tests pin the discovery contract and the failure behaviour without
-mutating any repository fixture during parallel runs.
+These tests pin the gate's failure behaviour without mutating any repository
+fixture during parallel runs. The discovery contract they build on lives in
+``test_fixture_lockfile_discovery.py``.
 """
 
 import subprocess  # ruff: ignore[suspicious-subprocess-import] - tests build stand-in CompletedProcess values without running anything.
@@ -10,19 +11,17 @@ from unittest import mock
 
 import pytest
 from check_fixture_lockfiles import (
-    FixtureLockfileError,
     cargo_metadata_command,
     check_fixtures,
-    discover_fixture_manifests,
-    is_staged_fixture,
-    is_workspace_root,
     main,
     refresh_fixtures,
     refresh_lockfile,
     run_cargo_command,
     run_cargo_metadata,
 )
+from fixture_lockfile_discovery import discover_fixture_manifests
 from fixture_lockfile_reporting import (
+    FixtureLockfileError,
     GateMode,
     print_check_summary,
     print_refresh_summary,
@@ -35,46 +34,6 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 STALE_OUTPUT = (
     "error: cannot update the lock file ... because --locked was passed to prevent this"
 )
-
-
-def test_discovery_includes_feature_addition_fixture() -> None:
-    """The authoritative fixture set covers the scenario-addition fixture."""
-    manifests = discover_fixture_manifests(REPO_ROOT)
-    names = {manifest.parent.name for manifest in manifests}
-    assert "feature_addition" in names, (
-        "discovery must include the feature_addition fixture; a fixture added "
-        "to the set without a committed lockfile would otherwise escape the gate"
-    )
-
-
-def test_discovery_includes_every_committed_standalone_lockfile() -> None:
-    """Every standalone lockfile on disk is covered by discovery."""
-    manifests = discover_fixture_manifests(REPO_ROOT)
-    lockfiles = {manifest.parent / "Cargo.lock" for manifest in manifests}
-    for lockfile in (
-        REPO_ROOT / "crates/cargo-bdd/tests/fixtures/minimal/Cargo.lock",
-        REPO_ROOT / "crates/rstest-bdd/tests/fixtures/feature_addition/Cargo.lock",
-        REPO_ROOT / "crates/rstest-bdd/tests/fixtures/rebuild_invalidation/Cargo.lock",
-        REPO_ROOT / "crates/rstest-bdd/tests/ui_lints/Cargo.lock",
-        REPO_ROOT / "tests/fixtures/published-gpui-0-2-2/Cargo.lock",
-    ):
-        assert lockfile in lockfiles, (
-            f"{lockfile.relative_to(REPO_ROOT)} must stay inside the "
-            "authoritative standalone fixture set"
-        )
-
-
-def test_discovery_excludes_the_workspace_root_and_staged_fixture() -> None:
-    """The root workspace and the staged e2e fixture are out of scope."""
-    manifests = discover_fixture_manifests(REPO_ROOT)
-    relative = {manifest.relative_to(REPO_ROOT).as_posix() for manifest in manifests}
-    assert "Cargo.toml" not in relative, (
-        "the workspace root resolves through the workspace lockfile and is not "
-        "a standalone fixture"
-    )
-    assert "tests/fixtures/published-gpui-e2e/Cargo.toml" not in relative, (
-        "the staged e2e fixture resolves against target/ artefacts, not a lockfile"
-    )
 
 
 def test_every_discovered_manifest_matches_its_lockfile() -> None:
@@ -170,36 +129,6 @@ def test_refresh_mode_regenerates_before_validating() -> None:
     assert observed == [m for m in manifests for _ in range(2)], (
         "every discovered fixture must be visited in order"
     )
-
-
-def test_workspace_root_is_never_a_fixture() -> None:
-    """The workspace root manifest is excluded from the fixture gate."""
-    assert is_workspace_root(REPO_ROOT / "Cargo.toml", REPO_ROOT), (
-        "the workspace root manifest must never be treated as a fixture"
-    )
-    assert not is_workspace_root(
-        REPO_ROOT / "crates/rstest-bdd/tests/ui_lints/Cargo.toml", REPO_ROOT
-    ), "a standalone fixture manifest must stay inside the gate"
-
-
-def test_staged_fixture_is_excluded_from_discovery() -> None:
-    """The target/-staged e2e fixture is validated by its own targets."""
-    staged = REPO_ROOT / "tests/fixtures/published-gpui-e2e/Cargo.toml"
-    assert is_staged_fixture(staged, REPO_ROOT), (
-        "the staged e2e fixture must be excluded from discovery"
-    )
-    assert not is_staged_fixture(
-        REPO_ROOT / "tests/fixtures/published-gpui-0-2-2/Cargo.toml", REPO_ROOT
-    ), "the published 0.2.2 fixture stays inside the gate"
-
-
-def test_discovery_error_names_the_missing_contract() -> None:
-    """An empty fixture set fails with a discoverable reason."""
-    with (
-        mock.patch("check_fixture_lockfiles.iter_cargo_manifests", return_value=[]),
-        pytest.raises(FixtureLockfileError, match="no standalone fixture"),
-    ):
-        discover_fixture_manifests(REPO_ROOT)
 
 
 def test_run_cargo_command_reports_a_missing_cargo_executable() -> None:
@@ -302,12 +231,26 @@ def test_refresh_failure_report_uses_the_refresh_wording() -> None:
 
 
 def test_gate_wrappers_delegate_to_the_shared_reporter() -> None:
-    """Each entry point delegates with its formatter, summary, and prep."""
+    """Each entry point delegates with its formatter, summary, and operation."""
     cases = [
-        (check_fixtures, GateMode(stale_failure_message, print_check_summary)),
+        (
+            check_fixtures,
+            GateMode(
+                stale_failure_message,
+                print_check_summary,
+                cargo_metadata_command,
+                run_cargo_metadata,
+            ),
+        ),
         (
             refresh_fixtures,
-            GateMode(refresh_failure_message, print_refresh_summary, refresh_lockfile),
+            GateMode(
+                refresh_failure_message,
+                print_refresh_summary,
+                cargo_metadata_command,
+                run_cargo_metadata,
+                refresh_lockfile,
+            ),
         ),
     ]
     for entry_point, mode in cases:

--- a/scripts/tests/test_check_fixture_lockfiles.py
+++ b/scripts/tests/test_check_fixture_lockfiles.py
@@ -11,8 +11,11 @@ from unittest import mock
 
 import pytest
 from check_fixture_lockfiles import (
+    cargo_fetch_command,
     cargo_metadata_command,
     check_fixtures,
+    fetch_fixture_dependencies,
+    fetch_fixtures,
     main,
     refresh_fixtures,
     refresh_lockfile,
@@ -23,7 +26,9 @@ from fixture_lockfile_discovery import discover_fixture_manifests
 from fixture_lockfile_reporting import (
     FixtureLockfileError,
     GateMode,
+    fetch_failure_message,
     print_check_summary,
+    print_fetch_summary,
     print_refresh_summary,
     refresh_failure_message,
     stale_failure_message,
@@ -157,16 +162,18 @@ def test_run_cargo_command_reports_a_missing_cargo_executable() -> None:
 
 
 def test_thin_wrappers_delegate_to_the_shared_runner() -> None:
-    """Both public entry points build their argv and hand it to one runner."""
+    """Every public entry point builds its argv and hands it to one runner."""
     manifest = REPO_ROOT / "crates/rstest-bdd/tests/ui_lints/Cargo.toml"
     with mock.patch("check_fixture_lockfiles.run_cargo_command") as runner:
         run_cargo_metadata(manifest)
         refresh_lockfile(manifest)
-    assert runner.call_count == 2, (
+        fetch_fixture_dependencies(manifest)
+    assert runner.call_count == 3, (
         "each wrapper must route through the shared Cargo runner exactly once"
     )
     metadata_argv, metadata_manifest = runner.call_args_list[0].args
     refresh_argv, refresh_manifest = runner.call_args_list[1].args
+    fetch_argv, fetch_manifest = runner.call_args_list[2].args
     assert metadata_argv == cargo_metadata_command(manifest), (
         "validation must always use the locked metadata argv"
     )
@@ -178,6 +185,10 @@ def test_thin_wrappers_delegate_to_the_shared_runner() -> None:
         str(manifest),
     ], "the refresh argv must stay cargo generate-lockfile --manifest-path"
     assert refresh_manifest == manifest, "refresh must name the manifest it regenerated"
+    assert fetch_argv == cargo_fetch_command(manifest), (
+        "the prefetch must use the locked fetch argv"
+    )
+    assert fetch_manifest == manifest, "the prefetch must name the manifest it warmed"
 
 
 def test_check_failure_output_carries_manifest_command_and_cargo_streams() -> None:
@@ -250,6 +261,15 @@ def test_gate_wrappers_delegate_to_the_shared_reporter() -> None:
                 cargo_metadata_command,
                 run_cargo_metadata,
                 refresh_lockfile,
+            ),
+        ),
+        (
+            fetch_fixtures,
+            GateMode(
+                fetch_failure_message,
+                print_fetch_summary,
+                cargo_fetch_command,
+                fetch_fixture_dependencies,
             ),
         ),
     ]

--- a/scripts/tests/test_fixture_lockfile_discovery.py
+++ b/scripts/tests/test_fixture_lockfile_discovery.py
@@ -137,7 +137,7 @@ def test_classification_ignores_comments_and_string_values(tmp_path: Path) -> No
         "patch-override",
     ],
 )
-def test_every_path_dependency_spelling_is_recognised(
+def test_every_path_dependency_spelling_is_recognized(
     tmp_path: Path, manifest_text: str
 ) -> None:
     """Each Cargo spelling of a local source counts as a path dependency."""
@@ -154,7 +154,7 @@ def test_every_path_dependency_spelling_is_recognised(
     ["[workspace]\n", "[ workspace ]\n", '["workspace"]\n'],
     ids=["bare", "padded", "quoted"],
 )
-def test_every_workspace_section_spelling_is_recognised(
+def test_every_workspace_section_spelling_is_recognized(
     tmp_path: Path, manifest_text: str
 ) -> None:
     """Each TOML spelling of the workspace table opts the fixture out."""

--- a/scripts/tests/test_fixture_lockfile_discovery.py
+++ b/scripts/tests/test_fixture_lockfile_discovery.py
@@ -1,0 +1,89 @@
+"""Unit tests for the standalone fixture discovery contract.
+
+Discovery is shared by the validation gate, the refresh path, and the mutation
+lane's dependency prefetch, so these tests pin the fixture set itself rather
+than the Cargo plumbing that consumes it.
+"""
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from fixture_lockfile_discovery import (
+    discover_fixture_manifests,
+    is_staged_fixture,
+    is_workspace_root,
+)
+from fixture_lockfile_reporting import FixtureLockfileError
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_discovery_includes_feature_addition_fixture() -> None:
+    """The authoritative fixture set covers the scenario-addition fixture."""
+    manifests = discover_fixture_manifests(REPO_ROOT)
+    names = {manifest.parent.name for manifest in manifests}
+    assert "feature_addition" in names, (
+        "discovery must include the feature_addition fixture; a fixture added "
+        "to the set without a committed lockfile would otherwise escape the gate"
+    )
+
+
+def test_discovery_includes_every_committed_standalone_lockfile() -> None:
+    """Every standalone lockfile on disk is covered by discovery."""
+    manifests = discover_fixture_manifests(REPO_ROOT)
+    lockfiles = {manifest.parent / "Cargo.lock" for manifest in manifests}
+    for lockfile in (
+        REPO_ROOT / "crates/cargo-bdd/tests/fixtures/minimal/Cargo.lock",
+        REPO_ROOT / "crates/rstest-bdd/tests/fixtures/feature_addition/Cargo.lock",
+        REPO_ROOT / "crates/rstest-bdd/tests/fixtures/rebuild_invalidation/Cargo.lock",
+        REPO_ROOT / "crates/rstest-bdd/tests/ui_lints/Cargo.lock",
+        REPO_ROOT / "tests/fixtures/published-gpui-0-2-2/Cargo.lock",
+    ):
+        assert lockfile in lockfiles, (
+            f"{lockfile.relative_to(REPO_ROOT)} must stay inside the "
+            "authoritative standalone fixture set"
+        )
+
+
+def test_discovery_excludes_the_workspace_root_and_staged_fixture() -> None:
+    """The root workspace and the staged e2e fixture are out of scope."""
+    manifests = discover_fixture_manifests(REPO_ROOT)
+    relative = {manifest.relative_to(REPO_ROOT).as_posix() for manifest in manifests}
+    assert "Cargo.toml" not in relative, (
+        "the workspace root resolves through the workspace lockfile and is not "
+        "a standalone fixture"
+    )
+    assert "tests/fixtures/published-gpui-e2e/Cargo.toml" not in relative, (
+        "the staged e2e fixture resolves against target/ artefacts, not a lockfile"
+    )
+
+
+def test_workspace_root_is_never_a_fixture() -> None:
+    """The workspace root manifest is excluded from the fixture gate."""
+    assert is_workspace_root(REPO_ROOT / "Cargo.toml", REPO_ROOT), (
+        "the workspace root manifest must never be treated as a fixture"
+    )
+    assert not is_workspace_root(
+        REPO_ROOT / "crates/rstest-bdd/tests/ui_lints/Cargo.toml", REPO_ROOT
+    ), "a standalone fixture manifest must stay inside the gate"
+
+
+def test_staged_fixture_is_excluded_from_discovery() -> None:
+    """The target/-staged e2e fixture is validated by its own targets."""
+    staged = REPO_ROOT / "tests/fixtures/published-gpui-e2e/Cargo.toml"
+    assert is_staged_fixture(staged, REPO_ROOT), (
+        "the staged e2e fixture must be excluded from discovery"
+    )
+    assert not is_staged_fixture(
+        REPO_ROOT / "tests/fixtures/published-gpui-0-2-2/Cargo.toml", REPO_ROOT
+    ), "the published 0.2.2 fixture stays inside the gate"
+
+
+def test_discovery_error_names_the_missing_contract() -> None:
+    """An empty fixture set fails with a discoverable reason."""
+    with (
+        mock.patch("fixture_lockfile_discovery.iter_cargo_manifests", return_value=[]),
+        pytest.raises(FixtureLockfileError, match="no standalone fixture"),
+    ):
+        discover_fixture_manifests(REPO_ROOT)

--- a/scripts/tests/test_fixture_lockfile_discovery.py
+++ b/scripts/tests/test_fixture_lockfile_discovery.py
@@ -11,8 +11,11 @@ from unittest import mock
 import pytest
 from fixture_lockfile_discovery import (
     discover_fixture_manifests,
+    has_path_dependency,
     is_staged_fixture,
+    is_standalone_workspace,
     is_workspace_root,
+    iter_cargo_manifests,
 )
 from fixture_lockfile_reporting import FixtureLockfileError
 
@@ -78,6 +81,102 @@ def test_staged_fixture_is_excluded_from_discovery() -> None:
     assert not is_staged_fixture(
         REPO_ROOT / "tests/fixtures/published-gpui-0-2-2/Cargo.toml", REPO_ROOT
     ), "the published 0.2.2 fixture stays inside the gate"
+
+
+def test_discovery_does_not_follow_directory_symlinks(tmp_path: Path) -> None:
+    """A directory symlink cannot send the walk back up its own tree."""
+    manifest = tmp_path / "fixture" / "Cargo.toml"
+    manifest.parent.mkdir()
+    manifest.write_text("[workspace]\n", encoding="utf-8")
+    try:
+        (tmp_path / "loop").symlink_to(tmp_path, target_is_directory=True)
+    except (OSError, NotImplementedError) as error:
+        pytest.skip(f"this platform cannot create directory symlinks: {error}")
+
+    assert list(iter_cargo_manifests(tmp_path)) == [manifest], (
+        "descending through the symlink would re-walk the same tree once per "
+        "symlink the platform resolves before refusing it"
+    )
+
+
+def test_classification_ignores_comments_and_string_values(tmp_path: Path) -> None:
+    """Comment text and string values never pass for a declaration."""
+    manifest = tmp_path / "Cargo.toml"
+    manifest.write_text(
+        "# [workspace] with a path = ../helper dependency\n"
+        "[package]\n"
+        'name = "fixture"\n'
+        'description = "a [workspace] with path = ../helper reference"\n',
+        encoding="utf-8",
+    )
+
+    assert not is_standalone_workspace(manifest), (
+        "a commented-out [workspace] stanza must not count as opting out"
+    )
+    assert not has_path_dependency(manifest), (
+        "a path named in a comment or a string value is not a dependency"
+    )
+
+
+@pytest.mark.parametrize(
+    "manifest_text",
+    [
+        '[dependencies]\nhelper = { path = "../helper" }\n',
+        '[dependencies]\nhelper = {path="../helper"}\n',
+        '[dependencies.helper]\npath = "../helper"\n',
+        '[dev-dependencies.helper]\npath = "../helper"\n',
+        '[target."cfg(unix)".dependencies]\nhelper = { path = "../helper" }\n',
+        '[patch.crates-io]\nhelper = { path = "../helper" }\n',
+    ],
+    ids=[
+        "inline-table",
+        "compact-inline-table",
+        "table-per-dependency",
+        "dev-dependency",
+        "target-qualified",
+        "patch-override",
+    ],
+)
+def test_every_path_dependency_spelling_is_recognised(
+    tmp_path: Path, manifest_text: str
+) -> None:
+    """Each Cargo spelling of a local source counts as a path dependency."""
+    manifest = tmp_path / "Cargo.toml"
+    manifest.write_text(manifest_text, encoding="utf-8")
+
+    assert has_path_dependency(manifest), (
+        f"{manifest_text!r} resolves a dependency from the local filesystem"
+    )
+
+
+@pytest.mark.parametrize(
+    "manifest_text",
+    ["[workspace]\n", "[ workspace ]\n", '["workspace"]\n'],
+    ids=["bare", "padded", "quoted"],
+)
+def test_every_workspace_section_spelling_is_recognised(
+    tmp_path: Path, manifest_text: str
+) -> None:
+    """Each TOML spelling of the workspace table opts the fixture out."""
+    manifest = tmp_path / "Cargo.toml"
+    manifest.write_text(manifest_text, encoding="utf-8")
+
+    assert is_standalone_workspace(manifest), (
+        f"{manifest_text!r} declares the fixture's own workspace section"
+    )
+
+
+def test_classification_tolerates_invalid_toml(tmp_path: Path) -> None:
+    """A manifest that is not valid TOML is classified as no fixture."""
+    manifest = tmp_path / "Cargo.toml"
+    manifest.write_text("[workspace\npath = ../helper\n", encoding="utf-8")
+
+    assert not is_standalone_workspace(manifest), (
+        "a manifest that is not valid TOML must not be reported as a workspace"
+    )
+    assert not has_path_dependency(manifest), (
+        "a manifest that is not valid TOML must not be reported as a path source"
+    )
 
 
 def test_discovery_error_names_the_missing_contract() -> None:

--- a/scripts/tests/test_fixture_lockfile_discovery.py
+++ b/scripts/tests/test_fixture_lockfile_discovery.py
@@ -10,6 +10,7 @@ from unittest import mock
 
 import pytest
 from fixture_lockfile_discovery import (
+    _value_declares_local_source,
     discover_fixture_manifests,
     has_path_dependency,
     is_staged_fixture,
@@ -147,6 +148,43 @@ def test_every_path_dependency_spelling_is_recognized(
     assert has_path_dependency(manifest), (
         f"{manifest_text!r} resolves a dependency from the local filesystem"
     )
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("dependencies", {"helper": {"path": "../helper"}}),
+        ("dev-dependencies", {"helper": {"path": "../helper"}}),
+        ("patch", {"crates-io": {"helper": {"path": "../helper"}}}),
+    ],
+    ids=["dependencies", "dev-dependencies", "patch"],
+)
+def test_dependency_tables_are_searched_whole_for_a_path_source(
+    key: str, value: dict[str, object]
+) -> None:
+    """A dependency or patch table is searched whole for a nested path key."""
+    assert _value_declares_local_source(key, value), (
+        f"a path key nested under {key!r} still names a local source"
+    )
+
+
+def test_wrapper_tables_reach_a_nested_dependency_table() -> None:
+    """A wrapper table such as a target section reaches nested dependencies."""
+    target_table: dict[str, object] = {
+        "cfg(unix)": {"dependencies": {"helper": {"path": "../helper"}}}
+    }
+
+    assert _value_declares_local_source("target", target_table), (
+        "a key that is not itself a dependency table must recurse into the "
+        "dependency table it holds"
+    )
+
+
+def test_registry_only_dependency_table_declares_no_local_source() -> None:
+    """A dependency table with no path key is not a local source."""
+    assert not _value_declares_local_source(
+        "dependencies", {"helper": {"version": "1"}}
+    ), "a registry dependency declares no local source"
 
 
 @pytest.mark.parametrize(

--- a/scripts/tests/test_fixture_lockfile_prefetch.py
+++ b/scripts/tests/test_fixture_lockfile_prefetch.py
@@ -7,19 +7,27 @@ validating anything itself.
 """
 
 import subprocess  # ruff: ignore[suspicious-subprocess-import] - tests build stand-in CompletedProcess values without running anything.
+import typing as typ
 from pathlib import Path
 from unittest import mock
 
-import pytest
 from check_fixture_lockfiles import (
     cargo_fetch_command,
-    fetch_fixture_dependencies,
     fetch_fixtures,
     main,
 )
 from fixture_lockfile_discovery import discover_fixture_manifests
 
+if typ.TYPE_CHECKING:
+    import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: A discovered standalone fixture. The prefetch tests stand in for Cargo's
+#: output, so any real fixture manifest serves as the one under test.
+FIXTURE_MANIFEST = (
+    REPO_ROOT / "crates/rstest-bdd/tests/fixtures/rebuild_invalidation/Cargo.toml"
+)
 
 FETCH_FAILURE = "error: failed to download `proc-macro-error-attr3 v3.1.0`"
 
@@ -42,7 +50,7 @@ def test_prefetch_fetches_every_discovered_fixture() -> None:
 
 def test_prefetch_failure_report_names_the_fixture_and_cargo_output() -> None:
     """A failed fetch names the fixture, the command, and Cargo's output."""
-    manifest = REPO_ROOT / "crates/rstest-bdd/tests/fixtures/rebuild_invalidation/Cargo.toml"
+    manifest = FIXTURE_MANIFEST
     failing = subprocess.CompletedProcess(
         args=cargo_fetch_command(manifest),
         returncode=101,
@@ -61,7 +69,7 @@ def test_prefetch_failure_report_names_the_fixture_and_cargo_output() -> None:
     assert report.startswith("failed to prefetch fixture dependencies: "), (
         "the prefetch must keep its own failure wording"
     )
-    assert "crates/rstest-bdd/tests/fixtures/rebuild_invalidation/Cargo.toml" in report, (
+    assert FIXTURE_MANIFEST.relative_to(REPO_ROOT).as_posix() in report, (
         "the report must name the fixture whose dependencies did not download"
     )
     assert f"command: {' '.join(cargo_fetch_command(manifest))}" in report, (
@@ -74,7 +82,7 @@ def test_prefetch_failure_summary_streams_to_stderr(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """A failed prefetch surfaces its summary on standard error, exit code 1."""
-    manifest = REPO_ROOT / "crates/rstest-bdd/tests/fixtures/rebuild_invalidation/Cargo.toml"
+    manifest = FIXTURE_MANIFEST
     failing = subprocess.CompletedProcess(
         args=cargo_fetch_command(manifest),
         returncode=101,
@@ -105,7 +113,8 @@ def test_main_fetch_flag_routes_to_prefetch_without_validating(
             "check_fixture_lockfiles.discover_fixture_manifests", return_value=manifests
         ),
         mock.patch(
-            "check_fixture_lockfiles.fetch_fixture_dependencies", return_value=successful
+            "check_fixture_lockfiles.fetch_fixture_dependencies",
+            return_value=successful,
         ),
         mock.patch("check_fixture_lockfiles.run_cargo_metadata") as metadata,
     ):

--- a/scripts/tests/test_fixture_lockfile_prefetch.py
+++ b/scripts/tests/test_fixture_lockfile_prefetch.py
@@ -8,6 +8,7 @@ covers the boundary the in-process tests mock out: the argv Cargo really
 receives, the process exit status, and the two output streams.
 """
 
+import json
 import os
 import shutil
 import stat
@@ -23,6 +24,7 @@ from check_fixture_lockfiles import (
     main,
 )
 from fixture_lockfile_discovery import discover_fixture_manifests
+from fixture_lockfile_reporting import PREFETCH_METRICS_PREFIX
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 GATE_SCRIPT = REPO_ROOT / "scripts" / "check_fixture_lockfiles.py"
@@ -253,6 +255,79 @@ def run_fetch_with_fake_cargo(
     return result, [record.rstrip("\0").split("\0") for record in records if record]
 
 
+def metrics_records(text: str) -> list[dict[str, object]]:
+    """Return every prefetch metrics record the *text* of one stream carries."""
+    return [
+        json.loads(line.removeprefix(PREFETCH_METRICS_PREFIX))
+        for line in text.splitlines()
+        if line.startswith(PREFETCH_METRICS_PREFIX)
+    ]
+
+
+def human_lines(text: str) -> list[str]:
+    """Return the wording of *text*: its non-blank, non-metrics lines."""
+    return [
+        line
+        for line in text.splitlines()
+        if line and not line.startswith(PREFETCH_METRICS_PREFIX)
+    ]
+
+
+@pytest.mark.parametrize("failing_index", [None, 0], ids=["clean", "failing"])
+def test_fetch_mode_emits_one_metrics_record_for_the_outcome(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failing_index: int | None
+) -> None:
+    """The run closes with one record of its counts on the outcome's stream."""
+    manifests = discover_fixture_manifests(REPO_ROOT)
+    failing = None if failing_index is None else manifests[failing_index]
+
+    result, _ = run_fetch_with_fake_cargo(tmp_path, monkeypatch, failing=failing)
+
+    failed = 0 if failing is None else 1
+    assert result.returncode == failed, result.stderr
+    outcome_stream = result.stdout if failing is None else result.stderr
+    (record,) = metrics_records(outcome_stream)
+    # Spelled out, not snapshotted: the field set is the contract under test.
+    expected = {
+        "schema_version": 1,
+        "total": len(manifests),
+        "succeeded": len(manifests) - failed,
+        "failed": failed,
+        "elapsed_ms": record["elapsed_ms"],
+        "outcome": "failure" if failed else "success",
+        "cache_outcome": "unknown",
+    }
+    assert record == expected, "the record must hold the run's counts and outcome"
+    elapsed = record["elapsed_ms"]
+    assert isinstance(elapsed, int), "the duration must be whole milliseconds"
+    assert elapsed >= 0, "the record must carry a non-negative duration"
+    other_stream = result.stderr if failing is None else result.stdout
+    assert not metrics_records(other_stream), (
+        "the record must ride the stream matching the outcome, never both"
+    )
+
+
+def test_metrics_record_carries_no_unbounded_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Paths, Cargo diagnostics, and command lines stay out of the record."""
+    manifests = discover_fixture_manifests(REPO_ROOT)
+    result, _ = run_fetch_with_fake_cargo(tmp_path, monkeypatch, failing=manifests[0])
+    (line,) = [
+        line
+        for line in result.stderr.splitlines()
+        if line.startswith(PREFETCH_METRICS_PREFIX)
+    ]
+    candidates = (
+        str(REPO_ROOT),
+        str(manifests[0]),
+        FETCH_FAILURE,
+        "error: failed to download fixture dependency",
+    )
+    leaked = [value for value in candidates if value in line]
+    assert leaked == [], f"the record must carry counts only, never {leaked!r}"
+
+
 def test_fetch_mode_warms_every_fixture_through_the_locked_fetch_argv(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -266,10 +341,9 @@ def test_fetch_mode_warms_every_fixture_through_the_locked_fetch_argv(
         ["fetch", "--locked", "--manifest-path", str(manifest)]
         for manifest in manifests
     ], "the gate must run one locked fetch per discovered fixture, in order"
-    summary = f"prefetched dependencies for {len(manifests)} fixture(s)"
-    assert summary in result.stdout, (
-        "a clean prefetch must confirm its count on standard output"
-    )
+    assert human_lines(result.stdout) == [
+        f"prefetched dependencies for {len(manifests)} fixture(s)"
+    ], "a clean prefetch keeps its exact success summary; the record joins it"
 
 
 def test_fetch_mode_reports_a_failing_fixture_and_exits_nonzero(
@@ -288,19 +362,16 @@ def test_fetch_mode_reports_a_failing_fixture_and_exits_nonzero(
         "one failing fixture must not stop the remaining prefetches"
     )
     relative = failing.relative_to(REPO_ROOT).as_posix()
-    assert f"failed to prefetch fixture dependencies: {relative}" in result.stderr, (
-        "the report must name the fixture whose dependencies did not download"
-    )
-    command = f"command: cargo fetch --locked --manifest-path {failing}"
-    assert command in result.stderr, (
-        "the report must quote the command the gate ran for reproduction"
-    )
-    assert "error: failed to download fixture dependency" in result.stderr, (
-        "the report must carry Cargo's own diagnostics"
-    )
-    summary = f"1 of {len(manifests)} fixture dependency prefetch(es) failed"
-    assert summary in result.stderr, (
-        "the summary must count the failed prefetch on standard error"
+    # The established wording is the contract, so it is written out in full.
+    expected = [
+        f"failed to prefetch fixture dependencies: {relative}",
+        f"command: cargo fetch --locked --manifest-path {failing}",
+        "cargo output:",
+        "error: failed to download fixture dependency",
+        f"1 of {len(manifests)} fixture dependency prefetch(es) failed",
+    ]
+    assert human_lines(result.stderr) == expected, (
+        "the metrics record must not reword the established failure report"
     )
 
 
@@ -324,3 +395,6 @@ def test_make_target_runs_the_fetch_mode_and_propagates_a_failure(
     assert "failed to prefetch fixture dependencies" in result.stderr, (
         "the target must let the gate's failure report reach the lane's log"
     )
+    (record,) = metrics_records(result.stderr)
+    assert record["total"] == len(manifests), "the record must count every fixture"
+    assert record["failed"] == 1, "the record must count the failed fixture"

--- a/scripts/tests/test_fixture_lockfile_prefetch.py
+++ b/scripts/tests/test_fixture_lockfile_prefetch.py
@@ -9,6 +9,7 @@ receives, the process exit status, and the two output streams.
 """
 
 import os
+import shutil
 import stat
 import subprocess  # ruff: ignore[suspicious-subprocess-import] - tests build stand-in CompletedProcess values and run the trusted gate script.
 import sys
@@ -164,10 +165,10 @@ def test_makefile_prefetch_target_runs_the_fetch_mode() -> None:
     """`make prefetch-fixture-deps` drives the gate's ``--fetch`` mode."""
     recipe = makefile_recipe("prefetch-fixture-deps")
 
-    assert "scripts/check_fixture_lockfiles.py" in recipe, (
-        "the mutation lane's prefetch must run the fixture-lockfile gate script"
+    assert "scripts/check_fixture_lockfiles.py --fetch" in recipe, (
+        "the mutation lane's prefetch must run the fixture-lockfile gate in "
+        "its fetch mode"
     )
-    assert "--fetch" in recipe, "the prefetch target must select the fetch mode"
 
 
 #: A Cargo stand-in that records each argument vector it receives and fails
@@ -191,8 +192,14 @@ def run_fetch_with_fake_cargo(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     failing: Path | None = None,
+    *,
+    via_make: bool = False,
 ) -> tuple[subprocess.CompletedProcess[str], list[list[str]]]:
     """Run the gate's ``--fetch`` mode against a recording Cargo stand-in.
+
+    The stand-in shadows ``cargo`` on ``PATH``, so the platform's real Cargo
+    never runs. ``via_make`` reaches the same mode the way the mutation lane
+    does: through the ``prefetch-fixture-deps`` target.
 
     Returns
     -------
@@ -202,18 +209,35 @@ def run_fetch_with_fake_cargo(
     """
     if os.name == "nt":
         pytest.skip("the recording Cargo stand-in is a POSIX shell script")
+    if via_make and shutil.which("make") is None:
+        pytest.skip("the make-driven prefetch needs make on PATH")
     cargo_directory = tmp_path / "bin"
     cargo_directory.mkdir()
     fake_cargo = cargo_directory / "cargo"
     fake_cargo.write_text(FAKE_CARGO, encoding="utf-8")
     fake_cargo.chmod(fake_cargo.stat().st_mode | stat.S_IXUSR)
     invocation_log = tmp_path / "cargo-invocations.log"
-    monkeypatch.setenv("PATH", f"{cargo_directory}{os.pathsep}{os.environ['PATH']}")
+    stand_in_path = f"{cargo_directory}{os.pathsep}{os.environ['PATH']}"
+    monkeypatch.setenv("PATH", stand_in_path)
     monkeypatch.setenv("FAKE_CARGO_LOG", str(invocation_log))
     monkeypatch.setenv("FAKE_CARGO_FAIL_MATCH", "" if failing is None else str(failing))
 
+    if via_make:
+        # The Makefile prepends the real Cargo directory to PATH, so the
+        # target's own PATH has to name the stand-in first. PROJECT_PYTHON
+        # stands in for the uv launcher: the recipe the target runs is
+        # otherwise untouched, and the test needs no toolchain of its own.
+        command = [
+            "make",
+            "prefetch-fixture-deps",
+            f"PATH={stand_in_path}",
+            f"PROJECT_PYTHON={sys.executable}",
+        ]
+    else:
+        command = [sys.executable, str(GATE_SCRIPT), "--fetch"]
+
     result = subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true] - the argv is this test's own command.
-        [sys.executable, str(GATE_SCRIPT), "--fetch"],
+        command,
         cwd=REPO_ROOT,
         env=os.environ.copy(),
         text=True,
@@ -277,4 +301,26 @@ def test_fetch_mode_reports_a_failing_fixture_and_exits_nonzero(
     summary = f"1 of {len(manifests)} fixture dependency prefetch(es) failed"
     assert summary in result.stderr, (
         "the summary must count the failed prefetch on standard error"
+    )
+
+
+def test_make_target_runs_the_fetch_mode_and_propagates_a_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The mutation lane's target delegates to the gate and fails with it."""
+    manifests = discover_fixture_manifests(REPO_ROOT)
+
+    result, invocations = run_fetch_with_fake_cargo(
+        tmp_path, monkeypatch, failing=manifests[0], via_make=True
+    )
+
+    assert result.returncode != 0, (
+        "the prefetch target must fail the lane when a fixture does not download"
+    )
+    assert invocations == [
+        ["fetch", "--locked", "--manifest-path", str(manifest)]
+        for manifest in manifests
+    ], "the target must run one locked fetch per discovered fixture, in order"
+    assert "failed to prefetch fixture dependencies" in result.stderr, (
+        "the target must let the gate's failure report reach the lane's log"
     )

--- a/scripts/tests/test_fixture_lockfile_prefetch.py
+++ b/scripts/tests/test_fixture_lockfile_prefetch.py
@@ -3,14 +3,19 @@
 The mutation lane runs this mode before cargo-mutants so its nested fixture
 builds resolve from a warm registry cache while ``--offline``; these tests pin
 that the mode fetches every discovered fixture and reports failures without
-validating anything itself.
+validating anything itself. A subprocess run against a recording Cargo stand-in
+covers the boundary the in-process tests mock out: the argv Cargo really
+receives, the process exit status, and the two output streams.
 """
 
-import subprocess  # ruff: ignore[suspicious-subprocess-import] - tests build stand-in CompletedProcess values without running anything.
-import typing as typ
+import os
+import stat
+import subprocess  # ruff: ignore[suspicious-subprocess-import] - tests build stand-in CompletedProcess values and run the trusted gate script.
+import sys
 from pathlib import Path
 from unittest import mock
 
+import pytest
 from check_fixture_lockfiles import (
     cargo_fetch_command,
     fetch_fixtures,
@@ -18,10 +23,9 @@ from check_fixture_lockfiles import (
 )
 from fixture_lockfile_discovery import discover_fixture_manifests
 
-if typ.TYPE_CHECKING:
-    import pytest
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
+GATE_SCRIPT = REPO_ROOT / "scripts" / "check_fixture_lockfiles.py"
+MAKEFILE = REPO_ROOT / "Makefile"
 
 #: A discovered standalone fixture. The prefetch tests stand in for Cargo's
 #: output, so any real fixture manifest serves as the one under test.
@@ -126,3 +130,151 @@ def test_main_fetch_flag_routes_to_prefetch_without_validating(
     assert f"prefetched dependencies for {len(manifests)} fixture(s)" in (
         capsys.readouterr().out
     ), "the prefetch summary must confirm the run"
+
+
+def test_cargo_fetch_command_pins_the_locked_fetch_argv() -> None:
+    """The prefetch argv is the locked fetch for exactly one manifest."""
+    assert cargo_fetch_command(FIXTURE_MANIFEST) == [
+        "cargo",
+        "fetch",
+        "--locked",
+        "--manifest-path",
+        str(FIXTURE_MANIFEST),
+    ], "the prefetch must pin the locked fetch argv the mutation lane relies on"
+
+
+def makefile_recipe(target: str) -> str:
+    """Return the tab-indented recipe of the named Makefile target."""
+    lines = MAKEFILE.read_text(encoding="utf-8").splitlines()
+    start = next(
+        (index for index, line in enumerate(lines) if line.startswith(f"{target}:")),
+        None,
+    )
+    assert start is not None, f"the Makefile must define the {target} target"
+    recipe: list[str] = []
+    for line in lines[start + 1 :]:
+        if not line.startswith("\t"):
+            break
+        recipe.append(line.strip())
+    assert recipe, f"the {target} target must have a recipe"
+    return "\n".join(recipe)
+
+
+def test_makefile_prefetch_target_runs_the_fetch_mode() -> None:
+    """`make prefetch-fixture-deps` drives the gate's ``--fetch`` mode."""
+    recipe = makefile_recipe("prefetch-fixture-deps")
+
+    assert "scripts/check_fixture_lockfiles.py" in recipe, (
+        "the mutation lane's prefetch must run the fixture-lockfile gate script"
+    )
+    assert "--fetch" in recipe, "the prefetch target must select the fetch mode"
+
+
+#: A Cargo stand-in that records each argument vector it receives and fails
+#: only for the manifest its caller names in FAKE_CARGO_FAIL_MATCH.
+FAKE_CARGO = """\
+#!/usr/bin/env sh
+status=0
+for argument in "$@"; do
+    printf "%s\\0" "$argument" >> "$FAKE_CARGO_LOG"
+    if [ "$argument" = "$FAKE_CARGO_FAIL_MATCH" ]; then
+        printf "error: failed to download fixture dependency\\n" >&2
+        status=101
+    fi
+done
+printf "\\n" >> "$FAKE_CARGO_LOG"
+exit "$status"
+"""
+
+
+def run_fetch_with_fake_cargo(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failing: Path | None = None,
+) -> tuple[subprocess.CompletedProcess[str], list[list[str]]]:
+    """Run the gate's ``--fetch`` mode against a recording Cargo stand-in.
+
+    Returns
+    -------
+    tuple[subprocess.CompletedProcess[str], list[list[str]]]
+        The gate's completed run and the argument vector of every Cargo
+        invocation it made, in order.
+    """
+    if os.name == "nt":
+        pytest.skip("the recording Cargo stand-in is a POSIX shell script")
+    cargo_directory = tmp_path / "bin"
+    cargo_directory.mkdir()
+    fake_cargo = cargo_directory / "cargo"
+    fake_cargo.write_text(FAKE_CARGO, encoding="utf-8")
+    fake_cargo.chmod(fake_cargo.stat().st_mode | stat.S_IXUSR)
+    invocation_log = tmp_path / "cargo-invocations.log"
+    monkeypatch.setenv("PATH", f"{cargo_directory}{os.pathsep}{os.environ['PATH']}")
+    monkeypatch.setenv("FAKE_CARGO_LOG", str(invocation_log))
+    monkeypatch.setenv("FAKE_CARGO_FAIL_MATCH", "" if failing is None else str(failing))
+
+    result = subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true] - the argv is this test's own command.
+        [sys.executable, str(GATE_SCRIPT), "--fetch"],
+        cwd=REPO_ROOT,
+        env=os.environ.copy(),
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=120,
+    )
+    records = (
+        invocation_log.read_text(encoding="utf-8").splitlines()
+        if invocation_log.exists()
+        else []
+    )
+    return result, [record.rstrip("\0").split("\0") for record in records if record]
+
+
+def test_fetch_mode_warms_every_fixture_through_the_locked_fetch_argv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The script fetches each discovered fixture once and exits zero."""
+    manifests = discover_fixture_manifests(REPO_ROOT)
+
+    result, invocations = run_fetch_with_fake_cargo(tmp_path, monkeypatch)
+
+    assert result.returncode == 0, result.stderr
+    assert invocations == [
+        ["fetch", "--locked", "--manifest-path", str(manifest)]
+        for manifest in manifests
+    ], "the gate must run one locked fetch per discovered fixture, in order"
+    summary = f"prefetched dependencies for {len(manifests)} fixture(s)"
+    assert summary in result.stdout, (
+        "a clean prefetch must confirm its count on standard output"
+    )
+
+
+def test_fetch_mode_reports_a_failing_fixture_and_exits_nonzero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A fixture whose download fails is reported, and the run still completes."""
+    manifests = discover_fixture_manifests(REPO_ROOT)
+    failing = manifests[0]
+
+    result, invocations = run_fetch_with_fake_cargo(
+        tmp_path, monkeypatch, failing=failing
+    )
+
+    assert result.returncode == 1, "a failed prefetch must fail the gate"
+    assert len(invocations) == len(manifests), (
+        "one failing fixture must not stop the remaining prefetches"
+    )
+    relative = failing.relative_to(REPO_ROOT).as_posix()
+    assert f"failed to prefetch fixture dependencies: {relative}" in result.stderr, (
+        "the report must name the fixture whose dependencies did not download"
+    )
+    command = f"command: cargo fetch --locked --manifest-path {failing}"
+    assert command in result.stderr, (
+        "the report must quote the command the gate ran for reproduction"
+    )
+    assert "error: failed to download fixture dependency" in result.stderr, (
+        "the report must carry Cargo's own diagnostics"
+    )
+    summary = f"1 of {len(manifests)} fixture dependency prefetch(es) failed"
+    assert summary in result.stderr, (
+        "the summary must count the failed prefetch on standard error"
+    )

--- a/scripts/tests/test_fixture_lockfile_prefetch.py
+++ b/scripts/tests/test_fixture_lockfile_prefetch.py
@@ -1,0 +1,119 @@
+"""Unit tests for the standalone fixture dependency prefetch.
+
+The mutation lane runs this mode before cargo-mutants so its nested fixture
+builds resolve from a warm registry cache while ``--offline``; these tests pin
+that the mode fetches every discovered fixture and reports failures without
+validating anything itself.
+"""
+
+import subprocess  # ruff: ignore[suspicious-subprocess-import] - tests build stand-in CompletedProcess values without running anything.
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from check_fixture_lockfiles import (
+    cargo_fetch_command,
+    fetch_fixture_dependencies,
+    fetch_fixtures,
+    main,
+)
+from fixture_lockfile_discovery import discover_fixture_manifests
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+FETCH_FAILURE = "error: failed to download `proc-macro-error-attr3 v3.1.0`"
+
+
+def test_prefetch_fetches_every_discovered_fixture() -> None:
+    """Every discovered fixture is warmed with locked ``cargo fetch``."""
+    manifests = discover_fixture_manifests(REPO_ROOT)
+    successful = subprocess.CompletedProcess(
+        args=cargo_fetch_command(manifests[0]), returncode=0, stdout="", stderr=""
+    )
+    with mock.patch(
+        "check_fixture_lockfiles.run_cargo_command", return_value=successful
+    ) as runner:
+        exit_code = fetch_fixtures(REPO_ROOT, manifests)
+    assert exit_code == 0, "a clean prefetch must pass"
+    assert [call.args for call in runner.call_args_list] == [
+        (cargo_fetch_command(manifest), manifest) for manifest in manifests
+    ], "the prefetch must warm every discovered fixture with its locked fetch argv"
+
+
+def test_prefetch_failure_report_names_the_fixture_and_cargo_output() -> None:
+    """A failed fetch names the fixture, the command, and Cargo's output."""
+    manifest = REPO_ROOT / "crates/rstest-bdd/tests/fixtures/rebuild_invalidation/Cargo.toml"
+    failing = subprocess.CompletedProcess(
+        args=cargo_fetch_command(manifest),
+        returncode=101,
+        stdout="",
+        stderr=FETCH_FAILURE,
+    )
+    with (
+        mock.patch(
+            "check_fixture_lockfiles.fetch_fixture_dependencies", return_value=failing
+        ),
+        mock.patch("check_fixture_lockfiles.print_failures") as emit_failures,
+    ):
+        exit_code = fetch_fixtures(REPO_ROOT, [manifest])
+    assert exit_code == 1, "a failed prefetch must fail the run"
+    report = emit_failures.call_args.args[0][0]
+    assert report.startswith("failed to prefetch fixture dependencies: "), (
+        "the prefetch must keep its own failure wording"
+    )
+    assert "crates/rstest-bdd/tests/fixtures/rebuild_invalidation/Cargo.toml" in report, (
+        "the report must name the fixture whose dependencies did not download"
+    )
+    assert f"command: {' '.join(cargo_fetch_command(manifest))}" in report, (
+        "the report must quote the command for reproduction"
+    )
+    assert FETCH_FAILURE in report, "the report must carry Cargo stderr"
+
+
+def test_prefetch_failure_summary_streams_to_stderr(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A failed prefetch surfaces its summary on standard error, exit code 1."""
+    manifest = REPO_ROOT / "crates/rstest-bdd/tests/fixtures/rebuild_invalidation/Cargo.toml"
+    failing = subprocess.CompletedProcess(
+        args=cargo_fetch_command(manifest),
+        returncode=101,
+        stdout="",
+        stderr=FETCH_FAILURE,
+    )
+    with mock.patch(
+        "check_fixture_lockfiles.fetch_fixture_dependencies", return_value=failing
+    ):
+        exit_code = fetch_fixtures(REPO_ROOT, [manifest])
+    assert exit_code == 1, "a failed prefetch must fail the run"
+    captured = capsys.readouterr()
+    assert "1 of 1 fixture dependency prefetch(es) failed" in captured.err, (
+        "the prefetch summary must report the failed count on standard error"
+    )
+
+
+def test_main_fetch_flag_routes_to_prefetch_without_validating(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--fetch warms the cache instead of validating the lockfiles."""
+    manifests = discover_fixture_manifests(REPO_ROOT)
+    successful = subprocess.CompletedProcess(
+        args=cargo_fetch_command(manifests[0]), returncode=0, stdout="", stderr=""
+    )
+    with (
+        mock.patch(
+            "check_fixture_lockfiles.discover_fixture_manifests", return_value=manifests
+        ),
+        mock.patch(
+            "check_fixture_lockfiles.fetch_fixture_dependencies", return_value=successful
+        ),
+        mock.patch("check_fixture_lockfiles.run_cargo_metadata") as metadata,
+    ):
+        exit_code = main(["--fetch"])
+    assert exit_code == 0, "a clean prefetch must exit zero"
+    assert metadata.call_count == 0, (
+        "the prefetch mode must not stand in for lockfile validation"
+    )
+    assert f"prefetched dependencies for {len(manifests)} fixture(s)" in (
+        capsys.readouterr().out
+    ), "the prefetch summary must confirm the run"

--- a/scripts/tests/test_fixture_lockfile_reporting.py
+++ b/scripts/tests/test_fixture_lockfile_reporting.py
@@ -4,6 +4,7 @@ import typing as typ
 from pathlib import Path
 
 import fixture_lockfile_reporting
+import pytest
 from fixture_lockfile_reporting import (
     fetch_failure_message,
     print_failures,
@@ -12,7 +13,7 @@ from fixture_lockfile_reporting import (
 )
 
 if typ.TYPE_CHECKING:
-    import pytest
+    import collections.abc as cabc
 
 #: A manifest path the tests never touch: they pin pure report formatting.
 MANIFEST = Path("/repo/crates/rstest-bdd/tests/ui_lints/Cargo.toml")
@@ -20,6 +21,12 @@ MANIFEST = Path("/repo/crates/rstest-bdd/tests/ui_lints/Cargo.toml")
 #: The validation command and the prefetch command the gate passes in.
 METADATA_COMMAND = ["cargo", "metadata", "--locked", "--manifest-path", str(MANIFEST)]
 FETCH_COMMAND = ["cargo", "fetch", "--locked", "--manifest-path", str(MANIFEST)]
+
+#: Each message's opening clause, carrying its established punctuation. The
+#: refresh heading has never ended in a colon, unlike its two siblings.
+STALE_HEADING = "stale or unusable fixture lockfile:"
+REFRESH_HEADING = "refresh failed for"
+FETCH_HEADING = "failed to prefetch fixture dependencies:"
 
 STDOUT = "resolving dependencies\n"
 STDERR = "error: failed to update\n"
@@ -73,37 +80,25 @@ def test_refresh_summary_reports_both_outcomes(
     )
 
 
-def test_stale_failure_message_reports_the_manifest_command_and_output() -> None:
-    """The stale report spells out the heading, the command, and both streams."""
-    assert stale_failure_message(MANIFEST, METADATA_COMMAND, STDOUT, STDERR) == (
-        "stale or unusable fixture lockfile: "
-        f"{MANIFEST}\n"
-        f"command: {' '.join(METADATA_COMMAND)}\n"
+@pytest.mark.parametrize(
+    ("formatter", "command", "heading"),
+    [
+        (stale_failure_message, METADATA_COMMAND, STALE_HEADING),
+        (refresh_failure_message, METADATA_COMMAND, REFRESH_HEADING),
+        (fetch_failure_message, FETCH_COMMAND, FETCH_HEADING),
+    ],
+    ids=["stale", "refresh", "fetch"],
+)
+def test_failure_message_reports_the_manifest_the_command_and_the_output(
+    formatter: cabc.Callable[[Path, list[str], str, str], str],
+    command: list[str],
+    heading: str,
+) -> None:
+    """Every report spells out the heading, the command, and both streams."""
+    assert formatter(MANIFEST, command, STDOUT, STDERR) == (
+        f"{heading} {MANIFEST}\n"
+        f"command: {' '.join(command)}\n"
         "cargo output:\n"
         f"{STDOUT}"
         f"{STDERR}"
-    ), "the stale report must keep the gate's established wording"
-
-
-def test_refresh_failure_message_reports_the_manifest_command_and_output() -> None:
-    """The refresh report keeps its own colon-free opening clause."""
-    assert refresh_failure_message(MANIFEST, METADATA_COMMAND, STDOUT, STDERR) == (
-        "refresh failed for "
-        f"{MANIFEST}\n"
-        f"command: {' '.join(METADATA_COMMAND)}\n"
-        "cargo output:\n"
-        f"{STDOUT}"
-        f"{STDERR}"
-    ), "the refresh report must not gain punctuation the gate never printed"
-
-
-def test_fetch_failure_message_reports_the_manifest_command_and_output() -> None:
-    """The prefetch report quotes the fetch command and Cargo's output."""
-    assert fetch_failure_message(MANIFEST, FETCH_COMMAND, STDOUT, STDERR) == (
-        "failed to prefetch fixture dependencies: "
-        f"{MANIFEST}\n"
-        f"command: {' '.join(FETCH_COMMAND)}\n"
-        "cargo output:\n"
-        f"{STDOUT}"
-        f"{STDERR}"
-    ), "the prefetch report must name the fixture, command, and Cargo output"
+    ), f"the {heading!r} report must keep the gate's established wording"

--- a/scripts/tests/test_fixture_lockfile_reporting.py
+++ b/scripts/tests/test_fixture_lockfile_reporting.py
@@ -1,12 +1,28 @@
 """Unit tests for the fixture-lockfile reporting helpers."""
 
 import typing as typ
+from pathlib import Path
 
 import fixture_lockfile_reporting
-from fixture_lockfile_reporting import print_failures
+from fixture_lockfile_reporting import (
+    fetch_failure_message,
+    print_failures,
+    refresh_failure_message,
+    stale_failure_message,
+)
 
 if typ.TYPE_CHECKING:
     import pytest
+
+#: A manifest path the tests never touch: they pin pure report formatting.
+MANIFEST = Path("/repo/crates/rstest-bdd/tests/ui_lints/Cargo.toml")
+
+#: The validation command and the prefetch command the gate passes in.
+METADATA_COMMAND = ["cargo", "metadata", "--locked", "--manifest-path", str(MANIFEST)]
+FETCH_COMMAND = ["cargo", "fetch", "--locked", "--manifest-path", str(MANIFEST)]
+
+STDOUT = "resolving dependencies\n"
+STDERR = "error: failed to update\n"
 
 
 def test_print_failures_writes_each_report_to_stderr(
@@ -55,3 +71,39 @@ def test_refresh_summary_reports_both_outcomes(
     assert refreshed.out == "refreshed 5 fixture lockfile(s)\n", (
         "the success line must confirm the refreshed count"
     )
+
+
+def test_stale_failure_message_reports_the_manifest_command_and_output() -> None:
+    """The stale report spells out the heading, the command, and both streams."""
+    assert stale_failure_message(MANIFEST, METADATA_COMMAND, STDOUT, STDERR) == (
+        "stale or unusable fixture lockfile: "
+        f"{MANIFEST}\n"
+        f"command: {' '.join(METADATA_COMMAND)}\n"
+        "cargo output:\n"
+        f"{STDOUT}"
+        f"{STDERR}"
+    ), "the stale report must keep the gate's established wording"
+
+
+def test_refresh_failure_message_reports_the_manifest_command_and_output() -> None:
+    """The refresh report keeps its own colon-free opening clause."""
+    assert refresh_failure_message(MANIFEST, METADATA_COMMAND, STDOUT, STDERR) == (
+        "refresh failed for "
+        f"{MANIFEST}\n"
+        f"command: {' '.join(METADATA_COMMAND)}\n"
+        "cargo output:\n"
+        f"{STDOUT}"
+        f"{STDERR}"
+    ), "the refresh report must not gain punctuation the gate never printed"
+
+
+def test_fetch_failure_message_reports_the_manifest_command_and_output() -> None:
+    """The prefetch report quotes the fetch command and Cargo's output."""
+    assert fetch_failure_message(MANIFEST, FETCH_COMMAND, STDOUT, STDERR) == (
+        "failed to prefetch fixture dependencies: "
+        f"{MANIFEST}\n"
+        f"command: {' '.join(FETCH_COMMAND)}\n"
+        "cargo output:\n"
+        f"{STDOUT}"
+        f"{STDERR}"
+    ), "the prefetch report must name the fixture, command, and Cargo output"

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -36,7 +36,9 @@ USES_RE = re.compile(
 
 #: The exact caller configuration: workspace source under crates/;
 #: example applications, standalone test-fixture crates, and test-support
-#: modules excluded as noise; feature-gated tests enabled to match `make test`.
+#: modules excluded as noise; feature-gated tests enabled to match
+#: `make test`; and the prefetch that lets the nested fixture harnesses
+#: resolve their lockfiles offline.
 EXPECTED_WITH = {
     "paths": "crates/",
     "exclude-globs": (
@@ -54,6 +56,7 @@ EXPECTED_WITH = {
         "crates/rstest-bdd-harness/src/trybuild_staging/**"
     ),
     "extra-args": "--all-features --test-workspace=true",
+    "setup-commands": "make prefetch-fixture-deps",
 }
 
 


### PR DESCRIPTION
## Summary

Closes #721

The scheduled mutation lane failed on its unmutated baseline (run 33953645992,
job 101272942083: "Found 168 mutants to test / FAILED Unmutated baseline in
130s build + 0s test"). The nested `cargo test --no-run` inside
`crates/rstest-bdd/tests/feature_rebuild_invalidation.rs` builds its fixture
crate with `--locked --offline`, and nothing in that lane had ever resolved the
standalone fixture lockfiles, so the build died on a crate that was in no local
registry cache:

    error: failed to download `proc-macro-error-attr3 v3.1.0`
    ... attempting to make an HTTP request, but --offline was specified

The ordinary CI lane never sees this: its workspace build and
`make check-fixture-lockfiles` warm `~/.cargo/registry` as a side effect. The
mutation lane runs no such outer online build.

## What changed

- **`scripts/check_fixture_lockfiles.py`** gains a `--fetch` mode. Reusing the
  same standalone-fixture discovery as the check and refresh modes, it runs
  `cargo fetch --locked --manifest-path <fixture>/Cargo.toml` for every
  discovered fixture, warming `~/.cargo/registry` from the committed lockfile
  without building anything. Failures are reported per fixture, in the same
  shape as the existing modes, and exit non-zero.
- **`make prefetch-fixture-deps`** calls that mode.
- **`.github/workflows/mutation-testing.yml`** passes `make prefetch-fixture-deps`
  through the reusable workflow's `setup-commands` input, which runs after Rust
  (and uv) are set up and before cargo-mutants starts. `paths`,
  `exclude-globs`, and `extra-args` are untouched, and the caller adds no steps
  of its own.
- **`tests/workflow_contracts/mutation_testing_test.py`** pins the new input
  alongside the existing caller configuration, so losing it fails CI on the
  pull request rather than in a scheduled run.
- **`docs/developers-guide.md`** documents the target, why the lane needs it,
  and how the prefetch stays distinct from the existing `--locked` contract:
  `make check-fixture-lockfiles` deliberately never passes `--offline`, because
  a lockfile that resolves only from a partial cache would hide the drift the
  gate exists to catch.

No runtime `CARGO_MUTANTS` environment-variable check was added, and no test is
skipped or gated.

## Testing

- `make prefetch-fixture-deps` → `prefetched dependencies for 5 fixture(s)`.
- `scripts/tests`: `--fetch` argv, per-fixture failure reporting, stderr
  summary, and the `--fetch` routing are covered; 122 tests pass.
- `tests/workflow_contracts`: 112 pass, including the updated contract.
- Full commit gates (`make check-fmt`, `make lint`, `make test`,
  `make markdownlint`, `make test-workflow-contracts`, `make nixie`) pass.

## References

- Lody session: `a5eef54e-6dbb-4169-9eab-37ea6e4d7c44`
- https://lody.ai/leynos/sessions/a5eef54e-6dbb-4169-9eab-37ea6e4d7c44

## Summary by Sourcery

Prefetch standalone fixture dependencies before mutation testing so nested offline builds can resolve their committed lockfiles.

New Features:
- Add a fixture dependency prefetch mode that resolves each standalone fixture's committed lockfile into Cargo's local registry cache.

Bug Fixes:
- Prevent mutation-testing baselines from failing when nested offline fixture builds require dependencies absent from the local Cargo cache.

Enhancements:
- Share robust standalone-fixture discovery across lockfile validation, refresh, and dependency prefetch operations.
- Emit bounded machine-readable prefetch metrics while preserving per-fixture failure reporting and stream-specific outcomes.

Build:
- Add the `prefetch-fixture-deps` Make target for warming fixture dependencies before offline builds.

CI:
- Configure the mutation-testing workflow to prefetch fixture dependencies before running cargo-mutants.
- Extend workflow contract tests to require the mutation lane prefetch configuration.

Documentation:
- Document the mutation-lane prefetch behavior and its distinction from online lockfile validation.

Tests:
- Add coverage for prefetch command routing, discovery classification, failure handling, metrics, Make integration, and workflow configuration.