### PR TITLE
Correct the Python rules on suppression syntax and delegated raises (#732)

### DIFF
--- a/.rules/python-00.md
+++ b/.rules/python-00.md
@@ -44,6 +44,56 @@
 - **Use Ruff for formatting**. Let Ruff handle whitespace and formatting
   entirely—don't fight it.
 
+## Suppressing a Diagnostic
+
+- **Fix the code first.** Suppress a diagnostic only when an external
+  constraint makes it wrong, never to quiet a rule the code could satisfy.
+- **Keep the scope to the site.** One directive, on the offending line or the
+  one definition it covers.
+- **Name the rules, not their codes.** Under the pinned Ruff, `# noqa: S404`
+  is refused (`noqa-comments`) and so is `# ruff: ignore[S404]`
+  (`rule-codes-in-suppression-comments`); `unused-noqa` refuses an entry that
+  suppresses nothing, and `invalid-suppression-comment` refuses a directive
+  that names no rule at all. Name only the rules that fire.
+- **State the external constraint** after a dash, as in the example below.
+- **Use the same shape for the other linters.** A pylint suppression goes on
+  the definition that needs it, as
+  `# pylint: disable-next=too-many-arguments`, never in a module-level
+  `disable`.
+
+```python
+import subprocess  # ruff: ignore[suspicious-subprocess-import] - runs the script this repository declares.
+```
+
+Arity is the usual reason a correct signature needs a directive: the project
+sets Ruff's `max-args` budget to four, so a helper that renders one report from
+five parts carries the directive on that one definition, with its reason, and
+leaves every other definition unannotated.
+
+## Shared Helpers and Sibling Functions
+
+- **Find the shared body.** When sibling functions differ only in one fixed
+  argument, keep that body in a single private helper and keep one entry point
+  per operation.
+- **Don't bundle parts to meet a budget.** A tuple or a purpose-built dataclass
+  that exists only to lower an argument count adds a transport type without
+  removing data or control flow, and splits one signature across two
+  definitions. A scoped directive on the helper states the real constraint; see
+  *Suppressing a Diagnostic* above.
+- **Keep the entry points documented.** An explicit function carries its NumPy
+  docstring, its annotations, and its place in the public API. A
+  `functools.partial` binding of the helper carries none of them, because the
+  docstring and annotation rules do not see an assignment. A binding is legal
+  where the entry points have no contract of their own—but the helper then
+  holds the only documentation those operations have.
+- **Preserve tested wording exactly.** Where the message text is a contract,
+  keep each operation's punctuation as it is.
+- **Answer a marker with the design, not with abstraction.** A CodeScene
+  `Code Duplication` or `Excess Number of Function Arguments` marker on such a
+  helper and its siblings is met by this shape; record the rationale in the
+  suppression note at the marker instead of widening a suppression or
+  reshaping the code.
+
 ## Documentation
 
 - **Use docstrings.** Document public functions, classes, and modules using

--- a/.rules/python-exception-design-raising-handling-and-logging.md
+++ b/.rules/python-exception-design-raising-handling-and-logging.md
@@ -281,16 +281,73 @@ select = [
 ]
 ```
 
-## 10) One‑page policy for repositories
+## 10) Documenting raises: the function's own, and the helper's
+
+A `Raises` section describes what the documented function itself raises, so a
+raise written in its own body is documented there:
+
+```python
+def read_pin(text: str) -> str:
+    """Return the commit an environment pin declares.
+
+    Returns
+    -------
+    str
+        The commit the pin names.
+
+    Raises
+    ------
+    PinMissingError
+        If the text names no commit.
+    """
+    match = PIN.search(text)
+    if match is None:
+        message = "the pin must name a commit"
+        raise PinMissingError(message)
+    return match["ref"]
+```
+
+A raise delegated to a shared guard is different. When a module funnels its
+shape checks through one helper — `_require(condition, message)` — the
+documented function's body holds no `raise` statement of its own, and a
+`Raises` section naming that exception is refused
+(`docstring-extraneous-exception`). The analysis is syntactic: it cannot see
+through the call.
+
+Describe the delegated failure in the docstring's prose instead, naming the
+causes, so a caller still learns what can fail and why:
+
+```python
+def read_lockfile(text: str) -> str:
+    """Return the commit a lock file resolves the dependency to.
+
+    Text naming no revision, or resolving the dependency to more than one,
+    raises :class:`PinMissingError` through :func:`_require`: either way the
+    lock file cannot say what a bare ``uv run`` installs.
+
+    Returns
+    -------
+    str
+        The commit the lock file records.
+    """
+```
+
+Neither form is a suppression, and neither is second best: choose the one the
+raise's location calls for. Do not keep a `Raises` section by silencing the
+lint, and do not hide a direct raise in prose to match a neighbour.
+
+## 11) One‑page policy for repositories
 
 > **Exceptions are part of the public API.** Define a small hierarchy with a
 > package base and `*Error` suffix; raise specific types; wrap external
 > failures with `raise … from …`; catch only what can be handled; use `else`
 > for the happy path; avoid `try/except` in hot loops; never format log
-> messages directly; log exceptions once at a boundary via `logger.exception`.
+> messages directly; log exceptions once at a boundary via `logger.exception`;
+> document a `Raises` section only for the exceptions a function raises itself,
+> describing a raise delegated to a helper in prose.
 > Enforce with Ruff (TRY/BLE/EM/LOG/N818/PERF203/B017).
 
-## 11) References
+## 12) References
 
 - Ruff rules: Tryceratops (TRY), Blind Except (BLE001), flake8‑errmsg
   (EM101/EM102), flake8‑logging (LOG004/LOG007/LOG009/LOG014/LOG015), N818,


### PR DESCRIPTION
## Summary

Closes #732.

`.rules/python-00.md` and
`.rules/python-exception-design-raising-handling-and-logging.md` now record the
syntax and the docstring shape the pinned gates accept, so a contributor or an
agent following the repository's own rules no longer writes a directive the
gates refuse.

Both defects #732 reports were reproduced against the pinned toolchain
(`ruff@0.16.4 --config pyproject.toml`, `preview = true`,
`target-version = "py314"`) before any text changed:

1. **Suppression syntax.** `# noqa: S404` is refused by `noqa-comments`, and
   `# ruff: ignore[S404]` by `rule-codes-in-suppression-comments`; the accepted
   spelling names the rule and carries a reason. The new *Suppressing a
   Diagnostic* section records that, with the companion policy: fix the code
   first; keep the directive on the site it covers; name only the rules that
   fire (`unused-noqa` refuses an entry that suppresses nothing,
   `invalid-suppression-comment` refuses one that names no rule); state the
   external constraint after a dash; and use the same shape for pylint
   (`# pylint: disable-next=...` on the definition, never a module-level
   `disable`).
2. **Raises documentation.** `docstring-extraneous-exception` refuses a `Raises`
   section for an exception the function does not raise syntactically, so a
   raise delegated to a shared guard such as `_require` cannot be documented
   that way. New §10 in the exception guide splits the two cases — a direct
   raise in a `Raises` section, a delegated raise described in the docstring's
   prose, naming the causes — and §11's one-page policy carries the same
   sentence. Neither form is a suppression.

The same change answers the CodeScene `Code Duplication` marker on
`scripts/fixture_lockfile_reporting.py` in #741 (`fetch_failure_message`,
`refresh_failure_message`, `stale_failure_message`). The new *Shared Helpers and
Sibling Functions* section says: keep the shared body in one private helper with
one entry point per operation; do not bundle the parts into a tuple or dataclass
that exists only to meet the arity budget; keep the entry points documented,
noting that a `functools.partial` binding of the helper carries neither a
docstring nor annotations because those rules do not see an assignment; keep
tested wording exact; and answer the marker with this design, recording the
rationale at the marker, rather than widening a suppression or reshaping the
code.

