### PR TITLE
Clarify Python exception documentation (#732)

### DIFF
--- a/.rules/python-00.md
+++ b/.rules/python-00.md
@@ -70,11 +70,11 @@ def scale(values: list[float], factor: float) -> list[float]:
 ```
 
 - **Document exception behaviour at the raising boundary.** A function that
-  raises `PublishReportShapeError` directly documents it in a `Raises` section.
-  A function that raises it through a helper such as `_require` documents the
-  behaviour in the docstring's prose instead, naming the causes; the docstring
-  lint refuses a `Raises` section for an exception the function does not raise
-  itself.
+  raises `PublishReportShapeError` directly documents it in a `Raises` section,
+  including when it also calls a helper such as `_require`. When `_require` is
+  the sole raising path, document the behaviour in the docstring's prose
+  instead, naming the causes; the docstring lint refuses a `Raises` section for
+  an exception the function does not raise itself.
 - **Explain tricky code.** Use inline comments for non-obvious logic or
   decisions.
 - **Colocate documentation.** Keep README.md or `docs/` near reusable packages;

--- a/.rules/python-00.md
+++ b/.rules/python-00.md
@@ -69,6 +69,12 @@ def scale(values: list[float], factor: float) -> list[float]:
     return [v * factor for v in values]
 ```
 
+- **Document exception behaviour at the raising boundary.** A function that
+  raises `PublishReportShapeError` directly documents it in a `Raises` section.
+  A function that raises it through a helper such as `_require` documents the
+  behaviour in the docstring's prose instead, naming the causes; the docstring
+  lint refuses a `Raises` section for an exception the function does not raise
+  itself.
 - **Explain tricky code.** Use inline comments for non-obvious logic or
   decisions.
 - **Colocate documentation.** Keep README.md or `docs/` near reusable packages;


### PR DESCRIPTION
## Summary

This branch updates [`.rules/python-00.md`](https://github.com/leynos/rstest-bdd/blob/issue-732-two-coderabbit-path-instructions-contradict-the-repositorys-ruff-gate/.rules/python-00.md#L72) to distinguish a direct `PublishReportShapeError` raise, which needs a NumPy `Raises` section, from a helper-mediated raise, whose causes belong in the docstring prose required by the Ruff pydoclint gate.

Closes #732.

## Review walkthrough

- Start with [`.rules/python-00.md`](https://github.com/leynos/rstest-bdd/blob/issue-732-two-coderabbit-path-instructions-contradict-the-repositorys-ruff-gate/.rules/python-00.md#L47) for the existing NumPy-docstring guidance and the new exception-documentation rule.

## Validation

- `make check-fmt`: passed after rebase
- `make test`: passed after rebase (1,928 Rust tests and 127 Python tests)
- `make typecheck`: passed after rebase
- `make lint`: passed after rebase

## Notes

The remainder of #732 is rejected as invalid. The requested changes to CodeRabbit path instructions concern hosted configuration that is not tracked by this repository, so this patch cannot alter or validate it. This branch records the documentation form accepted by the repository's Ruff gate.

## References

- Issue: https://github.com/leynos/rstest-bdd/issues/732
- Lody session: https://lody.ai/leynos/sessions/9b20a43c-324e-478a-9773-ac48d2a21482

## Summary by Sourcery

Clarify how Python exception behavior should be documented to satisfy the repository’s docstring linting rules.

Enhancements:
- Clarify Python docstring guidance for documenting exceptions at the boundary where they are raised, distinguishing direct raises from helper-mediated error paths.

Documentation:
- Update Python documentation rules to align exception documentation guidance with the repository’s Ruff pydoclint requirements.