### Wording adapted from the issue

The issue's proposed wording asks for "one rule per directive". The pinned gate
accepts several rule names in one directive — verified with
`# ruff: ignore[suspicious-subprocess-import, unused-import] - probe`, which
suppressed both rules, while the same directive naming only one left the other
reported — so the recorded rule is to name the rules that fire, not to split
them. The two suppressions in `publish_report_support.py` each name one rule
already, so nothing there changes.

### Rejected as invalid

The remainder of #732 is rejected as invalid. #732 also asks for the two
CodeRabbit *path instructions* to be reworded, and says of them that "neither
instruction lives in a tracked file, so this is a request to change them where
they are configured rather than a patch". They are configured in the hosted
review service, not in this repository, so no patch here can change them and no
gate here can hold them to account. The half a repository can act on — a
durable record of the syntax the gates actually accept, in the files reviewers
and agents read — is what this PR delivers.

## Verification

Docs-only change: two Markdown files, no code, build, or test files touched.

- `make markdownlint` — pass (117 files, 0 errors)
- `make -B spelling` — pass (full chain, including the `typos` pass over the new
  prose)

## References

- Issue: https://github.com/leynos/rstest-bdd/issues/732
- Related: https://github.com/leynos/rstest-bdd/pull/741 (the CodeScene marker)
- Lody session: https://lody.ai/leynos/sessions/c90d2df6-1273-404d-81c9-bc7302ec98b1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align the repository’s Python guidance with the pinned linting rules for suppressions, shared helpers, and delegated exception documentation.

Enhancements:
- Document accepted Ruff and pylint diagnostic-suppression syntax and the policy for narrowly scoped, justified suppressions.
- Add guidance for structuring shared helper and sibling functions without workaround abstractions or excessive suppressions.
- Clarify how to document direct versus helper-delegated exceptions in Python docstrings.

Documentation:
- Update Python rules with diagnostic-suppression and shared-helper guidance, and update exception documentation guidance for delegated raises.